### PR TITLE
feat(infra): SP3 D4 corpus re-index orchestration + runbook (#3269)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -288,6 +288,10 @@ infra/backups/*.txt
 infra/scripts/game-reset/.env.*
 !infra/scripts/game-reset/.env.example
 
+# Per-environment config for corpus re-index scripts (#3269; never commit actual values)
+infra/scripts/reindex-corpus/.env.*
+!infra/scripts/reindex-corpus/.env.example
+
 # Claude Design source bundle (derived folder linked to claude.ai/design, regenerated on demand via cp script)
 # Note: claude-design-handoff/ is intentionally NOT gitignored — exported prototypes are committed
 # so they're shareable across terminals and reviewable via PR (see folder README)

--- a/docs/for-claude/architecture/adr/adr-086-corpus-reindex-orchestration.md
+++ b/docs/for-claude/architecture/adr/adr-086-corpus-reindex-orchestration.md
@@ -1,0 +1,127 @@
+# ADR-086 — Corpus-Wide Big-Bang Re-Index Orchestrated Out-of-Band via Admin-Endpoint Loop
+
+**Status**: Accepted
+**Date**: 2026-07-26
+**Deciders**: @badsworm
+**Tracking**: Issue [#3269](https://github.com/meepleAi-app/meepleai-monorepo/issues/3269) (SP3, epic [#3266](https://github.com/meepleAi-app/meepleai-monorepo/issues/3266))
+**Extends**: [ADR-057](./adr-057-kb-reindex-async-channel.md) (KB reindex async via in-process channel)
+**Supersedes**: —
+
+## Context
+
+The heading-aware RAG pipeline (SP1 [#3264](https://github.com/meepleAi-app/meepleai-monorepo/issues/3264),
+SP2 [#3275](https://github.com/meepleAi-app/meepleai-monorepo/issues/3275)/[#3282](https://github.com/meepleAi-app/meepleai-monorepo/issues/3282))
+is merged to `main-dev` but **latent**: it only acts on fresh ingests. The already-indexed
+corpus has `PdfDocumentEntity.StructuredElementsJson = NULL` and flat `text_chunks`
+(`Level=1`, `Heading=NULL`, `role_tags=0`) on both the `text_chunks` and `pgvector_embeddings`
+sinks. SP3 is the **gate** that activates the epic on real data via a one-shot, corpus-wide
+re-index.
+
+SP3 Slice 1 (merged) added `POST /api/v1/admin/queue/reindex-ready` — a
+`BulkReindexReadyCommand` handler that selects Ready PDFs whose `IndexerVersion` differs from
+the target (heading-aware `v1.1`) and fans them out to `ReindexDocumentCommand` on the existing
+async Quartz processing rail. Per ADR-057, that rail is an in-process `Channel<T>` +
+`BackgroundService`; the reindex-ready selector paces itself against the queue capacity
+(`MaxQueueSize`), so **a single call enqueues at most one queue's worth** and returns
+`{ EnqueuedCount, SkippedCount, Errors[] }`. A large corpus therefore needs **repeated calls**
+to fully drain.
+
+The open question for Slice 3 (D4): **how do we drive those repeated calls per environment
+(staging → prod) for a one-time big-bang migration?**
+
+## Decision
+
+The corpus-wide big-bang re-index is orchestrated **out-of-band** by an operator-run shell loop
+over the existing admin endpoint — `infra/scripts/reindex-corpus/reindex-corpus.sh`, exposed as
+`make reindex-corpus ENV=<env>` — **not** by adding a new Quartz job and **not** by making the
+endpoint synchronous.
+
+The script:
+
+1. Loads a per-env `.env.<ENV>` (`API_BASE_URL`, `ADMIN_EMAIL`, `ADMIN_PASSWORD`, optional
+   `TARGET_VERSION`/`PACING_SECONDS`/`MAX_ITERATIONS`), copied from a committed `.env.example`;
+   filled files are gitignored.
+2. Refuses to run against `prod` without `--i-mean-it` (mirrors the `game-reset` prod guard).
+3. Logs in as admin (cookie auth) and, on `--dry-run`, prints the plan without enqueuing
+   (enqueuing is a real side effect; the endpoint has no read-only mode).
+4. On a real run, **loops**: `POST reindex-ready` → parse `EnqueuedCount` with `jq` → if `> 0`,
+   `sleep PACING_SECONDS` (lets the Quartz rail drain the queue) and repeat → if `0`, the corpus
+   is drained and it exits 0. A `MAX_ITERATIONS` safety cap fails loudly on a stuck queue.
+
+Idempotency / resumability comes for free from the Slice 1 selector
+(`IndexerVersion == null || IndexerVersion != target`): already-`v1.1` docs are skipped, so a
+crash mid-run is safe to re-run.
+
+## Alternatives considered
+
+### A. New Quartz job (`CorpusReindexJob`) that self-drains
+**Rejected.** A big-bang re-index is a **one-shot, per-env, operator-gated** migration, not a
+recurring background concern. A permanent scheduled job would need pause/resume, env-targeting,
+and a prod safety gate baked into application code — carrying operational surface forever for a
+handful of invocations. It also inverts control: an operator running a migration wants to watch
+it, pace it, and stop it, not dispatch-and-hope. The existing per-PDF Quartz rail (ADR-057)
+already does the actual work; a second job orchestrating the first is redundant.
+
+### B. Make `reindex-ready` synchronous / self-looping server-side
+**Rejected.** Would re-introduce exactly the "synchronous-pretending-async" long-request
+problem ADR-057 removed — a corpus-wide loop inside one HTTP request blocks for the entire
+migration and times out. Server-side looping also removes the operator's ability to pace/observe
+and couples the endpoint to a one-time concern.
+
+### C. `BackfillPdfCoversJob`-style bounded background job
+**Considered, rejected for this case.** `BackfillPdfCoversJob` is the right pattern for a gentle,
+bounded, *ongoing* backfill of a derived field. SP3 is a *migration event* with a clear start,
+a promotion gate (rag-smoke green on staging before prod), and a manual prod approval — an
+out-of-band script models that lifecycle better than an always-registered job. We reuse its
+**pacing ethos** (bounded batch, sleep between batches) in the loop, not its job scaffolding.
+
+### D. **Out-of-band admin-endpoint loop (chosen)**
+Zero new application code or dependencies — reuses the Slice 1 endpoint and the ADR-057 rail.
+Mirrors the established `infra/scripts/game-reset/` operator-script pattern (ENV-parametrized,
+`.env.<ENV>` config, `--i-mean-it` prod guard, `make` target + `-help` target). Pacing,
+observability (per-iteration log line), and stop-control live where the operator is.
+
+## Consequences
+
+### Positive
+
+- **No new application code, jobs, dependencies, or admin surface** — the endpoint and rail
+  already exist; the script is infra/ops only.
+- **Idempotent & resumable** via the IndexerVersion selector — re-running after a crash finishes
+  the job without double-processing.
+- **Operator-paced & observable** — one log line per iteration (`enqueued/skipped/errors`), a
+  dry-run that verifies auth and prints the plan, and a hard prod guard.
+- **Respects the async rail** (ADR-057): pacing between iterations lets the queue drain, so the
+  loop never saturates `MaxQueueSize` and the enqueue-swallow-on-full failure mode is avoided.
+- **Consistent with `game-reset`** — one mental model for per-env operator migrations.
+
+### Negative
+
+- **Manual invocation** — a human runs it per env. Acceptable: this is a rare, gated migration,
+  not an automated pipeline step.
+- **Enqueue ≠ done** — the script returns when PDFs are *enqueued*; completion is asynchronous.
+  The runbook adds a queue-drain wait + post-reindex SQL assert before promotion.
+- **Silent no-op if `unstructured` is stale** — a pre-SP1 container emits 0 elements → flat
+  chunks stamped `v1.1`. Not a property of the orchestration; mitigated by the runbook's
+  step-1 precondition check.
+- **Admin credentials in a local `.env.<ENV>`** — gitignored, same posture as `game-reset`.
+
+### Neutral
+
+- `IndexerVersion` remains a **provenance label**, not a dispatch key (per SP3 non-goals). The
+  script passes the target version **explicitly** every call to avoid stored-label drift
+  (`ReindexDocumentCommand` resolves `explicit ?? stored ?? Current`).
+- If corpus-wide re-indexes become frequent (e.g. every chunker change), revisit promoting this
+  to a first-class gated job — the endpoint and selector stay; only the driver changes.
+
+## References
+
+- Issue #3269 (SP3, D4 = this slice) · Epic #3266
+- ADR-057 (async reindex rail this orchestration drives)
+- Slice 1 endpoint: `Api.Routing.AdminQueueEndpoints.HandleBulkReindexReady` → `BulkReindexReadyCommand`
+- Per-PDF fan-out: `ReindexDocumentCommand` (delete chunks → reset Pending → enqueue on Quartz rail)
+- Pacing-ethos reference: `BackfillPdfCoversJob` (DocumentProcessing BC)
+- Operator-script pattern reference: `infra/scripts/game-reset/`
+- Script: `infra/scripts/reindex-corpus/reindex-corpus.sh`
+- Runbook: `docs/for-developers/operations/2026-07-26-corpus-reindex-runbook.md`
+- Plan: `docs/superpowers/plans/2026-07-26-issue-3269-sp3-bulk-reindex.md`

--- a/docs/for-developers/operations/2026-07-26-corpus-reindex-runbook.md
+++ b/docs/for-developers/operations/2026-07-26-corpus-reindex-runbook.md
@@ -1,0 +1,198 @@
+# Corpus Big-Bang Re-Index Runbook (SP3 #3269 / D4)
+
+Operational runbook for the **SP3 heading-aware big-bang re-index** — the gate that
+activates the heading-aware RAG pipeline (SP1 #3264, SP2 #3275/#3282) **on the existing
+corpus**. Sub-project 3/4 of epic [#3266](https://github.com/meepleAi-app/meepleai-monorepo/issues/3266).
+
+- **Slice 1** (merged): `POST /api/v1/admin/queue/reindex-ready` — enqueues Ready PDFs whose
+  `IndexerVersion != target`, capped by the processing queue.
+- **Slice 2** (merged): EN+IT golden baseline via `rag-smoke-dispatch.yml`.
+- **Slice 3 (this runbook)**: `make reindex-corpus ENV=…` — loops the Slice 1 endpoint until
+  the corpus is drained + ADR [adr-086](../../for-claude/architecture/adr/adr-086-corpus-reindex-orchestration.md).
+
+## Why a big-bang is needed
+
+The heading-aware pipeline is **latent**: it only runs on fresh ingests. The already-indexed
+corpus has `PdfDocumentEntity.StructuredElementsJson = NULL`, flat `text_chunks`
+(`Level=1`, `Heading=NULL`, `role_tags=0`) on **both** sinks (`text_chunks` +
+`pgvector_embeddings`). Re-indexing every Ready PDF to `v1.1` re-runs extract → chunk →
+embed → index, repopulating structured elements + role tags on both sinks.
+
+## How the orchestration works
+
+`reindex-ready` enqueues at most `MaxQueueSize - <currently queued>` PDFs per call, so one
+call cannot drain a large corpus. `reindex-corpus.sh` logs in as admin (cookie auth), then
+loops: `POST reindex-ready` → parse `EnqueuedCount` → if `> 0`, `sleep PACING_SECONDS` (lets
+the Quartz rail process the batch) and repeat → if `0`, the corpus is drained and it exits 0.
+A `MAX_ITERATIONS` cap fails loudly if the queue is stuck.
+
+**Idempotent / resumable**: the selector skips already-`v1.1` docs, so a crash mid-run leaves
+some PDFs re-indexed and some not — **safe to re-run**; already-migrated PDFs are not touched.
+
+---
+
+## Per-env procedure (run staging first, then prod)
+
+### 0. Per-env config (one-time)
+
+```bash
+cd infra
+cp scripts/reindex-corpus/.env.example scripts/reindex-corpus/.env.staging
+# edit .env.staging: ENV_NAME, API_BASE_URL, ADMIN_EMAIL, ADMIN_PASSWORD
+# (never commit the filled file — it is gitignored)
+```
+
+### 1. 🔴 Precondition — the `unstructured` container must be SP1-rebuilt
+
+A **stale** `unstructured` container returns 0 elements → the re-index silently produces flat
+chunks (`role_tags=0`, `Heading=NULL`) — a no-op that wastes the whole run. Verify the running
+container carries the SP1 code **before** re-indexing:
+
+```bash
+# On the target host (staging/prod):
+pwsh -c "docker inspect meepleai-unstructured --format '{{.Image}} {{.Created}}'"
+# The image must post-date the SP1 merge (#3264). If it predates it, rebuild:
+cd infra && docker compose build unstructured && docker compose up -d unstructured
+```
+
+Confirm it actually emits elements (should be a non-empty `elements[]`):
+
+```bash
+pwsh -c "docker logs meepleai-unstructured --tail=50"   # look for element extraction, not '0 elements'
+```
+
+### 2. 🔴 Capture the PRE-SP3 golden EN+IT baseline (Slice 2) — BEFORE the big-bang
+
+The big-bang **changes retrieval ranking**, so a baseline captured *after* it would silently
+absorb any pre-existing IT regression. Freeze the known-good EN+IT behavior first:
+
+1. Dispatch `.github/workflows/rag-smoke-dispatch.yml` with `update_baseline=true` (runs against
+   the current published snapshot).
+2. Download the `rag-golden-baseline-<run_id>` artifact and commit
+   `infra/fixtures/rag-golden-baseline.json`.
+
+See [rag-smoke-runbook.md § SP3 critical note](./rag-smoke-runbook.md) for the full sequence.
+**Skipping this step forfeits the epic #3266 non-regression signal.**
+
+### 3. Dry-run, then the real run (staging)
+
+```bash
+cd infra
+make reindex-corpus ENV=staging EXTRA=--dry-run   # verifies admin auth + prints the plan, NO enqueue
+make reindex-corpus ENV=staging                   # real run: loops reindex-ready until drained
+```
+
+Expected real-run log (one line per iteration):
+
+```
+[INFO]  iteration 1: enqueued=100 skipped=0 errors=0
+[INFO]  Pacing 5s to let the Quartz rail drain the queue before re-enqueuing the rest...
+[INFO]  iteration 2: enqueued=100 skipped=100 errors=0
+...
+[OK]    Corpus drained: EnqueuedCount==0 after N iteration(s). Total enqueued this run: <T>.
+```
+
+> `skipped` rising while `enqueued` falls is normal: already-`v1.1` docs (and PDFs still in the
+> queue) are skipped until the rail catches up. If `EnqueuedCount` never reaches 0 and the script
+> exits with `MAX_ITERATIONS exceeded`, the queue is stuck — re-check step 1 and that the Quartz
+> rail is running / not paused before raising `MAX_ITERATIONS`.
+
+The script returns when PDFs are **enqueued**, not when they finish. Wait for the queue to drain
+(async) before asserting:
+
+```bash
+# poll queue status until Queued + Processing == 0
+curl -s -b <cookie> https://staging.meepleai.app/api/v1/admin/queue/status | jq '{queued,processing}'
+```
+
+### 4. Post-reindex assert on a sample IT rulebook
+
+Pick one IT rulebook's `pdf_document_id` and confirm the structured fields landed on **both**
+sinks. Parent chunks are `Level=0`, children `Level=2`, children carry a `ParentChunkId`, and
+`role_tags != 0` on **both** `text_chunks` **and** `pgvector_embeddings`:
+
+```sql
+-- Parent + child chunk shape (text_chunks)
+SELECT level, (heading IS NOT NULL) AS has_heading,
+       (parent_chunk_id IS NOT NULL) AS has_parent,
+       (role_tags <> 0) AS has_role_tags,
+       COUNT(*)
+FROM text_chunks
+WHERE pdf_document_id = '<SAMPLE_IT_PDF_ID>'
+GROUP BY 1,2,3,4
+ORDER BY level;
+-- Expect: rows only at level 0 (parents, has_parent=false) and level 2 (children,
+-- has_parent=true); has_heading=true and has_role_tags=true on both.
+
+-- role_tags must ALSO be non-zero on the vector sink (the two sinks must agree)
+SELECT (role_tags <> 0) AS has_role_tags, COUNT(*)
+FROM pgvector_embeddings
+WHERE pdf_document_id = '<SAMPLE_IT_PDF_ID>'
+GROUP BY 1;
+-- Expect: has_role_tags=true for all rows.
+
+-- Version stamp landed
+SELECT indexer_version, structured_elements_json IS NOT NULL AS has_elements
+FROM pdf_documents WHERE id = '<SAMPLE_IT_PDF_ID>';
+-- Expect: indexer_version='v1.1', has_elements=true.
+```
+
+> If `role_tags=0` / `heading IS NULL` after a "successful" run, the `unstructured` container was
+> stale (step 1). Rebuild it and re-run `make reindex-corpus` — the selector will pick the
+> flat-but-`v1.1`-stamped docs back up only if you re-stamp them; if they were stamped `v1.1`
+> while flat, re-index them explicitly via `reindex-failed` / per-PDF reindex after fixing the
+> container. Prevention (step 1) is far cheaper than remediation.
+
+### 5. Re-capture the POST-SP3 golden baseline
+
+After the queue drains and the assert passes, re-capture the EN+IT baseline on the new corpus
+and commit it (same `rag-smoke-dispatch.yml update_baseline=true` flow as step 2), then diff it
+against the pre-SP3 baseline to review the **intentional** ranking change.
+
+### 6. Gate → promote to prod
+
+- **Gate**: `rag-smoke` green on staging (weekly cron or manual `make rag-smoke`).
+- **Promote the code**: `main-dev → main-staging → main` (standard release train).
+- **Prod re-index** (dry-run first, `IMEANIT` required):
+
+```bash
+cd infra
+cp scripts/reindex-corpus/.env.example scripts/reindex-corpus/.env.prod   # fill prod values
+make reindex-corpus ENV=prod EXTRA=--dry-run IMEANIT=--i-mean-it          # preview
+make reindex-corpus ENV=prod IMEANIT=--i-mean-it                          # execute
+```
+
+Then repeat steps 4–5 against prod (post-reindex assert + baseline re-capture).
+
+---
+
+## Rollback thinking
+
+The re-index **deletes and recreates** each PDF's chunks (per `ReindexDocumentCommand`:
+delete `TextChunks` → reset to Pending → re-run the pipeline). Consequences for a mid-run
+crash / abort:
+
+- **Partial state is expected and safe.** Some PDFs are re-indexed (`v1.1`, structured), others
+  are still flat (`v0`/`v1.0`/`NULL`). The selector (`IndexerVersion == null || != target`)
+  **skips already-`v1.1` docs**, so simply **re-run `make reindex-corpus ENV=…`** to finish —
+  it resumes, it does not double-process.
+- **No manual DB rollback is normally needed.** The forward path (finish the re-index) is the
+  rollback: a corpus with mixed `v0`/`v1.1` chunks still serves retrieval; the only downside is
+  degraded ranking on the not-yet-migrated PDFs until the re-run completes.
+- **If you must revert to the pre-SP3 corpus**: restore from the pre-SP3 DB snapshot / published
+  seed snapshot (the RAG data lives in `text_chunks` + `pgvector_embeddings`) and re-deploy the
+  pre-SP3 code. This is a heavier operation than re-running forward and is only warranted if the
+  new pipeline is producing bad chunks corpus-wide (e.g. the `unstructured` container was stale
+  the whole run — which step 1 exists to prevent).
+- **The `reindex-ready` endpoint never aborts a batch on a per-PDF failure** — failures are
+  counted in `Errors[]`/`skipped` and the loop continues. A nonzero `errors` count in the log is
+  a signal to inspect the affected job IDs in the API logs, not a reason to roll back.
+
+## References
+
+- Endpoint: `AdminQueueEndpoints.cs` `HandleBulkReindexReady` → `BulkReindexReadyCommand`
+- Script: `infra/scripts/reindex-corpus/reindex-corpus.sh`
+- ADR: [adr-086 — Corpus Re-Index Orchestration](../../for-claude/architecture/adr/adr-086-corpus-reindex-orchestration.md) (extends [adr-057](../../for-claude/architecture/adr/adr-057-kb-reindex-async-channel.md))
+- RAG smoke: [rag-smoke-runbook.md](./rag-smoke-runbook.md)
+- Plan: `docs/superpowers/plans/2026-07-26-issue-3269-sp3-bulk-reindex.md`
+- Epic [#3266](https://github.com/meepleAi-app/meepleai-monorepo/issues/3266) · Issue [#3269](https://github.com/meepleAi-app/meepleai-monorepo/issues/3269)

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -425,6 +425,27 @@ game-reset-verify: ## Run verification gates after EF migration applied (ENV=dev
 game-reset-rollback-rehearse: ## Run disposable docker rollback rehearsal
 	../tests/scripts/game-reset/rehearse-rollback.sh
 
+# === Corpus re-index orchestration (issue #3269 SP3 Slice 3 / D4) ===
+# Script lives in infra/scripts/reindex-corpus/. Wraps POST /admin/queue/reindex-ready
+# in a drain loop until the whole Ready corpus is re-indexed to heading-aware v1.1.
+
+reindex-corpus-help: ## Show corpus re-index (SP3 #3269) workflow help
+	@echo "Corpus big-bang re-index (SP3 #3269 D4) — usage:"
+	@echo "  make reindex-corpus ENV=staging EXTRA=--dry-run   # 1. preview (verifies auth, prints plan, NO enqueue)"
+	@echo "  make reindex-corpus ENV=staging                   # 2. real run: loop reindex-ready until corpus drained"
+	@echo ""
+	@echo "For prod, pass IMEANIT=--i-mean-it (production safety guard) — always dry-run first:"
+	@echo "  make reindex-corpus ENV=prod EXTRA=--dry-run IMEANIT=--i-mean-it"
+	@echo "  make reindex-corpus ENV=prod IMEANIT=--i-mean-it"
+	@echo ""
+	@echo "Per env, create infra/scripts/reindex-corpus/.env.<ENV> from .env.example (NEVER commit filled files)."
+	@echo "Full runbook: docs/for-developers/operations/2026-07-26-corpus-reindex-runbook.md"
+
+reindex-corpus: ## Big-bang re-index Ready PDFs to heading-aware v1.1 (ENV=staging|prod|dev; EXTRA=--dry-run for preview; prod needs IMEANIT=--i-mean-it)
+	@test -n "$(ENV)" || (echo "ENV required: make reindex-corpus ENV=staging" && exit 64)
+	@test -f scripts/reindex-corpus/.env.$(ENV) || (echo "Missing scripts/reindex-corpus/.env.$(ENV) — copy from .env.example" && exit 66)
+	./scripts/reindex-corpus/reindex-corpus.sh scripts/reindex-corpus/.env.$(ENV) $(EXTRA) $(IMEANIT)
+
 .PHONY: dev dev-core dev-down \
         tunnel tunnel-stop tunnel-status integration-check integration \
         integration-down work work-stop smoke smoke-staging smoke-pg-readback staging staging-minimal staging-with-tutor staging-tutor-down staging-core staging-down prod prod-down \
@@ -436,4 +457,5 @@ game-reset-rollback-rehearse: ## Run disposable docker rollback rehearsal
         sec-scan sec-pentest security-audit test-e2e test-visual test-perf validate-workflows \
         backup backup-verify backup-restore-test backup-status backup-cron-install backup-cron-show \
         db-snapshot db-snapshot-sanitized db-reset-migrations db-restore-snapshot db-rollback-safetynet \
-        game-reset-help game-reset-backup game-reset-mapping game-reset-relink game-reset-verify game-reset-rollback-rehearse
+        game-reset-help game-reset-backup game-reset-mapping game-reset-relink game-reset-verify game-reset-rollback-rehearse \
+        reindex-corpus reindex-corpus-help

--- a/infra/scripts/reindex-corpus/.env.example
+++ b/infra/scripts/reindex-corpus/.env.example
@@ -1,0 +1,33 @@
+# infra/scripts/reindex-corpus/.env.example
+# SP3 (#3269) Slice 3 / D4 — per-env big-bang corpus re-index config.
+#
+# Copy this to .env.<env-name> (e.g. .env.staging, .env.prod, .env.dev) and fill in
+# the values. NEVER commit the filled .env.* files — they hold admin credentials.
+# The whole directory's .env.* (except this .example) is gitignored.
+
+# Friendly name for the environment. If set to "prod", the script refuses to run
+# without --i-mean-it (make reindex-corpus ENV=prod IMEANIT=--i-mean-it).
+ENV_NAME="staging"
+
+# Base URL of the target API (no trailing slash). The script calls
+#   POST $API_BASE_URL/api/v1/auth/login
+#   POST $API_BASE_URL/api/v1/admin/queue/reindex-ready
+API_BASE_URL="https://staging.meepleai.app"
+
+# Admin credentials used to obtain the session cookie. Must be an Admin-role user
+# (the reindex-ready endpoint is admin-gated via RequireAdminSessionFilter).
+ADMIN_EMAIL="admin@example.com"
+ADMIN_PASSWORD="change-me"
+
+# OPTIONAL — target indexer version to re-index toward. Leave empty/unset to let the
+# server resolve its Current version (heading-aware v1.1). Set explicitly only to pin
+# a specific version during a controlled migration.
+TARGET_VERSION=""
+
+# OPTIONAL — seconds to sleep between reindex-ready iterations, giving the Quartz rail
+# time to drain the processing queue before the next batch is enqueued. Default: 5.
+PACING_SECONDS="5"
+
+# OPTIONAL — safety cap on the number of drain-loop iterations. If exceeded without
+# EnqueuedCount reaching 0, the script fails loudly (signals a stuck queue). Default: 200.
+MAX_ITERATIONS="200"

--- a/infra/scripts/reindex-corpus/reindex-corpus.sh
+++ b/infra/scripts/reindex-corpus/reindex-corpus.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# infra/scripts/reindex-corpus/reindex-corpus.sh
+# SP3 (#3269) Slice 3 / D4 — per-env big-bang corpus re-index ORCHESTRATION.
+#
+# Wraps the admin endpoint `POST /api/v1/admin/queue/reindex-ready` (Slice 1, #3269)
+# in a drain loop. That endpoint enqueues Ready PDFs whose IndexerVersion differs from
+# the target (heading-aware v1.1) but is capped by the processing queue (MaxQueueSize),
+# so a large corpus needs REPEATED calls. This script loops until EnqueuedCount == 0
+# (corpus drained), pacing between iterations so the Quartz rail can process the queue
+# before the next batch is enqueued.
+#
+# The selector skips already-v1.1 docs (IndexerVersion == target), so the loop is
+# idempotent / resumable — a crash mid-run is safe to re-run: already-re-indexed PDFs
+# are not touched again.
+#
+# Usage:
+#   ./reindex-corpus.sh <path-to-.env.ENV> [--dry-run] [--i-mean-it]
+#   make reindex-corpus ENV=staging EXTRA=--dry-run          (from infra/)
+#   make reindex-corpus ENV=prod IMEANIT=--i-mean-it         (from infra/)
+#
+# Exit codes: 0 = clean drain (or dry-run); 64 = usage / prod-guard refusal;
+#   65 = auth or HTTP error; 66 = env file missing; 69 = missing jq/curl;
+#   75 = MAX_ITERATIONS exceeded (stuck queue).
+#
+# Runbook: docs/for-developers/operations/2026-07-26-corpus-reindex-runbook.md
+# ADR:     docs/for-claude/architecture/adr/adr-086-corpus-reindex-orchestration.md
+#
+# NOTE: no `set -e` — curl/http failures are handled explicitly so the loop can report
+# a clear diagnosis instead of dying on a transient non-zero exit.
+set -uo pipefail
+
+# --- logging (mirrors infra/scripts/game-reset/lib/common.sh) ---
+log_info()  { printf '\033[0;36m[INFO]\033[0m  %s\n' "$*" >&2; }
+log_warn()  { printf '\033[1;33m[WARN]\033[0m  %s\n' "$*" >&2; }
+log_error() { printf '\033[0;31m[ERROR]\033[0m %s\n' "$*" >&2; }
+log_ok()    { printf '\033[0;32m[OK]\033[0m    %s\n' "$*" >&2; }
+
+# --- args: $1 = env file (required); then --dry-run / --i-mean-it in any order ---
+ENV_FILE="${1:-}"
+if [ -z "$ENV_FILE" ]; then
+  log_error "Usage: $0 <path-to-.env.ENV> [--dry-run] [--i-mean-it]"
+  log_error "Example: $0 scripts/reindex-corpus/.env.staging --dry-run"
+  exit 64  # EX_USAGE
+fi
+shift
+
+DRY_RUN=false
+I_MEAN_IT=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run)   DRY_RUN=true ;;
+    --i-mean-it) I_MEAN_IT=true ;;
+    "")          : ;;  # tolerate empty EXTRA=/IMEANIT= passthrough from make
+    *) log_error "Unknown argument: $arg"; exit 64 ;;
+  esac
+done
+
+# --- load + validate env ---
+if [ ! -f "$ENV_FILE" ]; then
+  log_error "Env file not found: $ENV_FILE (copy from scripts/reindex-corpus/.env.example)"
+  exit 66  # EX_NOINPUT
+fi
+# shellcheck disable=SC1090
+. "$ENV_FILE"
+
+: "${ENV_NAME:?ENV_NAME must be set in $ENV_FILE}"
+: "${API_BASE_URL:?API_BASE_URL must be set in $ENV_FILE}"
+: "${ADMIN_EMAIL:?ADMIN_EMAIL must be set in $ENV_FILE}"
+: "${ADMIN_PASSWORD:?ADMIN_PASSWORD must be set in $ENV_FILE}"
+TARGET_VERSION="${TARGET_VERSION:-}"      # empty → server resolves Current (v1.1)
+PACING_SECONDS="${PACING_SECONDS:-5}"
+MAX_ITERATIONS="${MAX_ITERATIONS:-200}"
+
+log_info "Loaded env: ENV_NAME=$ENV_NAME API_BASE_URL=$API_BASE_URL"
+
+# --- prod guard (mirrors game-reset guard_prod) ---
+if [ "$ENV_NAME" = "prod" ]; then
+  if [ "$I_MEAN_IT" != true ]; then
+    log_error "ENV_NAME=prod detected. Refusing to run a big-bang re-index without --i-mean-it."
+    log_error "Re-run as: make reindex-corpus ENV=prod IMEANIT=--i-mean-it"
+    exit 64  # EX_USAGE — deliberate hard stop on prod without the flag
+  fi
+  log_warn "Big-bang re-index against PROD with --i-mean-it. Ctrl-C now to abort (sleeping 5s)..."
+  sleep 5
+fi
+
+# --- deps ---
+command -v jq   >/dev/null 2>&1 || { log_error "jq is required";   exit 69; }  # EX_UNAVAILABLE
+command -v curl >/dev/null 2>&1 || { log_error "curl is required"; exit 69; }
+
+REINDEX_ENDPOINT="$API_BASE_URL/api/v1/admin/queue/reindex-ready"
+LOGIN_ENDPOINT="$API_BASE_URL/api/v1/auth/login"
+
+if [ -n "$TARGET_VERSION" ]; then
+  BODY=$(jq -n --arg v "$TARGET_VERSION" '{targetVersion:$v}')
+else
+  BODY='{}'   # omit targetVersion → server uses Current (heading-aware v1.1)
+fi
+
+COOKIE=$(mktemp)
+trap 'rm -f "$COOKIE"' EXIT
+
+# --- login (cookie auth, mirrors rag-smoke-assert.sh) ---
+login() {
+  local code
+  code=$(curl -s -o /dev/null -w '%{http_code}' -c "$COOKIE" -X POST "$LOGIN_ENDPOINT" \
+    -H 'Content-Type: application/json' \
+    -d "$(jq -n --arg e "$ADMIN_EMAIL" --arg p "$ADMIN_PASSWORD" '{email:$e, password:$p}')") || true
+  if [ "$code" != "200" ]; then
+    log_error "Admin login failed (HTTP ${code:-000}) for $ADMIN_EMAIL at $LOGIN_ENDPOINT"
+    exit 65
+  fi
+  log_ok "Admin login OK ($ADMIN_EMAIL @ $API_BASE_URL)"
+}
+
+# --- dry-run: verify auth + print the plan, but DO NOT enqueue (real side effect) ---
+if [ "$DRY_RUN" = true ]; then
+  login
+  log_info "DRY-RUN plan:"
+  log_info "  Environment : $ENV_NAME"
+  log_info "  Endpoint    : POST $REINDEX_ENDPOINT"
+  log_info "  Target ver  : ${TARGET_VERSION:-<server Current — heading-aware v1.1>}"
+  log_info "  Pacing      : ${PACING_SECONDS}s between iterations"
+  log_info "  Max iters   : $MAX_ITERATIONS (safety cap)"
+  log_info "  Plan        : loop POST reindex-ready until EnqueuedCount==0 (corpus drained)."
+  log_warn "DRY-RUN: NOT posting reindex-ready — enqueuing is a real side effect and the endpoint has no read-only mode."
+  log_ok "Auth verified; dry-run complete. Re-run WITHOUT --dry-run to execute."
+  exit 0
+fi
+
+# --- real run: login then drain-loop ---
+login
+
+log_info "Starting big-bang corpus re-index for ENV=$ENV_NAME (target=${TARGET_VERSION:-<server Current v1.1>})"
+total_enqueued=0
+iteration=0
+
+while [ "$iteration" -lt "$MAX_ITERATIONS" ]; do
+  iteration=$((iteration + 1))
+
+  http_body=$(mktemp)
+  code=$(curl -s -o "$http_body" -w '%{http_code}' -b "$COOKIE" -X POST "$REINDEX_ENDPOINT" \
+    -H 'Content-Type: application/json' -d "$BODY") || true
+
+  if [ "$code" != "200" ]; then
+    log_error "iteration $iteration: reindex-ready returned HTTP ${code:-000}"
+    log_error "  response: $(head -c 500 "$http_body" 2>/dev/null)"
+    rm -f "$http_body"
+    exit 65
+  fi
+
+  # Tolerate PascalCase (EnqueuedCount) OR camelCase (enqueuedCount) serialization.
+  # jq `//` only falls through on null/false, so a genuine 0 is preserved.
+  enqueued=$(jq -r '.EnqueuedCount // .enqueuedCount // empty' "$http_body")
+  skipped=$(jq -r '.SkippedCount // .skippedCount // empty' "$http_body")
+  errs=$(jq -r '(.Errors // .errors // []) | length' "$http_body")
+  rm -f "$http_body"
+
+  if [ -z "$enqueued" ]; then
+    log_error "iteration $iteration: could not parse EnqueuedCount from reindex-ready response"
+    exit 65
+  fi
+
+  log_info "iteration $iteration: enqueued=$enqueued skipped=${skipped:-?} errors=${errs:-0}"
+  total_enqueued=$((total_enqueued + enqueued))
+
+  if [ "${errs:-0}" -gt 0 ]; then
+    log_warn "iteration $iteration reported ${errs} per-PDF error(s) (skipped, not aborted). Inspect the API logs for the affected job IDs."
+  fi
+
+  if [ "$enqueued" -eq 0 ]; then
+    log_ok "Corpus drained: EnqueuedCount==0 after $iteration iteration(s). Total enqueued this run: $total_enqueued."
+    log_info "Enqueued PDFs still drain through the Quartz rail asynchronously — verify completion via the queue status endpoint + post-reindex SQL (see runbook)."
+    exit 0
+  fi
+
+  log_info "Pacing ${PACING_SECONDS}s to let the Quartz rail drain the queue before re-enqueuing the rest..."
+  sleep "$PACING_SECONDS"
+done
+
+log_error "MAX_ITERATIONS ($MAX_ITERATIONS) exceeded without draining (EnqueuedCount never reached 0)."
+log_error "This signals a STUCK queue: PDFs are re-enqueued but not progressing to $([ -n "$TARGET_VERSION" ] && echo "$TARGET_VERSION" || echo 'v1.1'). Check:"
+log_error "  - the 'unstructured' Docker container is rebuilt with SP1 code (stale → 0 elements → no version bump)"
+log_error "  - the Quartz processing rail is running and the queue is not paused"
+log_error "  - raise MAX_ITERATIONS only after confirming the queue is actually progressing"
+exit 75  # EX_TEMPFAIL


### PR DESCRIPTION
## Contesto (SP3 Slice 3 — D4)

Orchestrazione del big-bang re-index per-ambiente: attiva il pipeline heading-aware sul corpus esistente drenando l'endpoint di Slice 1 (`POST /admin/queue/reindex-ready`, cappato dalla coda) finché ogni PDF Ready raggiunge v1.1. Ultima slice "core" di #3269 (Slice 4 = suite etichettata, deferred).

## Modifiche
- **`infra/scripts/reindex-corpus/reindex-corpus.sh`**: login admin (cookie) → loop POST reindex-ready fino a `EnqueuedCount==0`, pacing tra iterazioni (lascia drenare la coda Quartz); `MAX_ITERATIONS` con diagnosi stuck-queue (inclusa la precondizione container `unstructured` stale). **Prod-guard** (`ENV_NAME=prod` rifiuta senza `--i-mean-it`); **`--dry-run` side-effect-free** (verifica auth + stampa il piano, non accoda mai). Idempotente/resumabile (il selettore salta i doc già v1.1).
- **`.env.example`** + parità `.gitignore`.
- **`infra/Makefile`**: `reindex-corpus ENV=… [EXTRA=--dry-run] [IMEANIT=--i-mean-it]` + `reindex-corpus-help` (mirror del pattern game-reset).
- **Runbook** (`docs/for-developers/operations/2026-07-26-corpus-reindex-runbook.md`): sequenza 6-step per-env — verifica `unstructured` ricostruito, cattura baseline pre-SP3 EN+IT, dry-run + run staging, assert SQL post-reindex su rulebook campione (Heading/Level/ParentChunkId/role_tags su entrambi i sink), ri-cattura golden, gate verde → promozione prod (`main-dev → main-staging → main`).
- **ADR-086** (estende ADR-057): il big-bang è orchestrato out-of-band via loop admin-endpoint — non un nuovo Quartz job né un endpoint sync — one-shot per-env che riusa il rail async con pacing.

## Verifica (sintattica — lo script gira su admin API staging, non locale)
- `bash -n` OK · Makefile parsa · guard ENV/prod scattano · `.env.example` committato, `.env.<ENV>` gitignored · contratto endpoint/DTO/auth verificato sul codice.

## Nota
L'esecuzione è ops su staging→prod (vedi runbook). Precondizioni: baseline EN+IT catturato (follow-up Slice 2) + container `unstructured` ricostruito con SP1.

Parte di #3269 (Slice 3/4). Slice 4 (ground-truth etichettato EN+IT) resta deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
