### PR TITLE
test(rag): SP3 extend rag-smoke with IT queries (EN+IT gate) (#3269)

### DIFF
--- a/docs/for-developers/operations/rag-smoke-runbook.md
+++ b/docs/for-developers/operations/rag-smoke-runbook.md
@@ -4,9 +4,19 @@ Tier 3 D8 quality gate of [#2126](https://github.com/meepleAi-app/meepleai-monor
 
 ## What it does
 
-`infra/scripts/rag-smoke-assert.sh` runs the 5 canonical queries in `infra/fixtures/rag-canonical-queries.json` against `POST /api/v1/knowledge-base/ask/global` (SSE) and asserts the **top-3 retrieved chunks** per query match `infra/fixtures/rag-golden-baseline.json`.
+`infra/scripts/rag-smoke-assert.sh` runs the canonical queries in `infra/fixtures/rag-canonical-queries.json` against `POST /api/v1/knowledge-base/ask/global` (SSE) and asserts the **top-3 retrieved chunks** per query match `infra/fixtures/rag-golden-baseline.json`.
+
+The suite covers **EN + IT** (10 queries: 5 EN + 5 IT, added for [#3269](https://github.com/meepleAi-app/meepleai-monorepo/issues/3269)). The corpus is English rulebooks; `multilingual-e5-base` does **cross-lingual retrieval**, so each `-it` query pins the IT→EN retrieval behavior. This is the concrete implementation of the epic [#3266](https://github.com/meepleAi-app/meepleai-monorepo/issues/3266) LOCKED safety-net: *"EN+IT non-regression suite on staging before prod"*. Motivating case: `catan-setup-it` ("Setup per N giocatori" style IT query) must still retrieve the right EN chunks.
 
 It reads the **Citations SSE event (`type: 1`)**, which the vector search emits *before* the LLM streams tokens — so the assertion is independent of OpenRouter/LLM availability. Each chunk is keyed by `{source, page}`; `score` is advisory (not asserted, to tolerate minor embedding/search float drift).
+
+### Per-query `language`
+
+The fixture top-level `language` (`"en"`) is the **default**. Each query MAY set a per-query `"language"` override — the IT queries carry `"language": "it"`, the 5 EN queries omit it and inherit the default. The harness resolves `(.language) // <top-level default>` per query and sends it as the request-body `language`, so retrieval ranking is deterministic per query.
+
+### SKIP for un-baselined queries
+
+A query with **no golden-baseline entry** reports `SKIP` (via a `::notice::`), not `FAIL`, and does **not** fail the gate. This lets new queries (e.g. the IT set) land *before* the ops `--update-baseline` capture without redding the weekly cron. Real drift and no-citations still `FAIL`. The summary reports `N passed, N failed, N skipped (pending baseline)`; exit is non-zero only on a real `FAIL`.
 
 ## Capturing / updating the golden baseline
 
@@ -29,6 +39,26 @@ The baseline must be captured against a **fresh, compatible snapshot** (`snapsho
 
 **Regenerate the baseline after any intentional re-index**: embedding model change, chunker change, or a `seed-schema.version` bump (which forces a snapshot rebuild). An *unintentional* drift is exactly what this gate is meant to flag — investigate before regenerating.
 
+### Capturing the EN + IT baseline via CI dispatch (preferred)
+
+The IT queries ship with **no baseline entries** — they `SKIP` until captured. To capture the full EN + IT baseline against the current published snapshot without a local boot:
+
+1. Dispatch `.github/workflows/rag-smoke-dispatch.yml` with `update_baseline=true` (runs against the published snapshot the workflow fetches).
+2. Download the `rag-golden-baseline-<run_id>` artifact from that run.
+3. Commit the artifact's `infra/fixtures/rag-golden-baseline.json` (now containing all 10 EN + IT entries).
+
+After the commit, the weekly assert run covers EN + IT with zero `SKIP`s.
+
+### 🔴 SP3 #3269 critical note — capture the EN + IT baseline BEFORE the big-bang re-index
+
+The SP3 big-bang re-index (**Slice 3**) changes retrieval ranking, so a baseline captured *after* it would silently absorb any pre-existing IT regression. Sequence:
+
+1. **Pre-SP3**: capture the EN + IT baseline on the *current* published snapshot (via the CI dispatch above) and commit it. This freezes the known-good IT→EN behavior.
+2. Run the Slice 3 big-bang re-index + publish the new snapshot.
+3. **Post-SP3**: re-capture the EN + IT baseline on the new snapshot and commit it — then diff against the pre-SP3 baseline to review the intentional ranking change.
+
+Skipping step 1 forfeits the non-regression signal the epic #3266 safety-net exists to provide.
+
 ## Asserting (CI / local)
 
 ```bash
@@ -50,12 +80,17 @@ The golden baseline was first committed for snapshot `meepleai_seed_20260628T211
 
 ## Canonical queries
 
-| queryId | game | targets |
-|---|---|---|
-| `catan-setup` | Catan | board setup, initial settlements/roads |
-| `wingspan-round-goals` | Wingspan | end-of-round goal scoring |
-| `dominion-buy-phase` | Dominion | buy phase, coins |
-| `ark-nova-conservation` | Ark Nova | conservation projects, reputation |
-| `seven-wonders-military` | 7 Wonders | military conflict per age |
+| queryId | game | language | targets |
+|---|---|---|---|
+| `catan-setup` | Catan | en (default) | board setup, initial settlements/roads |
+| `wingspan-round-goals` | Wingspan | en (default) | end-of-round goal scoring |
+| `dominion-buy-phase` | Dominion | en (default) | buy phase, coins |
+| `ark-nova-conservation` | Ark Nova | en (default) | conservation projects, reputation |
+| `seven-wonders-military` | 7 Wonders | en (default) | military conflict per age |
+| `catan-setup-it` | Catan | it | board setup, initial settlements/roads (IT→EN cross-lingual) |
+| `wingspan-round-goals-it` | Wingspan | it | end-of-round goal scoring (IT→EN cross-lingual) |
+| `dominion-buy-phase-it` | Dominion | it | buy phase, coins (IT→EN cross-lingual) |
+| `ark-nova-conservation-it` | Ark Nova | it | conservation projects, reputation (IT→EN cross-lingual) |
+| `seven-wonders-military-it` | 7 Wonders | it | military conflict per age (IT→EN cross-lingual) |
 
-All pinned to `language: en` for deterministic ranking. All 5 games are indexed in the `dev.yml` seed manifest.
+The 5 EN queries omit `language` and inherit the top-level default (`en`); the 5 IT queries (#3269) set `"language": "it"`. All 5 games are indexed in the `dev.yml` seed manifest. The IT queries report `SKIP` until their baseline is captured (see *Capturing the EN + IT baseline via CI dispatch* above).

--- a/infra/fixtures/rag-canonical-queries.json
+++ b/infra/fixtures/rag-canonical-queries.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "_comment": "Canonical RAG smoke queries (#2480). Each query targets a well-known game indexed in the dev.yml seed snapshot. The harness (infra/scripts/rag-smoke-assert.sh) POSTs each to /api/v1/knowledge-base/ask/global and asserts the top-3 retrieved chunks (Citations SSE event, type=1) match infra/fixtures/rag-golden-baseline.json. Language is pinned to 'en' so retrieval ranking is deterministic across runs.",
+  "_comment": "Canonical RAG smoke queries (#2480, IT coverage #3269). Each query targets a well-known game indexed in the dev.yml seed snapshot. The harness (infra/scripts/rag-smoke-assert.sh) POSTs each to /api/v1/knowledge-base/ask/global and asserts the top-3 retrieved chunks (Citations SSE event, type=1) match infra/fixtures/rag-golden-baseline.json. The suite now covers EN + IT: the top-level 'language' is the default, but each query MAY set a per-query 'language' override. The corpus is English rulebooks; multilingual-e5-base does cross-lingual retrieval, so the '-it' queries pin the IT->EN retrieval behavior (epic #3266 LOCKED safety-net: EN+IT non-regression on staging before prod). Newly-added queries report SKIP until their IT baseline is captured via `bash scripts/rag-smoke-assert.sh --update-baseline` on staging (see docs/for-developers/operations/rag-smoke-runbook.md).",
   "endpoint": "/api/v1/knowledge-base/ask/global",
   "topK": 3,
   "language": "en",
@@ -29,6 +29,36 @@
       "queryId": "seven-wonders-military",
       "game": "7 Wonders",
       "query": "How is military conflict resolved at the end of each age in 7 Wonders?"
+    },
+    {
+      "queryId": "catan-setup-it",
+      "game": "Catan",
+      "language": "it",
+      "query": "Come si prepara il tabellone e si piazzano i due insediamenti e le strade iniziali in Catan?"
+    },
+    {
+      "queryId": "wingspan-round-goals-it",
+      "game": "Wingspan",
+      "language": "it",
+      "query": "Come funziona il punteggio degli obiettivi di fine round in Wingspan?"
+    },
+    {
+      "queryId": "dominion-buy-phase-it",
+      "game": "Dominion",
+      "language": "it",
+      "query": "Durante la fase di acquisto quante carte posso comprare e come funzionano le monete in Dominion?"
+    },
+    {
+      "queryId": "ark-nova-conservation-it",
+      "game": "Ark Nova",
+      "language": "it",
+      "query": "Come funzionano i progetti di conservazione e i punti reputazione in Ark Nova?"
+    },
+    {
+      "queryId": "seven-wonders-military-it",
+      "game": "7 Wonders",
+      "language": "it",
+      "query": "Come si risolve il conflitto militare alla fine di ogni età in 7 Wonders?"
     }
   ]
 }

--- a/infra/scripts/rag-smoke-assert.sh
+++ b/infra/scripts/rag-smoke-assert.sh
@@ -59,22 +59,26 @@ else
 fi
 
 # Extract the top-K {source,page} from the first Citations SSE event (type=1).
+# $2 = per-query language override; falls back to the global $LANG default.
 fetch_top_chunks() {
   local query="$1"
+  local lang="${2:-$LANG}"
   curl -sN -b "$COOKIE" -X POST "$BASE_URL$ENDPOINT" \
     -H 'Content-Type: application/json' \
-    -d "$(jq -n --arg q "$query" --arg l "$LANG" --argjson k "$TOPK" '{query:$q, language:$l, topK:$k}')" 2>/dev/null \
+    -d "$(jq -n --arg q "$query" --arg l "$lang" --argjson k "$TOPK" '{query:$q, language:$l, topK:$k}')" 2>/dev/null \
     | grep '^data: ' | sed 's/^data: //' \
     | jq -c 'select(.type==1) | .data.citations' 2>/dev/null | head -1 \
     | jq -c "if . == null then [] else (sort_by(-.score, .source, .page) | .[0:$TOPK] | map({source, page})) end" 2>/dev/null
 }
 
-PASS=0; FAIL=0
+PASS=0; FAIL=0; SKIPPED=0
 TMP_BASELINE=$(mktemp); echo '{}' > "$TMP_BASELINE"
 
 while IFS= read -r qid; do
   query=$(jq -r --arg id "$qid" '.queries[] | select(.queryId==$id) | .query' "$QUERIES")
-  top=$(fetch_top_chunks "$query")
+  # Per-query language: use the query's own `language`, else the top-level default ($LANG).
+  qlang=$(jq -r --arg id "$qid" --arg def "$LANG" '.queries[] | select(.queryId==$id) | (.language // $def)' "$QUERIES")
+  top=$(fetch_top_chunks "$query" "$qlang")
 
   if [ -z "$top" ] || [ "$top" = "[]" ]; then
     echo "FAIL  $qid — no citations (type=1 empty/absent: cold index, auth failure, or non-SSE error body). Check login + that the snapshot is loaded."
@@ -84,14 +88,17 @@ while IFS= read -r qid; do
   if [ "$UPDATE_BASELINE" = true ]; then
     jq --arg id "$qid" --argjson v "$top" '.[$id]=$v' "$TMP_BASELINE" > "$TMP_BASELINE.2" \
       && mv "$TMP_BASELINE.2" "$TMP_BASELINE"
-    log "captured $qid → $top"
+    log "captured $qid ($qlang) → $top"
     continue
   fi
 
   expected=$(jq -c --arg id "$qid" '.baseline[$id] // empty' "$BASELINE")
   if [ -z "$expected" ]; then
-    echo "FAIL  $qid — no golden baseline entry (run with --update-baseline first)"
-    FAIL=$((FAIL+1)); continue
+    # A newly-added query without a baseline is a SKIP, not a FAIL: adding queries
+    # (e.g. the IT set, #3269) before the ops --update-baseline capture must NOT red
+    # the weekly gate. Real drift / no-citations still FAIL below.
+    echo "::notice:: SKIP $qid — no baseline yet (pending --update-baseline capture)"
+    SKIPPED=$((SKIPPED+1)); continue
   fi
 
   # Ordered comparison: both sides come from the same sort_by(-.score, .source, .page)
@@ -121,5 +128,6 @@ if [ "$UPDATE_BASELINE" = true ]; then
   exit 0
 fi
 
-log "result: $PASS passed, $FAIL failed"
+log "result: $PASS passed, $FAIL failed, $SKIPPED skipped (pending baseline)"
+# Exit non-zero ONLY on a real FAIL (drift / no-citations). SKIP (missing baseline) never fails the gate.
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Contesto (SP3 Slice 2 — D3-lite)

L'epic #3266 ha come safety-net LOCKED una **suite non-regressione retrieval EN+IT** su staging prima del big-bang re-index. Questa slice estende l'harness rag-smoke esistente (#2480) per coprire l'italiano. (Piano: `docs/superpowers/plans/2026-07-26-issue-3269-sp3-bulk-reindex.md`; DA-3 risolto = rag-smoke estesa come gate, suite etichettata full → Slice 4.)

## Modifiche
- **`infra/fixtures/rag-canonical-queries.json`**: campo `language` **per-query** opzionale (il top-level `language:"en"` resta il default; le 5 query EN sono **intatte**) + **5 query IT** che mirrorano gli stessi 5 giochi (`*-it`, `language:"it"`). Il corpus è in inglese; `multilingual-e5-base` fa retrieval cross-lingua, quindi una query IT pinna il retrieval IT→EN che #3269 non deve regredire (caso motivante: "Setup per N giocatori").
- **`infra/scripts/rag-smoke-assert.sh`**: risolve la lingua per-query (fallback al default globale) e la invia nel body. Una query **senza entry di baseline** ora fa **SKIP** (`::notice::`) invece di FAIL — così aggiungere le query IT **prima** della cattura ops `--update-baseline` non arrossa il gate settimanale; drift reale / no-citations continuano a FAIL. Il safety "no partial baseline" del capture-path è invariato.
- **`docs/for-developers/operations/rag-smoke-runbook.md`**: documenta il `language` per-query, il flusso di cattura baseline EN+IT (dispatch `update_baseline=true` → commit dell'artifact), e la nota SP3 (catturare il baseline **prima** del big-bang, ri-catturare dopo).

## Verifica (sintattica — l'harness gira solo su staging)
- `jq` → JSON valido, **10 query** (5 EN default + 5 IT `language:"it"`); EN identiche a `main-dev`.
- `bash -n` → script OK. Logica per-query-language + SKIP-pending rivista.

## Follow-up (ops, staging) — richiesto per attivare il gate IT
Dispatch `rag-smoke-dispatch.yml` con `update_baseline=true` sullo snapshot corrente → scarica l'artifact `rag-golden-baseline-<run_id>` → commit `infra/fixtures/rag-golden-baseline.json`. Fino ad allora le 5 query IT riportano **SKIP** (non FAIL). La suite EN+IT con ground-truth etichettato (recall/nDCG) resta **Slice 4**.

Parte di #3269. Prossima: Slice 3 (D4 orchestrazione big-bang per-env + runbook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
