### PR TITLE
fix(rag): reindex NoTracking persistence + extractor-health gate (#3269)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/Queue/BulkReindexReadyCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/Queue/BulkReindexReadyCommandHandler.cs
@@ -3,6 +3,7 @@ using Api.BoundedContexts.DocumentProcessing.Domain.Entities;
 using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
 using Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
 using Api.Infrastructure;
 using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
@@ -23,17 +24,20 @@ internal sealed class BulkReindexReadyCommandHandler
     private readonly MeepleAiDbContext _dbContext;
     private readonly IMediator _mediator;
     private readonly IProcessingJobRepository _jobRepository;
+    private readonly IPdfExtractorHealthProbe _healthProbe;
     private readonly ILogger<BulkReindexReadyCommandHandler> _logger;
 
     public BulkReindexReadyCommandHandler(
         MeepleAiDbContext dbContext,
         IMediator mediator,
         IProcessingJobRepository jobRepository,
+        IPdfExtractorHealthProbe healthProbe,
         ILogger<BulkReindexReadyCommandHandler> logger)
     {
         _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
         _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
         _jobRepository = jobRepository ?? throw new ArgumentNullException(nameof(jobRepository));
+        _healthProbe = healthProbe ?? throw new ArgumentNullException(nameof(healthProbe));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -41,6 +45,15 @@ internal sealed class BulkReindexReadyCommandHandler
         BulkReindexReadyCommand command, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(command);
+
+        // C2 gate: refuse to run the bulk re-index against a stale/misconfigured extractor. A
+        // silent flat-chunking regression would otherwise re-index the whole corpus into
+        // headingless chunks with no error signal (#3269 safety hardening).
+        if (!await _healthProbe.IsHealthyAsync(cancellationToken).ConfigureAwait(false))
+        {
+            throw new ConflictException(
+                "unstructured extractor unhealthy — refusing bulk reindex (would produce flat chunks)");
+        }
 
         var targetVersion = string.IsNullOrWhiteSpace(command.TargetVersion)
             ? IndexerVersionRegistry.Current.Version

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/ReindexDocumentCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/ReindexDocumentCommandHandler.cs
@@ -53,6 +53,7 @@ internal sealed class ReindexDocumentCommandHandler : ICommandHandler<ReindexDoc
         ArgumentNullException.ThrowIfNull(command);
 
         var pdf = await _dbContext.PdfDocuments
+            .AsTracking()
             .FirstOrDefaultAsync(p => p.Id == command.PdfId, cancellationToken)
             .ConfigureAwait(false);
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/DependencyInjection/DocumentProcessingServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/DependencyInjection/DocumentProcessingServiceExtensions.cs
@@ -425,6 +425,7 @@ internal static class DocumentProcessingServiceExtensions
             .AddServiceCallLogging("UnstructuredService");
 
         services.AddScoped<UnstructuredPdfTextExtractor>();
+        services.AddScoped<IPdfExtractorHealthProbe, UnstructuredExtractorHealthProbe>();
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/External/IPdfExtractorHealthProbe.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/External/IPdfExtractorHealthProbe.cs
@@ -1,0 +1,19 @@
+namespace Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
+
+/// <summary>
+/// Liveness probe for the PDF extraction pipeline's structural (heading-aware) capability.
+/// Unlike the Python service's own <c>/health</c> route (liveness-only), this probe exercises
+/// the real <c>/api/v1/extract</c> call path with a known tiny PDF and asserts the response
+/// actually carries structured <c>elements[]</c>. A stale/misconfigured extractor that only
+/// emits flat text (no elements) would silently produce headingless chunks on re-index — this
+/// probe lets callers (e.g. the bulk re-index orchestrator) refuse to run in that case.
+/// </summary>
+internal interface IPdfExtractorHealthProbe
+{
+    /// <summary>
+    /// Returns true when the extractor is reachable and returns at least one structured element
+    /// for a known-good sample PDF; false on any failure (network error, timeout, non-success
+    /// status, malformed response, or an empty/missing <c>elements</c> array).
+    /// </summary>
+    Task<bool> IsHealthyAsync(CancellationToken ct);
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/External/UnstructuredExtractorHealthProbe.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/External/UnstructuredExtractorHealthProbe.cs
@@ -1,0 +1,110 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
+
+/// <summary>
+/// Health probe for the Unstructured extractor (Stage 1 of the 3-stage PDF pipeline).
+/// Exercises the real <c>/api/v1/extract</c> call path with a tiny embedded known PDF and
+/// asserts the response carries at least one structured <c>elements[]</c> entry — the Python
+/// service's own <c>/health</c> route is liveness-only and does not exercise extraction, so it
+/// cannot detect a stale/misconfigured deployment that silently degrades to flat, headingless
+/// chunking (#3269). Any failure (network error, non-success status, malformed JSON, or an
+/// empty/missing elements array) degrades to "unhealthy" rather than throwing, so callers such
+/// as the bulk re-index orchestrator can safely gate on the result.
+/// </summary>
+internal sealed class UnstructuredExtractorHealthProbe : IPdfExtractorHealthProbe
+{
+    /// <summary>
+    /// Minimal single-page PDF used as the probe payload. No xref table is included — PDF
+    /// parsers used by the Unstructured service tolerate this via object-scanning recovery,
+    /// and a full byte-accurate xref adds no value for a throwaway health-check payload.
+    /// </summary>
+    private static readonly byte[] ProbePdfBytes = Encoding.ASCII.GetBytes(
+        "%PDF-1.4\n" +
+        "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n" +
+        "2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n" +
+        "3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R " +
+        "/Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n" +
+        "4 0 obj\n<< /Length 58 >>\nstream\nBT /F1 24 Tf 10 100 Td (Health Check) Tj ET\nendstream\nendobj\n" +
+        "5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n" +
+        "trailer\n<< /Root 1 0 R >>\n%%EOF");
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<UnstructuredExtractorHealthProbe> _logger;
+    private readonly JsonSerializerOptions _jsonOptions;
+
+    public UnstructuredExtractorHealthProbe(
+        IHttpClientFactory httpClientFactory,
+        ILogger<UnstructuredExtractorHealthProbe> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+        _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        };
+    }
+
+    public async Task<bool> IsHealthyAsync(CancellationToken ct)
+    {
+        try
+        {
+            var client = _httpClientFactory.CreateClient("UnstructuredService");
+            using var content = PrepareMultipartContent();
+            using var response = await client.PostAsync("/api/v1/extract", content, ct).ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "Unstructured extractor health probe failed: HTTP {StatusCode}",
+                    response.StatusCode);
+                return false;
+            }
+
+            var jsonContent = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            var extractionResponse = JsonSerializer.Deserialize<UnstructuredExtractionResponse>(jsonContent, _jsonOptions);
+
+            if (extractionResponse?.Elements is not { Count: > 0 })
+            {
+                _logger.LogWarning(
+                    "Unstructured extractor health probe returned no structured elements — " +
+                    "extractor may be stale/misconfigured and would produce flat, headingless chunks");
+                return false;
+            }
+
+            return true;
+        }
+#pragma warning disable CA1031
+        // INFRASTRUCTURE HEALTH-PROBE PATTERN: this is a best-effort refuse-to-run gate for the
+        // bulk re-index orchestrator (Task C2) - any failure (network error, timeout, malformed
+        // JSON, cancellation) must degrade to "unhealthy" (false), never throw, so callers can
+        // safely gate a batch operation on the result without needing their own try/catch.
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Unstructured extractor health probe threw an exception");
+            return false;
+        }
+#pragma warning restore CA1031
+    }
+
+    private static MultipartFormDataContent PrepareMultipartContent()
+    {
+        var content = new MultipartFormDataContent();
+#pragma warning disable CA2000 // Dispose objects before losing scope
+        // OWNERSHIP TRANSFER: MultipartFormDataContent takes ownership of added content and disposes them when it is disposed
+        var streamContent = new StreamContent(new MemoryStream(ProbePdfBytes));
+        var strategyContent = new StringContent("fast");
+        var languageContent = new StringContent("ita");
+#pragma warning restore CA2000
+
+        streamContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/pdf");
+        content.Add(streamContent, "file", "health-probe.pdf");
+        content.Add(strategyContent, "strategy");
+        content.Add(languageContent, "language");
+
+        return content;
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/Queue/BulkReindexReadyCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/Queue/BulkReindexReadyCommandHandlerTests.cs
@@ -4,6 +4,7 @@ using Api.BoundedContexts.DocumentProcessing.Domain.Entities;
 using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
 using Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
 using Api.Middleware.Exceptions;
@@ -33,6 +34,7 @@ public sealed class BulkReindexReadyCommandHandlerTests : IAsyncLifetime
     private MeepleAiDbContext _db = default!;
     private Mock<IMediator> _mediator = default!;
     private Mock<IProcessingJobRepository> _jobRepo = default!;
+    private Mock<IPdfExtractorHealthProbe> _healthProbe = default!;
 
     public ValueTask InitializeAsync()
     {
@@ -49,6 +51,13 @@ public sealed class BulkReindexReadyCommandHandlerTests : IAsyncLifetime
             .Setup(r => r.CountByStatusAsync(JobStatus.Queued, It.IsAny<CancellationToken>()))
             .ReturnsAsync(0);
 
+        // Default: extractor is healthy so all existing scenarios exercise the selector/pacing
+        // logic unimpeded. The unhealthy-gate scenario overrides this per-test.
+        _healthProbe = new Mock<IPdfExtractorHealthProbe>();
+        _healthProbe
+            .Setup(p => p.IsHealthyAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
         return ValueTask.CompletedTask;
     }
 
@@ -59,7 +68,7 @@ public sealed class BulkReindexReadyCommandHandlerTests : IAsyncLifetime
     }
 
     private BulkReindexReadyCommandHandler CreateHandler() =>
-        new(_db, _mediator.Object, _jobRepo.Object,
+        new(_db, _mediator.Object, _jobRepo.Object, _healthProbe.Object,
             NullLogger<BulkReindexReadyCommandHandler>.Instance);
 
     private async Task<PdfDocumentEntity> SeedPdfAsync(
@@ -237,5 +246,31 @@ public sealed class BulkReindexReadyCommandHandlerTests : IAsyncLifetime
         _mediator.Verify(
             m => m.Send(It.Is<ReindexDocumentCommand>(c => c.PdfId == pdfC.Id), It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_UnhealthyExtractor_ThrowsConflictAndSkipsSelectionEntirely()
+    {
+        // Even with a perfectly valid Ready/mismatched-version candidate in the DB, an unhealthy
+        // extractor must short-circuit BEFORE any candidate selection or fan-out — refusing to
+        // silently re-index the whole corpus into flat, headingless chunks (#3269 C2 gate).
+        await SeedPdfAsync(indexerVersion: "v1.0");
+        _healthProbe
+            .Setup(p => p.IsHealthyAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var handler = CreateHandler();
+
+        var act = () => handler.Handle(new BulkReindexReadyCommand(Guid.NewGuid()), CancellationToken.None);
+
+        await act.Should().ThrowAsync<ConflictException>()
+            .WithMessage("*unstructured extractor unhealthy*");
+
+        _mediator.Verify(
+            m => m.Send(It.IsAny<ReindexDocumentCommand>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _jobRepo.Verify(
+            r => r.CountByStatusAsync(It.IsAny<JobStatus>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 }

--- a/apps/api/tests/Api.Tests/Infrastructure/IntegrationServiceCollectionBuilder.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/IntegrationServiceCollectionBuilder.cs
@@ -57,8 +57,21 @@ internal static class IntegrationServiceCollectionBuilder
     /// because the default Moq mock returns null without invoking the factory and the read
     /// would miss the write. See issue #2162 follow-up.
     /// </param>
+    /// <param name="useNoTrackingDefault">
+    /// When true, configures <c>UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking)</c> on
+    /// the test <see cref="MeepleAiDbContext"/>, matching the production default set in
+    /// <c>InfrastructureServiceExtensions.cs</c> (PERF-06). By default this builder leaves EF Core's
+    /// tracking-by-default behavior in place, which SILENTLY MASKS handler bugs where a query is
+    /// missing an explicit <c>.AsTracking()</c> call — mutations on the returned entity would be
+    /// saved in a tracking-by-default test DbContext but silently dropped in production. Set this
+    /// to true for any test whose whole point is proving persistence of field mutations after a
+    /// plain (non-<c>.AsTracking()</c>) query. See issue #3269 follow-up (NoTracking gotcha).
+    /// </param>
     /// <returns>A ServiceCollection ready for test-specific repository registrations.</returns>
-    public static ServiceCollection CreateBase(string connectionString, bool useHybridCachePassthrough = false)
+    public static ServiceCollection CreateBase(
+        string connectionString,
+        bool useHybridCachePassthrough = false,
+        bool useNoTrackingDefault = false)
     {
         var services = new ServiceCollection();
 
@@ -87,6 +100,11 @@ internal static class IntegrationServiceCollectionBuilder
             options.ConfigureWarnings(w =>
                 w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.RelationalEventId.PendingModelChangesWarning));
             options.AddInterceptors(sp.GetRequiredService<AuditingSaveChangesInterceptor>());
+
+            if (useNoTrackingDefault)
+            {
+                options.UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking);
+            }
         });
 
         // Core infrastructure

--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/BulkReindexReadySelectorIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/BulkReindexReadySelectorIntegrationTests.cs
@@ -3,6 +3,7 @@ using Api.BoundedContexts.DocumentProcessing.Application.Commands.Queue;
 using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
 using Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
 using Api.Tests.Constants;
@@ -146,10 +147,16 @@ public sealed class BulkReindexReadySelectorIntegrationTests : IAsyncLifetime
             .Setup(r => r.CountByStatusAsync(JobStatus.Queued, It.IsAny<CancellationToken>()))
             .ReturnsAsync(0);
 
+        var healthProbeMock = new Mock<IPdfExtractorHealthProbe>();
+        healthProbeMock
+            .Setup(p => p.IsHealthyAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
         var handler = new BulkReindexReadyCommandHandler(
             _dbContext!,
             mediatorMock.Object,
             jobRepoMock.Object,
+            healthProbeMock.Object,
             NullLogger<BulkReindexReadyCommandHandler>.Instance);
 
         var result = await handler.Handle(

--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/ReindexDocumentPersistsResetIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/ReindexDocumentPersistsResetIntegrationTests.cs
@@ -1,0 +1,243 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Commands;
+using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
+using Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Integration.DocumentProcessing;
+
+/// <summary>
+/// Integration test proving <see cref="ReindexDocumentCommandHandler"/>'s field mutations
+/// (ProcessingState reset to Pending, ProcessedAt/ProcessingError clear, RetryCount reset,
+/// IndexerVersion stamp) are actually persisted when the fetch query runs under the SAME
+/// <c>QueryTrackingBehavior.NoTracking</c> default configured for the production
+/// <see cref="MeepleAiDbContext"/> (<c>InfrastructureServiceExtensions.cs</c> ~:178, PERF-06).
+/// Issue #3269 follow-up (SP3 bulk re-index safety hardening).
+///
+/// <para><b>The bug this guards against:</b> under <c>QueryTrackingBehavior.NoTracking</c>, a plain
+/// <c>_dbContext.PdfDocuments.FirstOrDefaultAsync(...)</c> (no <c>.AsTracking()</c>) returns a
+/// detached POCO the change tracker knows nothing about. Setting properties on it (ProcessingState,
+/// ProcessedAt, ProcessingError, RetryCount, ErrorCategory, FailedAtState, IndexerVersion) has zero
+/// effect on <c>SaveChangesAsync</c> — no UPDATE is ever generated for that row. Meanwhile
+/// <c>_dbContext.TextChunks.RemoveRange(chunks)</c> DOES persist, because <c>DbSet.RemoveRange</c>
+/// implicitly attaches untracked entities before marking them Deleted — a different code path than
+/// plain property mutation on a query result. Net effect: chunks are deleted but the document's
+/// ProcessingState never resets — a phantom success that leaves the document stuck (broken),
+/// exactly the scenario the SP3 <c>BulkReindexReadyCommandHandler</c> fan-out was built to fix.</para>
+///
+/// <para><b>Why a NEW test file instead of extending <see cref="ReindexDocumentVersionIntegrationTests"/>:</b>
+/// that sibling suite's DbContext (built via <see cref="IntegrationServiceCollectionBuilder.CreateBase"/>
+/// without <c>useNoTrackingDefault</c>) leaves EF Core's tracking-BY-DEFAULT behavior in place, so its
+/// <c>Reindex_ExplicitVersion_PersistsOnEntity</c> test would keep passing even if <c>.AsTracking()</c>
+/// were removed from the handler — it does not reproduce the production configuration and therefore
+/// cannot catch this regression. This suite explicitly opts into NoTracking to match production.</para>
+/// </summary>
+[Collection("Integration-GroupA")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "3269")]
+public sealed class ReindexDocumentPersistsResetIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _isolatedDbConnectionString = string.Empty;
+    private string _databaseName = string.Empty;
+    private MeepleAiDbContext? _dbContext;
+    private IServiceProvider? _serviceProvider;
+    private IMediator? _mediator;
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    private static readonly Guid TestUserId = new("A0000000-0000-0000-0000-000000003269");
+    private static readonly Guid TestSharedGameId = new("B0000000-0000-0000-0000-000000003269");
+
+    public ReindexDocumentPersistsResetIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_reindex_notrk_{Guid.NewGuid():N}";
+        _isolatedDbConnectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        // CRUX OF THE TEST: useNoTrackingDefault: true reproduces the production
+        // QueryTrackingBehavior.NoTracking default. Without this flag the test DbContext would
+        // track-by-default and mask the bug (see class doc comment).
+        var services = IntegrationServiceCollectionBuilder.CreateBase(
+            _isolatedDbConnectionString, useNoTrackingDefault: true);
+
+        // Best-effort enqueue fan-out (EnqueuePdfCommand) needs these registered so the inner
+        // mediator.Send resolves cleanly instead of being swallowed by the handler's CA1031 catch.
+        services.AddSingleton<IHttpContextAccessor>(new Mock<IHttpContextAccessor>().Object);
+        services.AddScoped<IPdfDocumentRepository, PdfDocumentRepository>();
+        services.AddScoped<IProcessingJobRepository, ProcessingJobRepository>();
+
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
+        _mediator = _serviceProvider.GetRequiredService<IMediator>();
+
+        await TestMigrationHelper.MigrateWithRetryAsync(_dbContext, TestCancellationToken);
+        await SeedBaseAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_dbContext is not null)
+        {
+            await _dbContext.DisposeAsync();
+        }
+        if (_serviceProvider is IAsyncDisposable d)
+        {
+            await d.DisposeAsync();
+        }
+        else
+        {
+            (_serviceProvider as IDisposable)?.Dispose();
+        }
+
+        if (!string.IsNullOrEmpty(_databaseName))
+        {
+            try
+            {
+                await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+            }
+            catch
+            {
+                // Ignore cleanup errors — test isolation already achieved
+            }
+        }
+    }
+
+    private async Task SeedBaseAsync()
+    {
+        _dbContext!.Set<UserEntity>().Add(new UserEntity
+        {
+            Id = TestUserId,
+            Email = "reindex-notrk-test@meepleai.test",
+            PasswordHash = "x",
+            DisplayName = "Reindex NoTracking Test",
+        });
+        _dbContext.Set<SharedGameEntity>().Add(new SharedGameEntity
+        {
+            Id = TestSharedGameId,
+            Title = "Reindex NoTracking Test Game",
+        });
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+    }
+
+    /// <summary>
+    /// Seeds a Ready PdfDocument with non-default reset-target field values (so a bug that drops
+    /// the mutations is observable, not masked by fields that already happen to equal their
+    /// post-reset value) plus 2 associated TextChunks.
+    ///
+    /// IMPORTANT: seeds via its OWN fresh scope/DbContext instance, deliberately separate from
+    /// the one the mediator call will use later. Reusing the same <see cref="MeepleAiDbContext"/>
+    /// instance for both seeding (via <c>Add()</c>, which always tracks regardless of the
+    /// NoTracking default) and the handler's later query would leave the seeded entities tracked
+    /// (Unchanged) in that same context's change tracker. The handler's own NoTracking query then
+    /// materializes SEPARATE, untracked instances for the same rows — and
+    /// <c>TextChunks.RemoveRange(...)</c> on those detached duplicates throws
+    /// <see cref="InvalidOperationException"/> ("already being tracked") because EF Core refuses
+    /// to attach a second instance under the same key. That collision is a test-harness artifact,
+    /// not the production bug: in production the row was written in a wholly separate prior
+    /// request with its own scoped DbContext, long disposed by the time reindex runs. Using an
+    /// isolated seeding scope here reproduces that same isolation.
+    /// </summary>
+    private async Task<Guid> SeedReadyPdfWithChunksAsync()
+    {
+        var pdfId = Guid.NewGuid();
+
+        using var seedScope = _serviceProvider!.CreateScope();
+        var seedDb = seedScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var pdf = new PdfDocumentEntity
+        {
+            Id = pdfId,
+            SharedGameId = TestSharedGameId,
+            UploadedByUserId = TestUserId,
+            FileName = $"reindex-notrk-{pdfId:N}.pdf",
+            FilePath = $"/tmp/{pdfId:N}.pdf",
+            FileSizeBytes = 1024,
+            ContentType = "application/pdf",
+            ProcessingState = "Ready",
+            UploadedAt = DateTime.UtcNow,
+            IndexerVersion = "v1.0",
+            ProcessedAt = DateTime.UtcNow.AddMinutes(-5),
+            ProcessingError = "stale-error-from-previous-run",
+            RetryCount = 3,
+            ErrorCategory = "Network",
+            FailedAtState = "Chunking",
+        };
+        seedDb.PdfDocuments.Add(pdf);
+
+        for (var i = 0; i < 2; i++)
+        {
+            seedDb.TextChunks.Add(new TextChunkEntity
+            {
+                Id = Guid.NewGuid(),
+                PdfDocumentId = pdfId,
+                SharedGameId = TestSharedGameId,
+                Content = $"Chunk {i} content",
+                ChunkIndex = i,
+                PageNumber = i + 1,
+                CharacterCount = 20,
+                CreatedAt = DateTime.UtcNow,
+            });
+        }
+
+        await seedDb.SaveChangesAsync(TestCancellationToken);
+        return pdfId;
+    }
+
+    [Fact]
+    public async Task Reindex_UnderProductionNoTrackingDefault_PersistsStateResetAndDeletesChunks()
+    {
+        var pdfId = await SeedReadyPdfWithChunksAsync();
+
+        await _mediator!.Send(
+            new ReindexDocumentCommand(pdfId, IndexerVersionRegistry.Current.Version),
+            TestCancellationToken);
+
+        // Verify from a FRESH, independent scope + AsNoTracking read — simulates what any other
+        // request/pipeline worker would observe after the command completes.
+        using var verifyScope = _serviceProvider!.CreateScope();
+        var verifyDb = verifyScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var reloaded = await verifyDb.PdfDocuments
+            .AsNoTracking()
+            .FirstAsync(p => p.Id == pdfId, TestCancellationToken);
+
+        reloaded.ProcessingState.Should().Be(
+            "Pending",
+            "ReindexDocumentCommandHandler must reset ProcessingState even when the fetch query "
+            + "runs under QueryTrackingBehavior.NoTracking (the production default) — a missing "
+            + "`.AsTracking()` silently drops this mutation, leaving the document stuck at its "
+            + "pre-reindex state forever.");
+        reloaded.ProcessedAt.Should().BeNull("ProcessedAt must be cleared on reindex");
+        reloaded.ProcessingError.Should().BeNull("ProcessingError must be cleared on reindex");
+        reloaded.RetryCount.Should().Be(0, "RetryCount must reset to 0 on reindex");
+        reloaded.ErrorCategory.Should().BeNull("ErrorCategory must be cleared on reindex");
+        reloaded.FailedAtState.Should().BeNull("FailedAtState must be cleared on reindex");
+        reloaded.IndexerVersion.Should().Be(
+            IndexerVersionRegistry.Current.Version,
+            "IndexerVersion must be stamped with the resolved version on reindex");
+
+        var remainingChunks = await verifyDb.TextChunks
+            .AsNoTracking()
+            .Where(tc => tc.PdfDocumentId == pdfId)
+            .ToListAsync(TestCancellationToken);
+        remainingChunks.Should().BeEmpty("all TextChunks for the document must be deleted on reindex");
+    }
+}

--- a/apps/api/tests/Api.Tests/Unit/DocumentProcessing/UnstructuredExtractorHealthProbeTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/DocumentProcessing/UnstructuredExtractorHealthProbeTests.cs
@@ -1,0 +1,169 @@
+// apps/api/tests/Api.Tests/Unit/DocumentProcessing/UnstructuredExtractorHealthProbeTests.cs
+using System.Net;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Api.Tests.Unit.DocumentProcessing;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "3269")]
+public sealed class UnstructuredExtractorHealthProbeTests
+{
+    private readonly Mock<IHttpClientFactory> _mockHttpClientFactory;
+    private readonly Mock<ILogger<UnstructuredExtractorHealthProbe>> _mockLogger;
+    private readonly Mock<HttpMessageHandler> _mockHttpMessageHandler;
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    public UnstructuredExtractorHealthProbeTests()
+    {
+        _mockHttpClientFactory = new Mock<IHttpClientFactory>();
+        _mockLogger = new Mock<ILogger<UnstructuredExtractorHealthProbe>>();
+        _mockHttpMessageHandler = new Mock<HttpMessageHandler>();
+    }
+
+    private UnstructuredExtractorHealthProbe CreateProbe()
+    {
+        var httpClient = new HttpClient(_mockHttpMessageHandler.Object)
+        {
+            BaseAddress = new Uri("http://test-unstructured:8001")
+        };
+
+        _mockHttpClientFactory
+            .Setup(x => x.CreateClient("UnstructuredService"))
+            .Returns(httpClient);
+
+        return new UnstructuredExtractorHealthProbe(
+            _mockHttpClientFactory.Object,
+            _mockLogger.Object);
+    }
+
+    private void SetupResponse(HttpResponseMessage response)
+    {
+        _mockHttpMessageHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(response);
+    }
+
+    private void SetupThrows(Exception exception)
+    {
+        _mockHttpMessageHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ThrowsAsync(exception);
+    }
+
+    [Fact]
+    public async Task IsHealthyAsync_NonEmptyElements_ReturnsTrue()
+    {
+        var probe = CreateProbe();
+        SetupResponse(new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent(
+                "{\"text\":\"hello\",\"chunks\":[],\"elements\":[{\"text\":\"Preparazione\",\"page_number\":1,\"category\":\"Title\"}],\"quality_score\":0.9,\"page_count\":1}")
+        });
+
+        var result = await probe.IsHealthyAsync(TestCancellationToken);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task IsHealthyAsync_EmptyElements_ReturnsFalse()
+    {
+        var probe = CreateProbe();
+        SetupResponse(new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent(
+                "{\"text\":\"hello\",\"chunks\":[],\"elements\":[],\"quality_score\":0.9,\"page_count\":1}")
+        });
+
+        var result = await probe.IsHealthyAsync(TestCancellationToken);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task IsHealthyAsync_MissingElements_ReturnsFalse()
+    {
+        var probe = CreateProbe();
+        SetupResponse(new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent(
+                "{\"text\":\"hello\",\"chunks\":[],\"quality_score\":0.9,\"page_count\":1}")
+        });
+
+        var result = await probe.IsHealthyAsync(TestCancellationToken);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task IsHealthyAsync_HandlerThrows_ReturnsFalse()
+    {
+        var probe = CreateProbe();
+        SetupThrows(new HttpRequestException("Connection refused"));
+
+        var result = await probe.IsHealthyAsync(TestCancellationToken);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task IsHealthyAsync_ServiceError500_ReturnsFalse()
+    {
+        var probe = CreateProbe();
+        SetupResponse(new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.InternalServerError,
+            Content = new StringContent("{\"error\":\"boom\"}")
+        });
+
+        var result = await probe.IsHealthyAsync(TestCancellationToken);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task IsHealthyAsync_InvalidJson_ReturnsFalse()
+    {
+        var probe = CreateProbe();
+        SetupResponse(new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent("not json{{{")
+        });
+
+        var result = await probe.IsHealthyAsync(TestCancellationToken);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task IsHealthyAsync_TaskCanceledException_ReturnsFalse()
+    {
+        // Probe is a best-effort refuse-to-run gate, not a cancellation-propagating call:
+        // any exception (including timeouts) is swallowed and surfaced as "unhealthy".
+        var probe = CreateProbe();
+        SetupThrows(new TaskCanceledException("Simulated timeout"));
+
+        var result = await probe.IsHealthyAsync(TestCancellationToken);
+
+        result.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

Focused follow-up to **#3301** (SP3 bulk re-index, just merged) fixing a **critical production bug** it shipped, plus adding the extractor-health safety gate it lacked.

### 🔴 Fix 1 (critical) — re-index persistence under NoTracking

`ReindexDocumentCommandHandler` fetched the `PdfDocument` **without `.AsTracking()`**. The app's `MeepleAiDbContext` defaults to `QueryTrackingBehavior.NoTracking`, so the handler's field mutations — **state reset to `Pending`, `IndexerVersion` stamp, `ProcessedAt`/error/retry clears** — were **silently dropped** by `SaveChangesAsync`; only the explicit `TextChunks.RemoveRange` persisted.

#3301's `BulkReindexReadyCommand` fans out exactly this command, so the SP3 bulk re-index was **broken in production**: it deleted every candidate doc's chunks but never reset state or stamped the version → docs left `Ready` with **no chunks** (broken RAG state), never re-processed, and re-selected by every subsequent run (thrash). The bug was masked in tests because the integration DbContext didn't apply the production NoTracking default.

**Fix:** add `.AsTracking()` to the fetch (matches the repo-wide NoTracking-default convention — 12+ sibling sites use `.AsTracking()`, not `.Update()`).

The new integration test (`ReindexDocumentPersistsResetIntegrationTests`) reproduces the bug **for real**: it opts the test DbContext into the production `NoTracking` default (new `useNoTrackingDefault` flag on `IntegrationServiceCollectionBuilder`) and asserts, via a **fresh independent context**, that state becomes `Pending` — **RED before the fix (stayed `Ready`), GREEN after**.

### Fix 2 — extractor-health gate on the bulk re-index

#3301's `BulkReindexReadyCommandHandler` had no guard: a stale `unstructured` extractor (which returns 0 `elements[]`) would make the bulk re-index silently re-process the **whole corpus into flat, headingless chunks** with no error. This injects `IPdfExtractorHealthProbe` and **refuses** (`ConflictException` → 409) at the top of `Handle` if the extractor is unhealthy, before any fan-out. The probe hits the real `/api/v1/extract` and validates non-empty `elements[]` (validated against the running `unstructured` container — no false-negative).

## Verification

- `dotnet build` (API): **0 warnings / 0 errors** (`TreatWarningsAsErrors`, Meziantou).
- 40/40 targeted tests + **465/465 DocumentProcessing unit** green; the AsTracking integration test's RED confirmed real under NoTracking.
- Health-probe unit + gate-refusal tests green.

## Notes

- Builds on #3301 (the v1.1 bump, stamp, `BulkReindexReadyCommand`, and alternate-finalizer stamps are already merged there — not re-implemented).
- **Pre-existing, NOT this branch:** 3 `PdfRowVersionConcurrencyIntegrationTests` (Barrier-based race, "found 2 instead of 1") fail on the baseline — confirmed **three independent ways** (revert-and-compare here, an A/B with the handler reverted to `main-dev`, and the whole-branch review's dynamic-version analysis). They fail identically with the AsTracking fix reverted. Recommend a separate root-cause + a `Known Flaky Tests` baseline row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
