### PR TITLE
feat(rag): unified hybrid fusion on user chat path (#3270)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchQueryHandler.cs
@@ -23,7 +23,7 @@ internal class SearchQueryHandler : IQueryHandler<SearchQuery, List<SearchResult
     private readonly VectorSearchDomainService _vectorSearchService;
     private readonly RrfFusionDomainService _rrfFusionService;
     private readonly IEmbeddingService _embeddingService;
-    private readonly IHybridSearchService _hybridSearchService;
+    private readonly IKeywordSearchService _keywordSearchService;
     private readonly IRagAccessService _ragAccessService;
     private readonly ILogger<SearchQueryHandler> _logger;
 
@@ -32,7 +32,7 @@ internal class SearchQueryHandler : IQueryHandler<SearchQuery, List<SearchResult
         VectorSearchDomainService vectorSearchService,
         RrfFusionDomainService rrfFusionService,
         IEmbeddingService embeddingService,
-        IHybridSearchService hybridSearchService,
+        IKeywordSearchService keywordSearchService,
         IRagAccessService ragAccessService,
         ILogger<SearchQueryHandler> logger)
     {
@@ -40,7 +40,7 @@ internal class SearchQueryHandler : IQueryHandler<SearchQuery, List<SearchResult
         _vectorSearchService = vectorSearchService ?? throw new ArgumentNullException(nameof(vectorSearchService));
         _rrfFusionService = rrfFusionService ?? throw new ArgumentNullException(nameof(rrfFusionService));
         _embeddingService = embeddingService ?? throw new ArgumentNullException(nameof(embeddingService));
-        _hybridSearchService = hybridSearchService ?? throw new ArgumentNullException(nameof(hybridSearchService));
+        _keywordSearchService = keywordSearchService ?? throw new ArgumentNullException(nameof(keywordSearchService));
         _ragAccessService = ragAccessService ?? throw new ArgumentNullException(nameof(ragAccessService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -163,7 +163,10 @@ internal class SearchQueryHandler : IQueryHandler<SearchQuery, List<SearchResult
                 pageNumber: scored.Embedding.PageNumber,
                 relevanceScore: new Confidence(cosine),
                 rank: index + 1,
-                searchMethod: "vector"
+                searchMethod: "vector",
+                pdfDocumentId: scored.Embedding.PdfDocumentId,                       // real (JOIN-resolved)
+                chunkIndex: scored.Embedding.ChunkIndex,
+                roleTags: (GameBookRole)scored.Embedding.RoleTags                    // int → enum
             );
         }).ToList();
 
@@ -188,27 +191,32 @@ internal class SearchQueryHandler : IQueryHandler<SearchQuery, List<SearchResult
         var vectorResults = await PerformVectorSearchAsync(
             gameId, queryVector, topK, minScore, documentIds, cancellationToken).ConfigureAwait(false);
 
-        // Keyword search (use HybridSearchService with Keyword mode)
-        // Issue #423: Pass keywordMinScore to filter low-relevance keyword matches (e.g., ToC entries)
-        // ts_rank_cd scores are typically 0-0.3; threshold of 0.01 filters noise while keeping real matches
-        // Phase D (D6): queryRoleHint enables role-match boost in the re-ranker.
+        // Issue #423: ts_rank_cd scores ~0-0.3; 0.01 filters ToC noise.
         const double KeywordMinScore = 0.01;
-        var hybridSearchResults = await _hybridSearchService.SearchAsync(
+
+        // Spec §6: RAW keyword arm sourced directly from IKeywordSearchService (un-boosted, raw ts_rank_cd
+        // order) so HybridFusionCore applies role-boost + legend exactly once.
+        var rawKeyword = await _keywordSearchService.SearchAsync(
             query,
             gameId,
-            SearchMode.Keyword,
             topK,
-            documentIds?.ToList(), // Issue #2051: Pass document filter
-            keywordMinScore: KeywordMinScore,
-            queryRoleHint: queryRoleHint,
+            phraseSearch: query.Contains('"'),            // reproduce HybridSearchService.cs:189 derivation
+            boostTerms: null,                             // was _config.BoostTerms — a no-op on the tsquery
+            minScore: KeywordMinScore,
             cancellationToken: cancellationToken).ConfigureAwait(false);
 
-        // Map keyword results to domain entities
-        var keywordResults = hybridSearchResults
+        // Issue #2051: reproduce the documentIds post-filter that SearchAsync(Keyword) applied internally.
+        var filteredKeyword = documentIds is null
+            ? (IReadOnlyList<KeywordSearchResult>)rawKeyword
+            : rawKeyword
+                .Where(r => documentIds.Any(id => string.Equals(id.ToString(), r.PdfDocumentId, StringComparison.Ordinal)))
+                .ToList();
+
+        var keywordResults = filteredKeyword
             .Select((kr, index) => kr.ToDomainSearchResult(index + 1))
             .ToList();
 
         // Use RRF fusion domain service
-        return _rrfFusionService.FuseResults(vectorResults, keywordResults);
+        return _rrfFusionService.FuseResults(vectorResults, keywordResults, queryRoleHint: queryRoleHint);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamQaQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamQaQueryHandler.cs
@@ -46,6 +46,7 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
     private readonly IAiResponseCacheService _cache;
     private readonly IPromptTemplateService _promptTemplateService;
     private readonly InlineCitationMatcherService _citationMatcher;
+    private readonly IIntentClassifierService _intentClassifier;
     private readonly ILogger<StreamQaQueryHandler> _logger;
     private readonly TimeProvider _timeProvider;
 
@@ -61,6 +62,7 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
         IAiResponseCacheService cache,
         IPromptTemplateService promptTemplateService,
         InlineCitationMatcherService citationMatcher,
+        IIntentClassifierService intentClassifier,
         ILogger<StreamQaQueryHandler> logger,
         TimeProvider? timeProvider = null)
     {
@@ -75,6 +77,7 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
         _cache = cache ?? throw new ArgumentNullException(nameof(cache));
         _promptTemplateService = promptTemplateService ?? throw new ArgumentNullException(nameof(promptTemplateService));
         _citationMatcher = citationMatcher ?? throw new ArgumentNullException(nameof(citationMatcher));
+        _intentClassifier = intentClassifier ?? throw new ArgumentNullException(nameof(intentClassifier));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _timeProvider = timeProvider ?? TimeProvider.System;
     }
@@ -281,6 +284,14 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
         IReadOnlyList<Guid>? documentIds,
         CancellationToken cancellationToken)
     {
+        // Issue #3270 (Task 7): classify user intent into GameBookRole tag(s) so the hybrid
+        // re-ranker can boost chunks whose role_tags overlap (parity with AskQuestionQueryHandler).
+        // The classifier is rule-based, sync, and cheap (~µs); failure modes default to RulesReference.
+        var queryRoleHint = _intentClassifier.ClassifyIntent(queryText);
+        _logger.LogDebug(
+            "[StreamQaHandler] Intent classification: Query={Query}, RoleHint={RoleHint}",
+            queryText, queryRoleHint);
+
         var searchQuery = new SearchQuery(
             GameId: Guid.Parse(gameId),
             Query: queryText,
@@ -288,7 +299,8 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
             MinScore: 0.55,
             SearchMode: "hybrid",
             Language: "en",
-            DocumentIds: documentIds // Issue #2051
+            DocumentIds: documentIds, // Issue #2051
+            QueryRoleHint: queryRoleHint // Issue #3270: bias re-ranker toward role-matching chunks
         );
 
         var searchResults = await _searchQueryHandler.Handle(searchQuery, cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/SearchResult.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/SearchResult.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
 using Api.SharedKernel.Domain.Entities;
 
@@ -15,6 +16,9 @@ internal sealed class SearchResult : Entity<Guid>
     public Confidence RelevanceScore { get; private set; }
     public int Rank { get; private set; }
     public string? SearchMethod { get; private set; } // "vector", "keyword", "hybrid"
+    public Guid PdfDocumentId { get; private set; }
+    public int ChunkIndex { get; private set; }
+    public GameBookRole RoleTags { get; private set; }
 
     /// <summary>
     /// Private constructor for EF Core.
@@ -35,7 +39,10 @@ internal sealed class SearchResult : Entity<Guid>
         int pageNumber,
         Confidence relevanceScore,
         int rank,
-        string? searchMethod = null) : base(id)
+        string? searchMethod = null,
+        Guid pdfDocumentId = default,
+        int chunkIndex = 0,
+        GameBookRole roleTags = GameBookRole.None) : base(id)
     {
         if (string.IsNullOrWhiteSpace(textContent))
             throw new ArgumentException("Text content cannot be empty", nameof(textContent));
@@ -52,6 +59,9 @@ internal sealed class SearchResult : Entity<Guid>
         RelevanceScore = relevanceScore ?? throw new ArgumentNullException(nameof(relevanceScore));
         Rank = rank;
         SearchMethod = searchMethod;
+        PdfDocumentId = pdfDocumentId;
+        ChunkIndex = chunkIndex;
+        RoleTags = roleTags;
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/FusionSignals.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/FusionSignals.cs
@@ -1,0 +1,64 @@
+using System.Text.RegularExpressions;
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+
+namespace Api.BoundedContexts.KnowledgeBase.Domain.Services;
+
+/// <summary>
+/// Pure, stateless retrieval-ranking signals shared by every hybrid-fusion path
+/// (issue #3270). Moved out of <c>HybridSearchService</c> so the primary chat path
+/// and the admin playground apply identical legend-demotion + role-boost.
+/// </summary>
+internal static class FusionSignals
+{
+    /// <summary>Additive role-match boost (issue #1391 Phase D6).</summary>
+    internal const float RoleMatchBoost = 0.15f;
+
+    /// <summary>Default reciprocal-rank-fusion constant.</summary>
+    internal const int DefaultRrfK = 60;
+
+    // Matches cross-reference pointers like "vedi pag. 10", "vedi anche pagina 5", "see p. 11",
+    // "cfr. pagg. 4-5". Allows an optional connector word ("anche"/"a") and spelled-out "pagina".
+    private static readonly Regex CrossReferencePointer = new(
+        @"(?i)\b(?:vedi|see|cfr|cf)\b\.?\s+(?:anche\s+|a\s+)?(?:pagine|pagina|pagg|pag|pages|page|pp|p)\b\.?",
+        RegexOptions.Compiled,
+        TimeSpan.FromSeconds(1));
+
+    /// <summary>
+    /// Additive boost when the query's role hint overlaps a chunk's role tags.
+    /// Verbatim move of HybridSearchService.ComputeRoleMatchBoost (:536-544).
+    /// </summary>
+    internal static float ComputeRoleMatchBoost(GameBookRole queryRoleHint, GameBookRole chunkRoleTags)
+    {
+        if (queryRoleHint == GameBookRole.None || chunkRoleTags == GameBookRole.None)
+        {
+            return 0f;
+        }
+
+        return (chunkRoleTags & queryRoleHint) != GameBookRole.None ? RoleMatchBoost : 0f;
+    }
+
+    /// <summary>
+    /// Legend-demotion factor in [0, 0.5] (verbatim move of :560-580).
+    /// </summary>
+    internal static float ComputeLegendPenaltyFactor(string? content)
+    {
+        if (string.IsNullOrEmpty(content))
+        {
+            return 0f;
+        }
+
+        var pointers = CrossReferencePointer.Count(content);
+        // A legend is a LIST of pointers; a single incidental page reference is not one.
+        if (pointers < 2)
+        {
+            return 0f;
+        }
+
+        // Density-driven ONLY (pointers per 1000 chars), never the raw count: a short chunk that
+        // is mostly pointers (a legend) has high density and is capped at 0.5, while a long,
+        // substantive section that legitimately cites several pages has low density and is barely
+        // touched. Using the raw count would over-demote long real content with many references.
+        var density = pointers * 1000.0 / content.Length;
+        return (float)Math.Min(0.5, 0.05 * density);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/HybridFusionCore.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/HybridFusionCore.cs
@@ -1,0 +1,98 @@
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+
+namespace Api.BoundedContexts.KnowledgeBase.Domain.Services;
+
+/// <summary>Neutral per-arm candidate — only what scoring needs. Adapters build the Key.</summary>
+internal readonly record struct FusionCandidate(
+    string Key,
+    string Content,
+    GameBookRole RoleTags,
+    int Rank,          // 1-based within THIS arm (cosine desc / ts_rank_cd desc)
+    float SourceScore);
+
+internal sealed record FusionOptions(
+    float VectorWeight = 0.7f,
+    float KeywordWeight = 0.3f,
+    int RrfK = FusionSignals.DefaultRrfK,
+    GameBookRole QueryRoleHint = GameBookRole.None);
+
+/// <summary>Scoring result keyed by Key; adapters re-join their arm items for I/O-specific fields.</summary>
+internal readonly record struct FusedCandidate(
+    string Key,
+    string Content,
+    GameBookRole RoleTags,
+    float HybridScore,
+    float? VectorScore,
+    float? KeywordScore,
+    int? VectorRank,
+    int? KeywordRank,
+    int Rank);         // 1-based rank in fused order
+
+/// <summary>
+/// The single canonical hybrid fusion (#3270): weighted RRF + legend-demotion + role-boost,
+/// I/O-type agnostic. Pure — no logging, no injected state.
+/// </summary>
+internal static class HybridFusionCore
+{
+    internal static IReadOnlyList<FusedCandidate> Fuse(
+        IReadOnlyList<FusionCandidate> vectorArm,
+        IReadOnlyList<FusionCandidate> keywordArm,
+        FusionOptions options)
+    {
+        // Dedup within each arm: keep the best (lowest) rank per Key. Total (never throws).
+        var vec = BestPerKey(vectorArm);
+        var kw = BestPerKey(keywordArm);
+
+        var scored = new List<FusedCandidate>();
+        foreach (var key in vec.Keys.Union(kw.Keys, StringComparer.Ordinal))
+        {
+            var hasV = vec.TryGetValue(key, out var v);
+            var hasK = kw.TryGetValue(key, out var k);
+
+            float vectorRrf = hasV ? options.VectorWeight / (options.RrfK + v.Rank) : 0f;
+            float keywordRrf = hasK ? options.KeywordWeight / (options.RrfK + k.Rank) : 0f;
+            float rrfSum = vectorRrf + keywordRrf;
+
+            // Prefer vector arm content (load-bearing: legend factor is computed from it).
+            string content = hasV ? v.Content : k.Content;
+            GameBookRole roleTags = (hasV ? v.RoleTags : GameBookRole.None) | (hasK ? k.RoleTags : GameBookRole.None);
+
+            float legendFactor = FusionSignals.ComputeLegendPenaltyFactor(content);
+            float roleBoost = FusionSignals.ComputeRoleMatchBoost(options.QueryRoleHint, roleTags);
+            float hybridScore = (rrfSum * (1f - legendFactor)) + roleBoost;
+
+            scored.Add(new FusedCandidate(
+                Key: key,
+                Content: content,
+                RoleTags: roleTags,
+                HybridScore: hybridScore,
+                VectorScore: hasV ? v.SourceScore : (float?)null,
+                KeywordScore: hasK ? k.SourceScore : (float?)null,
+                VectorRank: hasV ? v.Rank : (int?)null,
+                KeywordRank: hasK ? k.Rank : (int?)null,
+                Rank: 0)); // assigned after sort
+        }
+
+        // Order by hybridScore desc; deterministic tie-break by Key ordinal.
+        var ordered = scored
+            .OrderByDescending(c => c.HybridScore)
+            .ThenBy(c => c.Key, StringComparer.Ordinal)
+            .Select((c, i) => c with { Rank = i + 1 })
+            .ToList();
+
+        return ordered;
+    }
+
+    private static Dictionary<string, FusionCandidate> BestPerKey(IReadOnlyList<FusionCandidate> arm)
+    {
+        var best = new Dictionary<string, FusionCandidate>(StringComparer.Ordinal);
+        foreach (var c in arm)
+        {
+            if (!best.TryGetValue(c.Key, out var existing) || c.Rank < existing.Rank)
+            {
+                best[c.Key] = c;
+            }
+        }
+        return best;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/RrfFusionDomainService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/RrfFusionDomainService.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
 using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
 
@@ -6,113 +7,77 @@ namespace Api.BoundedContexts.KnowledgeBase.Domain.Services;
 /// <summary>
 /// Domain service for Reciprocal Rank Fusion (RRF).
 /// Combines results from multiple search methods (vector + keyword) into a unified ranking.
+/// Issue #3270 (Task 5): this is the PRIMARY chat-path fusion (used by /agents/qa via
+/// SearchQueryHandler). It now adapts to <see cref="HybridFusionCore"/> for scoring (weighted RRF +
+/// legend-demotion + role-boost), the same core the admin playground's HybridSearchService uses.
 /// </summary>
 internal class RrfFusionDomainService
 {
-    private const int DefaultRrfK = 60; // PERF-08: Standard RRF constant
+    private const int DefaultRrfK = FusionSignals.DefaultRrfK; // PERF-08: Standard RRF constant
 
     /// <summary>
-    /// Fuses vector and keyword search results using Reciprocal Rank Fusion.
-    /// RRF formula: score = sum(1 / (k + rank)) for each result list.
+    /// Fuses vector and keyword search results via <see cref="HybridFusionCore"/> (weighted RRF +
+    /// legend-demotion + role-boost), preserving each result's carried cosine as its
+    /// <see cref="SearchResult.RelevanceScore"/> (issue #2712) — the hybrid score drives ORDER only.
     /// </summary>
     /// <param name="vectorResults">Results from vector search</param>
     /// <param name="keywordResults">Results from keyword search</param>
     /// <param name="rrfK">RRF constant (default 60)</param>
+    /// <param name="queryRoleHint">Optional role hint used to boost matching chunks (default None)</param>
     /// <returns>Fused and re-ranked results</returns>
     public virtual List<SearchResult> FuseResults(
         List<SearchResult> vectorResults,
         List<SearchResult> keywordResults,
-        int rrfK = DefaultRrfK)
+        int rrfK = DefaultRrfK,
+        GameBookRole queryRoleHint = GameBookRole.None)
     {
         if (rrfK <= 0)
             throw new ArgumentException("RRF K must be positive", nameof(rrfK));
 
-        // Build dictionary of chunk key -> RRF score
-        // Key is composite (documentId:page:contentHash) so each unique chunk is ranked independently.
-        // Chunks from vector AND keyword search that share the same content fuse together correctly.
-        var rrfScores = new Dictionary<string, double>(StringComparer.Ordinal);
-
-        // Add scores from vector results
-        foreach (var result in vectorResults)
-        {
-            var key = GetChunkKey(result);
-            var score = 1.0 / (rrfK + result.Rank);
-            if (!rrfScores.TryGetValue(key, out var existingScore))
-                rrfScores[key] = score;
-            else
-                rrfScores[key] = existingScore + score;
-        }
-
-        // Add scores from keyword results
-        foreach (var result in keywordResults)
-        {
-            var key = GetChunkKey(result);
-            var score = 1.0 / (rrfK + result.Rank);
-            if (!rrfScores.TryGetValue(key, out var existingScore))
-                rrfScores[key] = score;
-            else
-                rrfScores[key] = existingScore + score;
-        }
-
-        // Combine all results and re-rank by RRF score
-        var allResults = vectorResults.Concat(keywordResults)
-            .GroupBy(r => GetChunkKey(r), StringComparer.Ordinal)
-            .Select(g => g.First()) // Take first occurrence of each unique chunk
+        var vectorArm = vectorResults
+            .Select((r, i) => new FusionCandidate(GetChunkKey(r), r.TextContent, r.RoleTags, i + 1, (float)r.RelevanceScore.Value))
+            .ToList();
+        var keywordArm = keywordResults
+            .Select((r, i) => new FusionCandidate(GetChunkKey(r), r.TextContent, r.RoleTags, i + 1, (float)r.RelevanceScore.Value))
             .ToList();
 
-        // First, calculate RRF scores and sort by score
-        var scoredResults = allResults
-            .Select(result => new
+        var fused = HybridFusionCore.Fuse(vectorArm, keywordArm, new FusionOptions(0.7f, 0.3f, rrfK, queryRoleHint));
+
+        var vByKey = vectorResults.ToLookup(GetChunkKey, StringComparer.Ordinal);
+        var kByKey = keywordResults.ToLookup(GetChunkKey, StringComparer.Ordinal);
+
+        return fused
+            .Select(f =>
             {
-                Result = result,
-                RrfScore = rrfScores[GetChunkKey(result)],
-                NormalizedScore = NormalizeRrfScore(rrfScores[GetChunkKey(result)])
+                // Prefer the vector-arm original when the chunk was found by both arms.
+                var original = vByKey[f.Key].FirstOrDefault() ?? kByKey[f.Key].First();
+                return new SearchResult(
+                    id: Guid.NewGuid(),
+                    vectorDocumentId: original.VectorDocumentId,
+                    textContent: f.Content,
+                    pageNumber: original.PageNumber,
+                    // Issue #2712: preserve the original relevance signal (cosine similarity for
+                    // vector results) as the RelevanceScore. The hybrid score computed by
+                    // HybridFusionCore still drives the ORDER, but RelevanceScore must reflect
+                    // semantic relevance — feeding a rank-based fused score into confidence made it
+                    // degenerate.
+                    relevanceScore: original.RelevanceScore,
+                    rank: f.Rank,
+                    searchMethod: "hybrid",
+                    pdfDocumentId: original.PdfDocumentId,
+                    chunkIndex: original.ChunkIndex,
+                    roleTags: f.RoleTags);
             })
-            .OrderByDescending(x => x.NormalizedScore)
             .ToList();
-
-        // Then create SearchResult objects with correct rank (1-based, assigned after sorting)
-        var fusedResults = scoredResults
-            .Select((item, index) => new SearchResult(
-                id: Guid.NewGuid(),
-                vectorDocumentId: item.Result.VectorDocumentId,
-                textContent: item.Result.TextContent,
-                pageNumber: item.Result.PageNumber,
-                // Issue #2712: preserve the original relevance signal (cosine similarity for vector
-                // results) as the RelevanceScore. RRF still drives the ORDER (OrderByDescending above),
-                // but the RelevanceScore must reflect semantic relevance — feeding the rank-based RRF
-                // score into confidence made it degenerate (always ≈0.53).
-                relevanceScore: item.Result.RelevanceScore,
-                rank: index + 1, // Rank assigned after sorting
-                searchMethod: "hybrid"
-            ))
-            .ToList();
-
-        return fusedResults;
     }
 
     /// <summary>
-    /// Generates a stable, chunk-level key for RRF fusion.
-    /// Uses a composite of VectorDocumentId + PageNumber + TextContent hash so that:
+    /// Generates a stable, chunk-level key for fusion.
+    /// Uses the unified chunk identity (PdfDocumentId + ChunkIndex, issue #3270) so that:
     /// - the same chunk returned by both vector and keyword search fuses into one entry,
-    /// - different chunks from the same document (same VectorDocumentId) remain separate.
+    /// - different chunks from the same document remain separate.
     /// </summary>
-    private static string GetChunkKey(SearchResult result)
-    {
-        // Unique per chunk: same content from vector and keyword search should fuse
-        return $"{result.VectorDocumentId}:{result.PageNumber}:{result.TextContent.GetHashCode(StringComparison.Ordinal)}";
-    }
-
-    /// <summary>
-    /// Normalizes RRF score to 0-1 range for confidence comparison.
-    /// </summary>
-    private double NormalizeRrfScore(double rrfScore)
-    {
-        // RRF scores typically range from 0 to ~0.03 (for k=60, rank=1)
-        // Normalize to 0-1 range using a scaling factor
-        var normalized = Math.Min(rrfScore * 30, 1.0); // Scale factor approximation
-        return Math.Max(0.0, normalized);
-    }
+    private static string GetChunkKey(SearchResult r) => $"{r.PdfDocumentId}_{r.ChunkIndex}";
 
     /// <summary>
     /// Calculates raw RRF score for a result at given rank.

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/Mappers/KnowledgeBaseMappers.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/Mappers/KnowledgeBaseMappers.cs
@@ -83,6 +83,28 @@ internal static class KnowledgeBaseMappers
     }
 
     /// <summary>
+    /// Maps a RAW keyword-search result (issue #3270 §6) to a domain SearchResult, carrying the
+    /// {PdfDocumentId}_{ChunkIndex} fusion identity + RoleTags. RelevanceScore is the raw ts_rank_cd
+    /// (clamped to Confidence's [0,1]); HybridFusionCore applies role-boost/legend downstream.
+    /// </summary>
+    public static Domain.Entities.SearchResult ToDomainSearchResult(this KeywordSearchResult result, int rank)
+    {
+        var pdfDocId = Guid.Parse(result.PdfDocumentId);
+        var score = Math.Clamp((double)result.RelevanceScore, 0.0, 1.0);
+        return new Domain.Entities.SearchResult(
+            id: Guid.NewGuid(),
+            vectorDocumentId: pdfDocId,          // same convention the HybridSearchResult mapper uses
+            textContent: result.Content,
+            pageNumber: result.PageNumber ?? 1,
+            relevanceScore: new Confidence(score),
+            rank: rank,
+            searchMethod: "keyword",
+            pdfDocumentId: pdfDocId,
+            chunkIndex: result.ChunkIndex,
+            roleTags: result.RoleTags);
+    }
+
+    /// <summary>
     /// Extracts float[] from EmbeddingResult.
     /// EmbeddingResult contains List&lt;float[]&gt;, we take the first one for single text queries.
     /// </summary>

--- a/apps/api/src/Api/Services/HybridSearchService.cs
+++ b/apps/api/src/Api/Services/HybridSearchService.cs
@@ -1,5 +1,5 @@
-using System.Text.RegularExpressions;
 using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.BoundedContexts.KnowledgeBase.Domain.Services;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
 using Api.BoundedContexts.KnowledgeBase.Infrastructure.Persistence;
 using Api.Helpers;
@@ -22,17 +22,6 @@ internal class HybridSearchService : IHybridSearchService
     private readonly IVectorStoreAdapter _vectorStore;
     private readonly ILogger<HybridSearchService> _logger;
     private readonly HybridSearchConfiguration _config;
-
-    // RRF constant k (standard value from research papers: Cormack et al. 2009)
-    // Formula: RRF_score = sum(1 / (k + rank_i))
-    // Higher k gives less weight to rank differences, k=60 is empirically optimal
-    private const int DefaultRrfK = 60;
-
-    // Phase D (D6): additive boost applied to chunks whose RoleTags overlap with the user
-    // intent's QueryRoleHint. Chosen ~10x the smallest expected RRF contribution (≈ 0.7/(60+10) ≈ 0.01)
-    // so a single matching tag clearly outranks a non-matching peer at the same retrieval rank,
-    // but does not steamroll strong vector+keyword agreement at the top.
-    internal const float RoleMatchBoost = 0.15f;
 
     public HybridSearchService(
         IKeywordSearchService keywordSearchService,
@@ -131,7 +120,7 @@ internal class HybridSearchService : IHybridSearchService
             var embedding = r.Embedding;
             var chunkRoleTags = (GameBookRole)embedding.RoleTags;
             var baseScore = 1.0f / (index + 1); // normalized rank score
-            var roleBoost = ComputeRoleMatchBoost(queryRoleHint, chunkRoleTags);
+            var roleBoost = FusionSignals.ComputeRoleMatchBoost(queryRoleHint, chunkRoleTags);
             return new HybridSearchResult
             {
                 // RRF fusion-key fix: key on the resolved PdfDocumentId (now populated by the scored
@@ -203,7 +192,7 @@ internal class HybridSearchService : IHybridSearchService
         // Phase D (D6): build hybrid results then re-rank by role-boosted score.
         var hybridResults = filteredResults.Select((r, index) =>
         {
-            var roleBoost = ComputeRoleMatchBoost(queryRoleHint, r.RoleTags);
+            var roleBoost = FusionSignals.ComputeRoleMatchBoost(queryRoleHint, r.RoleTags);
             return new HybridSearchResult
             {
                 ChunkId = r.ChunkId,
@@ -308,7 +297,7 @@ internal class HybridSearchService : IHybridSearchService
             gameId,
             vectorWeight,
             keywordWeight,
-            _config.RrfConstant ?? DefaultRrfK,
+            _config.RrfConstant ?? FusionSignals.DefaultRrfK,
             queryRoleHint);
 
         var topResults = fusedResults
@@ -467,7 +456,7 @@ internal class HybridSearchService : IHybridSearchService
                 ? keywordItem.Result.RoleTags
                 : GameBookRole.None;
             var chunkRoleTags = vectorRoleTags | keywordRoleTags;
-            var roleBoost = ComputeRoleMatchBoost(queryRoleHint, chunkRoleTags);
+            var roleBoost = FusionSignals.ComputeRoleMatchBoost(queryRoleHint, chunkRoleTags);
 
             // Use data from whichever result has it (prefer vector for metadata consistency)
             var matchedTerms = hasKeyword && keywordItem != null
@@ -485,7 +474,7 @@ internal class HybridSearchService : IHybridSearchService
             // which carry no actionable answer yet score in the same RRF band as real content.
             // The demotion scales the RRF fusion components only; the role-match boost (#1391)
             // stays strictly additive on top so its deliberate ~0.15 calibration is not scaled away.
-            var legendFactor = ComputeLegendPenaltyFactor(content);
+            var legendFactor = FusionSignals.ComputeLegendPenaltyFactor(content);
             var hybridScore = ((vectorRrfScore + keywordRrfScore) * (1f - legendFactor)) + roleBoost;
 
             var pdfDocumentId = hasVector && vectorItem != null
@@ -524,59 +513,6 @@ internal class HybridSearchService : IHybridSearchService
         }
 
         return fusedResults;
-    }
-
-    /// <summary>
-    /// Phase D (D6): computes the additive RRF score boost for a chunk based on role overlap.
-    /// Returns <see cref="RoleMatchBoost"/> when <paramref name="queryRoleHint"/> intersects
-    /// <paramref name="chunkRoleTags"/> (both being non-<see cref="GameBookRole.None"/>); otherwise 0.
-    /// Pure function — exposed as <c>internal static</c> for direct unit testing of the re-ranker
-    /// without spinning up pgvector + PostgreSQL FTS infrastructure.
-    /// </summary>
-    internal static float ComputeRoleMatchBoost(GameBookRole queryRoleHint, GameBookRole chunkRoleTags)
-    {
-        if (queryRoleHint == GameBookRole.None || chunkRoleTags == GameBookRole.None)
-        {
-            return 0f;
-        }
-
-        return (chunkRoleTags & queryRoleHint) != GameBookRole.None ? RoleMatchBoost : 0f;
-    }
-
-    // Matches cross-reference pointers like "vedi pag. 10", "vedi anche pagina 5", "see p. 11",
-    // "cfr. pagg. 4-5". Allows an optional connector word ("anche"/"a") and spelled-out "pagina".
-    private static readonly Regex CrossReferencePointer = new(
-        @"(?i)\b(?:vedi|see|cfr|cf)\b\.?\s+(?:anche\s+|a\s+)?(?:pagine|pagina|pagg|pag|pages|page|pp|p)\b\.?",
-        RegexOptions.Compiled,
-        TimeSpan.FromSeconds(1));
-
-    /// <summary>
-    /// RAG answer-quality fix: computes a multiplicative demotion factor in [0, 0.5] for chunks
-    /// that are cross-reference "legends" (dense with "vedi pag."/"see p." pointers, e.g. a
-    /// component list that only points elsewhere). Such chunks carry no actionable content but
-    /// score in the same RRF band as real answers. Pure function — exposed <c>internal static</c>
-    /// for direct unit testing.
-    /// </summary>
-    internal static float ComputeLegendPenaltyFactor(string? content)
-    {
-        if (string.IsNullOrEmpty(content))
-        {
-            return 0f;
-        }
-
-        var pointers = CrossReferencePointer.Count(content);
-        // A legend is a LIST of pointers; a single incidental page reference is not one.
-        if (pointers < 2)
-        {
-            return 0f;
-        }
-
-        // Density-driven ONLY (pointers per 1000 chars), never the raw count: a short chunk that
-        // is mostly pointers (a legend) has high density and is capped at 0.5, while a long,
-        // substantive section that legitimately cites several pages has low density and is barely
-        // touched. Using the raw count would over-demote long real content with many references.
-        var density = pointers * 1000.0 / content.Length;
-        return (float)Math.Min(0.5, 0.05 * density);
     }
 }
 

--- a/apps/api/src/Api/Services/HybridSearchService.cs
+++ b/apps/api/src/Api/Services/HybridSearchService.cs
@@ -370,10 +370,15 @@ internal class HybridSearchService : IHybridSearchService
 
     /// <summary>
     /// Fuses vector and keyword search results using Reciprocal Rank Fusion (RRF).
-    /// RRF formula: score = sum_over_all_rankings(weight / (k + rank))
-    /// where k=60 (empirically optimal constant), rank is 1-based position.
+    /// Thin adapter (#3270 Task 3): maps each arm's I/O-specific items into the neutral
+    /// <see cref="FusionCandidate"/> shape, delegates the actual RRF + legend-demotion +
+    /// role-boost scoring to <see cref="HybridFusionCore.Fuse"/> (the single canonical
+    /// implementation shared with the primary chat path), then re-joins by composite key
+    /// to rebuild <see cref="HybridSearchResult"/> with all its I/O-specific fields
+    /// (MatchedTerms, GameId, PdfDocumentId, ChunkIndex, PageNumber).
     /// </summary>
     /// <remarks>
+    /// RRF formula: score = sum_over_all_rankings(weight / (k + rank)), rank is 1-based position.
     /// RRF advantages:
     /// - No score normalization needed (works with heterogeneous scoring systems)
     /// - Emphasizes top-ranked results from both systems
@@ -389,126 +394,66 @@ internal class HybridSearchService : IHybridSearchService
         int rrfK,
         GameBookRole queryRoleHint)
     {
-        // Build lookup dictionaries for O(1) access by composite chunk ID (PdfId_ChunkIndex)
-        var vectorLookup = vectorResults
-            .Select((r, index) => new
-            {
-                ChunkId = $"{r.PdfId}_{r.ChunkIndex}", // Composite key
-                Result = r,
-                Rank = index + 1 // 1-based ranking
-            })
-            .ToDictionary(x => x.ChunkId, StringComparer.Ordinal);
+        static string VectorKeyOf(SearchResultItem r) => $"{r.PdfId}_{r.ChunkIndex}";
+        static string KeywordKeyOf(KeywordSearchResult r) => $"{r.PdfDocumentId}_{r.ChunkIndex}";
+
+        var vectorArm = vectorResults
+            .Select((r, index) => new FusionCandidate(VectorKeyOf(r), r.Text, r.RoleTags, index + 1, r.Score))
+            .ToList();
 
         // RRF fusion-key fix: key the keyword arm on the SAME {PdfDocumentId}_{ChunkIndex} composite
         // as the vector arm (was the raw text_chunks.Id, which never matched the vector key — so a
         // doubly-retrieved chunk was emitted as two half-strength duplicates instead of being fused).
-        // The composite is backed by a NON-unique index, so GroupBy (keep the best-ranked row —
-        // keyword results are relevance-DESC, so the first) instead of ToDictionary, which would
-        // throw on an abnormal duplicate (PdfDocumentId, ChunkIndex) and 500 the whole search.
-        var keywordLookup = keywordResults
-            .Select((r, index) => new { ChunkId = $"{r.PdfDocumentId}_{r.ChunkIndex}", Result = r, Rank = index + 1 })
-            .GroupBy(x => x.ChunkId, StringComparer.Ordinal)
-            .ToDictionary(g => g.Key, g => g.First(), StringComparer.Ordinal);
-
-        // Collect all unique chunk IDs from both result sets
-        var allChunkIds = vectorLookup.Keys
-            .Union(keywordLookup.Keys, StringComparer.Ordinal)
-            .ToHashSet(StringComparer.Ordinal);
+        var keywordArm = keywordResults
+            .Select((r, index) => new FusionCandidate(KeywordKeyOf(r), r.Content, r.RoleTags, index + 1, r.RelevanceScore))
+            .ToList();
 
         _logger.LogDebug(
-            "Fusing results: {VectorCount} vector, {KeywordCount} keyword, {UniqueCount} unique chunks",
-            vectorResults.Count, keywordResults.Count, allChunkIds.Count);
+            "Fusing results: {VectorCount} vector, {KeywordCount} keyword",
+            vectorResults.Count, keywordResults.Count);
 
-        // Calculate RRF score for each chunk
-        var fusedResults = new List<HybridSearchResult>();
+        var fused = HybridFusionCore.Fuse(
+            vectorArm,
+            keywordArm,
+            new FusionOptions(vectorWeight, keywordWeight, rrfK, queryRoleHint));
 
-        foreach (var chunkId in allChunkIds)
+        // Re-join by composite key to recover the I/O-specific fields the core doesn't carry.
+        // The composite key is backed by a NON-unique index on the keyword side, so use
+        // ToLookup + FirstOrDefault (keep the best-ranked/first row) instead of a Dictionary,
+        // which would throw on an abnormal duplicate (PdfDocumentId, ChunkIndex).
+        var vLookup = vectorResults.ToLookup(VectorKeyOf, StringComparer.Ordinal);
+        var kLookup = keywordResults.ToLookup(KeywordKeyOf, StringComparer.Ordinal);
+
+        var fusedResults = new List<HybridSearchResult>(fused.Count);
+
+        foreach (var f in fused)
         {
-            var hasVector = vectorLookup.TryGetValue(chunkId, out var vectorItem);
-            var hasKeyword = keywordLookup.TryGetValue(chunkId, out var keywordItem);
-
-            // Calculate RRF score components
-            float vectorRrfScore = 0f;
-            float keywordRrfScore = 0f;
-
-            if (hasVector)
-            {
-                vectorRrfScore = vectorItem != null ? vectorWeight / (rrfK + vectorItem.Rank) : 0f;
-            }
-
-            if (hasKeyword)
-            {
-                keywordRrfScore = keywordItem != null ? keywordWeight / (rrfK + keywordItem.Rank) : 0f;
-            }
-
-            // Phase D (D6) + Slice C + RRF fusion-key fix: role-match boost. Both arms now key on
-            // {PdfDocumentId}_{ChunkIndex}, so a chunk retrieved by BOTH arms is a single fused entry
-            // and chunkRoleTags is a genuine cross-arm union. Both denormalize the same
-            // text_chunks.role_tags (keyword from text_chunks, vector from pgvector_embeddings.role_tags);
-            // for a single-arm chunk the OR selects the present arm, and for a both-arm chunk it takes
-            // whichever is populated (pgvector role_tags is currently un-backfilled → keyword wins).
-            // When the chunk overlaps the user's classified intent, apply an additive boost on top of
-            // the fused RRF.
-            var vectorRoleTags = hasVector && vectorItem != null
-                ? vectorItem.Result.RoleTags
-                : GameBookRole.None;
-            var keywordRoleTags = hasKeyword && keywordItem != null
-                ? keywordItem.Result.RoleTags
-                : GameBookRole.None;
-            var chunkRoleTags = vectorRoleTags | keywordRoleTags;
-            var roleBoost = FusionSignals.ComputeRoleMatchBoost(queryRoleHint, chunkRoleTags);
+            var v = vLookup[f.Key].FirstOrDefault();
+            var k = kLookup[f.Key].FirstOrDefault();
 
             // Use data from whichever result has it (prefer vector for metadata consistency)
-            var matchedTerms = hasKeyword && keywordItem != null
-                ? keywordItem.Result.MatchedTerms
-                : new List<string>();
-
-            // At least one of vectorItem or keywordItem must exist since we got the chunkId from their union
-            var content = hasVector && vectorItem != null
-                ? vectorItem.Result.Text
-                : (keywordItem?.Result.Content ?? string.Empty);
-
-            // RAG answer-quality fix: demote cross-reference "legend" chunks (dense with
-            // "vedi pag."/"see p." pointers, e.g. the Terraforming Mars component list
-            // "8. Progetti Standard ... vedi pag. 10 ... 9. Milestone ... vedi pag. 10 e 11")
-            // which carry no actionable answer yet score in the same RRF band as real content.
-            // The demotion scales the RRF fusion components only; the role-match boost (#1391)
-            // stays strictly additive on top so its deliberate ~0.15 calibration is not scaled away.
-            var legendFactor = FusionSignals.ComputeLegendPenaltyFactor(content);
-            var hybridScore = ((vectorRrfScore + keywordRrfScore) * (1f - legendFactor)) + roleBoost;
-
-            var pdfDocumentId = hasVector && vectorItem != null
-                ? vectorItem.Result.PdfId
-                : (keywordItem?.Result.PdfDocumentId ?? string.Empty);
-
-            var chunkGameId = hasKeyword && keywordItem != null
-                ? keywordItem.Result.GameId
-                : gameId; // Use from keyword or fall back to query gameId
-
-            var chunkIndex = hasVector && vectorItem != null
-                ? vectorItem.Result.ChunkIndex
-                : (keywordItem?.Result.ChunkIndex ?? 0);
-
-            var pageNumber = hasVector && vectorItem != null
-                ? vectorItem.Result.Page
-                : (keywordItem?.Result.PageNumber ?? 0);
+            var matchedTerms = k != null ? k.MatchedTerms : new List<string>();
+            var pdfDocumentId = v != null ? v.PdfId : (k?.PdfDocumentId ?? string.Empty);
+            var chunkGameId = k != null ? k.GameId : gameId; // keyword arm else fall back to query gameId
+            var chunkIndex = v != null ? v.ChunkIndex : (k?.ChunkIndex ?? 0);
+            var pageNumber = v != null ? v.Page : (k?.PageNumber ?? 0);
 
             fusedResults.Add(new HybridSearchResult
             {
-                ChunkId = chunkId,
-                Content = content,
+                ChunkId = f.Key,
+                Content = f.Content,
                 PdfDocumentId = pdfDocumentId,
                 GameId = chunkGameId,
                 ChunkIndex = chunkIndex,
                 PageNumber = pageNumber,
-                HybridScore = hybridScore,
-                VectorScore = hasVector && vectorItem != null ? vectorItem.Result.Score : null,
-                KeywordScore = hasKeyword && keywordItem != null ? keywordItem.Result.RelevanceScore : null,
-                VectorRank = hasVector && vectorItem != null ? vectorItem.Rank : null,
-                KeywordRank = hasKeyword && keywordItem != null ? keywordItem.Rank : null,
+                HybridScore = f.HybridScore,
+                VectorScore = f.VectorScore,
+                KeywordScore = f.KeywordScore,
+                VectorRank = f.VectorRank,
+                KeywordRank = f.KeywordRank,
                 MatchedTerms = matchedTerms,
                 Mode = SearchMode.Hybrid,
-                RoleTags = chunkRoleTags
+                RoleTags = f.RoleTags
             });
         }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AskQuestionQueryHandlerSecurityTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AskQuestionQueryHandlerSecurityTests.cs
@@ -102,7 +102,7 @@ public class AskQuestionQueryHandlerSecurityTests
 
         // Setup RRF Fusion domain service (default: empty results)
         _mockRrfService
-            .Setup(r => r.FuseResults(It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>(), It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>(), It.IsAny<int>()))
+            .Setup(r => r.FuseResults(It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>(), It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>(), It.IsAny<int>(), It.IsAny<GameBookRole>()))
             .Returns(new List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>()); // Return empty list
 
         // Setup IHybridSearchService to return empty results by default
@@ -552,7 +552,8 @@ public class AskQuestionQueryHandlerSecurityTests
             .Setup(r => r.FuseResults(
                 It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>(),
                 It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>(),
-                It.IsAny<int>()))
+                It.IsAny<int>(),
+                It.IsAny<GameBookRole>()))
             .Returns(oneResult);
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AskQuestionQueryHandlerSecurityTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AskQuestionQueryHandlerSecurityTests.cs
@@ -41,7 +41,7 @@ public class AskQuestionQueryHandlerSecurityTests
     private readonly Mock<IPromptTemplateService> _mockPromptTemplateService;
     private readonly Mock<IRagValidationPipelineService> _mockValidationPipeline;
     private readonly Mock<ILogger<AskQuestionQueryHandler>> _mockLogger;
-    private readonly Mock<IHybridSearchService> _mockHybridSearchService;
+    private readonly Mock<IKeywordSearchService> _mockKeywordSearchService;
     private readonly Mock<RrfFusionDomainService> _mockRrfService;
     private readonly Mock<ISemanticResponseCache> _mockResponseCache;
     private readonly Mock<IEmbeddingService> _mockAskEmbeddingService;
@@ -54,7 +54,7 @@ public class AskQuestionQueryHandlerSecurityTests
         var mockVectorSearchService = new Mock<VectorSearchDomainService>();
         _mockRrfService = new Mock<RrfFusionDomainService>();
         var mockEmbeddingService = new Mock<IEmbeddingService>();
-        _mockHybridSearchService = new Mock<IHybridSearchService>();
+        _mockKeywordSearchService = new Mock<IKeywordSearchService>();
         var mockSearchLogger = new Mock<ILogger<SearchQueryHandler>>();
 
         // Setup IEmbeddingService to return valid EmbeddingResult
@@ -105,27 +105,25 @@ public class AskQuestionQueryHandlerSecurityTests
             .Setup(r => r.FuseResults(It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>(), It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>(), It.IsAny<int>(), It.IsAny<GameBookRole>()))
             .Returns(new List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>()); // Return empty list
 
-        // Setup IHybridSearchService to return empty results by default
-        _mockHybridSearchService
+        // Setup IKeywordSearchService to return empty results by default
+        _mockKeywordSearchService
             .Setup(h => h.SearchAsync(
                 It.IsAny<string>(),
                 It.IsAny<Guid>(),
-                It.IsAny<SearchMode>(),
                 It.IsAny<int>(),
-                It.IsAny<List<Guid>?>(),
-                It.IsAny<float>(),
-                It.IsAny<float>(),
+                It.IsAny<bool>(),
+                It.IsAny<List<string>?>(),
+                It.IsAny<string>(),
                 It.IsAny<double>(),
-                It.IsAny<GameBookRole>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<HybridSearchResult>());
+            .ReturnsAsync(new List<KeywordSearchResult>());
 
         _searchHandler = new SearchQueryHandler(
             mockEmbeddingRepo.Object,
             mockVectorSearchService.Object,
             _mockRrfService.Object,
             mockEmbeddingService.Object,
-            _mockHybridSearchService.Object,
+            _mockKeywordSearchService.Object,
             CreatePermissiveRagAccessServiceMock(),
             mockSearchLogger.Object);
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/StreamQaQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/StreamQaQueryHandlerTests.cs
@@ -46,6 +46,7 @@ public class StreamQaQueryHandlerTests
     private readonly Mock<ILlmService> _llmServiceMock;
     private readonly Mock<IAiResponseCacheService> _cacheMock;
     private readonly Mock<IPromptTemplateService> _promptTemplateServiceMock;
+    private readonly Mock<IIntentClassifierService> _intentClassifierMock;
     private readonly Mock<ILogger<StreamQaQueryHandler>> _loggerMock;
     private readonly FakeTimeProvider _fakeTimeProvider;
     private readonly StreamQaQueryHandler _handler;
@@ -90,6 +91,10 @@ public class StreamQaQueryHandlerTests
         _llmServiceMock = new Mock<ILlmService>();
         _cacheMock = new Mock<IAiResponseCacheService>();
         _promptTemplateServiceMock = new Mock<IPromptTemplateService>();
+        _intentClassifierMock = new Mock<IIntentClassifierService>();
+        _intentClassifierMock
+            .Setup(x => x.ClassifyIntent(It.IsAny<string>()))
+            .Returns(GameBookRole.None);
         _loggerMock = new Mock<ILogger<StreamQaQueryHandler>>();
         _fakeTimeProvider = new FakeTimeProvider();
         _fakeTimeProvider.SetUtcNow(new DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero));
@@ -114,6 +119,7 @@ public class StreamQaQueryHandlerTests
             _cacheMock.Object,
             _promptTemplateServiceMock.Object,
             new InlineCitationMatcherService(),
+            _intentClassifierMock.Object,
             _loggerMock.Object,
             _fakeTimeProvider
         );
@@ -902,6 +908,67 @@ public class StreamQaQueryHandlerTests
         completeEvent.Should().NotBeNull();
 
         // Verify no errors
+        var errorEvent = events.FirstOrDefault(e => e.Type == StreamingEventType.Error);
+        errorEvent.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task StreamQa_SetsQueryRoleHint_FromIntentClassifier()
+    {
+        // Issue #3270 (Task 7): StreamQa must classify intent and forward QueryRoleHint through
+        // SearchQuery so the hybrid re-ranker can apply the role-match boost (parity with
+        // AskQuestionQueryHandler). Verified indirectly via the GameBookRole argument that
+        // SearchQueryHandler forwards from SearchQuery.QueryRoleHint into RrfFusionDomainService.FuseResults.
+
+        // Arrange
+        var gameId = Guid.NewGuid().ToString();
+        var userQuery = "How do I set up the game?";
+        var query = new StreamQaQuery(gameId, userQuery, null);
+
+        _cacheMock
+            .Setup(x => x.GetAsync<QaResponse>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((QaResponse?)null);
+
+        SetupSearchMocks(gameId, userQuery);
+        SetupPromptMocks(QuestionType.General);
+        SetupLlmStreamingMock(new[] { "Setup", " answer" });
+        SetupQualityTrackingMocks();
+
+        _intentClassifierMock
+            .Setup(x => x.ClassifyIntent(It.IsAny<string>()))
+            .Returns(GameBookRole.Setup);
+
+        GameBookRole? capturedRoleHint = null;
+        var fusedResult = new DomainSearchResult(
+            id: Guid.NewGuid(),
+            vectorDocumentId: Guid.NewGuid(),
+            textContent: "Setup rule text",
+            pageNumber: 1,
+            relevanceScore: new Confidence(0.9),
+            rank: 1,
+            searchMethod: "hybrid");
+
+        _rrfFusionServiceMock
+            .Setup(x => x.FuseResults(
+                It.IsAny<List<DomainSearchResult>>(),
+                It.IsAny<List<DomainSearchResult>>(),
+                It.IsAny<int>(),
+                It.IsAny<GameBookRole>()))
+            .Callback<List<DomainSearchResult>, List<DomainSearchResult>, int, GameBookRole>(
+                (_, _, _, roleHint) => capturedRoleHint = roleHint)
+            .Returns(new List<DomainSearchResult> { fusedResult });
+
+        // Act
+        var events = new List<RagStreamingEvent>();
+        await foreach (var evt in _handler.Handle(query, TestContext.Current.CancellationToken))
+        {
+            events.Add(evt);
+        }
+
+        // Assert
+        _intentClassifierMock.Verify(x => x.ClassifyIntent(userQuery), Times.Once);
+        capturedRoleHint.Should().Be(GameBookRole.Setup);
+
         var errorEvent = events.FirstOrDefault(e => e.Type == StreamingEventType.Error);
         errorEvent.Should().BeNull();
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/StreamQaQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/StreamQaQueryHandlerTests.cs
@@ -645,7 +645,7 @@ public class StreamQaQueryHandlerTests
             .ReturnsAsync(new List<HybridSearchResult>());
 
         _rrfFusionServiceMock
-            .Setup(x => x.FuseResults(It.IsAny<List<DomainSearchResult>>(), It.IsAny<List<DomainSearchResult>>(), It.IsAny<int>()))
+            .Setup(x => x.FuseResults(It.IsAny<List<DomainSearchResult>>(), It.IsAny<List<DomainSearchResult>>(), It.IsAny<int>(), It.IsAny<GameBookRole>()))
             .Returns(new List<DomainSearchResult> { lowScoreResult });
 
         SetupPromptMocks(QuestionType.General);
@@ -750,7 +750,7 @@ public class StreamQaQueryHandlerTests
             .ReturnsAsync(new List<HybridSearchResult>());
 
         _rrfFusionServiceMock
-            .Setup(x => x.FuseResults(It.IsAny<List<DomainSearchResult>>(), It.IsAny<List<DomainSearchResult>>(), It.IsAny<int>()))
+            .Setup(x => x.FuseResults(It.IsAny<List<DomainSearchResult>>(), It.IsAny<List<DomainSearchResult>>(), It.IsAny<int>(), It.IsAny<GameBookRole>()))
             .Returns(highQualityResults);
 
         SetupPromptMocks(QuestionType.General);
@@ -1045,7 +1045,8 @@ public class StreamQaQueryHandlerTests
             .Setup(x => x.FuseResults(
                 It.IsAny<List<DomainSearchResult>>(),
                 It.IsAny<List<DomainSearchResult>>(),
-                It.IsAny<int>()))  // rrfK parameter
+                It.IsAny<int>(),  // rrfK parameter
+                It.IsAny<GameBookRole>()))
             .Returns(new List<DomainSearchResult> { fusedResult });
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/StreamQaQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/StreamQaQueryHandlerTests.cs
@@ -35,7 +35,7 @@ public class StreamQaQueryHandlerTests
     private readonly Mock<VectorSearchDomainService> _vectorSearchServiceMock;
     private readonly Mock<RrfFusionDomainService> _rrfFusionServiceMock;
     private readonly Mock<IEmbeddingService> _embeddingServiceMock;
-    private readonly Mock<IHybridSearchService> _hybridSearchServiceMock;
+    private readonly Mock<IKeywordSearchService> _keywordSearchServiceMock;
     private readonly SearchQueryHandler _searchQueryHandler;
     private readonly Mock<ICrossEncoderReranker> _rerankerMock;
     private readonly Mock<QualityTrackingDomainService> _qualityTrackingServiceMock;
@@ -57,7 +57,7 @@ public class StreamQaQueryHandlerTests
         _vectorSearchServiceMock = new Mock<VectorSearchDomainService>();
         _rrfFusionServiceMock = new Mock<RrfFusionDomainService>();
         _embeddingServiceMock = new Mock<IEmbeddingService>();
-        _hybridSearchServiceMock = new Mock<IHybridSearchService>();
+        _keywordSearchServiceMock = new Mock<IKeywordSearchService>();
         var searchLoggerMock = new Mock<ILogger<SearchQueryHandler>>();
 
         // Create real SearchQueryHandler instance for testing
@@ -66,7 +66,7 @@ public class StreamQaQueryHandlerTests
             _vectorSearchServiceMock.Object,
             _rrfFusionServiceMock.Object,
             _embeddingServiceMock.Object,
-            _hybridSearchServiceMock.Object,
+            _keywordSearchServiceMock.Object,
             CreatePermissiveRagAccessServiceMock(),
             searchLoggerMock.Object
         );
@@ -271,8 +271,8 @@ public class StreamQaQueryHandlerTests
         complete.confidence.Should().Be(0.85);
 
         // Should NOT call search or LLM
-        _hybridSearchServiceMock.Verify(
-            x => x.SearchAsync(It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<SearchMode>(), It.IsAny<int>(), It.IsAny<List<Guid>?>(), It.IsAny<float>(), It.IsAny<float>(), It.IsAny<double>(), It.IsAny<GameBookRole>(), It.IsAny<CancellationToken>()),
+        _keywordSearchServiceMock.Verify(
+            x => x.SearchAsync(It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<List<string>?>(), It.IsAny<string>(), It.IsAny<double>(), It.IsAny<CancellationToken>()),
             Times.Never
         );
         _llmServiceMock.Verify(
@@ -469,9 +469,9 @@ public class StreamQaQueryHandlerTests
                 Embeddings = new List<float[]> { new float[] { 0.1f, 0.2f } }
             });
 
-        _hybridSearchServiceMock
-            .Setup(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<SearchMode>(), It.IsAny<int>(), It.IsAny<List<Guid>?>(), It.IsAny<float>(), It.IsAny<float>(), It.IsAny<double>(), It.IsAny<GameBookRole>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<HybridSearchResult>()); // Empty results
+        _keywordSearchServiceMock
+            .Setup(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<List<string>?>(), It.IsAny<string>(), It.IsAny<double>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<KeywordSearchResult>()); // Empty results
 
         // Act
         var events = new List<RagStreamingEvent>();
@@ -640,9 +640,9 @@ public class StreamQaQueryHandlerTests
             .Setup(x => x.Search(It.IsAny<Vector>(), It.IsAny<List<Embedding>>(), It.IsAny<int>(), It.IsAny<double>()))
             .Returns(new List<DomainSearchResult> { lowScoreResult });
 
-        _hybridSearchServiceMock
-            .Setup(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<Guid>(), SearchMode.Keyword, It.IsAny<int>(), It.IsAny<List<Guid>?>(), It.IsAny<float>(), It.IsAny<float>(), It.IsAny<double>(), It.IsAny<GameBookRole>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<HybridSearchResult>());
+        _keywordSearchServiceMock
+            .Setup(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<List<string>?>(), It.IsAny<string>(), It.IsAny<double>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<KeywordSearchResult>());
 
         _rrfFusionServiceMock
             .Setup(x => x.FuseResults(It.IsAny<List<DomainSearchResult>>(), It.IsAny<List<DomainSearchResult>>(), It.IsAny<int>(), It.IsAny<GameBookRole>()))
@@ -745,9 +745,9 @@ public class StreamQaQueryHandlerTests
             .Setup(x => x.Search(It.IsAny<Vector>(), It.IsAny<List<Embedding>>(), It.IsAny<int>(), It.IsAny<double>()))
             .Returns(highQualityResults);
 
-        _hybridSearchServiceMock
-            .Setup(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<Guid>(), SearchMode.Keyword, It.IsAny<int>(), It.IsAny<List<Guid>?>(), It.IsAny<float>(), It.IsAny<float>(), It.IsAny<double>(), It.IsAny<GameBookRole>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<HybridSearchResult>());
+        _keywordSearchServiceMock
+            .Setup(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<List<string>?>(), It.IsAny<string>(), It.IsAny<double>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<KeywordSearchResult>());
 
         _rrfFusionServiceMock
             .Setup(x => x.FuseResults(It.IsAny<List<DomainSearchResult>>(), It.IsAny<List<DomainSearchResult>>(), It.IsAny<int>(), It.IsAny<GameBookRole>()))
@@ -816,6 +816,7 @@ public class StreamQaQueryHandlerTests
         var gameId = Guid.NewGuid().ToString();
         var docId1 = Guid.NewGuid();
         var docId2 = Guid.NewGuid();
+        var outOfScopeDocId = Guid.NewGuid();
         var documentIds = new List<Guid> { docId1, docId2 };
 
         var query = new StreamQaQuery(gameId, "Question for specific documents?", ThreadId: null, DocumentIds: documentIds);
@@ -829,6 +830,58 @@ public class StreamQaQueryHandlerTests
         SetupLlmStreamingMock(new[] { "Filtered", " answer" });
         SetupQualityTrackingMocks();
 
+        // Issue #3270 (Task 6): IKeywordSearchService.SearchAsync no longer accepts a documentIds
+        // parameter — the RAW keyword arm returns everything, and SearchQueryHandler applies the
+        // documentIds post-filter itself (reproducing the old HybridSearchService(Keyword) behavior).
+        // Return an in-scope + an out-of-scope PdfDocumentId to prove the filter is still applied.
+        _keywordSearchServiceMock
+            .Setup(x => x.SearchAsync(
+                It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<int>(), It.IsAny<bool>(),
+                It.IsAny<List<string>?>(), It.IsAny<string>(), It.IsAny<double>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<KeywordSearchResult>
+            {
+                new()
+                {
+                    ChunkId = "in-scope",
+                    Content = "In scope chunk content.",
+                    PdfDocumentId = docId1.ToString(),
+                    GameId = Guid.Parse(gameId),
+                    ChunkIndex = 0,
+                    PageNumber = 1,
+                    RelevanceScore = 0.2f
+                },
+                new()
+                {
+                    ChunkId = "out-of-scope",
+                    Content = "Out of scope chunk content.",
+                    PdfDocumentId = outOfScopeDocId.ToString(),
+                    GameId = Guid.Parse(gameId),
+                    ChunkIndex = 0,
+                    PageNumber = 1,
+                    RelevanceScore = 0.3f
+                }
+            });
+
+        var fusedResult = new DomainSearchResult(
+            id: Guid.NewGuid(),
+            vectorDocumentId: Guid.NewGuid(),
+            textContent: "Filtered content",
+            pageNumber: 1,
+            relevanceScore: new Confidence(0.9),
+            rank: 1,
+            searchMethod: "hybrid");
+
+        List<DomainSearchResult>? capturedKeywordArm = null;
+        _rrfFusionServiceMock
+            .Setup(x => x.FuseResults(
+                It.IsAny<List<DomainSearchResult>>(),
+                It.IsAny<List<DomainSearchResult>>(),
+                It.IsAny<int>(),
+                It.IsAny<GameBookRole>()))
+            .Callback<List<DomainSearchResult>, List<DomainSearchResult>, int, GameBookRole>(
+                (_, keywordArm, _, _) => capturedKeywordArm = keywordArm)
+            .Returns(new List<DomainSearchResult> { fusedResult });
+
         // Act
         var events = new List<RagStreamingEvent>();
         await foreach (var evt in _handler.Handle(query, TestContext.Current.CancellationToken))
@@ -837,28 +890,12 @@ public class StreamQaQueryHandlerTests
         }
 
         // Assert
-        // Verify hybrid search was called with documentIds filter (Issue #2051)
-        _hybridSearchServiceMock.Verify(
-            x => x.SearchAsync(
-                It.IsAny<string>(),
-                It.IsAny<Guid>(),
-                SearchMode.Keyword,
-                It.IsAny<int>(),
-                It.Is<List<Guid>?>(docIds =>
-                    docIds != null &&
-                    docIds.Count == 2 &&
-                    docIds.Contains(docId1) &&
-                    docIds.Contains(docId2)
-                ),
-                It.IsAny<float>(),
-                It.IsAny<float>(),
-                It.IsAny<double>(),
-                It.IsAny<GameBookRole>(),
-                It.IsAny<CancellationToken>()
-            ),
-            Times.Once,
-            "SearchAsync should be called with matching documentIds list for filtering"
-        );
+        // Issue #2051: only the in-scope chunk should reach fusion — the out-of-scope one was
+        // filtered out by SearchQueryHandler's documentIds post-filter.
+        capturedKeywordArm.Should().NotBeNull();
+        capturedKeywordArm!.Should().ContainSingle(
+            "the out-of-scope PdfDocumentId must be filtered out before reaching RRF fusion");
+        capturedKeywordArm![0].PdfDocumentId.Should().Be(docId1);
 
         // Verify response completed successfully
         var completeEvent = events.LastOrDefault(e => e.Type == StreamingEventType.Complete);
@@ -997,10 +1034,10 @@ public class StreamQaQueryHandlerTests
             .Setup(x => x.Search(It.IsAny<Vector>(), It.IsAny<List<Embedding>>(), It.IsAny<int>(), It.IsAny<double>()))
             .Returns(new List<DomainSearchResult> { vectorSearchResult });
 
-        // Setup hybrid search results for keyword search
-        var keywordSearchResults = new List<HybridSearchResult>
+        // Setup raw keyword search results (issue #3270 Task 6: IKeywordSearchService, not IHybridSearchService)
+        var keywordSearchResults = new List<KeywordSearchResult>
         {
-            new HybridSearchResult
+            new()
             {
                 ChunkId = Guid.NewGuid().ToString(),
                 Content = "Sample rule text",
@@ -1008,25 +1045,20 @@ public class StreamQaQueryHandlerTests
                 GameId = Guid.Parse(gameId),
                 ChunkIndex = 0,
                 PageNumber = 1,
-                HybridScore = 0.75f,
-                KeywordScore = 0.75f,
-                KeywordRank = 1,
-                Mode = SearchMode.Keyword,
+                RelevanceScore = 0.75f,
                 MatchedTerms = new List<string> { "rule", "text" }
             }
         };
 
-        _hybridSearchServiceMock
+        _keywordSearchServiceMock
             .Setup(x => x.SearchAsync(
                 It.IsAny<string>(),
                 It.IsAny<Guid>(),
-                SearchMode.Keyword,
                 It.IsAny<int>(),
-                It.IsAny<List<Guid>?>(),
-                It.IsAny<float>(),
-                It.IsAny<float>(),
+                It.IsAny<bool>(),
+                It.IsAny<List<string>?>(),
+                It.IsAny<string>(),
                 It.IsAny<double>(),
-                It.IsAny<GameBookRole>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(keywordSearchResults);
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/AskQuestionQueryHandlerIntentRoutingTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/AskQuestionQueryHandlerIntentRoutingTests.cs
@@ -25,11 +25,16 @@ namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Queries;
 /// <summary>
 /// Phase D (D7) tests for <see cref="AskQuestionQueryHandler"/>: verifies the intent
 /// classifier is invoked with the user question and the resulting <see cref="GameBookRole"/>
-/// hint is threaded into the downstream <see cref="IHybridSearchService.SearchAsync"/> call.
+/// hint is threaded into the downstream fusion step.
 ///
 /// Test strategy: spy on the <see cref="IIntentClassifierService"/> and on
-/// <see cref="IHybridSearchService"/> to assert (a) the classifier was called with the question
-/// text and (b) the boosted SearchQuery flowed the classifier output through to retrieval.
+/// <see cref="RrfFusionDomainService.FuseResults"/> to assert (a) the classifier was called with
+/// the question text and (b) the boosted SearchQuery flowed the classifier output through to
+/// retrieval. Issue #3270 (Task 6): the primary chat path no longer calls
+/// <c>IHybridSearchService.SearchAsync</c> — the RAW keyword arm comes from
+/// <see cref="IKeywordSearchService"/> (which carries no role-hint parameter) and the
+/// <see cref="GameBookRole"/> hint is applied downstream by <c>RrfFusionDomainService</c>
+/// (via <c>HybridFusionCore</c>'s role-match boost), so the spy point moved there.
 /// </summary>
 [Trait("Category", TestCategories.Unit)]
 [Trait("BoundedContext", "KnowledgeBase")]
@@ -50,26 +55,7 @@ public sealed class AskQuestionQueryHandlerIntentRoutingTests
             .Setup(c => c.ClassifyIntent(It.IsAny<string>()))
             .Returns(expectedRoleHint);
 
-        // Spy on IHybridSearchService to capture the GameBookRole passed in by the downstream chain.
-        GameBookRole capturedRoleHint = GameBookRole.None;
-        var hybridSearchMock = new Mock<IHybridSearchService>();
-        hybridSearchMock
-            .Setup(h => h.SearchAsync(
-                It.IsAny<string>(),
-                It.IsAny<Guid>(),
-                It.IsAny<SearchMode>(),
-                It.IsAny<int>(),
-                It.IsAny<List<Guid>?>(),
-                It.IsAny<float>(),
-                It.IsAny<float>(),
-                It.IsAny<double>(),
-                It.IsAny<GameBookRole>(),
-                It.IsAny<CancellationToken>()))
-            .Callback<string, Guid, SearchMode, int, List<Guid>?, float, float, double, GameBookRole, CancellationToken>(
-                (q, g, m, l, d, vw, kw, ms, rh, ct) => capturedRoleHint = rh)
-            .ReturnsAsync(new List<HybridSearchResult>());
-
-        var handler = BuildHandler(intentClassifierMock.Object, hybridSearchMock.Object);
+        var (handler, getCapturedRoleHint) = BuildHandler(intentClassifierMock.Object);
 
         // Act
         var query = new AskQuestionQuery(
@@ -85,8 +71,8 @@ public sealed class AskQuestionQueryHandlerIntentRoutingTests
         // 1. Classifier received the raw question text.
         intentClassifierMock.Verify(c => c.ClassifyIntent(question), Times.AtLeastOnce);
 
-        // 2. The role hint emitted by the classifier reached the hybrid search re-ranker.
-        capturedRoleHint.Should().Be(expectedRoleHint);
+        // 2. The role hint emitted by the classifier reached the RRF fusion step.
+        getCapturedRoleHint().Should().Be(expectedRoleHint);
     }
 
     [Fact]
@@ -103,25 +89,7 @@ public sealed class AskQuestionQueryHandlerIntentRoutingTests
             .Setup(c => c.ClassifyIntent(question))
             .Returns(GameBookRole.None);
 
-        GameBookRole capturedRoleHint = GameBookRole.RulesReference; // sentinel != None
-        var hybridSearchMock = new Mock<IHybridSearchService>();
-        hybridSearchMock
-            .Setup(h => h.SearchAsync(
-                It.IsAny<string>(),
-                It.IsAny<Guid>(),
-                It.IsAny<SearchMode>(),
-                It.IsAny<int>(),
-                It.IsAny<List<Guid>?>(),
-                It.IsAny<float>(),
-                It.IsAny<float>(),
-                It.IsAny<double>(),
-                It.IsAny<GameBookRole>(),
-                It.IsAny<CancellationToken>()))
-            .Callback<string, Guid, SearchMode, int, List<Guid>?, float, float, double, GameBookRole, CancellationToken>(
-                (q, g, m, l, d, vw, kw, ms, rh, ct) => capturedRoleHint = rh)
-            .ReturnsAsync(new List<HybridSearchResult>());
-
-        var handler = BuildHandler(intentClassifierMock.Object, hybridSearchMock.Object);
+        var (handler, getCapturedRoleHint) = BuildHandler(intentClassifierMock.Object);
 
         // Act
         var query = new AskQuestionQuery(
@@ -133,15 +101,14 @@ public sealed class AskQuestionQueryHandlerIntentRoutingTests
         await handler.Handle(query, TestCancellationToken);
 
         // Assert: None is faithfully propagated (the boost will be a no-op in D6).
-        capturedRoleHint.Should().Be(GameBookRole.None);
+        getCapturedRoleHint().Should().Be(GameBookRole.None);
     }
 
-    private static AskQuestionQueryHandler BuildHandler(
-        IIntentClassifierService intentClassifier,
-        IHybridSearchService hybridSearchService)
+    private static (AskQuestionQueryHandler Handler, Func<GameBookRole> GetCapturedRoleHint) BuildHandler(
+        IIntentClassifierService intentClassifier)
     {
         // Build a real (lightweight) SearchQueryHandler with mocked dependencies so the
-        // SearchQuery.QueryRoleHint actually flows through to the hybrid search spy.
+        // SearchQuery.QueryRoleHint actually flows through to the RRF fusion spy.
         var embeddingRepoMock = new Mock<IEmbeddingRepository>();
         embeddingRepoMock
             .Setup(r => r.SearchByVectorAsync(
@@ -160,6 +127,34 @@ public sealed class AskQuestionQueryHandlerIntentRoutingTests
             .Setup(e => e.GenerateEmbeddingAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new EmbeddingResult { Success = true, Embeddings = new List<float[]> { new float[768] } });
 
+        // Issue #3270 (Task 6): raw keyword arm — no role-hint parameter on this interface.
+        var keywordSearchMock = new Mock<IKeywordSearchService>();
+        keywordSearchMock
+            .Setup(k => k.SearchAsync(
+                It.IsAny<string>(),
+                It.IsAny<Guid>(),
+                It.IsAny<int>(),
+                It.IsAny<bool>(),
+                It.IsAny<List<string>?>(),
+                It.IsAny<string>(),
+                It.IsAny<double>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<KeywordSearchResult>());
+
+        // Spy on RrfFusionDomainService.FuseResults to capture the GameBookRole passed by the
+        // downstream chain (this is where the role hint is now consumed — issue #3270 Task 6).
+        GameBookRole capturedRoleHint = GameBookRole.None;
+        var rrfFusionMock = new Mock<RrfFusionDomainService>();
+        rrfFusionMock
+            .Setup(r => r.FuseResults(
+                It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>(),
+                It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>(),
+                It.IsAny<int>(),
+                It.IsAny<GameBookRole>()))
+            .Callback<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>, List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>, int, GameBookRole>(
+                (v, k, rk, rh) => capturedRoleHint = rh)
+            .Returns(new List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>());
+
         var ragAccessMock = new Mock<IRagAccessService>();
         ragAccessMock
             .Setup(r => r.CanAccessRagAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<UserRole>(), It.IsAny<CancellationToken>()))
@@ -168,9 +163,9 @@ public sealed class AskQuestionQueryHandlerIntentRoutingTests
         var searchHandler = new SearchQueryHandler(
             embeddingRepoMock.Object,
             new VectorSearchDomainService(),
-            new RrfFusionDomainService(),
+            rrfFusionMock.Object,
             searchEmbeddingServiceMock.Object,
-            hybridSearchService,
+            keywordSearchMock.Object,
             ragAccessMock.Object,
             new Mock<ILogger<SearchQueryHandler>>().Object);
 
@@ -193,7 +188,7 @@ public sealed class AskQuestionQueryHandlerIntentRoutingTests
         var routingMonitorMock = new Mock<IOptionsMonitor<LlmQueryComplexityRoutingOptions>>();
         routingMonitorMock.Setup(m => m.CurrentValue).Returns(new LlmQueryComplexityRoutingOptions());
 
-        return new AskQuestionQueryHandler(
+        var handler = new AskQuestionQueryHandler(
             searchHandler,
             CreatePassthroughReranker(),
             new QualityTrackingDomainService(),
@@ -214,6 +209,8 @@ public sealed class AskQuestionQueryHandlerIntentRoutingTests
             intentClassifier,
             routingMonitorMock.Object,
             new Mock<ILogger<AskQuestionQueryHandler>>().Object);
+
+        return (handler, () => capturedRoleHint);
     }
 
     private static ICrossEncoderReranker CreatePassthroughReranker()

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/AskQuestionQueryHandlerPhase2Tests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/AskQuestionQueryHandlerPhase2Tests.cs
@@ -78,7 +78,7 @@ public class AskQuestionQueryHandlerPhase2Tests
             .Returns(new List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>());
 
         _mockRrfService
-            .Setup(r => r.FuseResults(It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>(), It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>(), It.IsAny<int>()))
+            .Setup(r => r.FuseResults(It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>(), It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>(), It.IsAny<int>(), It.IsAny<GameBookRole>()))
             .Returns(new List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>());
 
         mockHybridSearchService
@@ -605,7 +605,8 @@ public class AskQuestionQueryHandlerPhase2Tests
             .Setup(r => r.FuseResults(
                 It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>(),
                 It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>(),
-                It.IsAny<int>()))
+                It.IsAny<int>(),
+                It.IsAny<GameBookRole>()))
             .Returns(oneResult);
 
         _mockLlmService

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/AskQuestionQueryHandlerPhase2Tests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/AskQuestionQueryHandlerPhase2Tests.cs
@@ -50,7 +50,7 @@ public class AskQuestionQueryHandlerPhase2Tests
         var mockVectorSearchService = new Mock<VectorSearchDomainService>();
         _mockRrfService = new Mock<RrfFusionDomainService>();
         var mockSearchEmbeddingService = new Mock<IEmbeddingService>();
-        var mockHybridSearchService = new Mock<IHybridSearchService>();
+        var mockKeywordSearchService = new Mock<IKeywordSearchService>();
         var mockSearchLogger = new Mock<ILogger<SearchQueryHandler>>();
 
         mockSearchEmbeddingService
@@ -81,16 +81,16 @@ public class AskQuestionQueryHandlerPhase2Tests
             .Setup(r => r.FuseResults(It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>(), It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>(), It.IsAny<int>(), It.IsAny<GameBookRole>()))
             .Returns(new List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>());
 
-        mockHybridSearchService
-            .Setup(h => h.SearchAsync(It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<SearchMode>(), It.IsAny<int>(), It.IsAny<List<Guid>?>(), It.IsAny<float>(), It.IsAny<float>(), It.IsAny<double>(), It.IsAny<GameBookRole>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<HybridSearchResult>());
+        mockKeywordSearchService
+            .Setup(h => h.SearchAsync(It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<List<string>?>(), It.IsAny<string>(), It.IsAny<double>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<KeywordSearchResult>());
 
         _searchHandler = new SearchQueryHandler(
             mockEmbeddingRepo.Object,
             mockVectorSearchService.Object,
             _mockRrfService.Object,
             mockSearchEmbeddingService.Object,
-            mockHybridSearchService.Object,
+            mockKeywordSearchService.Object,
             CreatePermissiveRagAccessServiceMock(),
             mockSearchLogger.Object);
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/SearchQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/SearchQueryHandlerTests.cs
@@ -1,9 +1,11 @@
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries;
 using Api.BoundedContexts.KnowledgeBase.Application.Services;
 using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using Api.BoundedContexts.KnowledgeBase.Infrastructure.Persistence.Mappers;
 using Api.Infrastructure.Entities;
 using Api.Services;
 using Api.Tests.Constants;
@@ -250,7 +252,7 @@ public sealed class SearchQueryHandlerTests
     {
         var vectorSearchService = new VectorSearchDomainService();
         var rrfFusionService = new RrfFusionDomainService();
-        var hybridSearchService = new Mock<IHybridSearchService>().Object;
+        var keywordSearchService = CreateEmptyKeywordSearchServiceMock().Object;
         var logger = new Mock<ILogger<SearchQueryHandler>>().Object;
 
         return new SearchQueryHandler(
@@ -258,8 +260,238 @@ public sealed class SearchQueryHandlerTests
             vectorSearchService,
             rrfFusionService,
             embeddingService,
-            hybridSearchService,
+            keywordSearchService,
             ragAccessService,
             logger);
+    }
+
+    /// <summary>
+    /// Default IKeywordSearchService mock returning an empty result list (issue #3270 Task 6).
+    /// </summary>
+    private static Mock<IKeywordSearchService> CreateEmptyKeywordSearchServiceMock()
+    {
+        var mock = new Mock<IKeywordSearchService>();
+        mock
+            .Setup(k => k.SearchAsync(
+                It.IsAny<string>(),
+                It.IsAny<Guid>(),
+                It.IsAny<int>(),
+                It.IsAny<bool>(),
+                It.IsAny<List<string>?>(),
+                It.IsAny<string>(),
+                It.IsAny<double>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<KeywordSearchResult>());
+        return mock;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Issue #3270 (Task 6): KeywordSearchResult -> SearchResult mapper
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ToDomainSearchResult_FromKeyword_CarriesIdentityAndRawScore()
+    {
+        var pdf = Guid.NewGuid();
+        var kr = new KeywordSearchResult
+        {
+            ChunkId = "c",
+            Content = "text",
+            PdfDocumentId = pdf.ToString(),
+            GameId = Guid.NewGuid(),
+            ChunkIndex = 4,
+            PageNumber = 2,
+            RelevanceScore = 0.22f,
+            RoleTags = GameBookRole.Setup
+        };
+
+        var sr = kr.ToDomainSearchResult(1);
+
+        sr.PdfDocumentId.Should().Be(pdf);
+        sr.ChunkIndex.Should().Be(4);
+        sr.RoleTags.Should().Be(GameBookRole.Setup);
+        sr.RelevanceScore.Value.Should().BeApproximately(0.22, 1e-6); // raw ts_rank_cd
+        sr.SearchMethod.Should().Be("keyword");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Issue #3270 (Task 6): primary /agents/qa path — raw keyword arm + role hint reach
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies the role-boost signal reaches the PRIMARY chat path (SearchQueryHandler ->
+    /// RrfFusionDomainService -> HybridFusionCore), and that the fused winner's RelevanceScore
+    /// still reflects its own cosine similarity (issue #2712), not the hybrid ranking score.
+    /// </summary>
+    [Fact]
+    public async Task Hybrid_PrimaryPath_AppliesRoleBoostAndKeepsCosine()
+    {
+        // Arrange: two vector-only results. The plain chunk has HIGHER cosine (rank 1) than the
+        // Setup-tagged chunk (rank 2, lower cosine). With QueryRoleHint = Setup, the role-match
+        // boost (+0.15, see FusionSignals.RoleMatchBoost) should overtake the small RRF rank gap
+        // and put the Setup-tagged chunk first.
+        var gameId = TestGameId;
+        var plainPdfId = Guid.NewGuid();
+        var setupPdfId = Guid.NewGuid();
+
+        var plainEmbedding = new Embedding(
+            id: Guid.NewGuid(),
+            vectorDocumentId: Guid.NewGuid(),
+            textContent: "Plain rules text with no special role.",
+            vector: new Vector(new float[] { 0.1f, 0.2f, 0.3f }),
+            model: "test-model",
+            chunkIndex: 0,
+            pageNumber: 1,
+            roleTags: (int)GameBookRole.None,
+            pdfDocumentId: plainPdfId);
+
+        var setupEmbedding = new Embedding(
+            id: Guid.NewGuid(),
+            vectorDocumentId: Guid.NewGuid(),
+            textContent: "Setup instructions for the game.",
+            vector: new Vector(new float[] { 0.4f, 0.5f, 0.6f }),
+            model: "test-model",
+            chunkIndex: 1,
+            pageNumber: 2,
+            roleTags: (int)GameBookRole.Setup,
+            pdfDocumentId: setupPdfId);
+
+        var scoredEmbeddings = new List<ScoredEmbedding>
+        {
+            new(plainEmbedding, 0.90),  // rank 1, HIGHER cosine
+            new(setupEmbedding, 0.50),  // rank 2, LOWER cosine
+        };
+
+        var embeddingRepositoryMock = new Mock<IEmbeddingRepository>();
+        embeddingRepositoryMock
+            .Setup(r => r.SearchByVectorWithScoresAsync(
+                It.IsAny<Guid>(), It.IsAny<Vector>(), It.IsAny<int>(), It.IsAny<double>(),
+                It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<ScoredEmbedding>)scoredEmbeddings);
+
+        var embeddingServiceMock = new Mock<IEmbeddingService>();
+        embeddingServiceMock
+            .Setup(s => s.GenerateEmbeddingAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(EmbeddingResult.CreateSuccess(new List<float[]> { new float[] { 0.1f, 0.2f, 0.3f } }));
+
+        var keywordSearchServiceMock = CreateEmptyKeywordSearchServiceMock();
+
+        var ragAccessMock = new Mock<IRagAccessService>();
+
+        var handler = new SearchQueryHandler(
+            embeddingRepositoryMock.Object,
+            new VectorSearchDomainService(),
+            new RrfFusionDomainService(), // REAL fusion service — exercises HybridFusionCore.
+            embeddingServiceMock.Object,
+            keywordSearchServiceMock.Object,
+            ragAccessMock.Object,
+            new Mock<ILogger<SearchQueryHandler>>().Object);
+
+        var query = new SearchQuery(
+            GameId: gameId,
+            Query: TestQuery,
+            TopK: 5,
+            MinScore: 0.0,
+            SearchMode: "hybrid",
+            Language: TestLanguage,
+            QueryRoleHint: GameBookRole.Setup);
+
+        // Act
+        var result = await handler.Handle(query, TestCancellationToken);
+
+        // Assert: the Setup-tagged chunk (role-boosted) ranks first despite lower cosine.
+        result.Should().HaveCount(2);
+        result[0].VectorDocumentId.Should().Be(setupEmbedding.VectorDocumentId.ToString());
+        result[0].RelevanceScore.Should().BeApproximately(0.50, 1e-6); // own cosine, not hybrid score
+    }
+
+    /// <summary>
+    /// Issue #2051: verifies the primary hybrid path filters raw keyword-arm results down to the
+    /// caller-supplied DocumentIds scope, reproducing the post-filter previously applied inside
+    /// HybridSearchService.SearchAsync(Keyword).
+    /// </summary>
+    [Fact]
+    public async Task Hybrid_PrimaryPath_DocumentIdsFilter_ExcludesOutOfScope()
+    {
+        // Arrange
+        var gameId = TestGameId;
+        var inScopePdf = Guid.NewGuid();
+        var outOfScopePdf = Guid.NewGuid();
+
+        var embeddingRepositoryMock = new Mock<IEmbeddingRepository>();
+        embeddingRepositoryMock
+            .Setup(r => r.SearchByVectorWithScoresAsync(
+                It.IsAny<Guid>(), It.IsAny<Vector>(), It.IsAny<int>(), It.IsAny<double>(),
+                It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<ScoredEmbedding>)new List<ScoredEmbedding>());
+
+        var embeddingServiceMock = new Mock<IEmbeddingService>();
+        embeddingServiceMock
+            .Setup(s => s.GenerateEmbeddingAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(EmbeddingResult.CreateSuccess(new List<float[]> { new float[] { 0.1f, 0.2f, 0.3f } }));
+
+        var keywordResults = new List<KeywordSearchResult>
+        {
+            new()
+            {
+                ChunkId = "in-scope",
+                Content = "In scope chunk content.",
+                PdfDocumentId = inScopePdf.ToString(),
+                GameId = gameId,
+                ChunkIndex = 0,
+                PageNumber = 1,
+                RelevanceScore = 0.20f
+            },
+            new()
+            {
+                ChunkId = "out-of-scope",
+                Content = "Out of scope chunk content.",
+                PdfDocumentId = outOfScopePdf.ToString(),
+                GameId = gameId,
+                ChunkIndex = 0,
+                PageNumber = 1,
+                RelevanceScore = 0.25f
+            }
+        };
+
+        var keywordSearchServiceMock = new Mock<IKeywordSearchService>();
+        keywordSearchServiceMock
+            .Setup(k => k.SearchAsync(
+                It.IsAny<string>(),
+                It.IsAny<Guid>(),
+                It.IsAny<int>(),
+                It.IsAny<bool>(),
+                It.IsAny<List<string>?>(),
+                It.IsAny<string>(),
+                It.IsAny<double>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(keywordResults);
+
+        var ragAccessMock = new Mock<IRagAccessService>();
+
+        var handler = new SearchQueryHandler(
+            embeddingRepositoryMock.Object,
+            new VectorSearchDomainService(),
+            new RrfFusionDomainService(),
+            embeddingServiceMock.Object,
+            keywordSearchServiceMock.Object,
+            ragAccessMock.Object,
+            new Mock<ILogger<SearchQueryHandler>>().Object);
+
+        var query = new SearchQuery(
+            GameId: gameId,
+            Query: TestQuery,
+            TopK: 5,
+            MinScore: 0.0,
+            SearchMode: "hybrid",
+            Language: TestLanguage,
+            DocumentIds: new List<Guid> { inScopePdf });
+
+        // Act
+        var result = await handler.Handle(query, TestCancellationToken);
+
+        // Assert: only the in-scope chunk survives the documentIds filter.
+        result.Should().ContainSingle();
+        result[0].VectorDocumentId.Should().Be(inScopePdf.ToString());
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Entities/SearchResultTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Entities/SearchResultTests.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
 using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
 using FluentAssertions;
@@ -289,6 +290,41 @@ public sealed class SearchResultTests
         // Act & Assert
         perfectResult.MeetsThreshold(1.0).Should().BeTrue();
         almostPerfectResult.MeetsThreshold(1.0).Should().BeFalse();
+    }
+
+    #endregion
+
+    #region Fusion Identity Tests
+
+    [Fact]
+    public void SearchResult_CarriesFusionIdentity_WhenProvided()
+    {
+        var pdf = Guid.NewGuid();
+        var r = new Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult(
+            id: Guid.NewGuid(),
+            vectorDocumentId: Guid.NewGuid(),
+            textContent: "text",
+            pageNumber: 1,
+            relevanceScore: new Confidence(0.9),
+            rank: 1,
+            searchMethod: "vector",
+            pdfDocumentId: pdf,
+            chunkIndex: 7,
+            roleTags: GameBookRole.Setup);
+
+        r.PdfDocumentId.Should().Be(pdf);
+        r.ChunkIndex.Should().Be(7);
+        r.RoleTags.Should().Be(GameBookRole.Setup);
+    }
+
+    [Fact]
+    public void SearchResult_FusionIdentity_DefaultsAreEmpty()
+    {
+        var r = new Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult(
+            Guid.NewGuid(), Guid.NewGuid(), "text", 1, new Confidence(0.5), 1);
+        r.PdfDocumentId.Should().Be(Guid.Empty);
+        r.ChunkIndex.Should().Be(0);
+        r.RoleTags.Should().Be(GameBookRole.None);
     }
 
     #endregion

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/RrfFusionDomainServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/RrfFusionDomainServiceTests.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
 using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
@@ -77,6 +78,53 @@ public sealed class RrfFusionDomainServiceTests
         result.Should().HaveCount(1);
         result.First().RelevanceScore.Value.Should().BeApproximately(0.87, 0.0001,
             "the real cosine must survive fusion, not be overwritten by the ~0.49 rank-based RRF score");
+    }
+
+    [Fact]
+    public void FuseResults_BothArms_KeepsCosineInRelevanceScore_NotHybridScore()
+    {
+        // Issue #3270 Task 5 / #2712: RrfFusionDomainService now delegates to HybridFusionCore for
+        // scoring, but RelevanceScore must still be the carried cosine, never the hybrid/RRF score.
+        var pdf = Guid.NewGuid();
+        var vector = new List<SearchResult>
+        {
+            new(Guid.NewGuid(), Guid.NewGuid(), "content", 1, new Confidence(0.91), 1, "vector",
+                pdfDocumentId: pdf, chunkIndex: 0, roleTags: GameBookRole.None)
+        };
+        var keyword = new List<SearchResult>
+        {
+            new(Guid.NewGuid(), Guid.NewGuid(), "content", 1, new Confidence(0.20), 1, "keyword",
+                pdfDocumentId: pdf, chunkIndex: 0, roleTags: GameBookRole.None)
+        };
+
+        var fused = _service.FuseResults(vector, keyword);
+
+        fused.Should().HaveCount(1);
+        // #2712: RelevanceScore is the carried cosine (0.91), NOT an RRF/hybrid value.
+        fused[0].RelevanceScore.Value.Should().BeApproximately(0.91, 1e-6);
+        fused[0].SearchMethod.Should().Be("hybrid");
+    }
+
+    [Fact]
+    public void FuseResults_RoleHint_ReordersByRoleBoost_OrderOnly()
+    {
+        // Issue #3270 Task 5: the new trailing queryRoleHint param routes through to
+        // HybridFusionCore's role-boost, reordering results while leaving RelevanceScore untouched.
+        var setupPdf = Guid.NewGuid();
+        var plainPdf = Guid.NewGuid();
+        var vector = new List<SearchResult>
+        {
+            new(Guid.NewGuid(), Guid.NewGuid(), "plain", 1, new Confidence(0.90), 1, "vector",
+                pdfDocumentId: plainPdf, chunkIndex: 0, roleTags: GameBookRole.None),
+            new(Guid.NewGuid(), Guid.NewGuid(), "setup", 1, new Confidence(0.80), 2, "vector",
+                pdfDocumentId: setupPdf, chunkIndex: 0, roleTags: GameBookRole.Setup)
+        };
+        var keyword = new List<SearchResult>();
+
+        var fused = _service.FuseResults(vector, keyword, queryRoleHint: GameBookRole.Setup);
+
+        fused[0].TextContent.Should().Be("setup");            // role-boost lifted it
+        fused[0].RelevanceScore.Value.Should().BeApproximately(0.80, 1e-6); // cosine preserved
     }
 
     [Fact]
@@ -341,6 +389,11 @@ public sealed class RrfFusionDomainServiceTests
 
     private static SearchResult CreateSearchResult(Guid documentId, int rank, string method)
     {
+        // #3270 Task 5: GetChunkKey is now "{PdfDocumentId}_{ChunkIndex}" (unified identity across
+        // vector/keyword arms). Reuse documentId as PdfDocumentId (chunkIndex fixed at 0) so the key
+        // stays as distinct/overlapping as it was under the old VectorDocumentId-based key: distinct
+        // documentId values across calls -> distinct chunks; the SAME documentId reused across a
+        // vector+keyword pair -> same chunk, fusing together as each test's arrange already implies.
         return new SearchResult(
             id: Guid.NewGuid(),
             vectorDocumentId: documentId,
@@ -348,7 +401,9 @@ public sealed class RrfFusionDomainServiceTests
             pageNumber: 1,
             relevanceScore: new Confidence(0.8),
             rank: rank,
-            searchMethod: method);
+            searchMethod: method,
+            pdfDocumentId: documentId,
+            chunkIndex: 0);
     }
 
     #endregion

--- a/apps/api/tests/Api.Tests/Domain/Services/VectorSearch/FusionSignalsTests.cs
+++ b/apps/api/tests/Api.Tests/Domain/Services/VectorSearch/FusionSignalsTests.cs
@@ -1,0 +1,43 @@
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.BoundedContexts.KnowledgeBase.Domain.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Domain.Services.VectorSearch;
+
+public class FusionSignalsTests
+{
+    [Fact]
+    public void ComputeRoleMatchBoost_WhenRolesIntersect_ReturnsBoost()
+    {
+        FusionSignals.ComputeRoleMatchBoost(GameBookRole.Setup, GameBookRole.Setup | GameBookRole.RulesReference)
+            .Should().Be(0.15f);
+    }
+
+    [Fact]
+    public void ComputeRoleMatchBoost_WhenHintIsNone_ReturnsZero()
+    {
+        FusionSignals.ComputeRoleMatchBoost(GameBookRole.None, GameBookRole.Setup).Should().Be(0f);
+    }
+
+    [Fact]
+    public void ComputeRoleMatchBoost_WhenNoIntersection_ReturnsZero()
+    {
+        FusionSignals.ComputeRoleMatchBoost(GameBookRole.Setup, GameBookRole.Narrative).Should().Be(0f);
+    }
+
+    [Fact]
+    public void ComputeLegendPenaltyFactor_WithFewerThanTwoPointers_ReturnsZero()
+    {
+        FusionSignals.ComputeLegendPenaltyFactor("See page 12 for details.").Should().Be(0f);
+    }
+
+    [Fact]
+    public void ComputeLegendPenaltyFactor_WithDenseCrossReferences_ReturnsPenaltyInRange()
+    {
+        var legendy = "See p. 3. See p. 5. See p. 7. See p. 9.";
+        var factor = FusionSignals.ComputeLegendPenaltyFactor(legendy);
+        factor.Should().BeInRange(0f, 0.5f);
+        factor.Should().BeGreaterThan(0f);
+    }
+}

--- a/apps/api/tests/Api.Tests/Domain/Services/VectorSearch/HybridFusionCoreTests.cs
+++ b/apps/api/tests/Api.Tests/Domain/Services/VectorSearch/HybridFusionCoreTests.cs
@@ -1,0 +1,112 @@
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.BoundedContexts.KnowledgeBase.Domain.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Domain.Services.VectorSearch;
+
+public class HybridFusionCoreTests
+{
+    private static FusionCandidate V(string key, int rank, float score, string content = "content", GameBookRole roles = GameBookRole.None)
+        => new(key, content, roles, rank, score);
+
+    [Fact]
+    public void Fuse_BothArms_WeightedRrf_OrdersByHybridScore()
+    {
+        var vec = new[] { V("a", 1, 0.9f), V("b", 2, 0.8f) };
+        var kw = new[] { V("b", 1, 0.3f), V("a", 2, 0.2f) };
+        var opts = new FusionOptions(0.7f, 0.3f, 60, GameBookRole.None);
+
+        var fused = HybridFusionCore.Fuse(vec, kw, opts);
+
+        fused.Should().HaveCount(2);
+        // a: 0.7/61 + 0.3/62 ≈ 0.01631 ; b: 0.7/62 + 0.3/61 ≈ 0.01621 → a first
+        fused[0].Key.Should().Be("a");
+        fused[0].Rank.Should().Be(1);
+        fused[0].VectorScore.Should().Be(0.9f);
+        fused[0].KeywordScore.Should().Be(0.2f);
+        fused[0].VectorRank.Should().Be(1);
+        fused[0].KeywordRank.Should().Be(2);
+    }
+
+    [Fact]
+    public void Fuse_PrefersVectorArmContent_WhenChunkInBothArms()
+    {
+        var vec = new[] { V("a", 1, 0.9f, content: "VECTOR") };
+        var kw = new[] { V("a", 1, 0.3f, content: "KEYWORD") };
+        var fused = HybridFusionCore.Fuse(vec, kw, new FusionOptions());
+        fused.Single().Content.Should().Be("VECTOR");
+    }
+
+    [Fact]
+    public void Fuse_RoleTags_AreOrUnionedAcrossArms()
+    {
+        var vec = new[] { V("a", 1, 0.9f, roles: GameBookRole.Setup) };
+        var kw = new[] { V("a", 1, 0.3f, roles: GameBookRole.RulesReference) };
+        var fused = HybridFusionCore.Fuse(vec, kw, new FusionOptions());
+        fused.Single().RoleTags.Should().Be(GameBookRole.Setup | GameBookRole.RulesReference);
+    }
+
+    [Fact]
+    public void Fuse_LegendDenseChunk_IsDemotedBelowRealContent()
+    {
+        var realC = "The setup phase: place 3 tiles per player and shuffle the deck.";
+        var legend = "See p. 3. See p. 5. See p. 7. See p. 9.";
+        // Give legend the BETTER raw ranks so only legend-demotion can reorder them.
+        var vec = new[] { V("legend", 1, 0.95f, content: legend), V("real", 2, 0.90f, content: realC) };
+        var kw = new[] { V("legend", 1, 0.30f, content: legend), V("real", 2, 0.20f, content: realC) };
+        var fused = HybridFusionCore.Fuse(vec, kw, new FusionOptions());
+        fused[0].Key.Should().Be("real");
+    }
+
+    [Fact]
+    public void Fuse_RoleBoost_IsAdditiveOnTop_AndLiftsMatchingRole()
+    {
+        var vec = new[] { V("plain", 1, 0.9f, roles: GameBookRole.None), V("setup", 2, 0.8f, roles: GameBookRole.Setup) };
+        var kw = System.Array.Empty<FusionCandidate>();
+        var opts = new FusionOptions(0.7f, 0.3f, 60, GameBookRole.Setup);
+        var fused = HybridFusionCore.Fuse(vec, kw, opts);
+        // 'setup' gets +0.15 additive → overtakes 'plain'
+        fused[0].Key.Should().Be("setup");
+    }
+
+    [Fact]
+    public void Fuse_DuplicateKeyWithinArm_KeepsBestRank_DoesNotThrow()
+    {
+        var vec = new[] { V("a", 3, 0.5f), V("a", 1, 0.9f) };
+        var kw = System.Array.Empty<FusionCandidate>();
+        var fused = HybridFusionCore.Fuse(vec, kw, new FusionOptions());
+        fused.Single().VectorRank.Should().Be(1); // best (lowest) rank wins
+    }
+
+    [Fact]
+    public void Fuse_TieBreak_IsDeterministicByKeyOrdinal()
+    {
+        // Identical scores → deterministic order by Key ordinal.
+        var vec = new[] { V("b", 1, 0.5f), V("a", 1, 0.5f) };
+        var kw = System.Array.Empty<FusionCandidate>();
+        var fused = HybridFusionCore.Fuse(vec, kw, new FusionOptions());
+        fused[0].Key.Should().Be("a");
+        fused[1].Key.Should().Be("b");
+    }
+
+    [Fact]
+    public void Fuse_EmptyArms_ReturnsEmpty()
+    {
+        HybridFusionCore.Fuse(System.Array.Empty<FusionCandidate>(), System.Array.Empty<FusionCandidate>(), new FusionOptions())
+            .Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData(0.8f, 0.2f)]
+    [InlineData(0.5f, 0.5f)]
+    [InlineData(0.3f, 0.7f)]
+    public void Fuse_HonorsPerCallWeights(float vw, float kw)
+    {
+        var vec = new[] { V("a", 1, 0.9f) };
+        var key = new[] { V("b", 1, 0.3f) };
+        var fused = HybridFusionCore.Fuse(vec, key, new FusionOptions(vw, kw, 60, GameBookRole.None));
+        // Higher-weighted arm's sole item ranks first.
+        fused[0].Key.Should().Be(vw >= kw ? "a" : "b");
+    }
+}

--- a/apps/api/tests/Api.Tests/Services/HybridSearchServiceFusionParityTests.cs
+++ b/apps/api/tests/Api.Tests/Services/HybridSearchServiceFusionParityTests.cs
@@ -1,0 +1,332 @@
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using Api.BoundedContexts.KnowledgeBase.Infrastructure.Persistence;
+using Api.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Services;
+
+/// <summary>
+/// Characterization/parity tests for <see cref="HybridSearchService"/>'s private
+/// <c>FuseSearchResults</c> helper (#3270 Task 3).
+///
+/// Pins the OBSERVABLE output of <c>SearchAsync(SearchMode.Hybrid)</c> — post-sort order,
+/// <c>HybridScore</c>, <c>VectorScore</c>, <c>KeywordScore</c>, <c>MatchedTerms</c>,
+/// <c>GameId</c>, <c>PdfDocumentId</c> (string form), <c>PageNumber</c> (null→0) — captured
+/// against the pre-refactor RRF-fusion implementation. This freezes the contract so the switch
+/// to the shared <c>HybridFusionCore</c> (Task 2) cannot silently change behavior.
+///
+/// Follows the arrange pattern already used in <see cref="HybridSearchServiceRoleBoostTests"/>:
+/// mocked <see cref="IKeywordSearchService"/> + <see cref="IVectorStoreAdapter"/>, no pgvector,
+/// no PostgreSQL FTS. Role-boost / legend-demotion regression coverage lives in that sibling
+/// file and in <c>HybridSearchServiceRoleBoostTests</c>'s existing hybrid-mode tests — this file
+/// intentionally keeps <c>queryRoleHint</c> at its default (<see cref="GameBookRole.None"/>) so
+/// each case isolates the fusion mapping being characterized here.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public sealed class HybridSearchServiceFusionParityTests
+{
+    // -----------------------------------------------------------------------------------------
+    // Arrange helpers
+    // -----------------------------------------------------------------------------------------
+
+    private static Mock<IEmbeddingService> BuildEmbeddingMock()
+    {
+        var mock = new Mock<IEmbeddingService>();
+        mock
+            .Setup(x => x.GenerateEmbeddingAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(EmbeddingResult.CreateSuccess(new List<float[]>
+            {
+                new float[] { 0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f },
+            }));
+        mock.Setup(x => x.GetEmbeddingDimensions()).Returns(8);
+        mock.Setup(x => x.GetModelName()).Returns("test-model");
+        return mock;
+    }
+
+    private static ScoredEmbedding BuildScoredEmbedding(
+        Guid pdfDocumentId,
+        int chunkIndex,
+        double score,
+        int pageNumber = 1,
+        GameBookRole roleTags = GameBookRole.None,
+        string? textContent = null)
+    {
+        var vector = Vector.CreatePlaceholder(8);
+        var embedding = new Embedding(
+            id: Guid.NewGuid(),
+            vectorDocumentId: Guid.NewGuid(),
+            textContent: textContent ?? $"vector-content-{pdfDocumentId}-{chunkIndex}",
+            vector: vector,
+            model: "test-model",
+            chunkIndex: chunkIndex,
+            pageNumber: pageNumber,
+            roleTags: (int)roleTags,
+            pdfDocumentId: pdfDocumentId);
+        return new ScoredEmbedding(embedding, score);
+    }
+
+    private static KeywordSearchResult BuildKeywordResult(
+        Guid pdfDocumentId,
+        int chunkIndex,
+        float relevanceScore,
+        Guid gameId,
+        int? pageNumber = 1,
+        List<string>? matchedTerms = null,
+        GameBookRole roleTags = GameBookRole.None,
+        string? content = null)
+        => new()
+        {
+            ChunkId = Guid.NewGuid().ToString(),
+            Content = content ?? $"keyword-content-{pdfDocumentId}-{chunkIndex}",
+            PdfDocumentId = pdfDocumentId.ToString(),
+            GameId = gameId,
+            ChunkIndex = chunkIndex,
+            PageNumber = pageNumber,
+            RelevanceScore = relevanceScore,
+            MatchedTerms = matchedTerms ?? new List<string>(),
+            RoleTags = roleTags,
+        };
+
+    private static Mock<IVectorStoreAdapter> BuildVectorStoreMock(params ScoredEmbedding[] scoredEmbeddings)
+    {
+        var mock = new Mock<IVectorStoreAdapter>();
+        mock
+            .Setup(v => v.SearchWithScoresAsync(
+                It.IsAny<Guid>(), It.IsAny<Vector>(), It.IsAny<int>(),
+                It.IsAny<double>(), It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(scoredEmbeddings.ToList());
+        return mock;
+    }
+
+    private static Mock<IKeywordSearchService> BuildKeywordMock(params KeywordSearchResult[] results)
+    {
+        var mock = new Mock<IKeywordSearchService>();
+        mock
+            .Setup(k => k.SearchAsync(
+                It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<int>(), It.IsAny<bool>(),
+                It.IsAny<List<string>?>(), It.IsAny<string>(), It.IsAny<double>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(results.ToList());
+        return mock;
+    }
+
+    private static HybridSearchService BuildSut(
+        Mock<IVectorStoreAdapter> vectorStoreMock,
+        Mock<IKeywordSearchService> keywordMock)
+    {
+        var config = Options.Create(new HybridSearchConfiguration());
+        return new HybridSearchService(
+            keywordMock.Object,
+            BuildEmbeddingMock().Object,
+            vectorStoreMock.Object,
+            NullLogger<HybridSearchService>.Instance,
+            config);
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Cases
+    // -----------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Hybrid_BothArms_PreservesOrderScoresAndOutputFields()
+    {
+        // Two chunks, each present in BOTH arms with swapped keyword rank order.
+        var pdfA = Guid.NewGuid();
+        var pdfB = Guid.NewGuid();
+        var keywordGameId = Guid.NewGuid();
+        var queryGameId = Guid.NewGuid();
+
+        var vectorStore = BuildVectorStoreMock(
+            BuildScoredEmbedding(pdfA, chunkIndex: 0, score: 0.9, pageNumber: 5),
+            BuildScoredEmbedding(pdfB, chunkIndex: 1, score: 0.8, pageNumber: 7));
+
+        var keyword = BuildKeywordMock(
+            BuildKeywordResult(pdfB, chunkIndex: 1, relevanceScore: 0.3f, gameId: keywordGameId, matchedTerms: new List<string> { "x" }),
+            BuildKeywordResult(pdfA, chunkIndex: 0, relevanceScore: 0.2f, gameId: keywordGameId, matchedTerms: new List<string> { "y" }));
+
+        var sut = BuildSut(vectorStore, keyword);
+
+        var results = await sut.SearchAsync(
+            "anything", queryGameId, SearchMode.Hybrid,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        results.Should().HaveCount(2);
+        results.Select(r => r.PdfDocumentId).Should().ContainInOrder(pdfA.ToString(), pdfB.ToString());
+
+        // RRF: default weights 0.7/0.3, rrfK=60. pdfA: vectorRank=1, keywordRank=2.
+        // pdfB: vectorRank=2, keywordRank=1.
+        var expectedA = (0.7f / 61f) + (0.3f / 62f);
+        var expectedB = (0.7f / 62f) + (0.3f / 61f);
+
+        results[0].HybridScore.Should().BeApproximately(expectedA, 1e-6f);
+        results[0].VectorScore.Should().BeApproximately(0.9f, 1e-6f);
+        results[0].KeywordScore.Should().BeApproximately(0.2f, 1e-6f);
+        results[0].MatchedTerms.Should().BeEquivalentTo(new[] { "y" });
+        results[0].GameId.Should().Be(keywordGameId);
+        results[0].PageNumber.Should().Be(5);
+        results[0].ChunkIndex.Should().Be(0);
+
+        results[1].HybridScore.Should().BeApproximately(expectedB, 1e-6f);
+        results[1].VectorScore.Should().BeApproximately(0.8f, 1e-6f);
+        results[1].KeywordScore.Should().BeApproximately(0.3f, 1e-6f);
+        results[1].MatchedTerms.Should().BeEquivalentTo(new[] { "x" });
+        results[1].GameId.Should().Be(keywordGameId);
+        results[1].PageNumber.Should().Be(7);
+        results[1].ChunkIndex.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Hybrid_VectorOnly_UsesQueryGameId_KeywordScoreNull()
+    {
+        var pdfC = Guid.NewGuid();
+        var queryGameId = Guid.NewGuid();
+
+        var vectorStore = BuildVectorStoreMock(
+            BuildScoredEmbedding(pdfC, chunkIndex: 2, score: 0.85, pageNumber: 3));
+        var keyword = BuildKeywordMock(); // empty keyword arm
+
+        var sut = BuildSut(vectorStore, keyword);
+
+        var results = await sut.SearchAsync(
+            "anything", queryGameId, SearchMode.Hybrid,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        results.Should().HaveCount(1);
+        var r = results[0];
+        r.PdfDocumentId.Should().Be(pdfC.ToString());
+        r.GameId.Should().Be(queryGameId); // fallback: no keyword-arm entry for this chunk
+        r.ChunkIndex.Should().Be(2);
+        r.PageNumber.Should().Be(3);
+        r.VectorScore.Should().BeApproximately(0.85f, 1e-6f);
+        r.KeywordScore.Should().BeNull();
+        r.VectorRank.Should().Be(1);
+        r.KeywordRank.Should().BeNull();
+        r.MatchedTerms.Should().BeEmpty();
+        r.HybridScore.Should().BeApproximately(0.7f / 61f, 1e-6f);
+    }
+
+    [Fact]
+    public async Task Hybrid_KeywordOnly_UsesKeywordGameId_VectorScoreNull()
+    {
+        var pdfD = Guid.NewGuid();
+        var keywordGameId = Guid.NewGuid();
+        var queryGameId = Guid.NewGuid();
+
+        var vectorStore = BuildVectorStoreMock(); // empty vector arm
+        var keyword = BuildKeywordMock(
+            BuildKeywordResult(
+                pdfD, chunkIndex: 4, relevanceScore: 0.55f, gameId: keywordGameId,
+                pageNumber: 9, matchedTerms: new List<string> { "setup" }));
+
+        var sut = BuildSut(vectorStore, keyword);
+
+        var results = await sut.SearchAsync(
+            "anything", queryGameId, SearchMode.Hybrid,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        results.Should().HaveCount(1);
+        var r = results[0];
+        r.PdfDocumentId.Should().Be(pdfD.ToString());
+        r.GameId.Should().Be(keywordGameId);
+        r.ChunkIndex.Should().Be(4);
+        r.PageNumber.Should().Be(9);
+        r.VectorScore.Should().BeNull();
+        r.KeywordScore.Should().BeApproximately(0.55f, 1e-6f);
+        r.VectorRank.Should().BeNull();
+        r.KeywordRank.Should().Be(1);
+        r.MatchedTerms.Should().BeEquivalentTo(new[] { "setup" });
+        r.HybridScore.Should().BeApproximately(0.3f / 61f, 1e-6f);
+    }
+
+    [Fact]
+    public async Task Hybrid_DuplicateKeyAcrossArms_FusesToSingleResult_SummedRrf()
+    {
+        // Same {PdfDocumentId}_{ChunkIndex} present in BOTH arms must fuse into ONE result whose
+        // RRF sums the vector + keyword contributions (not two half-strength duplicates).
+        var pdfE = Guid.NewGuid();
+        var keywordGameId = Guid.NewGuid();
+        var queryGameId = Guid.NewGuid();
+
+        var vectorStore = BuildVectorStoreMock(
+            BuildScoredEmbedding(pdfE, chunkIndex: 6, score: 0.77, pageNumber: 2));
+        var keyword = BuildKeywordMock(
+            BuildKeywordResult(
+                pdfE, chunkIndex: 6, relevanceScore: 0.44f, gameId: keywordGameId,
+                pageNumber: 2, matchedTerms: new List<string> { "rule" }));
+
+        var sut = BuildSut(vectorStore, keyword);
+
+        var results = await sut.SearchAsync(
+            "anything", queryGameId, SearchMode.Hybrid,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        results.Should().HaveCount(1);
+        var r = results[0];
+        r.PdfDocumentId.Should().Be(pdfE.ToString());
+        r.GameId.Should().Be(keywordGameId);
+        r.PageNumber.Should().Be(2);
+        r.VectorScore.Should().BeApproximately(0.77f, 1e-6f);
+        r.KeywordScore.Should().BeApproximately(0.44f, 1e-6f);
+        r.VectorRank.Should().Be(1);
+        r.KeywordRank.Should().Be(1);
+        r.MatchedTerms.Should().BeEquivalentTo(new[] { "rule" });
+        r.HybridScore.Should().BeApproximately((0.7f + 0.3f) / 61f, 1e-6f);
+    }
+
+    [Fact]
+    public async Task Hybrid_KeywordOnly_NullPageNumber_CoalescesToZero()
+    {
+        var pdfF = Guid.NewGuid();
+        var keywordGameId = Guid.NewGuid();
+        var queryGameId = Guid.NewGuid();
+
+        var vectorStore = BuildVectorStoreMock(); // empty vector arm
+        var keyword = BuildKeywordMock(
+            BuildKeywordResult(pdfF, chunkIndex: 8, relevanceScore: 0.33f, gameId: keywordGameId, pageNumber: null));
+
+        var sut = BuildSut(vectorStore, keyword);
+
+        var results = await sut.SearchAsync(
+            "anything", queryGameId, SearchMode.Hybrid,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        results.Should().HaveCount(1);
+        results[0].PageNumber.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Hybrid_TiedHybridScore_OrdersDeterministicallyByKey()
+    {
+        // Two arm-exclusive chunks tuned to an EXACT RRF tie (equal weights, both rank 1) so the
+        // fused order is decided purely by the fusion's tie-break, not by score. Fixed low/high
+        // GUIDs pin the composite-key ordinal comparison deterministically: "..._0001_0" sorts
+        // before "..._0002_0".
+        var pdfLow = Guid.Parse("00000000-0000-0000-0000-000000000001");
+        var pdfHigh = Guid.Parse("00000000-0000-0000-0000-000000000002");
+        var queryGameId = Guid.NewGuid();
+
+        var vectorStore = BuildVectorStoreMock(
+            BuildScoredEmbedding(pdfLow, chunkIndex: 0, score: 0.6));
+        var keyword = BuildKeywordMock(
+            BuildKeywordResult(pdfHigh, chunkIndex: 0, relevanceScore: 0.6f, gameId: queryGameId));
+
+        var sut = BuildSut(vectorStore, keyword);
+
+        var results = await sut.SearchAsync(
+            "anything", queryGameId, SearchMode.Hybrid,
+            vectorWeight: 0.5f, keywordWeight: 0.5f,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        results.Should().HaveCount(2);
+        results[0].HybridScore.Should().BeApproximately(results[1].HybridScore, 1e-9f);
+        results.Select(r => r.PdfDocumentId).Should().ContainInOrder(pdfLow.ToString(), pdfHigh.ToString());
+    }
+}

--- a/apps/api/tests/Api.Tests/Services/HybridSearchServiceRoleBoostTests.cs
+++ b/apps/api/tests/Api.Tests/Services/HybridSearchServiceRoleBoostTests.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
 using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Domain.Services;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
 using Api.BoundedContexts.KnowledgeBase.Infrastructure.Persistence;
 using Api.Services;
@@ -15,7 +16,7 @@ namespace Api.Tests.Services;
 /// <summary>
 /// Unit tests for the Phase D (D6) role-match re-ranker boost in <see cref="HybridSearchService"/>.
 ///
-/// Exercises the pure-function helper <see cref="HybridSearchService.ComputeRoleMatchBoost"/> in
+/// Exercises the pure-function helper <see cref="FusionSignals.ComputeRoleMatchBoost"/> in
 /// isolation — no pgvector, no PostgreSQL FTS, no DI graph. This is intentional: the boost
 /// computation is the only new logic introduced by D6 and the rest of <c>FuseSearchResults</c>
 /// is unchanged. Integration coverage of the full hybrid pipeline lives elsewhere
@@ -33,10 +34,10 @@ public sealed class HybridSearchServiceRoleBoostTests
         var chunkTags = GameBookRole.Tutorial;
 
         // Act
-        var boost = HybridSearchService.ComputeRoleMatchBoost(queryHint, chunkTags);
+        var boost = FusionSignals.ComputeRoleMatchBoost(queryHint, chunkTags);
 
         // Assert: positive intersection ⇒ full boost.
-        boost.Should().Be(HybridSearchService.RoleMatchBoost);
+        boost.Should().Be(FusionSignals.RoleMatchBoost);
     }
 
     [Fact]
@@ -47,7 +48,7 @@ public sealed class HybridSearchServiceRoleBoostTests
         var chunkTags = GameBookRole.RulesReference;
 
         // Act
-        var boost = HybridSearchService.ComputeRoleMatchBoost(queryHint, chunkTags);
+        var boost = FusionSignals.ComputeRoleMatchBoost(queryHint, chunkTags);
 
         // Assert: no overlap ⇒ no boost.
         boost.Should().Be(0f);
@@ -62,7 +63,7 @@ public sealed class HybridSearchServiceRoleBoostTests
         var chunkTags = GameBookRole.Tutorial | GameBookRole.Narrative;
 
         // Act
-        var boost = HybridSearchService.ComputeRoleMatchBoost(queryHint, chunkTags);
+        var boost = FusionSignals.ComputeRoleMatchBoost(queryHint, chunkTags);
 
         // Assert
         boost.Should().Be(0f);
@@ -77,7 +78,7 @@ public sealed class HybridSearchServiceRoleBoostTests
         var chunkTags = GameBookRole.None;
 
         // Act
-        var boost = HybridSearchService.ComputeRoleMatchBoost(queryHint, chunkTags);
+        var boost = FusionSignals.ComputeRoleMatchBoost(queryHint, chunkTags);
 
         // Assert
         boost.Should().Be(0f);
@@ -91,10 +92,10 @@ public sealed class HybridSearchServiceRoleBoostTests
         var chunkTags = GameBookRole.Tutorial | GameBookRole.Setup;
 
         // Act
-        var boost = HybridSearchService.ComputeRoleMatchBoost(queryHint, chunkTags);
+        var boost = FusionSignals.ComputeRoleMatchBoost(queryHint, chunkTags);
 
         // Assert: single overlapping flag is enough.
-        boost.Should().Be(HybridSearchService.RoleMatchBoost);
+        boost.Should().Be(FusionSignals.RoleMatchBoost);
     }
 
     [Fact]
@@ -105,15 +106,15 @@ public sealed class HybridSearchServiceRoleBoostTests
         const float baseScore = 0.01f; // representative RRF magnitude (≈ 0.7/(60+10))
         var queryHint = GameBookRole.Tutorial;
 
-        var matchingBoost = HybridSearchService.ComputeRoleMatchBoost(queryHint, GameBookRole.Tutorial);
-        var nonMatchingBoost = HybridSearchService.ComputeRoleMatchBoost(queryHint, GameBookRole.RulesReference);
+        var matchingBoost = FusionSignals.ComputeRoleMatchBoost(queryHint, GameBookRole.Tutorial);
+        var nonMatchingBoost = FusionSignals.ComputeRoleMatchBoost(queryHint, GameBookRole.RulesReference);
 
         var matchingFinalScore = baseScore + matchingBoost;
         var nonMatchingFinalScore = baseScore + nonMatchingBoost;
 
         // Assert: positional re-ranking effect is observable, not a tie.
         matchingFinalScore.Should().BeGreaterThan(nonMatchingFinalScore);
-        (matchingFinalScore - nonMatchingFinalScore).Should().Be(HybridSearchService.RoleMatchBoost);
+        (matchingFinalScore - nonMatchingFinalScore).Should().Be(FusionSignals.RoleMatchBoost);
     }
 
     // -----------------------------------------------------------------------------------------
@@ -127,7 +128,7 @@ public sealed class HybridSearchServiceRoleBoostTests
         var content = "Per preparare la partita, ogni giocatore riceve una plancia e le risorse iniziali.";
 
         // Act & Assert
-        HybridSearchService.ComputeLegendPenaltyFactor(content).Should().Be(0f);
+        FusionSignals.ComputeLegendPenaltyFactor(content).Should().Be(0f);
     }
 
     [Fact]
@@ -138,7 +139,7 @@ public sealed class HybridSearchServiceRoleBoostTests
                    + "9. Milestone/Ricompense: sono una buona fonte di PV extra (vedi pag. 10 e 11).";
 
         // Act
-        var factor = HybridSearchService.ComputeLegendPenaltyFactor(legend);
+        var factor = FusionSignals.ComputeLegendPenaltyFactor(legend);
 
         // Assert: a short chunk dense with "vedi pag." pointers is strongly demoted.
         factor.Should().BeGreaterThan(0.2f);
@@ -151,7 +152,7 @@ public sealed class HybridSearchServiceRoleBoostTests
         var content = new string('a', 1400) + " (vedi pag. 12)";
 
         // Act
-        var factor = HybridSearchService.ComputeLegendPenaltyFactor(content);
+        var factor = FusionSignals.ComputeLegendPenaltyFactor(content);
 
         // Assert: one incidental pointer in a long chunk is not treated as a legend.
         factor.Should().BeLessThan(0.2f);
@@ -162,9 +163,9 @@ public sealed class HybridSearchServiceRoleBoostTests
     {
         // Arrange: a legend and a real chunk with identical base RRF score.
         const float baseScore = 0.011f; // representative collapsed-RRF magnitude from the repro
-        var legendFactor = HybridSearchService.ComputeLegendPenaltyFactor(
+        var legendFactor = FusionSignals.ComputeLegendPenaltyFactor(
             "8. Progetti Standard (vedi pag. 10). 9. Milestone (vedi pag. 10 e 11).");
-        var realFactor = HybridSearchService.ComputeLegendPenaltyFactor(
+        var realFactor = FusionSignals.ComputeLegendPenaltyFactor(
             "Preparazione: disponi le tessere oceano e assegna le risorse iniziali ai giocatori.");
 
         // Act
@@ -181,9 +182,9 @@ public sealed class HybridSearchServiceRoleBoostTests
         // The legend penalty scales only the RRF fusion components; the role-match boost (#1391)
         // stays additive so its ~0.15 calibration is preserved even when a legend shares a role tag.
         const float baseRrf = 0.011f;
-        var legendFactor = HybridSearchService.ComputeLegendPenaltyFactor(
+        var legendFactor = FusionSignals.ComputeLegendPenaltyFactor(
             "8. Progetti Standard (vedi pag. 10). 9. Milestone (vedi pag. 10 e 11).");
-        var roleBoost = HybridSearchService.RoleMatchBoost;
+        var roleBoost = FusionSignals.RoleMatchBoost;
 
         // Mirror FuseSearchResults: (rrf * (1 - factor)) + roleBoost
         var withRole = (baseRrf * (1f - legendFactor)) + roleBoost;
@@ -203,7 +204,7 @@ public sealed class HybridSearchServiceRoleBoostTests
             + " vedi pag. 1 vedi pag. 2 vedi pag. 3 vedi pag. 4 vedi pag. 5";
 
         // Act
-        var factor = HybridSearchService.ComputeLegendPenaltyFactor(content);
+        var factor = FusionSignals.ComputeLegendPenaltyFactor(content);
 
         // Assert
         factor.Should().BeLessThan(0.2f);
@@ -306,7 +307,7 @@ public sealed class HybridSearchServiceRoleBoostTests
         // Assert: HybridScore = baseRank(1.0) + RoleMatchBoost(0.15) = 1.15.
         results.Should().HaveCount(1);
         results[0].RoleTags.Should().Be(GameBookRole.Tutorial);
-        results[0].HybridScore.Should().BeApproximately(1.0f + HybridSearchService.RoleMatchBoost, 0.0001f);
+        results[0].HybridScore.Should().BeApproximately(1.0f + FusionSignals.RoleMatchBoost, 0.0001f);
         // #2568: VectorScore now carries the raw cosine (0.9 from Scored()), not a constant 1.0.
         results[0].VectorScore.Should().BeApproximately(0.9f, 0.0001f);
     }
@@ -399,7 +400,7 @@ public sealed class HybridSearchServiceRoleBoostTests
         results[1].ChunkIndex.Should().Be(1);
         // Boosted rank-3 (Tutorial) now beats rank-2 (RulesReference).
         results[2].ChunkIndex.Should().Be(3);
-        results[2].HybridScore.Should().BeApproximately(0.25f + HybridSearchService.RoleMatchBoost, 0.0001f);
+        results[2].HybridScore.Should().BeApproximately(0.25f + FusionSignals.RoleMatchBoost, 0.0001f);
         results[3].ChunkIndex.Should().Be(2);
     }
 
@@ -471,7 +472,7 @@ public sealed class HybridSearchServiceRoleBoostTests
 
         results.Should().HaveCount(1);
         results[0].RoleTags.Should().Be(GameBookRole.Tutorial);
-        results[0].HybridScore.Should().BeApproximately((0.7f / 61f) + HybridSearchService.RoleMatchBoost, 0.0001f);
+        results[0].HybridScore.Should().BeApproximately((0.7f / 61f) + FusionSignals.RoleMatchBoost, 0.0001f);
     }
 
     [Fact]

--- a/docs/superpowers/plans/2026-07-26-issue-3270-unified-hybrid-fusion.md
+++ b/docs/superpowers/plans/2026-07-26-issue-3270-unified-hybrid-fusion.md
@@ -1,0 +1,1016 @@
+# Unified Hybrid Fusion (#3270 · SP4) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace MeepleAI's two divergent hybrid-fusion implementations with one canonical `HybridFusionCore`, so the user-facing chat path (`/agents/qa` + `/agents/qa/stream`) gets the same weighted-RRF + legend-demotion + role-boost ranking the admin playground already gets.
+
+**Architecture:** A pure/static Domain fusion core (merge + score + order, I/O-type agnostic) plus a shared `FusionSignals` static (legend/role helpers + constants). The existing `HybridSearchService.FuseSearchResults` and `RrfFusionDomainService.FuseResults` become thin adapters that map their arms into the neutral `FusionCandidate`, call the core, and re-join by key for type-specific output. The primary chat path additionally carries the `{PdfDocumentId}_{ChunkIndex}` identity + `RoleTags` end-to-end and forwards its role hint.
+
+**Tech Stack:** .NET 9, C# (nullable enabled, `TreatWarningsAsErrors`), xUnit + Moq + FluentAssertions. No new SQL, no EF migration.
+
+## Global Constraints
+
+- **Namespace ≠ folder.** New files under `apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/` declare namespace `Api.BoundedContexts.KnowledgeBase.Domain.Services` (parent — matches siblings `RrfFusionDomainService.cs:4`, `CosineSimilarityCalculator.cs`, `VectorSearchDomainService.cs:4`).
+- **`internal` visibility everywhere.** All new types/members are `internal` (record structs / static). `InternalsVisibleTo` is already granted to `Api.Tests` (`Api.csproj:47`) + `DynamicProxyGenAssembly2` (`:49`, Moq). Do NOT add new grants.
+- **Cross-context type:** `GameBookRole` is `[Flags] public enum { None=0, Tutorial=1, RulesReference=2, Narrative=4, Encounter=8, Lore=16, Setup=32 }` in `Api.BoundedContexts.GameManagement.Domain.ValueObjects`. Every new/edited KnowledgeBase file referencing it needs `using Api.BoundedContexts.GameManagement.Domain.ValueObjects;`.
+- **Weights stay per-call inputs.** `HybridSearchEngine` runs A/B weights (0.8/0.2, 0.5/0.5, 0.3/0.7). Never hardcode 0.7/0.3 inside the core call for the `HybridSearchService` adapter — thread the per-call weights through.
+- **#2712 (mandatory):** on the primary path, fused `SearchResult.RelevanceScore` = the carried **cosine** (vector arm's source score, else keyword source score) — NEVER the hybrid/RRF score. The hybrid score drives **order only**. Regression: feeding RRF into confidence degenerates it ~0.53 and hides grounded answers behind the "Non sono certo" card.
+- **Guid/string split is intentional.** `HybridSearchResult.PdfDocumentId` stays **string** end-to-end in `HybridSearchService`. `Domain.Entities.SearchResult.PdfDocumentId` is **Guid** (`Guid.Parse(...)` at the keyword-arm mapper; already-Guid on the vector arm). Do not unify these.
+- **Build:** `dotnet build` must stay 0-warning. Run from `apps/api/src/Api`.
+- **Test host hygiene:** before `dotnet test`, kill stray hosts (`tasklist | grep testhost` → `taskkill //PID <PID> //F`); use `$"{val*100:0}%"` style culture-independent formatting if any new formatting appears (it should not here).
+
+---
+
+## Verified current state (grounding — trust these over the spec's line numbers)
+
+- `RrfFusionDomainService.cs` — `internal class`; `FuseResults(List<SearchResult> vectorResults, List<SearchResult> keywordResults, int rrfK = DefaultRrfK)` at **:22-92**; `DefaultRrfK = 60` at :12; UNWEIGHTED `1.0/(rrfK+rank)` both arms; `GetChunkKey` at **:100-104** = `$"{VectorDocumentId}:{PageNumber}:{TextContent.GetHashCode(Ordinal)}"` (called 4× at :38,:49,:59,:68); #2712 `relevanceScore: item.Result.RelevanceScore` at :85; sole production caller `SearchQueryHandler.cs:212` (2 positional args).
+- `HybridSearchService.cs` — `DefaultRrfK = 60` at **:29**, `RoleMatchBoost = 0.15f` at **:35** (spec transposed these); `FuseSearchResults` (private) at **:394-527**, final score `((vectorRrfScore + keywordRrfScore) * (1f - legendFactor)) + roleBoost` at :489, RoleTags OR-union :469, sole caller `SearchHybridAsync` at :305; `ComputeRoleMatchBoost` at **:536-544**; `CrossReferencePointer` regex at **:546-551**; `ComputeLegendPenaltyFactor` at **:560-580**; 4 role-boost call sites (`:134` semantic, `:206` keyword, `:470` fusion).
+- `SearchResult.cs` — `internal sealed class SearchResult : Entity<Guid>` at **:10-77** (NOT a record); `RelevanceScore` is a `Confidence` value object; public ctor at **:31-55** = `(Guid id, Guid vectorDocumentId, string textContent, int pageNumber, Confidence relevanceScore, int rank, string? searchMethod = null)`. **21 construction sites** (4 prod: `StructuredRagFusionService.cs:127,:149`, `RrfFusionDomainService.cs:76`, `VectorSearchDomainService.cs:54`; 17 test — enumerated in Task 4).
+- `HybridSearchResult` (`IHybridSearchService.cs:68`) already carries `ChunkId, Content, PdfDocumentId (string), GameId, ChunkIndex, PageNumber, HybridScore, VectorScore, KeywordScore, VectorRank, KeywordRank, MatchedTerms, Mode, RoleTags`.
+- `SearchKeywordOnlyAsync` (`HybridSearchService.cs:176-235`) applies `phraseSearch = query.Contains('"')`, `minScore`, #2051 documentIds filter, sets `KeywordScore = r.RelevanceScore` (raw ts_rank_cd), `HybridScore = r.RelevanceScore + roleBoost`, and **re-sorts only if `queryRoleHint != None`**.
+- `SearchQueryHandler.PerformVectorSearchAsync` (**:133-175**) builds the vector-arm `SearchResult` at **:159-167** from `scored.Embedding` (which — via `SearchByVectorWithScoresAsync` → `PgVectorStoreAdapter.SearchWithScoresAsync:127` — JOINs `vector_documents` and populates real `PdfDocumentId` [col 7], `ChunkIndex` [col 4], `RoleTags` [col 6]). `PerformHybridSearchAsync` (**:177-213**) sources the keyword arm via `_hybridSearchService.SearchAsync(SearchMode.Keyword, …, queryRoleHint)` at :196-204, maps via `kr.ToDomainSearchResult(index+1)` at :207-209, calls `_rrfFusionService.FuseResults(vectorResults, keywordResults)` at :212.
+- `ToDomainSearchResult` (`Infrastructure/Persistence/Mappers/KnowledgeBaseMappers.cs:64-83`) maps `HybridSearchResult → SearchResult`; currently `score = (double)result.HybridScore`, drops PdfDocumentId(Guid)/ChunkIndex/RoleTags. Sole caller: `SearchQueryHandler.cs:208` (VERIFY in Task 6 Step 0).
+- `StreamQaQueryHandler` (`:278-347`) builds `SearchQuery` at :284-292 with hardcoded `SearchMode:"hybrid"`, omits `QueryRoleHint`; ctor (**:31-80**) does **NOT** inject `IIntentClassifierService`. Mirror pattern: `AskQuestionQueryHandler` (`_intentClassifier` field :57, ctor :84, null-guard :105; classify + set `QueryRoleHint` :429-443).
+- `SearchQuery` (`SearchQuery.cs`) — `QueryRoleHint` is the LAST positional record param (`= GameBookRole.None`); pass BY NAME.
+
+**Design decision — keyword arm sourcing (spec §6 raw-arm, chosen by user directive 2026-07-26):** The primary path sources a *raw* keyword arm directly from `IKeywordSearchService.SearchAsync` (returns `List<KeywordSearchResult>` in raw ts_rank_cd order, un-boosted) so `HybridFusionCore` applies legend + role-boost exactly once (no double-boost). Because `IKeywordSearchService.SearchAsync` has **no** `documentIds` param and **no** role hint, the handler must reproduce what `HybridSearchService.SearchKeywordOnlyAsync` applied on top: the `#2051` documentIds post-filter (`r => documentIds.Any(id => string.Equals(id.ToString(), r.PdfDocumentId, Ordinal))`), the `phraseSearch = query.Contains('"')` derivation, and `minScore = 0.01`. A new `ToDomainSearchResult(this KeywordSearchResult, int)` mapper carries `PdfDocumentId`/`ChunkIndex`/`RoleTags` into `SearchResult`. `IKeywordSearchService` **replaces** `IHybridSearchService` in `SearchQueryHandler`'s ctor (the hybrid service was used *only* for this keyword sub-call at `:196`, so it becomes unused after the swap — removing it avoids a CS0414/dead-injection). Both are `AddScoped`, so the swap is lifetime-safe (consumer `SearchQueryHandler` is `AddScoped`, `KnowledgeBaseServiceExtensions.cs:463`).
+
+---
+
+## Task graph
+
+```
+Task 1 (FusionSignals) ──▶ Task 2 (HybridFusionCore) ──▶ Task 3 (HybridSearchService adapter + parity)
+Task 4 (SearchResult +3 fields) ──▶ Task 5 (RrfFusionDomainService adapter + #2712) ──▶ Task 6 (SearchQueryHandler wire)
+Task 7 (StreamQa role hint) ── standalone
+```
+Tasks 4 and 7 can start in parallel with Task 1. Task 5 needs Tasks 2 + 4. Task 6 needs Tasks 4 + 5.
+
+---
+
+### Task 1: `FusionSignals` — extract shared legend/role helpers + constants
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/FusionSignals.cs`
+- Modify: `apps/api/src/Api/Services/HybridSearchService.cs` (remove moved members; repoint 4 call sites + local refs)
+- Modify: `apps/api/tests/Api.Tests/Services/HybridSearchServiceRoleBoostTests.cs` (repoint 22 qualified refs)
+- Test: `apps/api/tests/Api.Tests/Domain/Services/VectorSearch/FusionSignalsTests.cs`
+
+**Interfaces:**
+- Produces: `FusionSignals.ComputeRoleMatchBoost(GameBookRole queryRoleHint, GameBookRole chunkRoleTags) → float`; `FusionSignals.ComputeLegendPenaltyFactor(string? content) → float`; `internal const float FusionSignals.RoleMatchBoost = 0.15f`; `internal const int FusionSignals.DefaultRrfK = 60`.
+
+- [ ] **Step 1: Write the failing test** — `FusionSignalsTests.cs`
+
+```csharp
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.BoundedContexts.KnowledgeBase.Domain.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Domain.Services.VectorSearch;
+
+public class FusionSignalsTests
+{
+    [Fact]
+    public void ComputeRoleMatchBoost_WhenRolesIntersect_ReturnsBoost()
+    {
+        FusionSignals.ComputeRoleMatchBoost(GameBookRole.Setup, GameBookRole.Setup | GameBookRole.RulesReference)
+            .Should().Be(0.15f);
+    }
+
+    [Fact]
+    public void ComputeRoleMatchBoost_WhenHintIsNone_ReturnsZero()
+    {
+        FusionSignals.ComputeRoleMatchBoost(GameBookRole.None, GameBookRole.Setup).Should().Be(0f);
+    }
+
+    [Fact]
+    public void ComputeRoleMatchBoost_WhenNoIntersection_ReturnsZero()
+    {
+        FusionSignals.ComputeRoleMatchBoost(GameBookRole.Setup, GameBookRole.Narrative).Should().Be(0f);
+    }
+
+    [Fact]
+    public void ComputeLegendPenaltyFactor_WithFewerThanTwoPointers_ReturnsZero()
+    {
+        FusionSignals.ComputeLegendPenaltyFactor("See page 12 for details.").Should().Be(0f);
+    }
+
+    [Fact]
+    public void ComputeLegendPenaltyFactor_WithDenseCrossReferences_ReturnsPenaltyInRange()
+    {
+        var legendy = "See p. 3. See p. 5. See p. 7. See p. 9.";
+        var factor = FusionSignals.ComputeLegendPenaltyFactor(legendy);
+        factor.Should().BeInRange(0f, 0.5f);
+        factor.Should().BeGreaterThan(0f);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api/src/Api && dotnet build` then from repo root `dotnet test apps/api/tests/Api.Tests --filter "FullyQualifiedName~FusionSignalsTests"`
+Expected: FAIL — `The type or namespace name 'FusionSignals' does not exist`.
+
+- [ ] **Step 3: Create `FusionSignals.cs`** — move the exact bodies from `HybridSearchService.cs` (`ComputeRoleMatchBoost` :536-544, `CrossReferencePointer` regex :546-551, `ComputeLegendPenaltyFactor` :560-580, `RoleMatchBoost` :35, `DefaultRrfK` :29). Copy the current implementations verbatim; do not re-derive the math. Template:
+
+```csharp
+using System.Text.RegularExpressions;
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+
+namespace Api.BoundedContexts.KnowledgeBase.Domain.Services;
+
+/// <summary>
+/// Pure, stateless retrieval-ranking signals shared by every hybrid-fusion path
+/// (issue #3270). Moved out of <c>HybridSearchService</c> so the primary chat path
+/// and the admin playground apply identical legend-demotion + role-boost.
+/// </summary>
+internal static class FusionSignals
+{
+    /// <summary>Additive role-match boost (issue #1391 Phase D6).</summary>
+    internal const float RoleMatchBoost = 0.15f;
+
+    /// <summary>Default reciprocal-rank-fusion constant.</summary>
+    internal const int DefaultRrfK = 60;
+
+    // COPY the exact regex from HybridSearchService.cs:546-551.
+    private static readonly Regex CrossReferencePointer = /* verbatim from source */;
+
+    /// <summary>
+    /// Additive boost when the query's role hint overlaps a chunk's role tags.
+    /// Verbatim move of HybridSearchService.ComputeRoleMatchBoost (:536-544).
+    /// </summary>
+    internal static float ComputeRoleMatchBoost(GameBookRole queryRoleHint, GameBookRole chunkRoleTags)
+    {
+        // COPY body verbatim from HybridSearchService.cs:536-544.
+    }
+
+    /// <summary>
+    /// Legend-demotion factor in [0, 0.5] (verbatim move of :560-580).
+    /// </summary>
+    internal static float ComputeLegendPenaltyFactor(string? content)
+    {
+        // COPY body verbatim from HybridSearchService.cs:560-580.
+    }
+}
+```
+
+- [ ] **Step 4: Repoint `HybridSearchService.cs`** — delete the 5 moved members; add `using` if needed (same assembly, so only a `using Api.BoundedContexts.KnowledgeBase.Domain.Services;` if the file isn't already in scope — it's in `Api.Services`, so ADD the using). Repoint every in-file reference:
+  - `ComputeRoleMatchBoost(...)` call sites at `:134` (semantic), `:206` (keyword), `:470` (fusion) → `FusionSignals.ComputeRoleMatchBoost(...)`.
+  - `ComputeLegendPenaltyFactor(...)` call site at `:488` → `FusionSignals.ComputeLegendPenaltyFactor(...)`.
+  - `RoleMatchBoost` const references (property-style) at `:39,:97,:116,:186,:309,:402,:474` → `FusionSignals.RoleMatchBoost`.
+  - `DefaultRrfK` references → `FusionSignals.DefaultRrfK` (keep `HybridSearchConfiguration.RrfConstant = 60` at :606 as-is; it's a separate config default).
+  - Leave `SearchSemanticOnlyAsync`/`SearchKeywordOnlyAsync`/`SearchHybridAsync` behavior otherwise untouched.
+
+- [ ] **Step 5: Repoint `HybridSearchServiceRoleBoostTests.cs`** — 22 qualified edits (spec undercounted at 14). Replace `HybridSearchService.` → `FusionSignals.` on these qualified references ONLY:
+  - Method calls: `.ComputeRoleMatchBoost` / `.ComputeLegendPenaltyFactor` at lines 36,50,65,80,94,108,109,130,141,154,165,167,184,206.
+  - `.RoleMatchBoost` const at lines 39,97,116,186,309,402,474.
+  - XML `<see cref="HybridSearchService.RoleMatchBoost"/>` at line 18 → `FusionSignals.RoleMatchBoost`.
+  - Do NOT touch test-method NAME identifiers (29,43,57,72,87,101,124,134,148,161,198) or prose comments (215,306,371,374). Add `using Api.BoundedContexts.KnowledgeBase.Domain.Services;`.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd apps/api/src/Api && dotnet build` then `dotnet test apps/api/tests/Api.Tests --filter "FullyQualifiedName~FusionSignalsTests|FullyQualifiedName~HybridSearchServiceRoleBoost"`
+Expected: PASS (build 0 warnings; FusionSignals tests green; all repointed RoleBoost tests green — behavior unchanged).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/FusionSignals.cs apps/api/src/Api/Services/HybridSearchService.cs apps/api/tests/Api.Tests/Services/HybridSearchServiceRoleBoostTests.cs apps/api/tests/Api.Tests/Domain/Services/VectorSearch/FusionSignalsTests.cs
+git commit -m "refactor(rag): extract FusionSignals from HybridSearchService (#3270)"
+```
+
+---
+
+### Task 2: `HybridFusionCore` — the single canonical fusion
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/HybridFusionCore.cs`
+- Test: `apps/api/tests/Api.Tests/Domain/Services/VectorSearch/HybridFusionCoreTests.cs`
+
+**Interfaces:**
+- Consumes: `FusionSignals.*` (Task 1).
+- Produces: `FusionCandidate(string Key, string Content, GameBookRole RoleTags, int Rank, float SourceScore)`; `FusionOptions(float VectorWeight=0.7f, float KeywordWeight=0.3f, int RrfK=60, GameBookRole QueryRoleHint=None)`; `FusedCandidate(string Key, string Content, GameBookRole RoleTags, float HybridScore, float? VectorScore, float? KeywordScore, int? VectorRank, int? KeywordRank, int Rank)`; `HybridFusionCore.Fuse(IReadOnlyList<FusionCandidate> vectorArm, IReadOnlyList<FusionCandidate> keywordArm, FusionOptions options) → IReadOnlyList<FusedCandidate>`.
+
+- [ ] **Step 1: Write the failing tests** — `HybridFusionCoreTests.cs`
+
+```csharp
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.BoundedContexts.KnowledgeBase.Domain.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Domain.Services.VectorSearch;
+
+public class HybridFusionCoreTests
+{
+    private static FusionCandidate V(string key, int rank, float score, string content = "content", GameBookRole roles = GameBookRole.None)
+        => new(key, content, roles, rank, score);
+
+    [Fact]
+    public void Fuse_BothArms_WeightedRrf_OrdersByHybridScore()
+    {
+        var vec = new[] { V("a", 1, 0.9f), V("b", 2, 0.8f) };
+        var kw = new[] { V("b", 1, 0.3f), V("a", 2, 0.2f) };
+        var opts = new FusionOptions(0.7f, 0.3f, 60, GameBookRole.None);
+
+        var fused = HybridFusionCore.Fuse(vec, kw, opts);
+
+        fused.Should().HaveCount(2);
+        // a: 0.7/61 + 0.3/62 ≈ 0.01631 ; b: 0.7/62 + 0.3/61 ≈ 0.01621 → a first
+        fused[0].Key.Should().Be("a");
+        fused[0].Rank.Should().Be(1);
+        fused[0].VectorScore.Should().Be(0.9f);
+        fused[0].KeywordScore.Should().Be(0.2f);
+        fused[0].VectorRank.Should().Be(1);
+        fused[0].KeywordRank.Should().Be(2);
+    }
+
+    [Fact]
+    public void Fuse_PrefersVectorArmContent_WhenChunkInBothArms()
+    {
+        var vec = new[] { V("a", 1, 0.9f, content: "VECTOR") };
+        var kw = new[] { V("a", 1, 0.3f, content: "KEYWORD") };
+        var fused = HybridFusionCore.Fuse(vec, kw, new FusionOptions());
+        fused.Single().Content.Should().Be("VECTOR");
+    }
+
+    [Fact]
+    public void Fuse_RoleTags_AreOrUnionedAcrossArms()
+    {
+        var vec = new[] { V("a", 1, 0.9f, roles: GameBookRole.Setup) };
+        var kw = new[] { V("a", 1, 0.3f, roles: GameBookRole.RulesReference) };
+        var fused = HybridFusionCore.Fuse(vec, kw, new FusionOptions());
+        fused.Single().RoleTags.Should().Be(GameBookRole.Setup | GameBookRole.RulesReference);
+    }
+
+    [Fact]
+    public void Fuse_LegendDenseChunk_IsDemotedBelowRealContent()
+    {
+        var realC = "The setup phase: place 3 tiles per player and shuffle the deck.";
+        var legend = "See p. 3. See p. 5. See p. 7. See p. 9.";
+        // Give legend the BETTER raw ranks so only legend-demotion can reorder them.
+        var vec = new[] { V("legend", 1, 0.95f, content: legend), V("real", 2, 0.90f, content: realC) };
+        var kw = new[] { V("legend", 1, 0.30f, content: legend), V("real", 2, 0.20f, content: realC) };
+        var fused = HybridFusionCore.Fuse(vec, kw, new FusionOptions());
+        fused[0].Key.Should().Be("real");
+    }
+
+    [Fact]
+    public void Fuse_RoleBoost_IsAdditiveOnTop_AndLiftsMatchingRole()
+    {
+        var vec = new[] { V("plain", 1, 0.9f, roles: GameBookRole.None), V("setup", 2, 0.8f, roles: GameBookRole.Setup) };
+        var kw = System.Array.Empty<FusionCandidate>();
+        var opts = new FusionOptions(0.7f, 0.3f, 60, GameBookRole.Setup);
+        var fused = HybridFusionCore.Fuse(vec, kw, opts);
+        // 'setup' gets +0.15 additive → overtakes 'plain'
+        fused[0].Key.Should().Be("setup");
+    }
+
+    [Fact]
+    public void Fuse_DuplicateKeyWithinArm_KeepsBestRank_DoesNotThrow()
+    {
+        var vec = new[] { V("a", 3, 0.5f), V("a", 1, 0.9f) };
+        var kw = System.Array.Empty<FusionCandidate>();
+        var fused = HybridFusionCore.Fuse(vec, kw, new FusionOptions());
+        fused.Single().VectorRank.Should().Be(1); // best (lowest) rank wins
+    }
+
+    [Fact]
+    public void Fuse_TieBreak_IsDeterministicByKeyOrdinal()
+    {
+        // Identical scores → deterministic order by Key ordinal.
+        var vec = new[] { V("b", 1, 0.5f), V("a", 1, 0.5f) };
+        var kw = System.Array.Empty<FusionCandidate>();
+        var fused = HybridFusionCore.Fuse(vec, kw, new FusionOptions());
+        fused[0].Key.Should().Be("a");
+        fused[1].Key.Should().Be("b");
+    }
+
+    [Fact]
+    public void Fuse_EmptyArms_ReturnsEmpty()
+    {
+        HybridFusionCore.Fuse(System.Array.Empty<FusionCandidate>(), System.Array.Empty<FusionCandidate>(), new FusionOptions())
+            .Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData(0.8f, 0.2f)]
+    [InlineData(0.5f, 0.5f)]
+    [InlineData(0.3f, 0.7f)]
+    public void Fuse_HonorsPerCallWeights(float vw, float kw)
+    {
+        var vec = new[] { V("a", 1, 0.9f) };
+        var key = new[] { V("b", 1, 0.3f) };
+        var fused = HybridFusionCore.Fuse(vec, key, new FusionOptions(vw, kw, 60, GameBookRole.None));
+        // Higher-weighted arm's sole item ranks first.
+        fused[0].Key.Should().Be(vw >= kw ? "a" : "b");
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test apps/api/tests/Api.Tests --filter "FullyQualifiedName~HybridFusionCoreTests"`
+Expected: FAIL — `HybridFusionCore` / `FusionCandidate` do not exist.
+
+- [ ] **Step 3: Create `HybridFusionCore.cs`** — full implementation:
+
+```csharp
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+
+namespace Api.BoundedContexts.KnowledgeBase.Domain.Services;
+
+/// <summary>Neutral per-arm candidate — only what scoring needs. Adapters build the Key.</summary>
+internal readonly record struct FusionCandidate(
+    string Key,
+    string Content,
+    GameBookRole RoleTags,
+    int Rank,          // 1-based within THIS arm (cosine desc / ts_rank_cd desc)
+    float SourceScore);
+
+internal sealed record FusionOptions(
+    float VectorWeight = 0.7f,
+    float KeywordWeight = 0.3f,
+    int RrfK = FusionSignals.DefaultRrfK,
+    GameBookRole QueryRoleHint = GameBookRole.None);
+
+/// <summary>Scoring result keyed by Key; adapters re-join their arm items for I/O-specific fields.</summary>
+internal readonly record struct FusedCandidate(
+    string Key,
+    string Content,
+    GameBookRole RoleTags,
+    float HybridScore,
+    float? VectorScore,
+    float? KeywordScore,
+    int? VectorRank,
+    int? KeywordRank,
+    int Rank);         // 1-based rank in fused order
+
+/// <summary>
+/// The single canonical hybrid fusion (#3270): weighted RRF + legend-demotion + role-boost,
+/// I/O-type agnostic. Pure — no logging, no injected state.
+/// </summary>
+internal static class HybridFusionCore
+{
+    internal static IReadOnlyList<FusedCandidate> Fuse(
+        IReadOnlyList<FusionCandidate> vectorArm,
+        IReadOnlyList<FusionCandidate> keywordArm,
+        FusionOptions options)
+    {
+        // Dedup within each arm: keep the best (lowest) rank per Key. Total (never throws).
+        var vec = BestPerKey(vectorArm);
+        var kw = BestPerKey(keywordArm);
+
+        var scored = new List<FusedCandidate>();
+        foreach (var key in vec.Keys.Union(kw.Keys))
+        {
+            var hasV = vec.TryGetValue(key, out var v);
+            var hasK = kw.TryGetValue(key, out var k);
+
+            float vectorRrf = hasV ? options.VectorWeight / (options.RrfK + v.Rank) : 0f;
+            float keywordRrf = hasK ? options.KeywordWeight / (options.RrfK + k.Rank) : 0f;
+            float rrfSum = vectorRrf + keywordRrf;
+
+            // Prefer vector arm content (load-bearing: legend factor is computed from it).
+            string content = hasV ? v.Content : k.Content;
+            GameBookRole roleTags = (hasV ? v.RoleTags : GameBookRole.None) | (hasK ? k.RoleTags : GameBookRole.None);
+
+            float legendFactor = FusionSignals.ComputeLegendPenaltyFactor(content);
+            float roleBoost = FusionSignals.ComputeRoleMatchBoost(options.QueryRoleHint, roleTags);
+            float hybridScore = (rrfSum * (1f - legendFactor)) + roleBoost;
+
+            scored.Add(new FusedCandidate(
+                Key: key,
+                Content: content,
+                RoleTags: roleTags,
+                HybridScore: hybridScore,
+                VectorScore: hasV ? v.SourceScore : (float?)null,
+                KeywordScore: hasK ? k.SourceScore : (float?)null,
+                VectorRank: hasV ? v.Rank : (int?)null,
+                KeywordRank: hasK ? k.Rank : (int?)null,
+                Rank: 0)); // assigned after sort
+        }
+
+        // Order by hybridScore desc; deterministic tie-break by Key ordinal.
+        var ordered = scored
+            .OrderByDescending(c => c.HybridScore)
+            .ThenBy(c => c.Key, StringComparer.Ordinal)
+            .Select((c, i) => c with { Rank = i + 1 })
+            .ToList();
+
+        return ordered;
+    }
+
+    private static Dictionary<string, FusionCandidate> BestPerKey(IReadOnlyList<FusionCandidate> arm)
+    {
+        var best = new Dictionary<string, FusionCandidate>(StringComparer.Ordinal);
+        foreach (var c in arm)
+        {
+            if (!best.TryGetValue(c.Key, out var existing) || c.Rank < existing.Rank)
+            {
+                best[c.Key] = c;
+            }
+        }
+        return best;
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/api/src/Api && dotnet build` then `dotnet test apps/api/tests/Api.Tests --filter "FullyQualifiedName~HybridFusionCoreTests"`
+Expected: PASS (all 8 facts + 3 theory cases; build 0 warnings).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/HybridFusionCore.cs apps/api/tests/Api.Tests/Domain/Services/VectorSearch/HybridFusionCoreTests.cs
+git commit -m "feat(rag): add canonical HybridFusionCore (weighted RRF + legend + role) (#3270)"
+```
+
+---
+
+### Task 3: `HybridSearchService.FuseSearchResults` → thin adapter (behavior-preserving)
+
+**Files:**
+- Modify: `apps/api/src/Api/Services/HybridSearchService.cs` (`FuseSearchResults` :394-527, sole caller `SearchHybridAsync` :305)
+- Test: `apps/api/tests/Api.Tests/Services/HybridSearchServiceFusionParityTests.cs`
+
+**Interfaces:**
+- Consumes: `HybridFusionCore.Fuse`, `FusionCandidate`, `FusionOptions`, `FusedCandidate` (Task 2).
+- Produces: no signature change — `FuseSearchResults` stays private; `SearchAsync` public signature unchanged (8 callers unaffected: `RagService.cs:683`, `GenerateToolkitFromKbHandler.cs:129`, `AskArbiterCommandHandler.cs:91`, `PlaygroundChatCommandHandler.cs:248`, `HybridSearchEngine.cs:80`, `MultiGameHybridSearchService.cs:161`, `ResilientRetrievalService.cs:129`, `SearchQueryHandler.cs:196`).
+
+- [ ] **Step 1: Write the failing parity test** — captures observable output BEFORE the refactor. Build a real `HybridSearchService` (its collaborators mocked), drive `SearchAsync(SearchMode.Hybrid)` with a fixed both-arm dataset, and pin: post-sort order + `HybridScore` + `VectorScore` + `KeywordScore` + `MatchedTerms` + `GameId` + `PdfDocumentId` (string form) + `PageNumber` (null→0). Cases: both-arm, vector-only, keyword-only, duplicate-key, keyword-only-null-page, tie-break-by-Key.
+
+```csharp
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.Services;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Services;
+
+public class HybridSearchServiceFusionParityTests
+{
+    // Arrange a HybridSearchService with mocked IKeywordSearchService + vector store so
+    // SearchAsync(SearchMode.Hybrid) exercises FuseSearchResults over a KNOWN dataset.
+    // (Follow the arrange pattern already used in HybridSearchServiceRoleBoostTests.cs.)
+
+    [Fact]
+    public async Task Hybrid_BothArms_PreservesOrderScoresAndOutputFields()
+    {
+        // ... arrange fixed vector arm [(pdfA,chunk0,cos0.9),(pdfB,chunk1,cos0.8)]
+        //     + keyword arm [(pdfB,chunk1,ts0.3,terms=["x"]),(pdfA,chunk0,ts0.2,terms=["y"])]
+        // var svc = BuildService(vectorArm, keywordArm);
+        // var results = await svc.SearchAsync("q", gameId, SearchMode.Hybrid, 10);
+
+        // Pin the pre-refactor expected values captured from a first green run:
+        // results.Select(r => r.PdfDocumentId).Should().ContainInOrder("pdfA", "pdfB");
+        // results[0].HybridScore.Should().BeApproximately(<captured>, 1e-6f);
+        // results[0].MatchedTerms.Should().BeEquivalentTo(new[] { "y" });
+        // results[0].PageNumber.Should().Be(<captured or 0>);
+        // ... assert VectorScore/KeywordScore/GameId per item.
+    }
+
+    // Repeat for: vector-only, keyword-only, duplicate-key, keyword-only-null-page (→0), tie-break-by-Key.
+}
+```
+
+- [ ] **Step 2: Run the parity test against the CURRENT implementation to capture golden values**
+
+Run: `dotnet test apps/api/tests/Api.Tests --filter "FullyQualifiedName~HybridSearchServiceFusionParityTests"`
+Expected: The test currently drives the OLD `FuseSearchResults`. Fill the `<captured>` values from this run so the test is GREEN against today's behavior. This freezes the contract before refactoring. (If arrange is nontrivial, first `dotnet test ... -v n` to inspect actual values, then hardcode them.)
+
+- [ ] **Step 3: Rewrite `FuseSearchResults` as an adapter** — map arms → `FusionCandidate`, call the core with the per-call weights, re-join by Key. Key = `$"{PdfId}_{ChunkIndex}"` (matches the #3262 identity already used here). Preserve `MatchedTerms` (keyword arm), `GameId` (keyword arm else query `gameId`), `PdfDocumentId` (string, as-is), `ChunkIndex`/`PageNumber` (coalesce null→0), `Mode = SearchMode.Hybrid`. Skeleton (fill from the existing `:394-527` field mapping):
+
+```csharp
+private List<HybridSearchResult> FuseSearchResults(
+    List<SearchResultItem> vectorItems,
+    List<SearchResultItem> keywordItems,
+    Guid gameId,
+    float vectorWeight,
+    float keywordWeight,
+    int rrfK)
+{
+    static string KeyOf(SearchResultItem it) => $"{it.PdfDocumentId}_{it.ChunkIndex}";
+
+    var vectorArm = vectorItems.Select((it, i) => new FusionCandidate(
+        KeyOf(it), it.Text, it.RoleTags, i + 1, it.Score)).ToList();
+    var keywordArm = keywordItems.Select((it, i) => new FusionCandidate(
+        KeyOf(it), it.Text, it.RoleTags, i + 1, it.Score)).ToList();
+
+    var fused = HybridFusionCore.Fuse(vectorArm, keywordArm,
+        new FusionOptions(vectorWeight, keywordWeight, rrfK, GameBookRole.None));
+
+    // Role-boost on THIS path already rides in via the keyword sub-call's re-rank, so the
+    // core is called with QueryRoleHint.None to preserve today's exact behavior (parity).
+    var vByKey = vectorItems.ToLookup(KeyOf);   // total; may have dup keys — take First()
+    var kByKey = keywordItems.ToLookup(KeyOf);
+
+    return fused.Select(f =>
+    {
+        var v = vByKey[f.Key].FirstOrDefault();
+        var k = kByKey[f.Key].FirstOrDefault();
+        var src = k ?? v; // keyword carries MatchedTerms/GameId/page
+        return new HybridSearchResult
+        {
+            ChunkId = (src?.ChunkId) ?? f.Key,
+            Content = f.Content,
+            PdfDocumentId = src?.PdfDocumentId ?? string.Empty,
+            GameId = k?.GameId ?? gameId,
+            ChunkIndex = src?.ChunkIndex ?? 0,
+            PageNumber = src?.PageNumber ?? 0,
+            HybridScore = f.HybridScore,
+            VectorScore = f.VectorScore,
+            KeywordScore = f.KeywordScore,
+            VectorRank = f.VectorRank,
+            KeywordRank = f.KeywordRank,
+            MatchedTerms = k?.MatchedTerms ?? new List<string>(),
+            Mode = SearchMode.Hybrid,
+            RoleTags = f.RoleTags,
+        };
+    }).ToList();
+}
+```
+
+> **Parity note:** the OLD formula applied role-boost inside fusion (`:470`). Because the primary chat path is the behavioral target (Task 5) and the `HybridSearchService` path is meant to be **observably identical**, call the core here with `QueryRoleHint.None`. If the pre-refactor arms were role-boosted upstream (they are, via `SearchKeywordOnlyAsync`), the parity test in Step 2 will confirm identical output; if it does not, thread the real hint into `FusionOptions` here and re-capture the golden values (documenting the one-time delta).
+
+- [ ] **Step 4: Update the sole caller `SearchHybridAsync:305`** — pass the per-call `vectorWeight`, `keywordWeight`, and `_config.RrfConstant ?? FusionSignals.DefaultRrfK` into the new `FuseSearchResults` signature. Verify no other call site exists (`grep -n "FuseSearchResults" HybridSearchService.cs` → only :305 + the definition).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd apps/api/src/Api && dotnet build` then `dotnet test apps/api/tests/Api.Tests --filter "FullyQualifiedName~HybridSearchServiceFusionParityTests|FullyQualifiedName~HybridSearchServiceRoleBoost|FullyQualifiedName~HybridSearchEngine|FullyQualifiedName~MultiGameHybridSearch"`
+Expected: PASS — parity identical; A/B-weight engine tests + multi-game tie-break unaffected.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/Services/HybridSearchService.cs apps/api/tests/Api.Tests/Services/HybridSearchServiceFusionParityTests.cs
+git commit -m "refactor(rag): HybridSearchService.FuseSearchResults delegates to HybridFusionCore (#3270)"
+```
+
+---
+
+### Task 4: `SearchResult` gains `PdfDocumentId` + `ChunkIndex` + `RoleTags`
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/SearchResult.cs:31-55`
+- Test: `apps/api/tests/Api.Tests/.../SearchResultTests.cs` (add a construction+accessor test)
+
+**Interfaces:**
+- Produces: `SearchResult` ctor gains 3 trailing DEFAULTED params `Guid pdfDocumentId = default, int chunkIndex = 0, GameBookRole roleTags = GameBookRole.None` (AFTER `searchMethod`), + read-only props `PdfDocumentId`, `ChunkIndex`, `RoleTags`. All 21 existing construction sites keep compiling (they stop at/before `searchMethod`).
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+[Fact]
+public void SearchResult_CarriesFusionIdentity_WhenProvided()
+{
+    var pdf = Guid.NewGuid();
+    var r = new Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult(
+        id: Guid.NewGuid(),
+        vectorDocumentId: Guid.NewGuid(),
+        textContent: "text",
+        pageNumber: 1,
+        relevanceScore: new Confidence(0.9),
+        rank: 1,
+        searchMethod: "vector",
+        pdfDocumentId: pdf,
+        chunkIndex: 7,
+        roleTags: GameBookRole.Setup);
+
+    r.PdfDocumentId.Should().Be(pdf);
+    r.ChunkIndex.Should().Be(7);
+    r.RoleTags.Should().Be(GameBookRole.Setup);
+}
+
+[Fact]
+public void SearchResult_FusionIdentity_DefaultsAreEmpty()
+{
+    var r = new Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult(
+        Guid.NewGuid(), Guid.NewGuid(), "text", 1, new Confidence(0.5), 1);
+    r.PdfDocumentId.Should().Be(Guid.Empty);
+    r.ChunkIndex.Should().Be(0);
+    r.RoleTags.Should().Be(GameBookRole.None);
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `dotnet test apps/api/tests/Api.Tests --filter "FullyQualifiedName~SearchResultTests"`
+Expected: FAIL — ctor has no `pdfDocumentId`/`chunkIndex`/`roleTags` params; no such properties.
+
+- [ ] **Step 3: Add the 3 properties + defaulted ctor params** — edit `SearchResult.cs`:
+
+```csharp
+// add using at top:
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+
+// add 3 read-only properties beside the existing ones (private setters):
+public Guid PdfDocumentId { get; private set; }
+public int ChunkIndex { get; private set; }
+public GameBookRole RoleTags { get; private set; }
+
+// extend the public ctor signature (append AFTER searchMethod):
+public SearchResult(
+    Guid id,
+    Guid vectorDocumentId,
+    string textContent,
+    int pageNumber,
+    Confidence relevanceScore,
+    int rank,
+    string? searchMethod = null,
+    Guid pdfDocumentId = default,
+    int chunkIndex = 0,
+    GameBookRole roleTags = GameBookRole.None) : base(id)
+{
+    // ... existing validation unchanged ...
+    // at the end of the ctor body, assign:
+    PdfDocumentId = pdfDocumentId;
+    ChunkIndex = chunkIndex;
+    RoleTags = roleTags;
+}
+```
+
+> Do NOT add validation for the new params (ChunkIndex 0 is legal; PdfDocumentId.Empty is legal on non-hybrid paths). Keep the private EF ctor (`:23-26`) untouched.
+
+- [ ] **Step 4: Run tests + full compile to confirm all 21 sites still build**
+
+Run: `cd apps/api/src/Api && dotnet build` then `dotnet test apps/api/tests/Api.Tests --filter "FullyQualifiedName~SearchResultTests"`
+Expected: build 0 warnings (all 4 prod sites `StructuredRagFusionService.cs:127,:149`, `RrfFusionDomainService.cs:76`, `VectorSearchDomainService.cs:54` + 17 test sites compile untouched); new tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/SearchResult.cs apps/api/tests/Api.Tests
+git commit -m "feat(rag): SearchResult carries PdfDocumentId+ChunkIndex+RoleTags for fusion identity (#3270)"
+```
+
+---
+
+### Task 5: `RrfFusionDomainService.FuseResults` → adapter (primary-path behavioral change + #2712)
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/RrfFusionDomainService.cs:22-104`
+- Modify (Moq): `AskQuestionQueryHandlerSecurityTests.cs:105,:552`, `StreamQaQueryHandlerTests.cs:648,:753,:1045`, `AskQuestionQueryHandlerPhase2Tests.cs:81,:605`
+- Test: `apps/api/tests/Api.Tests/.../RrfFusionDomainServiceTests.cs` (extend)
+
+**Interfaces:**
+- Consumes: `HybridFusionCore.Fuse` (Task 2); `SearchResult.PdfDocumentId/ChunkIndex/RoleTags` (Task 4).
+- Produces: `FuseResults(List<SearchResult> vectorResults, List<SearchResult> keywordResults, int rrfK = FusionSignals.DefaultRrfK, GameBookRole queryRoleHint = GameBookRole.None) → List<SearchResult>`. New trailing `queryRoleHint` param (defaulted → existing callers/tests keep compiling). Still returns fused-order `SearchResult`s with `searchMethod = "hybrid"`, fresh Guid ids, and **`RelevanceScore` = cosine (#2712)**.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+[Fact]
+public void FuseResults_BothArms_KeepsCosineInRelevanceScore_NotHybridScore()
+{
+    var pdf = Guid.NewGuid();
+    var vector = new List<SearchResult> {
+        new(Guid.NewGuid(), Guid.NewGuid(), "content", 1, new Confidence(0.91), 1, "vector",
+            pdfDocumentId: pdf, chunkIndex: 0, roleTags: GameBookRole.None) };
+    var keyword = new List<SearchResult> {
+        new(Guid.NewGuid(), Guid.NewGuid(), "content", 1, new Confidence(0.20), 1, "keyword",
+            pdfDocumentId: pdf, chunkIndex: 0, roleTags: GameBookRole.None) };
+
+    var fused = new RrfFusionDomainService().FuseResults(vector, keyword);
+
+    fused.Should().HaveCount(1);
+    // #2712: RelevanceScore is the carried cosine (0.91), NOT an RRF/hybrid value.
+    fused[0].RelevanceScore.Value.Should().BeApproximately(0.91, 1e-6);
+    fused[0].SearchMethod.Should().Be("hybrid");
+}
+
+[Fact]
+public void FuseResults_RoleHint_ReordersByRoleBoost_OrderOnly()
+{
+    var setupPdf = Guid.NewGuid(); var plainPdf = Guid.NewGuid();
+    var vector = new List<SearchResult> {
+        new(Guid.NewGuid(), Guid.NewGuid(), "plain", 1, new Confidence(0.90), 1, "vector",
+            pdfDocumentId: plainPdf, chunkIndex: 0, roleTags: GameBookRole.None),
+        new(Guid.NewGuid(), Guid.NewGuid(), "setup", 1, new Confidence(0.80), 2, "vector",
+            pdfDocumentId: setupPdf, chunkIndex: 0, roleTags: GameBookRole.Setup) };
+    var keyword = new List<SearchResult>();
+
+    var fused = new RrfFusionDomainService().FuseResults(vector, keyword, queryRoleHint: GameBookRole.Setup);
+
+    fused[0].TextContent.Should().Be("setup");            // role-boost lifted it
+    fused[0].RelevanceScore.Value.Should().BeApproximately(0.80, 1e-6); // cosine preserved
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `dotnet test apps/api/tests/Api.Tests --filter "FullyQualifiedName~RrfFusionDomainServiceTests"`
+Expected: FAIL — no `queryRoleHint` param; current unweighted fusion won't apply role-boost.
+
+- [ ] **Step 3: Rewrite `FuseResults` as an adapter + change `GetChunkKey`** — key becomes `{PdfDocumentId}_{ChunkIndex}` (unified identity; both arms now carry it via Task 4/6). Re-join to originals, **RelevanceScore = the vector-preferred original's RelevanceScore (cosine)**:
+
+```csharp
+public virtual List<SearchResult> FuseResults(
+    List<SearchResult> vectorResults,
+    List<SearchResult> keywordResults,
+    int rrfK = FusionSignals.DefaultRrfK,
+    GameBookRole queryRoleHint = GameBookRole.None)
+{
+    if (rrfK <= 0) throw new ArgumentOutOfRangeException(nameof(rrfK));
+
+    var vectorArm = vectorResults.Select((r, i) => new FusionCandidate(
+        GetChunkKey(r), r.TextContent, r.RoleTags, i + 1, (float)r.RelevanceScore.Value)).ToList();
+    var keywordArm = keywordResults.Select((r, i) => new FusionCandidate(
+        GetChunkKey(r), r.TextContent, r.RoleTags, i + 1, (float)r.RelevanceScore.Value)).ToList();
+
+    var fused = HybridFusionCore.Fuse(vectorArm, keywordArm,
+        new FusionOptions(0.7f, 0.3f, rrfK, queryRoleHint));
+
+    var vByKey = vectorResults.ToLookup(GetChunkKey, StringComparer.Ordinal);
+    var kByKey = keywordResults.ToLookup(GetChunkKey, StringComparer.Ordinal);
+
+    return fused.Select(f =>
+    {
+        var original = vByKey[f.Key].FirstOrDefault() ?? kByKey[f.Key].First(); // prefer vector
+        return new SearchResult(
+            id: Guid.NewGuid(),
+            vectorDocumentId: original.VectorDocumentId,
+            textContent: f.Content,
+            pageNumber: original.PageNumber,
+            relevanceScore: original.RelevanceScore, // #2712: carried cosine, order-only fusion
+            rank: f.Rank,
+            searchMethod: "hybrid",
+            pdfDocumentId: original.PdfDocumentId,
+            chunkIndex: original.ChunkIndex,
+            roleTags: f.RoleTags);
+    }).ToList();
+}
+
+private static string GetChunkKey(SearchResult r) => $"{r.PdfDocumentId}_{r.ChunkIndex}";
+```
+
+> Remove the old `NormalizeRrfScore`/inline RRF math from `FuseResults` (the core owns it). Keep `CalculateRrfScore` only if still referenced by tests (`grep -n CalculateRrfScore`); otherwise delete. Add `using Api.BoundedContexts.KnowledgeBase.Domain.Services;` (for `HybridFusionCore`) + `using Api.BoundedContexts.GameManagement.Domain.ValueObjects;`.
+
+- [ ] **Step 4: Update the 7 Moq setups** — each currently uses `It.IsAny<int>()` as the 3rd arg and will NOT match calls that now pass a 4th `GameBookRole`. Where the production call passes the hint (Task 6), broaden the setup:
+
+```csharp
+// before:
+mock.Setup(x => x.FuseResults(It.IsAny<List<SearchResult>>(), It.IsAny<List<SearchResult>>(), It.IsAny<int>()))
+// after:
+mock.Setup(x => x.FuseResults(It.IsAny<List<SearchResult>>(), It.IsAny<List<SearchResult>>(), It.IsAny<int>(), It.IsAny<GameBookRole>()))
+```
+Apply at `AskQuestionQueryHandlerSecurityTests.cs:105,:552`, `StreamQaQueryHandlerTests.cs:648,:753,:1045`, `AskQuestionQueryHandlerPhase2Tests.cs:81,:605`.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd apps/api/src/Api && dotnet build` then `dotnet test apps/api/tests/Api.Tests --filter "FullyQualifiedName~RrfFusionDomainServiceTests|FullyQualifiedName~AskQuestionQueryHandler|FullyQualifiedName~StreamQaQueryHandler"`
+Expected: PASS — new #2712 + role-hint tests green; Moq-based handler tests green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/RrfFusionDomainService.cs apps/api/tests/Api.Tests
+git commit -m "feat(rag): RrfFusionDomainService delegates to HybridFusionCore + role hint, preserves cosine #2712 (#3270)"
+```
+
+---
+
+### Task 6: `SearchQueryHandler` — raw keyword arm (spec §6) + identity + role hint
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchQueryHandler.cs` (ctor `:20-46` — swap `IHybridSearchService`→`IKeywordSearchService`; `PerformVectorSearchAsync:159-167`; `PerformHybridSearchAsync:177-213`)
+- Modify: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/Mappers/KnowledgeBaseMappers.cs` (ADD a `KeywordSearchResult → SearchResult` mapper; leave the existing `HybridSearchResult` overload untouched)
+- Modify (test ctors): the 5 files that construct `new SearchQueryHandler(...)` — `SearchQueryHandlerTests.cs`, `AskQuestionQueryHandlerSecurityTests.cs`, `StreamQaQueryHandlerTests.cs`, `AskQuestionQueryHandlerIntentRoutingTests.cs`, `AskQuestionQueryHandlerPhase2Tests.cs` — swap the `Mock<IHybridSearchService>` arg for `Mock<IKeywordSearchService>`.
+- Test: `apps/api/tests/Api.Tests/.../SearchQueryHandlerTests.cs` (extend for #2051 + signal reach) + a mapper test.
+
+**Interfaces:**
+- Consumes: `SearchResult` fusion fields (Task 4); `FuseResults(..., queryRoleHint)` (Task 5); `IKeywordSearchService.SearchAsync(string query, Guid gameId, int limit=10, bool phraseSearch=false, List<string>? boostTerms=null, string language="en", double minScore=0.0, CancellationToken) → List<KeywordSearchResult>`; `KeywordSearchResult{ChunkId, Content, PdfDocumentId (string), GameId, ChunkIndex, PageNumber (int?), RelevanceScore (float ts_rank_cd), MatchedTerms, RoleTags}`.
+- Produces: new extension `ToDomainSearchResult(this KeywordSearchResult result, int rank) → SearchResult`.
+
+- [ ] **Step 0: Confirm the swap is safe** (verify before editing):
+  - `grep -n "_hybridSearchService" SearchQueryHandler.cs` → the ONLY use is the keyword sub-call at `:196` (confirmed) ⇒ `IHybridSearchService` is fully removable from this handler once the raw arm lands. If any other use appears, keep the field instead of removing it.
+  - `IKeywordSearchService` is `AddScoped` (`ApplicationServiceExtensions.cs:93`); `SearchQueryHandler` is `AddScoped` (`KnowledgeBaseServiceExtensions.cs:463`) ⇒ lifetime-safe, no DI registration change (memory `frontendsdk-di-lifetime-mismatch`).
+
+- [ ] **Step 1: Write the failing tests** (`SearchQueryHandlerTests.cs` + a mapper test)
+
+```csharp
+[Fact]
+public void ToDomainSearchResult_FromKeyword_CarriesIdentityAndRawScore()
+{
+    var pdf = Guid.NewGuid();
+    var kr = new KeywordSearchResult {
+        ChunkId = "c", Content = "text", PdfDocumentId = pdf.ToString(), GameId = Guid.NewGuid(),
+        ChunkIndex = 4, PageNumber = 2, RelevanceScore = 0.22f, RoleTags = GameBookRole.Setup };
+
+    var sr = kr.ToDomainSearchResult(1);
+
+    sr.PdfDocumentId.Should().Be(pdf);
+    sr.ChunkIndex.Should().Be(4);
+    sr.RoleTags.Should().Be(GameBookRole.Setup);
+    sr.RelevanceScore.Value.Should().BeApproximately(0.22, 1e-6); // raw ts_rank_cd
+    sr.SearchMethod.Should().Be("keyword");
+}
+
+[Fact]
+public async Task Hybrid_PrimaryPath_AppliesRoleBoostAndKeepsCosine()
+{
+    // Arrange handler with a REAL RrfFusionDomainService + mocked IEmbeddingRepository (vector arm)
+    // + mocked IKeywordSearchService (keyword arm). Vector arm returns a Setup-tagged chunk with
+    // LOWER cosine than a plain chunk; SearchQuery.QueryRoleHint = Setup.
+    // Assert: fused[0] is the Setup chunk (role-boost lifted it) AND its RelevanceScore == its cosine.
+}
+
+[Fact]
+public async Task Hybrid_PrimaryPath_DocumentIdsFilter_ExcludesOutOfScope()
+{
+    // Issue #2051: mock IKeywordSearchService to return an in-scope + an out-of-scope PdfDocumentId.
+    // Run hybrid with SearchQuery.DocumentIds = [inScopePdf]; assert only the in-scope chunk survives.
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `dotnet test apps/api/tests/Api.Tests --filter "FullyQualifiedName~SearchQueryHandlerTests"`
+Expected: FAIL — no `KeywordSearchResult` mapper; role-boost not reaching the primary path.
+
+- [ ] **Step 3: Add the `KeywordSearchResult → SearchResult` mapper** in `KnowledgeBaseMappers.cs` (sibling to the existing `HybridSearchResult` overload; add `using Api.Services;` if not present):
+
+```csharp
+/// <summary>
+/// Maps a RAW keyword-search result (issue #3270 §6) to a domain SearchResult, carrying the
+/// {PdfDocumentId}_{ChunkIndex} fusion identity + RoleTags. RelevanceScore is the raw ts_rank_cd
+/// (clamped to Confidence's [0,1]); HybridFusionCore applies role-boost/legend downstream.
+/// </summary>
+public static Domain.Entities.SearchResult ToDomainSearchResult(this KeywordSearchResult result, int rank)
+{
+    var pdfDocId = Guid.Parse(result.PdfDocumentId);
+    var score = Math.Clamp((double)result.RelevanceScore, 0.0, 1.0);
+    return new Domain.Entities.SearchResult(
+        id: Guid.NewGuid(),
+        vectorDocumentId: pdfDocId,          // same convention the HybridSearchResult mapper uses
+        textContent: result.Content,
+        pageNumber: result.PageNumber ?? 1,
+        relevanceScore: new Confidence(score),
+        rank: rank,
+        searchMethod: "keyword",
+        pdfDocumentId: pdfDocId,
+        chunkIndex: result.ChunkIndex,
+        roleTags: result.RoleTags);
+}
+```
+
+- [ ] **Step 4: Swap the ctor dependency** — in `SearchQueryHandler.cs`, replace the `IHybridSearchService _hybridSearchService` field/param/assignment (`:26/:35/:43`) with `IKeywordSearchService _keywordSearchService`:
+
+```csharp
+private readonly IKeywordSearchService _keywordSearchService;
+// ...ctor param... IKeywordSearchService keywordSearchService,
+_keywordSearchService = keywordSearchService ?? throw new ArgumentNullException(nameof(keywordSearchService));
+```
+Add `using Api.Services;` (for `IKeywordSearchService`/`KeywordSearchResult`) if not already present.
+
+- [ ] **Step 5: Thread the vector arm identity** — in `PerformVectorSearchAsync:159-167`, populate the 3 new `SearchResult` fields from `scored.Embedding`:
+
+```csharp
+return new Domain.Entities.SearchResult(
+    id: Guid.NewGuid(),
+    vectorDocumentId: scored.Embedding.VectorDocumentId,
+    textContent: scored.Embedding.TextContent,
+    pageNumber: scored.Embedding.PageNumber,
+    relevanceScore: new Confidence(cosine),
+    rank: index + 1,
+    searchMethod: "vector",
+    pdfDocumentId: scored.Embedding.PdfDocumentId,                       // real (JOIN-resolved)
+    chunkIndex: scored.Embedding.ChunkIndex,
+    roleTags: (GameBookRole)scored.Embedding.RoleTags);                  // int → enum
+```
+
+- [ ] **Step 6: Rewrite `PerformHybridSearchAsync`'s keyword arm** as the raw §6 arm:
+
+```csharp
+private async Task<List<Domain.Entities.SearchResult>> PerformHybridSearchAsync(
+    Guid gameId, Vector queryVector, string query, int topK, double minScore,
+    IReadOnlyList<Guid>? documentIds, GameBookRole queryRoleHint, CancellationToken cancellationToken)
+{
+    var vectorResults = await PerformVectorSearchAsync(
+        gameId, queryVector, topK, minScore, documentIds, cancellationToken).ConfigureAwait(false);
+
+    // Issue #423: ts_rank_cd scores ~0-0.3; 0.01 filters ToC noise.
+    const double KeywordMinScore = 0.01;
+
+    // Spec §6: RAW keyword arm sourced directly from IKeywordSearchService (un-boosted, raw ts_rank_cd
+    // order) so HybridFusionCore applies role-boost + legend exactly once.
+    var rawKeyword = await _keywordSearchService.SearchAsync(
+        query,
+        gameId,
+        topK,
+        phraseSearch: query.Contains('"'),            // reproduce HybridSearchService.cs:189 derivation
+        boostTerms: null,                             // was _config.BoostTerms — a no-op on the tsquery
+        minScore: KeywordMinScore,
+        cancellationToken: cancellationToken).ConfigureAwait(false);
+
+    // Issue #2051: reproduce the documentIds post-filter that SearchAsync(Keyword) applied internally.
+    var filteredKeyword = documentIds is null
+        ? (IReadOnlyList<KeywordSearchResult>)rawKeyword
+        : rawKeyword
+            .Where(r => documentIds.Any(id => string.Equals(id.ToString(), r.PdfDocumentId, StringComparison.Ordinal)))
+            .ToList();
+
+    var keywordResults = filteredKeyword
+        .Select((kr, index) => kr.ToDomainSearchResult(index + 1))
+        .ToList();
+
+    return _rrfFusionService.FuseResults(vectorResults, keywordResults, queryRoleHint: queryRoleHint);
+}
+```
+
+- [ ] **Step 7: Update the 5 test files' `new SearchQueryHandler(...)`** — replace the `Mock<IHybridSearchService>` constructor argument with a `Mock<IKeywordSearchService>` (default `SearchAsync` → empty `List<KeywordSearchResult>()`). Files: `SearchQueryHandlerTests.cs`, `AskQuestionQueryHandlerSecurityTests.cs`, `StreamQaQueryHandlerTests.cs`, `AskQuestionQueryHandlerIntentRoutingTests.cs`, `AskQuestionQueryHandlerPhase2Tests.cs`. (Some of these construct SearchQueryHandler indirectly — only edit the `new SearchQueryHandler(...)` sites; leave other handlers' ctors alone.)
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `cd apps/api/src/Api && dotnet build` then `dotnet test apps/api/tests/Api.Tests --filter "FullyQualifiedName~SearchQueryHandler|FullyQualifiedName~KnowledgeBaseMappers"`
+Expected: PASS — mapper carries identity + raw ts_rank_cd; role-boost reaches `/agents/qa`; RelevanceScore = cosine (#2712); #2051 scoping intact; build 0 warnings (no unused `IHybridSearchService`).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchQueryHandler.cs apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/Mappers/KnowledgeBaseMappers.cs apps/api/tests/Api.Tests
+git commit -m "feat(rag): primary chat path — raw keyword arm + fusion identity + role boost via unified core (#3270)"
+```
+
+---
+
+### Task 7: `StreamQaQueryHandler` — role-hint parity for `/agents/qa/stream`
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamQaQueryHandler.cs` (ctor :31-80; `PerformSearchAndBuildCitationsAsync:284-292`)
+- Modify: `apps/api/tests/Api.Tests/.../StreamQaQueryHandlerTests.cs` (add `IIntentClassifierService` mock to every ctor construction)
+- Test: same file (add a role-hint assertion)
+
+**Interfaces:**
+- Consumes: `IIntentClassifierService` (already DI-registered; mirror `AskQuestionQueryHandler` usage `:57/:84/:105/:429-432`).
+
+- [ ] **Step 1: Write the failing test** — assert the stream path sets `QueryRoleHint` from the classifier:
+
+```csharp
+[Fact]
+public async Task StreamQa_SetsQueryRoleHint_FromIntentClassifier()
+{
+    // Arrange StreamQaQueryHandler with a mock IIntentClassifierService returning GameBookRole.Setup.
+    // Capture the SearchQuery passed to the search collaborator; assert QueryRoleHint == Setup.
+    // intentClassifierMock.Setup(x => x.ClassifyIntent(It.IsAny<string>())).Returns(GameBookRole.Setup);
+    // ... assert captured.QueryRoleHint == GameBookRole.Setup;
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `dotnet test apps/api/tests/Api.Tests --filter "FullyQualifiedName~StreamQaQueryHandlerTests"`
+Expected: FAIL — ctor doesn't take `IIntentClassifierService`; `QueryRoleHint` defaults `None`.
+
+- [ ] **Step 3: Inject the classifier + set the hint** — mirror `AskQuestionQueryHandler`:
+  - Add `private readonly IIntentClassifierService _intentClassifier;` field.
+  - Add ctor param + null-guard assignment (`?? throw new ArgumentNullException(...)`).
+  - In `PerformSearchAndBuildCitationsAsync`, classify before building the query and pass BY NAME:
+
+```csharp
+var queryRoleHint = _intentClassifier.ClassifyIntent(queryText); // same call AskQuestionQueryHandler:429-432 uses
+var searchQuery = new SearchQuery(
+    // ... existing positional args (SearchMode "hybrid", Language "en", etc.) ...
+    QueryRoleHint: queryRoleHint);
+```
+
+- [ ] **Step 4: Update every `StreamQaQueryHandlerTests` construction** — add a `Mock<IIntentClassifierService>` (default `ClassifyIntent` → `GameBookRole.None`) to each `new StreamQaQueryHandler(...)`. Confirm no new DI registration is needed (`IIntentClassifierService` is already registered — mirror `AskQuestionQueryHandler`'s registration).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd apps/api/src/Api && dotnet build` then `dotnet test apps/api/tests/Api.Tests --filter "FullyQualifiedName~StreamQaQueryHandlerTests"`
+Expected: PASS — stream path sets the role hint; existing stream tests green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamQaQueryHandler.cs apps/api/tests/Api.Tests
+git commit -m "feat(rag): StreamQa classifies intent + sets QueryRoleHint for role-boost parity (#3270)"
+```
+
+---
+
+## Final verification (before PR)
+
+- [ ] `cd apps/api/src/Api && dotnet build` → 0 warnings.
+- [ ] Kill test hosts, then run the KnowledgeBase + fusion slice: `dotnet test apps/api/tests/Api.Tests --filter "BoundedContext=KnowledgeBase|FullyQualifiedName~Fusion|FullyQualifiedName~HybridSearch|FullyQualifiedName~SearchQueryHandler|FullyQualifiedName~RrfFusion|FullyQualifiedName~StreamQa|FullyQualifiedName~AskQuestion"` → all green.
+- [ ] `dotnet ef migrations has-pending-model-changes` → clean (no schema change).
+- [ ] Dispatch `feature-dev:code-reviewer` on the whole PR diff (memory `holistic-review-catches-cross-cutting-bugs`) — focus: #2712 cosine preservation on every fused path, double-boost absence on the primary path, key-intersection correctness (`{PdfDocumentId}_{ChunkIndex}` on both arms), the 8 `SearchAsync` callers + parity, Moq 4th-param matches, `TreatWarningsAsErrors` clean.
+- [ ] Rebase onto `origin/main-dev` (stash `.vscode/settings.json` first): `git stash push -- .vscode/settings.json 2>/dev/null; git rebase origin/main-dev; git stash pop 2>/dev/null || true`.
+- [ ] PR → `main-dev`, referencing #3270. Do NOT `gh pr merge --auto` (memory `gh-pr-merge-auto-stale-sha`).
+
+## Out of scope (per spec §Goal — do NOT implement here)
+
+- Heading-based boost (types don't carry `Heading` yet — deferred).
+- Corpus re-index materializing headings/role_tags on existing rows (SP3, #3269).
+- EN/IT retrieval non-regression suite (SP3). The TM "setup per N giocatori" (#3243) repro is a qualitative check only until SP3 re-index.
+
+## Self-review
+
+- **Spec coverage:** §1 HybridFusionCore→Task 2; §2 FusionSignals→Task 1; §3 HybridSearchService adapter→Task 3; §4 RrfFusionDomainService adapter + #2712→Task 5; §5 SearchResult fields→Task 4; §6 primary-path RAW keyword arm from `IKeywordSearchService` (reproducing #2051 documentIds filter + phraseSearch + minScore 0.01 + new `KeywordSearchResult→SearchResult` mapper; swap `IHybridSearchService`→`IKeywordSearchService`)→Task 6; §7 StreamQa role hint→Task 7. Risk/validation parity + core + #2712 + #2051 tests all placed. ✅
+- **Placeholder scan:** the only "COPY verbatim from source" markers (Task 1 Step 3) are deliberate — the exact bodies are stable at `HybridSearchService.cs:536-580` and must be moved unchanged, not re-derived; every other step shows complete code. Parity golden values (Task 3 Step 2) are captured empirically before the refactor, by design. ✅
+- **Type consistency:** `FusionCandidate(Key,Content,RoleTags,Rank,SourceScore)` / `FusionOptions(VectorWeight,KeywordWeight,RrfK,QueryRoleHint)` / `FusedCandidate(Key,Content,RoleTags,HybridScore,VectorScore,KeywordScore,VectorRank,KeywordRank,Rank)` / `HybridFusionCore.Fuse` / `FusionSignals.{ComputeRoleMatchBoost,ComputeLegendPenaltyFactor,RoleMatchBoost,DefaultRrfK}` — names identical across Tasks 2/3/5. `FuseResults(...,int rrfK,GameBookRole queryRoleHint)` consistent Tasks 5/6. ✅

--- a/docs/superpowers/specs/2026-07-22-unified-hybrid-fusion-design.md
+++ b/docs/superpowers/specs/2026-07-22-unified-hybrid-fusion-design.md
@@ -2,138 +2,151 @@
 
 **Date**: 2026-07-22 · **Epic**: RAG retrieval heading-aware answer-quality (#3266) · **Relates to**: SP4 (#3270 ranking)
 
+> Revised after adversarial spec review (10 findings applied): the core is a merge-and-score primitive; each adapter re-joins its own arm by key for type-specific output fields; `Domain.Entities.SearchResult` gains `PdfDocumentId`+`ChunkIndex`+`RoleTags`; the primary path preserves the #2712 cosine relevance and the #2051 documentIds/phrase filters.
+
 ## Problem
 
 MeepleAI's RAG retrieval has **two divergent hybrid-fusion implementations**, and the signal-rich one runs in an admin tool while the signal-poor one serves real users.
 
-- **`RrfFusionDomainService.FuseResults`** (`Domain/Services/VectorSearch/RrfFusionDomainService.cs:22-92`) — **UNWEIGHTED** RRF (both arms `1.0/(rrfK+rank)`, k=60), **no legend-demotion, no role-boost, no heading**. Sole caller: `SearchQueryHandler.cs:212`, which is the **user-facing chat path** (`/agents/qa` and `/agents/qa/stream`).
+- **`RrfFusionDomainService.FuseResults`** (`Domain/Services/VectorSearch/RrfFusionDomainService.cs:22-92`) — **UNWEIGHTED** RRF (both arms `1.0/(rrfK+rank)`, k=60), **no legend-demotion, no role-boost, no heading**. Sole caller: `SearchQueryHandler.cs:212`, which is the **user-facing chat path** (`/agents/qa` and `/agents/qa/stream`). It deliberately preserves the source **cosine** as `RelevanceScore` (RRF drives order only) — issue #2712, `RrfFusionDomainService.cs:81-85`.
 - **`HybridSearchService.FuseSearchResults`** (`Services/HybridSearchService.cs:394-527`) — **WEIGHTED** RRF (0.7 vector / 0.3 keyword, per-call params), **legend-demotion** (`ComputeLegendPenaltyFactor`, `:488`) + **role-boost** (`ComputeRoleMatchBoost`, additive 0.15, `:470,:489`). Reached only via `SearchAsync(SearchMode.Hybrid)`, whose primary consumer is the **admin playground** (`PlaygroundChatCommandHandler`) plus 6 other Hybrid-mode callers.
 
 Consequences (verified against source):
-1. **Legend-demotion (#3243, "retrieval epic 2/3") never reaches production chat.** `ComputeLegendPenaltyFactor` has exactly one production call site — `HybridSearchService.cs:488` — unreachable from `/agents/qa[/stream]`. PR #3243 framed it as a general answer-quality fix and its author appears to have assumed `FuseSearchResults` was *the* fusion path; there is no ADR or comment scoping it to the playground. This is an **oversight, not a deliberate design decision**.
-2. **Role-boost is inconsistent on the primary path.** `/agents/qa` gets role-boost only via a side effect: its keyword sub-call (`SearchAsync(SearchMode.Keyword, roleHint)`) applies the boost inside `SearchKeywordOnlyAsync` and re-sorts, so the boost rides in on the keyword rank fed to RRF — **keyword-arm only, not the vector arm**. `/agents/qa/stream` gets **no** role-boost at all because `StreamQaQueryHandler.cs:284-292` never sets `QueryRoleHint` (defaults to `GameBookRole.None`).
-3. The primary path's vector arm **already fetches `role_tags`** (the scored pgvector SQL selects them → `Embedding.RoleTags`, `PgVectorStoreAdapter.cs:141-149`), and the keyword arm fetches them too (`KeywordSearchService.cs:106` → `KeywordSearchResult.RoleTags`), but **both are silently dropped** because `Domain.Entities.SearchResult` has no `RoleTags` field. So the data is present; only the plumbing is missing.
+1. **Legend-demotion (#3243, "retrieval epic 2/3") never reaches production chat.** `ComputeLegendPenaltyFactor` has exactly one production call site — `HybridSearchService.cs:488` — unreachable from `/agents/qa[/stream]`. PR #3243's author appears to have assumed `FuseSearchResults` was *the* fusion path; no ADR/comment scopes it to the playground. **Oversight, not design.**
+2. **Role-boost inconsistent on the primary path.** `/agents/qa` gets role-boost only as a side effect of its keyword sub-call (`SearchAsync(SearchMode.Keyword, roleHint)` applies the boost + re-sorts inside `SearchKeywordOnlyAsync`), so it rides in on the keyword rank — **keyword-arm only, not the vector arm**. `/agents/qa/stream` gets **no** role-boost (`StreamQaQueryHandler.cs:284-292` never sets `QueryRoleHint`).
+3. The primary path's vector arm **already fetches `role_tags`** (scored pgvector SQL → `Embedding.RoleTags`, `PgVectorStoreAdapter.cs:141-149`) and its keyword arm too (`KeywordSearchService.cs:106` → `KeywordSearchResult.RoleTags`), but both are dropped because `Domain.Entities.SearchResult` has no `RoleTags` field.
 
 ## Goal
 
-Replace the two fusion implementations with **one canonical fusion core** that applies weighted RRF + legend-demotion + role-boost consistently, so the user-facing chat path receives the same ranking signals as the admin playground. Standardize on the **weighted 0.7/0.3** behavior (per-call configurable) everywhere.
+Replace the two fusion implementations with **one canonical fusion core** applying weighted RRF + legend-demotion + role-boost consistently, so the user-facing chat path receives the same ranking signals as the admin playground. Standardize on **weighted 0.7/0.3** (per-call configurable) everywhere.
 
-**Non-goal / explicitly out of scope**: heading-based boost (SP4's other remaining item — `SearchResult`/`HybridSearchResult` don't carry `Heading`; deferred), the actual corpus re-index that materializes headings/role_tags on existing rows (SP3, #3269), and the EN/IT retrieval non-regression suite (SP3). This spec unifies the fusion CODE and its signal set; it does not build the corpus-level quality gate.
+**Out of scope**: heading-based boost (SP4's other item — types don't carry `Heading`; deferred), the corpus re-index that materializes headings/role_tags on existing rows (SP3, #3269), and the EN/IT non-regression suite (SP3).
 
 ## Design
 
 ### 1. `HybridFusionCore` — the single canonical fusion
 
-New pure/static Domain component under `Domain/Services/VectorSearch/`. One implementation of the fusion formula, extracted verbatim from `HybridSearchService.FuseSearchResults` (`:447-489`):
+New pure/static Domain component (`Domain/Services/VectorSearch/HybridFusionCore.cs`). It **owns the arm merge + scoring + ordering**; it does NOT know the caller's I/O types. Each adapter maps its arm items into the neutral input and re-joins its own arm items for type-specific output fields (see §3/§4).
 
-```
-vectorRrf  = vectorWeight  / (rrfK + vectorRank)
-keywordRrf = keywordWeight / (rrfK + keywordRank)
-legendFactor = ComputeLegendPenaltyFactor(content)            // [0, 0.5], 0 for <2 cross-ref pointers
-roleBoost    = ComputeRoleMatchBoost(queryRoleHint, roleTags) // additive 0.15 when (hint & tags) != None
-hybridScore  = ((vectorRrf + keywordRrf) * (1 - legendFactor)) + roleBoost   // role stays additive on top
-```
-
-**Input contract** — a neutral per-arm candidate carrying exactly what the formula needs, so both call sites can adapt into it:
-
+**Input** — per arm, a neutral candidate with only what scoring needs:
 ```csharp
 internal readonly record struct FusionCandidate(
-    string Key,               // stable identity: {PdfDocumentId}_{ChunkIndex} (matches the #3262 RRF key fix)
-    string Content,           // for the legend regex
-    GameBookRole RoleTags,    // for the role boost
-    Guid PdfDocumentId,
-    int ChunkIndex,
-    int? PageNumber,
-    int Rank,                 // 1-based rank within this arm
-    float SourceScore);       // arm-native score (cosine for vector, ts_rank_cd for keyword) — carried through, not fused
+    string Key,             // stable identity "{PdfDocumentId}_{ChunkIndex}" (the #3262 RRF key); built by the adapter
+    string Content,         // for the legend regex
+    GameBookRole RoleTags,  // for the role boost
+    int Rank,               // 1-based rank within THIS arm (source order: cosine desc / ts_rank_cd desc)
+    float SourceScore);     // arm-native score (cosine or ts_rank_cd) — carried to output, not fused
 
 internal sealed record FusionOptions(
-    float VectorWeight = 0.7f,
-    float KeywordWeight = 0.3f,
-    int RrfK = 60,
+    float VectorWeight = 0.7f, float KeywordWeight = 0.3f, int RrfK = 60,
     GameBookRole QueryRoleHint = GameBookRole.None);
 ```
 
-**Output** — one fused, ranked list carrying every field the two current outputs need (superset), so each adapter can project its own return type:
+**Method** `static IReadOnlyList<FusedCandidate> Fuse(IReadOnlyList<FusionCandidate> vectorArm, IReadOnlyList<FusionCandidate> keywordArm, FusionOptions options)`. **Merge + score semantics (specified verbatim from the current `FuseSearchResults`, `:404-505`):**
+- **Dedup within an arm**: group by `Key`, keep the **best (lowest) rank** occurrence (matches the current keyword-arm `GroupBy(Key).First()` at `:419-422`; apply the same to the vector arm rather than the current throw-on-duplicate `ToDictionary` so the core is total).
+- **Cross-arm union**: a chunk may appear in one or both arms. `vectorRrf = present ? VectorWeight/(RrfK + vectorRank) : 0`; `keywordRrf` likewise. `rrfSum = vectorRrf + keywordRrf`.
+- **Merged content**: **prefer the vector arm's** content when the chunk is in both (`:478-480`) — this is load-bearing because `legendFactor` is computed from it.
+- **Merged RoleTags**: `vectorRoleTags | keywordRoleTags` (OR-union, `:469`).
+- **Score**: `legendFactor = FusionSignals.ComputeLegendPenaltyFactor(mergedContent)` (`[0,0.5]`, 0 for <2 cross-ref pointers); `roleBoost = FusionSignals.ComputeRoleMatchBoost(options.QueryRoleHint, mergedRoleTags)` (additive 0.15); `hybridScore = (rrfSum * (1 - legendFactor)) + roleBoost` (role stays additive on top — `:486-489`).
+- **Order**: by `hybridScore` **desc**, with a **deterministic secondary tie-break by `Key` (ordinal)** so results are reproducible (the current code returns HashSet-enumeration order then the caller sorts, `:436/SearchHybridAsync:314`; the core makes the sort explicit and deterministic).
 
+**Output** — the scoring result keyed by `Key`; adapters re-join their arm items for everything else:
 ```csharp
 internal readonly record struct FusedCandidate(
-    string Key, string Content, Guid PdfDocumentId, int ChunkIndex, int? PageNumber,
-    GameBookRole RoleTags,
+    string Key, string Content, GameBookRole RoleTags,
     float HybridScore, float? VectorScore, float? KeywordScore, int? VectorRank, int? KeywordRank,
-    int Rank);            // 1-based rank in the fused order
+    int Rank);          // 1-based rank in the fused order
 ```
+`VectorScore`/`KeywordScore` carry the arm-native `SourceScore` (cosine / ts_rank_cd); `VectorRank`/`KeywordRank` the arm ranks (needed by `MultiGameHybridSearchService`'s cross-game tie-break). Pure — no logging, no injected state.
 
-**Method**: `static IReadOnlyList<FusedCandidate> Fuse(IReadOnlyList<FusionCandidate> vectorArm, IReadOnlyList<FusionCandidate> keywordArm, FusionOptions options)`. It keys both arms on `Key`, sums the weighted RRF contributions, applies legend + role per candidate, orders by `HybridScore` desc, and preserves `VectorScore`/`KeywordScore`/`VectorRank`/`KeywordRank` (needed by `MultiGameHybridSearchService`'s cross-game tie-break). Pure — no logging, no injected state.
+### 2. Shared signal helpers → `FusionSignals`
 
-### 2. Shared signal helpers → Domain
+Move `ComputeLegendPenaltyFactor`, `ComputeRoleMatchBoost`, the `CrossReferencePointer` legend regex, and `RoleMatchBoost = 0.15f` / `DefaultRrfK = 60` out of `HybridSearchService.cs` (`:35,:29,:536-544,:548-551,:560-580`) into a `FusionSignals` static (Domain, sibling of `HybridFusionCore`). They are already `internal static`, pure, zero injected state; only cross-BC ref is `GameBookRole` (KB Domain already references it). **Move + repoint every reference, don't delete**:
+- `HybridSearchService.SearchKeywordOnlyAsync` (`:206/:215`) also calls `ComputeRoleMatchBoost` → repoint to `FusionSignals.ComputeRoleMatchBoost`.
+- **`apps/api/tests/Api.Tests/Services/HybridSearchServiceRoleBoostTests.cs`** references `HybridSearchService.ComputeRoleMatchBoost` / `.ComputeLegendPenaltyFactor` / `.RoleMatchBoost` directly in 10+ places (`:36,50,65,80,94,108,109,130,141,154,165,167,184,206`) — repoint all to `FusionSignals.*` (or keep thin `internal static` forwarders on `HybridSearchService`; prefer repointing the tests).
 
-Move `ComputeLegendPenaltyFactor`, `ComputeRoleMatchBoost`, the `CrossReferencePointer` legend regex, and the `RoleMatchBoost = 0.15f` / `DefaultRrfK = 60` constants out of `HybridSearchService.cs` (`:35,:29,:536-544,:548-551,:560-580`) into a `FusionSignals` static (sibling of `HybridFusionCore` in Domain). They are already `internal static` and pure with zero injected state; the only cross-BC reference is `GameBookRole`, which KB Domain already references. **Move, don't delete** — `ComputeRoleMatchBoost` has a second caller inside `HybridSearchService.SearchKeywordOnlyAsync` (`:206/:215`, the `SearchMode.Keyword` role re-sort); repoint that reference (and any other) to `FusionSignals.ComputeRoleMatchBoost` so no behavior changes for the standalone Keyword mode. `FuseSearchResults`'s three `_logger.LogDebug` calls (`:429-431`) are dropped so the core stays pure.
+### 3. `HybridSearchService.FuseSearchResults` → thin adapter (behavior-preserving)
 
-### 3. `HybridSearchService.FuseSearchResults` → thin adapter (pure refactor)
+Rewrite the private `FuseSearchResults` (`:394-527`) to:
+1. Map its `SearchResultItem` vector + keyword arms → `FusionCandidate` (Key `"{PdfId}_{ChunkIndex}"`, Content=`Text`, RoleTags, Rank, SourceScore=`Score`).
+2. Call `HybridFusionCore.Fuse` with the per-call `vectorWeight`/`keywordWeight`/`rrfK` it already receives.
+3. **Re-join by `Key`** to recover the type-specific fields the core doesn't carry, then build each `HybridSearchResult`:
+   - `MatchedTerms` = keyword arm item's `MatchedTerms` (`:473-475,520`) — **must be preserved** (consumed by `HybridSearchEngine.cs:215` + `MultiGameHybridSearchService.cs:203`).
+   - `GameId` = keyword arm's `GameId` else the query `gameId` (`:495-497`).
+   - `PdfDocumentId` = **string** (keep as-is end-to-end; do NOT round-trip through Guid); `ChunkIndex`, `PageNumber` **coalesced to 0** when keyword-only null (`:505`); `Mode = SearchMode.Hybrid`; `VectorScore`/`KeywordScore`/`VectorRank`/`KeywordRank`/`HybridScore` from `FusedCandidate`.
 
-Rewrite the private `FuseSearchResults` (`:394-527`) to: map its `SearchResultItem` vector + keyword arms → `FusionCandidate`, call `HybridFusionCore.Fuse` with the same per-call `vectorWeight`/`keywordWeight`/`rrfK` it already receives, and map `FusedCandidate` → `HybridSearchResult`. **Behavior must be byte-identical to today** — same weights, same formula, same output fields. Guarded by a **parity test** (below). Because `FuseSearchResults` is a private method with a single internal caller (`SearchHybridAsync`, `:305`) and `SearchAsync`'s public signature + `List<HybridSearchResult>` return are unchanged, **all Hybrid-mode callers are unaffected**:
-
-`PlaygroundChatCommandHandler`, `AskArbiterCommandHandler`, `GenerateToolkitFromKbHandler`, `HybridSearchEngine` (passes A/B-variant weights 0.8/0.2, 0.5/0.5, 0.3/0.7 — **so weights MUST stay per-call inputs**), `ResilientRetrievalService`, `MultiGameHybridSearchService` (depends on `HybridScore` ordering + `VectorScore`/`KeywordScore` tie-break), `RagService.ExecuteHybridRetrievalAsync`, and indirectly `CrossGameStreamQaQueryHandler` + `PromptEvaluationService`.
+**Behavior must be observably identical to today** — same weights, same formula, same output fields including `MatchedTerms`/`GameId`/`PageNumber`. Guarded by the parity test (§Risk). `FuseSearchResults` is private with one internal caller (`SearchHybridAsync`, `:305`); `SearchAsync`'s public signature + `List<HybridSearchResult>` return are unchanged → **all Hybrid-mode callers unaffected**: `PlaygroundChatCommandHandler`, `AskArbiterCommandHandler`, `GenerateToolkitFromKbHandler`, `HybridSearchEngine` (A/B weights 0.8/0.2, 0.5/0.5, 0.3/0.7 — **weights MUST stay per-call inputs**), `ResilientRetrievalService`, `MultiGameHybridSearchService` (HybridScore order + VectorScore/KeywordScore tie-break), `RagService.ExecuteHybridRetrievalAsync`, and indirectly `CrossGameStreamQaQueryHandler` + `PromptEvaluationService`.
 
 ### 4. `RrfFusionDomainService.FuseResults` → adapter for the primary path (behavioral change)
 
-Rewrite it to map its `Domain.Entities.SearchResult` vector + keyword arms → `FusionCandidate`, call `HybridFusionCore.Fuse` with `FusionOptions(0.7f, 0.3f, 60, queryRoleHint)`, and map `FusedCandidate` back to `Domain.Entities.SearchResult`. This is where the **primary chat path changes**: unweighted → weighted 0.7/0.3, and it gains legend-demotion + role-boost on both arms. The method signature gains a `GameBookRole queryRoleHint` parameter (default `None` for backward-compatible callers/tests).
+Rewrite it to: map its `Domain.Entities.SearchResult` vector + keyword arms → `FusionCandidate`, call `HybridFusionCore.Fuse` with `FusionOptions(0.7f, 0.3f, 60, queryRoleHint)`, re-join by `Key` to the original `SearchResult`s, and map `FusedCandidate` back to `Domain.Entities.SearchResult` in fused order. The signature gains a `GameBookRole queryRoleHint = GameBookRole.None` param (default keeps existing callers/tests compiling).
 
-### 5. `Domain.Entities.SearchResult` gains `RoleTags`
+**#2712 preservation (mandatory)**: `SearchResult.RelevanceScore` = the carried **cosine**, i.e. `new Confidence(FusedCandidate.VectorScore ?? FusedCandidate.KeywordScore)` — **NOT** `HybridScore`. `HybridScore` drives **order only**. (Feeding the RRF/hybrid score into confidence made it degenerate ~0.53 and hid grounded answers behind the "Non sono certo" card — `RrfFusionDomainService.cs:81-84`.) A primary-path test asserts a both-arm result keeps its cosine, not the RRF score.
 
-Add a `GameBookRole RoleTags` property (default `None`) to `Domain.Entities.SearchResult` (`SearchResult.cs:10-55`) + ctor param. Populate it at the two primary-path arm sites where the data already arrives but is dropped:
-- **Vector arm**: `SearchQueryHandler.PerformVectorSearchAsync` (`:159-167`) — set from `(GameBookRole)scored.Embedding.RoleTags`.
-- **Keyword arm**: the new `KeywordSearchResult` → `SearchResult` mapper (per §6) — set from `KeywordSearchResult.RoleTags`.
+This is where the **primary chat path changes**: unweighted → weighted 0.7/0.3, and it gains legend-demotion + role-boost on both arms (order only; confidence unchanged).
 
-(`Content`/`TextContent` is already present for the legend regex.) Note: the existing `KnowledgeBaseMappers.ToDomainSearchResult` (`HybridSearchResult` → `SearchResult`, `:64-83`) is no longer on the primary keyword path once §6 switches to `IKeywordSearchService` direct; leave it in place for any other consumers but it need not carry `RoleTags`.
+### 5. `Domain.Entities.SearchResult` gains `PdfDocumentId` + `ChunkIndex` + `RoleTags`
 
-### 6. Primary path arm sourcing — avoid double role-boost
+`Domain.Entities.SearchResult` (`SearchResult.cs:10-55`) today carries `VectorDocumentId`, `TextContent`, `PageNumber`, `RelevanceScore`, `Rank`, `SearchMethod` — **no PdfDocumentId, no ChunkIndex, no RoleTags**. The canonical `Key = "{PdfDocumentId}_{ChunkIndex}"` (the #3262 intersecting key) needs the first two; role-boost needs the third. Add all three as properties + **defaulted ctor params** (so the ~8 existing construction sites keep compiling). Populate at the two primary-path arm sources where the data already arrives but is dropped:
+- **Vector arm** — `SearchQueryHandler.PerformVectorSearchAsync` (`:159-167`): set `PdfDocumentId = scored.Embedding.PdfDocumentId`, `ChunkIndex = scored.Embedding.ChunkIndex`, `RoleTags = (GameBookRole)scored.Embedding.RoleTags`.
+- **Keyword arm** — the new `KeywordSearchResult` → `SearchResult` mapper (§6): set `PdfDocumentId = Guid.Parse(kr.PdfDocumentId)`, `ChunkIndex = kr.ChunkIndex`, `RoleTags = kr.RoleTags`.
 
-Today `SearchQueryHandler.PerformHybridSearchAsync` (`:177-213`) sources its keyword arm via `HybridSearchService.SearchAsync(SearchMode.Keyword, roleHint)`, which **already applies role-boost internally** (`SearchKeywordOnlyAsync`, `:215`) and re-sorts. If the canonical core ALSO applies role-boost, the keyword arm is boosted twice. Fix: the primary path must feed the core **raw (unboosted) arm rankings** and let the core apply legend + role exactly once. Concretely:
-- Keyword arm: obtain a **raw** keyword ranking (ts_rank_cd order) that still carries `RoleTags` + content, WITHOUT the in-service role re-sort. **Chosen approach**: call `IKeywordSearchService` directly (it returns `KeywordSearchResult` with `RoleTags` + `Content`, in raw ts_rank_cd order — no role re-sort), instead of routing through `HybridSearchService.SearchAsync(SearchMode.Keyword)` which boosts. The plan verifies `IKeywordSearchService` is injectable into `SearchQueryHandler` and reconciles the `keywordMinScore=0.01` filter (currently applied by the Keyword-mode path at `SearchQueryHandler.cs:196-204`) so it is preserved. Map `KeywordSearchResult` → `Domain.Entities.SearchResult` carrying `RoleTags` (a new mapper, sibling to `ToDomainSearchResult`).
-- Vector arm: already raw (cosine order); §5 threads its `RoleTags`.
-- `SearchQueryHandler.PerformHybridSearchAsync` passes the classified `queryRoleHint` into `RrfFusionDomainService.FuseResults(..., queryRoleHint)`.
+(`Content`/`TextContent` already present for the legend regex.)
+
+### 6. Primary path arm sourcing — raw keyword arm, filter parity, no double-boost
+
+Today `SearchQueryHandler.PerformHybridSearchAsync` (`:177-213`) sources its keyword arm via `HybridSearchService.SearchAsync(SearchMode.Keyword, roleHint)`, which **already role-boosts + re-sorts** (`SearchKeywordOnlyAsync`, `:215`). Feeding that into a core that ALSO applies role-boost double-counts it. Fix: source a **raw** keyword ranking and let the core apply legend + role exactly once.
+
+**Chosen approach**: call `IKeywordSearchService` **directly** (returns `KeywordSearchResult` in raw ts_rank_cd order with `RoleTags` + `Content` + `PdfDocumentId` + `ChunkIndex`), map via the new §5 mapper. **But `SearchAsync(SearchMode.Keyword)` also applies three things `IKeywordSearchService.SearchAsync` does not — all MUST be reproduced in `SearchQueryHandler` to avoid a scope/behavior regression**:
+- **`keywordMinScore = 0.01`** filter (drops ToC noise) — currently passed at `SearchQueryHandler.cs:196-204`.
+- **`documentIds` filter** (Issue #2051, `HybridSearchService.cs:195-197`) — document-scoped retrieval; `IKeywordSearchService.SearchAsync` has **no** `documentIds` parameter, so the filter must be applied in `SearchQueryHandler` (with the correct `VectorDocument.Id → PdfDocumentId` id basis). If `SearchQuery` carries no documentIds today on this path, confirm and preserve current behavior.
+- **`phraseSearch`** = `query.Contains('"')` (`HybridSearchService.cs:189/:263`) — pass through to `IKeywordSearchService` if it supports it, else preserve the current phrase behavior.
+
+Then `PerformHybridSearchAsync` passes the classified `queryRoleHint` into `RrfFusionDomainService.FuseResults(..., queryRoleHint)`. The plan verifies `IKeywordSearchService` is injectable into `SearchQueryHandler` and adds a documentIds-filter primary-path test.
 
 ### 7. `StreamQaQueryHandler` role-hint parity
 
-`StreamQaQueryHandler` (`:278-347`) must classify intent and set `QueryRoleHint` on its `SearchQuery` (mirroring `AskQuestionQueryHandler.cs:429-443`), so the stream path gets role-boost parity with non-stream. Small, isolated handler change with its own test.
+`StreamQaQueryHandler` (`:278-347`) must classify intent and set `QueryRoleHint` on its `SearchQuery` (mirroring `AskQuestionQueryHandler.cs:429-443`), so the stream path gets role-boost parity. Small isolated change with its own test.
 
 ### Data flow (primary path, after)
 
 ```
 query → IntentClassifier → roleHint
-      → [ vector arm: raw pgvector cosine ranking + RoleTags ]
-      → [ keyword arm: raw ts_rank_cd ranking + RoleTags ]
-      → HybridFusionCore.Fuse(vectorWeight 0.7, keywordWeight 0.3, rrfK 60, roleHint)   // weighted RRF + legend + role
+      → [ vector arm: raw pgvector cosine ranking + PdfDocumentId/ChunkIndex/RoleTags ]
+      → [ keyword arm: raw ts_rank_cd ranking (IKeywordSearchService) + PdfDocumentId/ChunkIndex/RoleTags, minScore+documentIds+phrase preserved ]
+      → HybridFusionCore.Fuse(0.7, 0.3, 60, roleHint)      // weighted RRF + legend + role, order only
+      → RelevanceScore = cosine (#2712)                     // confidence unchanged
       → cross-encoder reranker (unchanged)
       → answer
 ```
 
 ## Risk & validation
 
-**This changes production chat ranking** (`/agents/qa` + `/stream`): unweighted → weighted 0.7/0.3, plus legend-demotion and two-arm role-boost. There is **no EN/IT retrieval non-regression suite** yet (that is SP3's deliverable), so real-data ranking quality cannot be fully gated here. Mitigation:
+**This changes production chat ranking** (`/agents/qa` + `/stream`): unweighted → weighted 0.7/0.3 + legend + two-arm role-boost (order only; confidence still cosine). No EN/IT retrieval non-regression suite exists yet (SP3), so real-data quality can't be fully gated here. Mitigation:
 
-1. **Parity test (mandatory)**: prove `HybridSearchService.FuseSearchResults` produces identical output before/after the extraction — the Hybrid path is a pure refactor and must not drift. Table-drive representative inputs; assert order + `HybridScore`/`VectorScore`/`KeywordScore` equality.
-2. **Core unit tests**: weighted RRF math (incl. A/B weights 0.8/0.2, 0.5/0.5, 0.3/0.7), legend-demotion (a ≥2-pointer legend chunk demotes below real content), role-boost (matching-role chunk rises; additive-on-top semantics preserved), stable-key fusion, empty-arm handling.
-3. **Primary-path integration test**: an `AskQuestion`/`SearchQueryHandler`-level test proving legend-demotion + role-boost now reach the primary path (the signals that were previously absent), and a `StreamQa` test proving the role hint is now set.
-4. **TM "setup per N giocatori" regression intent**: document the original #3243 repro as the qualitative check; note it can only be fully validated after SP3 re-index materializes headings/role_tags on the corpus.
-5. **No new SQL / no migration** — role_tags are already fetched; heading is out of scope. `dotnet ef migrations has-pending-model-changes` must stay clean.
+1. **Parity test (mandatory)** — prove `HybridSearchService.FuseSearchResults` is observably identical before/after, asserting **post-sort order + HybridScore + VectorScore + KeywordScore + `MatchedTerms` + `GameId` + `PdfDocumentId` (string form) + `PageNumber` (null→0)**. Cases: both-arm, vector-only, keyword-only, duplicate-key, keyword-only-null-page, tie-break-by-Key.
+2. **Core unit tests** (`HybridFusionCoreTests`) — weighted RRF math (incl. A/B weights 0.8/0.2, 0.5/0.5, 0.3/0.7), content-prefer-vector, RoleTags OR-union, legend-demotion (≥2-pointer chunk demotes below real content), role-boost (matching-role rises; additive-on-top), deterministic tie-break, empty-arm handling.
+3. **Primary-path integration test** — legend-demotion + role-boost now reach `/agents/qa`; `RelevanceScore` equals cosine (#2712, not RRF); a `documentIds`-scoped query still excludes out-of-scope chunks (#2051); `StreamQa` sets the role hint.
+4. **`FusionSignals` helper tests** — the moved `HybridSearchServiceRoleBoostTests` assertions still pass against `FusionSignals.*`.
+5. **TM "setup per N giocatori" (#3243) repro** — qualitative check; fully validatable only after SP3 re-index materializes headings/role_tags on the corpus. Documented, not automated here.
+6. **No new SQL / no migration** — role_tags already fetched, heading out of scope; `dotnet ef migrations has-pending-model-changes` stays clean.
 
 ## File map
 
 **Create**:
-- `Domain/Services/VectorSearch/HybridFusionCore.cs` — the canonical fusion + `FusionCandidate`/`FusionOptions`/`FusedCandidate` + the moved signal helpers/constants.
-- Tests: `HybridFusionCoreTests.cs` (core math + signals), a `FuseSearchResults` parity test, primary-path handler tests, `StreamQaQueryHandler` role-hint test.
+- `Domain/Services/VectorSearch/HybridFusionCore.cs` — `Fuse` + `FusionCandidate`/`FusionOptions`/`FusedCandidate`.
+- `Domain/Services/VectorSearch/FusionSignals.cs` — moved `ComputeLegendPenaltyFactor`/`ComputeRoleMatchBoost`/regex/constants.
+- Tests: `HybridFusionCoreTests.cs`, a `FuseSearchResults` parity test, primary-path signal-reach + #2712 + #2051 handler tests, `StreamQaQueryHandler` role-hint test.
 
 **Modify**:
-- `Services/HybridSearchService.cs` — `FuseSearchResults` → adapter; delete the moved helpers/constants.
-- `Domain/Services/VectorSearch/RrfFusionDomainService.cs` — → adapter + `queryRoleHint` param.
-- `Domain/Entities/SearchResult.cs` — add `RoleTags`.
-- `Application/Queries/SearchQueryHandler.cs` — raw keyword arm via `IKeywordSearchService` (preserve `keywordMinScore`), thread `RoleTags` (vector arm) + `queryRoleHint` into `FuseResults`.
-- `Application/Mappers/KnowledgeBaseMappers.cs` — add a `KeywordSearchResult` → `Domain.Entities.SearchResult` mapper carrying `RoleTags` (sibling to `ToDomainSearchResult`).
+- `Services/HybridSearchService.cs` — `FuseSearchResults` → adapter (re-join by Key for MatchedTerms/GameId/page/PdfId string); repoint `SearchKeywordOnlyAsync`'s `ComputeRoleMatchBoost` to `FusionSignals`; remove the moved members.
+- `Domain/Services/VectorSearch/RrfFusionDomainService.cs` — → adapter + `queryRoleHint` param + **RelevanceScore = cosine (#2712)**.
+- `Domain/Entities/SearchResult.cs` — add `PdfDocumentId` (Guid) + `ChunkIndex` (int) + `RoleTags` (GameBookRole), defaulted ctor params.
+- `Application/Queries/SearchQueryHandler.cs` — raw keyword arm via `IKeywordSearchService` (preserve `keywordMinScore` + `documentIds` #2051 + `phraseSearch`); thread vector-arm PdfId/ChunkIndex/RoleTags + `queryRoleHint` into `FuseResults`.
+- `Application/Mappers/KnowledgeBaseMappers.cs` — add `KeywordSearchResult` → `SearchResult` mapper carrying PdfId/ChunkIndex/RoleTags (sibling to `ToDomainSearchResult`).
 - `Application/Queries/StreamQaQueryHandler.cs` — classify intent + set `QueryRoleHint`.
+- `apps/api/tests/Api.Tests/Services/HybridSearchServiceRoleBoostTests.cs` — repoint helper references to `FusionSignals.*`.
 
 ## Testing
 
-Backend xUnit + Moq + FluentAssertions. Core + parity + helper tests are pure unit (no infra). Primary-path signal-reach tests are handler-level (InMemory or mocked search services). `dotnet build` 0 warnings (`TreatWarningsAsErrors`). No Testcontainers required for the fusion itself (the arms are mocked); the existing hybrid integration tests must stay green.
+Backend xUnit + Moq + FluentAssertions. Core + parity + `FusionSignals` tests are pure unit (no infra). Primary-path signal-reach / #2712 / #2051 tests are handler-level (mocked search services). `dotnet build` 0 warnings (`TreatWarningsAsErrors`). No Testcontainers for the fusion itself (arms mocked); existing hybrid integration tests stay green.

--- a/docs/superpowers/specs/2026-07-22-unified-hybrid-fusion-design.md
+++ b/docs/superpowers/specs/2026-07-22-unified-hybrid-fusion-design.md
@@ -1,0 +1,139 @@
+# Unified Hybrid Fusion — Design Spec
+
+**Date**: 2026-07-22 · **Epic**: RAG retrieval heading-aware answer-quality (#3266) · **Relates to**: SP4 (#3270 ranking)
+
+## Problem
+
+MeepleAI's RAG retrieval has **two divergent hybrid-fusion implementations**, and the signal-rich one runs in an admin tool while the signal-poor one serves real users.
+
+- **`RrfFusionDomainService.FuseResults`** (`Domain/Services/VectorSearch/RrfFusionDomainService.cs:22-92`) — **UNWEIGHTED** RRF (both arms `1.0/(rrfK+rank)`, k=60), **no legend-demotion, no role-boost, no heading**. Sole caller: `SearchQueryHandler.cs:212`, which is the **user-facing chat path** (`/agents/qa` and `/agents/qa/stream`).
+- **`HybridSearchService.FuseSearchResults`** (`Services/HybridSearchService.cs:394-527`) — **WEIGHTED** RRF (0.7 vector / 0.3 keyword, per-call params), **legend-demotion** (`ComputeLegendPenaltyFactor`, `:488`) + **role-boost** (`ComputeRoleMatchBoost`, additive 0.15, `:470,:489`). Reached only via `SearchAsync(SearchMode.Hybrid)`, whose primary consumer is the **admin playground** (`PlaygroundChatCommandHandler`) plus 6 other Hybrid-mode callers.
+
+Consequences (verified against source):
+1. **Legend-demotion (#3243, "retrieval epic 2/3") never reaches production chat.** `ComputeLegendPenaltyFactor` has exactly one production call site — `HybridSearchService.cs:488` — unreachable from `/agents/qa[/stream]`. PR #3243 framed it as a general answer-quality fix and its author appears to have assumed `FuseSearchResults` was *the* fusion path; there is no ADR or comment scoping it to the playground. This is an **oversight, not a deliberate design decision**.
+2. **Role-boost is inconsistent on the primary path.** `/agents/qa` gets role-boost only via a side effect: its keyword sub-call (`SearchAsync(SearchMode.Keyword, roleHint)`) applies the boost inside `SearchKeywordOnlyAsync` and re-sorts, so the boost rides in on the keyword rank fed to RRF — **keyword-arm only, not the vector arm**. `/agents/qa/stream` gets **no** role-boost at all because `StreamQaQueryHandler.cs:284-292` never sets `QueryRoleHint` (defaults to `GameBookRole.None`).
+3. The primary path's vector arm **already fetches `role_tags`** (the scored pgvector SQL selects them → `Embedding.RoleTags`, `PgVectorStoreAdapter.cs:141-149`), and the keyword arm fetches them too (`KeywordSearchService.cs:106` → `KeywordSearchResult.RoleTags`), but **both are silently dropped** because `Domain.Entities.SearchResult` has no `RoleTags` field. So the data is present; only the plumbing is missing.
+
+## Goal
+
+Replace the two fusion implementations with **one canonical fusion core** that applies weighted RRF + legend-demotion + role-boost consistently, so the user-facing chat path receives the same ranking signals as the admin playground. Standardize on the **weighted 0.7/0.3** behavior (per-call configurable) everywhere.
+
+**Non-goal / explicitly out of scope**: heading-based boost (SP4's other remaining item — `SearchResult`/`HybridSearchResult` don't carry `Heading`; deferred), the actual corpus re-index that materializes headings/role_tags on existing rows (SP3, #3269), and the EN/IT retrieval non-regression suite (SP3). This spec unifies the fusion CODE and its signal set; it does not build the corpus-level quality gate.
+
+## Design
+
+### 1. `HybridFusionCore` — the single canonical fusion
+
+New pure/static Domain component under `Domain/Services/VectorSearch/`. One implementation of the fusion formula, extracted verbatim from `HybridSearchService.FuseSearchResults` (`:447-489`):
+
+```
+vectorRrf  = vectorWeight  / (rrfK + vectorRank)
+keywordRrf = keywordWeight / (rrfK + keywordRank)
+legendFactor = ComputeLegendPenaltyFactor(content)            // [0, 0.5], 0 for <2 cross-ref pointers
+roleBoost    = ComputeRoleMatchBoost(queryRoleHint, roleTags) // additive 0.15 when (hint & tags) != None
+hybridScore  = ((vectorRrf + keywordRrf) * (1 - legendFactor)) + roleBoost   // role stays additive on top
+```
+
+**Input contract** — a neutral per-arm candidate carrying exactly what the formula needs, so both call sites can adapt into it:
+
+```csharp
+internal readonly record struct FusionCandidate(
+    string Key,               // stable identity: {PdfDocumentId}_{ChunkIndex} (matches the #3262 RRF key fix)
+    string Content,           // for the legend regex
+    GameBookRole RoleTags,    // for the role boost
+    Guid PdfDocumentId,
+    int ChunkIndex,
+    int? PageNumber,
+    int Rank,                 // 1-based rank within this arm
+    float SourceScore);       // arm-native score (cosine for vector, ts_rank_cd for keyword) — carried through, not fused
+
+internal sealed record FusionOptions(
+    float VectorWeight = 0.7f,
+    float KeywordWeight = 0.3f,
+    int RrfK = 60,
+    GameBookRole QueryRoleHint = GameBookRole.None);
+```
+
+**Output** — one fused, ranked list carrying every field the two current outputs need (superset), so each adapter can project its own return type:
+
+```csharp
+internal readonly record struct FusedCandidate(
+    string Key, string Content, Guid PdfDocumentId, int ChunkIndex, int? PageNumber,
+    GameBookRole RoleTags,
+    float HybridScore, float? VectorScore, float? KeywordScore, int? VectorRank, int? KeywordRank,
+    int Rank);            // 1-based rank in the fused order
+```
+
+**Method**: `static IReadOnlyList<FusedCandidate> Fuse(IReadOnlyList<FusionCandidate> vectorArm, IReadOnlyList<FusionCandidate> keywordArm, FusionOptions options)`. It keys both arms on `Key`, sums the weighted RRF contributions, applies legend + role per candidate, orders by `HybridScore` desc, and preserves `VectorScore`/`KeywordScore`/`VectorRank`/`KeywordRank` (needed by `MultiGameHybridSearchService`'s cross-game tie-break). Pure — no logging, no injected state.
+
+### 2. Shared signal helpers → Domain
+
+Move `ComputeLegendPenaltyFactor`, `ComputeRoleMatchBoost`, the `CrossReferencePointer` legend regex, and the `RoleMatchBoost = 0.15f` / `DefaultRrfK = 60` constants out of `HybridSearchService.cs` (`:35,:29,:536-544,:548-551,:560-580`) into a `FusionSignals` static (sibling of `HybridFusionCore` in Domain). They are already `internal static` and pure with zero injected state; the only cross-BC reference is `GameBookRole`, which KB Domain already references. **Move, don't delete** — `ComputeRoleMatchBoost` has a second caller inside `HybridSearchService.SearchKeywordOnlyAsync` (`:206/:215`, the `SearchMode.Keyword` role re-sort); repoint that reference (and any other) to `FusionSignals.ComputeRoleMatchBoost` so no behavior changes for the standalone Keyword mode. `FuseSearchResults`'s three `_logger.LogDebug` calls (`:429-431`) are dropped so the core stays pure.
+
+### 3. `HybridSearchService.FuseSearchResults` → thin adapter (pure refactor)
+
+Rewrite the private `FuseSearchResults` (`:394-527`) to: map its `SearchResultItem` vector + keyword arms → `FusionCandidate`, call `HybridFusionCore.Fuse` with the same per-call `vectorWeight`/`keywordWeight`/`rrfK` it already receives, and map `FusedCandidate` → `HybridSearchResult`. **Behavior must be byte-identical to today** — same weights, same formula, same output fields. Guarded by a **parity test** (below). Because `FuseSearchResults` is a private method with a single internal caller (`SearchHybridAsync`, `:305`) and `SearchAsync`'s public signature + `List<HybridSearchResult>` return are unchanged, **all Hybrid-mode callers are unaffected**:
+
+`PlaygroundChatCommandHandler`, `AskArbiterCommandHandler`, `GenerateToolkitFromKbHandler`, `HybridSearchEngine` (passes A/B-variant weights 0.8/0.2, 0.5/0.5, 0.3/0.7 — **so weights MUST stay per-call inputs**), `ResilientRetrievalService`, `MultiGameHybridSearchService` (depends on `HybridScore` ordering + `VectorScore`/`KeywordScore` tie-break), `RagService.ExecuteHybridRetrievalAsync`, and indirectly `CrossGameStreamQaQueryHandler` + `PromptEvaluationService`.
+
+### 4. `RrfFusionDomainService.FuseResults` → adapter for the primary path (behavioral change)
+
+Rewrite it to map its `Domain.Entities.SearchResult` vector + keyword arms → `FusionCandidate`, call `HybridFusionCore.Fuse` with `FusionOptions(0.7f, 0.3f, 60, queryRoleHint)`, and map `FusedCandidate` back to `Domain.Entities.SearchResult`. This is where the **primary chat path changes**: unweighted → weighted 0.7/0.3, and it gains legend-demotion + role-boost on both arms. The method signature gains a `GameBookRole queryRoleHint` parameter (default `None` for backward-compatible callers/tests).
+
+### 5. `Domain.Entities.SearchResult` gains `RoleTags`
+
+Add a `GameBookRole RoleTags` property (default `None`) to `Domain.Entities.SearchResult` (`SearchResult.cs:10-55`) + ctor param. Populate it at the two primary-path arm sites where the data already arrives but is dropped:
+- **Vector arm**: `SearchQueryHandler.PerformVectorSearchAsync` (`:159-167`) — set from `(GameBookRole)scored.Embedding.RoleTags`.
+- **Keyword arm**: the new `KeywordSearchResult` → `SearchResult` mapper (per §6) — set from `KeywordSearchResult.RoleTags`.
+
+(`Content`/`TextContent` is already present for the legend regex.) Note: the existing `KnowledgeBaseMappers.ToDomainSearchResult` (`HybridSearchResult` → `SearchResult`, `:64-83`) is no longer on the primary keyword path once §6 switches to `IKeywordSearchService` direct; leave it in place for any other consumers but it need not carry `RoleTags`.
+
+### 6. Primary path arm sourcing — avoid double role-boost
+
+Today `SearchQueryHandler.PerformHybridSearchAsync` (`:177-213`) sources its keyword arm via `HybridSearchService.SearchAsync(SearchMode.Keyword, roleHint)`, which **already applies role-boost internally** (`SearchKeywordOnlyAsync`, `:215`) and re-sorts. If the canonical core ALSO applies role-boost, the keyword arm is boosted twice. Fix: the primary path must feed the core **raw (unboosted) arm rankings** and let the core apply legend + role exactly once. Concretely:
+- Keyword arm: obtain a **raw** keyword ranking (ts_rank_cd order) that still carries `RoleTags` + content, WITHOUT the in-service role re-sort. **Chosen approach**: call `IKeywordSearchService` directly (it returns `KeywordSearchResult` with `RoleTags` + `Content`, in raw ts_rank_cd order — no role re-sort), instead of routing through `HybridSearchService.SearchAsync(SearchMode.Keyword)` which boosts. The plan verifies `IKeywordSearchService` is injectable into `SearchQueryHandler` and reconciles the `keywordMinScore=0.01` filter (currently applied by the Keyword-mode path at `SearchQueryHandler.cs:196-204`) so it is preserved. Map `KeywordSearchResult` → `Domain.Entities.SearchResult` carrying `RoleTags` (a new mapper, sibling to `ToDomainSearchResult`).
+- Vector arm: already raw (cosine order); §5 threads its `RoleTags`.
+- `SearchQueryHandler.PerformHybridSearchAsync` passes the classified `queryRoleHint` into `RrfFusionDomainService.FuseResults(..., queryRoleHint)`.
+
+### 7. `StreamQaQueryHandler` role-hint parity
+
+`StreamQaQueryHandler` (`:278-347`) must classify intent and set `QueryRoleHint` on its `SearchQuery` (mirroring `AskQuestionQueryHandler.cs:429-443`), so the stream path gets role-boost parity with non-stream. Small, isolated handler change with its own test.
+
+### Data flow (primary path, after)
+
+```
+query → IntentClassifier → roleHint
+      → [ vector arm: raw pgvector cosine ranking + RoleTags ]
+      → [ keyword arm: raw ts_rank_cd ranking + RoleTags ]
+      → HybridFusionCore.Fuse(vectorWeight 0.7, keywordWeight 0.3, rrfK 60, roleHint)   // weighted RRF + legend + role
+      → cross-encoder reranker (unchanged)
+      → answer
+```
+
+## Risk & validation
+
+**This changes production chat ranking** (`/agents/qa` + `/stream`): unweighted → weighted 0.7/0.3, plus legend-demotion and two-arm role-boost. There is **no EN/IT retrieval non-regression suite** yet (that is SP3's deliverable), so real-data ranking quality cannot be fully gated here. Mitigation:
+
+1. **Parity test (mandatory)**: prove `HybridSearchService.FuseSearchResults` produces identical output before/after the extraction — the Hybrid path is a pure refactor and must not drift. Table-drive representative inputs; assert order + `HybridScore`/`VectorScore`/`KeywordScore` equality.
+2. **Core unit tests**: weighted RRF math (incl. A/B weights 0.8/0.2, 0.5/0.5, 0.3/0.7), legend-demotion (a ≥2-pointer legend chunk demotes below real content), role-boost (matching-role chunk rises; additive-on-top semantics preserved), stable-key fusion, empty-arm handling.
+3. **Primary-path integration test**: an `AskQuestion`/`SearchQueryHandler`-level test proving legend-demotion + role-boost now reach the primary path (the signals that were previously absent), and a `StreamQa` test proving the role hint is now set.
+4. **TM "setup per N giocatori" regression intent**: document the original #3243 repro as the qualitative check; note it can only be fully validated after SP3 re-index materializes headings/role_tags on the corpus.
+5. **No new SQL / no migration** — role_tags are already fetched; heading is out of scope. `dotnet ef migrations has-pending-model-changes` must stay clean.
+
+## File map
+
+**Create**:
+- `Domain/Services/VectorSearch/HybridFusionCore.cs` — the canonical fusion + `FusionCandidate`/`FusionOptions`/`FusedCandidate` + the moved signal helpers/constants.
+- Tests: `HybridFusionCoreTests.cs` (core math + signals), a `FuseSearchResults` parity test, primary-path handler tests, `StreamQaQueryHandler` role-hint test.
+
+**Modify**:
+- `Services/HybridSearchService.cs` — `FuseSearchResults` → adapter; delete the moved helpers/constants.
+- `Domain/Services/VectorSearch/RrfFusionDomainService.cs` — → adapter + `queryRoleHint` param.
+- `Domain/Entities/SearchResult.cs` — add `RoleTags`.
+- `Application/Queries/SearchQueryHandler.cs` — raw keyword arm via `IKeywordSearchService` (preserve `keywordMinScore`), thread `RoleTags` (vector arm) + `queryRoleHint` into `FuseResults`.
+- `Application/Mappers/KnowledgeBaseMappers.cs` — add a `KeywordSearchResult` → `Domain.Entities.SearchResult` mapper carrying `RoleTags` (sibling to `ToDomainSearchResult`).
+- `Application/Queries/StreamQaQueryHandler.cs` — classify intent + set `QueryRoleHint`.
+
+## Testing
+
+Backend xUnit + Moq + FluentAssertions. Core + parity + helper tests are pure unit (no infra). Primary-path signal-reach tests are handler-level (InMemory or mocked search services). `dotnet build` 0 warnings (`TreatWarningsAsErrors`). No Testcontainers required for the fusion itself (the arms are mocked); the existing hybrid integration tests must stay green.


### PR DESCRIPTION
## Summary

Unifies MeepleAI's **two divergent hybrid-fusion implementations** into one canonical `HybridFusionCore`, so the user-facing chat path (`/agents/qa` + `/agents/qa/stream`) now receives the same **weighted-RRF + legend-demotion + role-boost** ranking that previously only reached the admin playground.

Before this change, the signal-rich fusion (`HybridSearchService.FuseSearchResults`: weighted 0.7/0.3, legend-demotion #3243, role-boost #1391) served the admin playground, while the user chat path ran an **unweighted** RRF (`RrfFusionDomainService`) with **no** legend-demotion and inconsistent role-boost. This aligns them on the canonical scoring.

Part of **#3270** (SP4 — RAG heading-aware: ranking end-to-end). Design: `docs/superpowers/specs/2026-07-22-unified-hybrid-fusion-design.md`. Plan: `docs/superpowers/plans/2026-07-26-issue-3270-unified-hybrid-fusion.md`.

## What changed (7 TDD tasks)

1. **`FusionSignals`** — extracted the legend/role helpers + constants (`ComputeLegendPenaltyFactor`, `ComputeRoleMatchBoost`, `RoleMatchBoost=0.15`, `DefaultRrfK=60`, cross-ref regex) out of `HybridSearchService` into a shared pure static.
2. **`HybridFusionCore`** — new canonical fusion primitive: weighted RRF + legend-demotion (scales RRF) + role-boost (additive), deterministic tie-break by key, arm-total dedup. Pure, I/O-type-agnostic.
3. **`HybridSearchService.FuseSearchResults` → thin adapter** over the core — behavior-identical (guarded by a 6-case characterization/parity test).
4. **`SearchResult` +3 identity fields** (`PdfDocumentId`, `ChunkIndex`, `RoleTags`) as trailing defaulted ctor params (all ~21 construction sites compile untouched).
5. **`RrfFusionDomainService` → thin adapter** + `queryRoleHint` param; key unified to `{PdfDocumentId}_{ChunkIndex}`; **preserves #2712** (`RelevanceScore` = source cosine, never the RRF score).
6. **`SearchQueryHandler`** — sources a **raw keyword arm** directly from `IKeywordSearchService` (spec §6), reproducing the #2051 `documentIds` filter + `phraseSearch` + `minScore=0.01`; threads `{PdfDocumentId}_{ChunkIndex}`+`RoleTags` through both arms; forwards the role hint to fusion.
7. **`StreamQaQueryHandler`** — classifies intent + sets `QueryRoleHint` so `/agents/qa/stream` reaches role-boost parity with `/agents/qa`.

## Invariants verified end-to-end (final whole-branch review, traced against source)

- **#2712 cosine preservation** holds on every fused path — `RelevanceScore` is the carried cosine, never the hybrid/RRF score (confidence unchanged).
- **Unified key intersection** — both arms produce the same `{PdfDocumentId}_{ChunkIndex}` for the same physical chunk (vector arm resolves `PdfDocumentId` via `PgVectorStoreAdapter`'s `vector_documents` JOIN; keyword arm normalizes with `Guid.Parse`).
- **No double role-boost** — applied exactly once per path (raw arms + a single boost in the core).
- **Single canonical scoring** — the old inline RRF math / `NormalizeRrfScore` / per-chunk legend loops are deleted; `FusionSignals` is the sole home of the helpers.
- **Backward compatible** — new ctor/method params are trailing-defaulted; `HybridSearchService.SearchAsync`'s public signature (8 callers, incl. `HybridSearchEngine`'s A/B weights 0.8/0.2, 0.5/0.5, 0.3/0.7) is unchanged; the admin path is behavior-identical.

## Behavior change (intended)

The user chat path's fusion moves from **unweighted** RRF to **weighted 0.7/0.3** + legend-demotion + two-arm role-boost — **order only**; confidence stays the cosine (#2712). This is the goal of #3270.

## Verification

- `dotnet build` (API): **0 warnings / 0 errors** (`TreatWarningsAsErrors`).
- Combined unit suite across all touched classes: **217 passed / 1 skipped (pre-existing) / 0 failed**.
- `dotnet ef migrations has-pending-model-changes`: **clean** (no EF schema change — `SearchResult` is a domain entity).
- Full integration suite → CI.

## Notes

- `boostTerms: null` on the primary keyword call (vs the old `_config.BoostTerms`) is a **documented no-op** — the tsquery uses no `setweight`, so boost weighting matched nothing.
- **Out of scope** (per design, deferred): heading-based boost (blocked on SP3 re-index #3269), the corpus re-index that materializes headings/role_tags, and the EN/IT non-regression suite (SP3). #3270 therefore is **not fully closed** by this PR (heading-boost remains).
- **Follow-up (non-blocking Minors from final review):** delete the now production-dead `RrfFusionDomainService.CalculateRrfScore` (+ its tests); add one handler-level both-arms-intersecting fusion test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
