### PR TITLE
fix(api): enforce RAG access control on QA + reindex endpoints (IDOR)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/RebuildRaptorCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/RebuildRaptorCommand.cs
@@ -17,5 +17,6 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Commands;
 /// </summary>
 /// <param name="GameId">The ID of the game whose RAPTOR tree should be rebuilt.</param>
 /// <param name="UserId">The ID of the user triggering the rebuild (used for tier check).</param>
-internal record RebuildRaptorCommand(Guid GameId, Guid UserId)
+/// <param name="UserRole">Bug B6: the user's role (string), parsed for per-game RAG access (admin bypass).</param>
+internal record RebuildRaptorCommand(Guid GameId, Guid UserId, string? UserRole = null)
     : ICommand<KbJobResponse>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/RebuildRaptorCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/RebuildRaptorCommandHandler.cs
@@ -1,5 +1,7 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Services;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services.Enhancements;
 using Api.Infrastructure;
+using Api.Infrastructure.Entities;
 using Api.Infrastructure.Entities.KnowledgeBase;
 using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
@@ -31,17 +33,20 @@ internal sealed class RebuildRaptorCommandHandler : ICommandHandler<RebuildRapto
 {
     private readonly MeepleAiDbContext _db;
     private readonly ITierEnforcementService _tierEnforcement;
+    private readonly IRagAccessService _ragAccessService;
     private readonly IRaptorIndexer? _raptorIndexer;
     private readonly ILogger<RebuildRaptorCommandHandler> _logger;
 
     public RebuildRaptorCommandHandler(
         MeepleAiDbContext db,
         ITierEnforcementService tierEnforcement,
+        IRagAccessService ragAccessService,
         ILogger<RebuildRaptorCommandHandler> logger,
         IRaptorIndexer? raptorIndexer = null)
     {
         _db = db ?? throw new ArgumentNullException(nameof(db));
         _tierEnforcement = tierEnforcement ?? throw new ArgumentNullException(nameof(tierEnforcement));
+        _ragAccessService = ragAccessService ?? throw new ArgumentNullException(nameof(ragAccessService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _raptorIndexer = raptorIndexer;
     }
@@ -49,6 +54,16 @@ internal sealed class RebuildRaptorCommandHandler : ICommandHandler<RebuildRapto
     public async Task<KbJobResponse> Handle(RebuildRaptorCommand command, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(command);
+
+        // Bug B6: user-facing RAPTOR rebuild must enforce per-game RAG access (owner/admin/public only)
+        // BEFORE the tier gate. Without this, any authenticated user could trigger LLM-cost rebuilds on
+        // another user's KB. Mirror AskArbiter/TutorQuery handlers.
+        var userRole = Enum.TryParse<UserRole>(command.UserRole, ignoreCase: true, out var parsedRole)
+            ? parsedRole : UserRole.User;
+        var canAccess = await _ragAccessService.CanAccessRagAsync(
+            command.UserId, command.GameId, userRole, cancellationToken).ConfigureAwait(false);
+        if (!canAccess)
+            throw new ForbiddenException("Accesso RAG non autorizzato");
 
         // === Tier gate ===
         var canRebuild = await _tierEnforcement

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ReindexGameKbCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ReindexGameKbCommand.cs
@@ -12,7 +12,8 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Commands;
 /// </summary>
 /// <param name="GameId">The ID of the game whose KB should be re-indexed.</param>
 /// <param name="UserId">The ID of the user triggering the re-index (for authorization).</param>
-internal record ReindexGameKbCommand(Guid GameId, Guid UserId)
+/// <param name="UserRole">Bug B6: the user's role (string), parsed for per-game RAG access (admin bypass).</param>
+internal record ReindexGameKbCommand(Guid GameId, Guid UserId, string? UserRole = null)
     : ICommand<KbJobResponse>;
 
 /// <summary>

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ReindexGameKbCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ReindexGameKbCommandHandler.cs
@@ -1,7 +1,9 @@
 using Api.BoundedContexts.KnowledgeBase.Application.Channels;
+using Api.BoundedContexts.KnowledgeBase.Application.Services;
 using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.Infrastructure;
+using Api.Infrastructure.Entities;
 using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
@@ -28,6 +30,7 @@ internal sealed class ReindexGameKbCommandHandler : ICommandHandler<ReindexGameK
     private readonly IKbReindexJobRepository _jobRepository;
     private readonly KbReindexChannel _channel;
     private readonly IUnitOfWork _unitOfWork;
+    private readonly IRagAccessService _ragAccessService;
     private readonly ILogger<ReindexGameKbCommandHandler> _logger;
 
     public ReindexGameKbCommandHandler(
@@ -35,18 +38,30 @@ internal sealed class ReindexGameKbCommandHandler : ICommandHandler<ReindexGameK
         IKbReindexJobRepository jobRepository,
         KbReindexChannel channel,
         IUnitOfWork unitOfWork,
+        IRagAccessService ragAccessService,
         ILogger<ReindexGameKbCommandHandler> logger)
     {
         _db = db ?? throw new ArgumentNullException(nameof(db));
         _jobRepository = jobRepository ?? throw new ArgumentNullException(nameof(jobRepository));
         _channel = channel ?? throw new ArgumentNullException(nameof(channel));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _ragAccessService = ragAccessService ?? throw new ArgumentNullException(nameof(ragAccessService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     public async Task<KbJobResponse> Handle(ReindexGameKbCommand command, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(command);
+
+        // Bug B6: user-facing reindex must enforce per-game RAG access (owner/admin/public only).
+        // Without this, any authenticated user could trigger an LLM-cost reindex on — and mutate —
+        // another user's KB (incl. PrivateGameId cross-user). Mirror AskArbiter/TutorQuery handlers.
+        var userRole = Enum.TryParse<UserRole>(command.UserRole, ignoreCase: true, out var parsedRole)
+            ? parsedRole : UserRole.User;
+        var canAccess = await _ragAccessService.CanAccessRagAsync(
+            command.UserId, command.GameId, userRole, cancellationToken).ConfigureAwait(false);
+        if (!canAccess)
+            throw new ForbiddenException("Accesso RAG non autorizzato");
 
         // 1. Count indexable PDFs.
         var pdfCount = await _db.PdfDocuments

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamQaQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamQaQuery.cs
@@ -15,11 +15,15 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Queries;
 /// <param name="DocumentIds">Optional document IDs to filter sources (null = all documents)</param>
 /// <param name="ResponseStyle">Response style: "concise" (default), "detailed", or "continuation"</param>
 /// <param name="ContinuationContext">Partial answer text from a previous truncated response</param>
+/// <param name="UserId">Bug B5: authenticated user id — when present, per-game RAG access is enforced</param>
+/// <param name="UserRole">Bug B5: authenticated user role (string) — parsed for RAG access (admin bypass)</param>
 internal record StreamQaQuery(
     string GameId,
     string Query,
     Guid? ThreadId = null,
     IReadOnlyList<Guid>? DocumentIds = null,
     string? ResponseStyle = null,
-    string? ContinuationContext = null
+    string? ContinuationContext = null,
+    Guid? UserId = null,
+    string? UserRole = null
 ) : IStreamingQuery<RagStreamingEvent>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamQaQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamQaQueryHandler.cs
@@ -8,6 +8,8 @@ using Api.BoundedContexts.KnowledgeBase.Domain.Services;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services.Reranking;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
 using Api.Helpers;
+using Api.Infrastructure.Entities;
+using Api.Middleware.Exceptions;
 using Api.Models;
 using Api.Observability;
 using Api.Services;
@@ -47,6 +49,7 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
     private readonly IPromptTemplateService _promptTemplateService;
     private readonly InlineCitationMatcherService _citationMatcher;
     private readonly IIntentClassifierService _intentClassifier;
+    private readonly IRagAccessService _ragAccessService;
     private readonly ILogger<StreamQaQueryHandler> _logger;
     private readonly TimeProvider _timeProvider;
 
@@ -63,6 +66,7 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
         IPromptTemplateService promptTemplateService,
         InlineCitationMatcherService citationMatcher,
         IIntentClassifierService intentClassifier,
+        IRagAccessService ragAccessService,
         ILogger<StreamQaQueryHandler> logger,
         TimeProvider? timeProvider = null)
     {
@@ -78,6 +82,7 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
         _promptTemplateService = promptTemplateService ?? throw new ArgumentNullException(nameof(promptTemplateService));
         _citationMatcher = citationMatcher ?? throw new ArgumentNullException(nameof(citationMatcher));
         _intentClassifier = intentClassifier ?? throw new ArgumentNullException(nameof(intentClassifier));
+        _ragAccessService = ragAccessService ?? throw new ArgumentNullException(nameof(ragAccessService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _timeProvider = timeProvider ?? TimeProvider.System;
     }
@@ -86,6 +91,20 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
         StreamQaQuery query,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
+        // Bug B5: streaming QA must enforce per-game RAG access before any retrieval/LLM work
+        // (mirror AskQuestionQueryHandler). Without this, any authenticated user could stream-QA
+        // a non-public game's KB. Enforced only when the endpoint threads the authenticated
+        // identity (UserId present) and the game id is a valid Guid.
+        if (query.UserId.HasValue && Guid.TryParse(query.GameId, out var accessGameId))
+        {
+            var userRole = Enum.TryParse<UserRole>(query.UserRole, ignoreCase: true, out var parsedRole)
+                ? parsedRole : UserRole.User;
+            var canAccess = await _ragAccessService.CanAccessRagAsync(
+                query.UserId.Value, accessGameId, userRole, cancellationToken).ConfigureAwait(false);
+            if (!canAccess)
+                throw new ForbiddenException("Accesso RAG non autorizzato");
+        }
+
         // Issue #1445: Use centralized query validation
         // Skip query validation for continuation requests (query may be empty)
         if (string.IsNullOrWhiteSpace(query.ContinuationContext))

--- a/apps/api/src/Api/Routing/AiEndpoints.cs
+++ b/apps/api/src/Api/Routing/AiEndpoints.cs
@@ -196,7 +196,7 @@ internal static class AiEndpoints
 
         try
         {
-            await ExecuteQaStreamingAsync(req, context, mediator, logger, generateFollowUps, streamContext, ct).ConfigureAwait(false);
+            await ExecuteQaStreamingAsync(req, context, mediator, logger, generateFollowUps, streamContext, session, ct).ConfigureAwait(false);
             logger.LogInformation("Streaming QA completed for game {GameId}, query: {Query}", req.gameId, req.query);
         }
         catch (OperationCanceledException ex)
@@ -254,6 +254,7 @@ internal static class AiEndpoints
         ILogger<Program> logger,
         bool generateFollowUps,
         QaStreamContext streamContext,
+        SessionStatusDto session,
         CancellationToken ct)
     {
         // CHAT-02: Follow-up question generation (fire-and-forget after Complete event)
@@ -279,7 +280,12 @@ internal static class AiEndpoints
         }
 
         var responseStyle = !string.IsNullOrWhiteSpace(req.continuationToken) ? "continuation" : req.responseStyle;
-        var query = new StreamQaQuery(req.gameId, req.query, req.chatId, req.documentIds, responseStyle, continuationContext); // Issue #2051
+        // Bug B5: thread the authenticated identity into the streaming query so the handler enforces
+        // per-game RAG access (mirror the non-stream AskQuestion path). Subject.Id = the acting user;
+        // EffectiveActor.Role = the role used for authorization (admin bypass), per Principal semantics.
+        var query = new StreamQaQuery(
+            req.gameId, req.query, req.chatId, req.documentIds, responseStyle, continuationContext, // Issue #2051
+            session.Principal!.Subject.Id, session.Principal!.EffectiveActor.Role);
         await foreach (var evt in mediator.CreateStream(query, ct).ConfigureAwait(false))
         {
             // Serialize event as JSON
@@ -397,7 +403,12 @@ internal static class AiEndpoints
             ThreadId: null, // No thread context for legacy endpoint
             SearchMode: req.searchMode.ToString(),
             Language: "en",
-            BypassCache: bypassCache
+            BypassCache: bypassCache,
+            // Bug B5 (QA endpoints, plural): thread the authenticated identity so the handler's
+            // per-game RAG access check fires (mirror the stream path + KnowledgeBaseEndpoints).
+            // Subject.Id = acting user; EffectiveActor.Role = role for authz (admin bypass).
+            UserId: session.Principal!.Subject.Id,
+            UserRole: session.Principal!.EffectiveActor.Role
         );
 
         var qaResponse = await mediator.Send(askQuery, ct).ConfigureAwait(false);

--- a/apps/api/src/Api/Routing/KbManagementEndpoints.cs
+++ b/apps/api/src/Api/Routing/KbManagementEndpoints.cs
@@ -48,7 +48,10 @@ internal static class KbManagementEndpoints
             var (authenticated, session, error) = httpContext.TryGetActiveSession();
             if (!authenticated) return error!;
 
-            var command = new ReindexGameKbCommand(GameId: gameId, UserId: session.Principal!.Subject.Id);
+            var command = new ReindexGameKbCommand(
+                GameId: gameId,
+                UserId: session.Principal!.Subject.Id,
+                UserRole: session.Principal!.EffectiveActor.Role); // Bug B6: enforce per-game RAG access (admin bypass)
             var result = await mediator.Send(command, ct).ConfigureAwait(false);
 
             return Results.Accepted(
@@ -129,7 +132,10 @@ internal static class KbManagementEndpoints
 
             try
             {
-                var command = new RebuildRaptorCommand(GameId: gameId, UserId: session.Principal!.Subject.Id);
+                var command = new RebuildRaptorCommand(
+                    GameId: gameId,
+                    UserId: session.Principal!.Subject.Id,
+                    UserRole: session.Principal!.EffectiveActor.Role); // Bug B6: enforce per-game RAG access (admin bypass)
                 var result = await mediator.Send(command, ct).ConfigureAwait(false);
 
                 return Results.Accepted(

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/RebuildRaptorCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/RebuildRaptorCommandHandlerTests.cs
@@ -1,0 +1,112 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Commands;
+using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Commands;
+
+/// <summary>
+/// Bug B6: <see cref="RebuildRaptorCommandHandler"/> must enforce per-game RAG access
+/// (owner / admin / public game) before the tier gate and before any rebuild work. Without this
+/// gate any authenticated user could trigger LLM-cost RAPTOR rebuilds on another user's KB.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+public class RebuildRaptorCommandHandlerTests
+{
+    private static MeepleAiDbContext CreateInMemoryDb(string testName)
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase($"RebuildRaptorTests_{testName}_{Guid.NewGuid()}")
+            .Options;
+        return new MeepleAiDbContext(
+            options,
+            Mock.Of<IMediator>(),
+            Mock.Of<IDomainEventCollector>());
+    }
+
+    [Fact]
+    public async Task Handle_NonOwner_ThrowsForbidden_AndDoesNotCheckTierOrRebuild()
+    {
+        // Arrange — a user with NO RAG access to the game.
+        var gameId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        await using var db = CreateInMemoryDb(nameof(Handle_NonOwner_ThrowsForbidden_AndDoesNotCheckTierOrRebuild));
+
+        var tier = new Mock<ITierEnforcementService>();
+        var ragAccess = new Mock<IRagAccessService>();
+        ragAccess
+            .Setup(s => s.CanAccessRagAsync(userId, gameId, It.IsAny<UserRole>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var handler = new RebuildRaptorCommandHandler(
+            db, tier.Object, ragAccess.Object,
+            Mock.Of<ILogger<RebuildRaptorCommandHandler>>(),
+            raptorIndexer: null);
+
+        var command = new RebuildRaptorCommand(GameId: gameId, UserId: userId, UserRole: "User");
+
+        // Act & Assert — access is checked FIRST, so the tier gate is never consulted.
+        await Assert.ThrowsAsync<ForbiddenException>(
+            () => handler.Handle(command, TestContext.Current.CancellationToken));
+
+        ragAccess.Verify(
+            s => s.CanAccessRagAsync(userId, gameId, It.IsAny<UserRole>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        tier.Verify(
+            t => t.CanPerformAsync(It.IsAny<Guid>(), It.IsAny<TierAction>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "the tier gate must not be reached when RAG access is denied");
+    }
+
+    [Fact]
+    public async Task Handle_Admin_IsAllowed_AndProceedsToTierGate()
+    {
+        // Arrange — admin passes the access gate; tier gate allows; no RAPTOR indexer registered →
+        // handler returns completed with 0 nodes (proving it proceeded past the access gate).
+        var gameId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        await using var db = CreateInMemoryDb(nameof(Handle_Admin_IsAllowed_AndProceedsToTierGate));
+
+        var tier = new Mock<ITierEnforcementService>();
+        tier
+            .Setup(t => t.CanPerformAsync(userId, TierAction.RaptorRebuild, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var ragAccess = new Mock<IRagAccessService>();
+        ragAccess
+            .Setup(s => s.CanAccessRagAsync(userId, gameId, It.IsAny<UserRole>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var handler = new RebuildRaptorCommandHandler(
+            db, tier.Object, ragAccess.Object,
+            Mock.Of<ILogger<RebuildRaptorCommandHandler>>(),
+            raptorIndexer: null);
+
+        var command = new RebuildRaptorCommand(GameId: gameId, UserId: userId, UserRole: "Admin");
+
+        // Act
+        var result = await handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        ragAccess.Verify(
+            s => s.CanAccessRagAsync(userId, gameId, It.IsAny<UserRole>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        tier.Verify(
+            t => t.CanPerformAsync(userId, TierAction.RaptorRebuild, It.IsAny<CancellationToken>()),
+            Times.Once);
+        result.Should().NotBeNull();
+        result.Status.Should().Be("completed");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ReindexGameKbCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ReindexGameKbCommandHandlerTests.cs
@@ -1,0 +1,114 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Channels;
+using Api.BoundedContexts.KnowledgeBase.Application.Commands;
+using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Commands;
+
+/// <summary>
+/// Bug B6: <see cref="ReindexGameKbCommandHandler"/> must enforce per-game RAG access
+/// (owner / admin / public game) before performing any reindex work. Without this gate any
+/// authenticated user could trigger an LLM-cost reindex on — and mutate — another user's KB.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+public class ReindexGameKbCommandHandlerTests
+{
+    private static MeepleAiDbContext CreateInMemoryDb(string testName)
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase($"ReindexGameKbTests_{testName}_{Guid.NewGuid()}")
+            .Options;
+        return new MeepleAiDbContext(
+            options,
+            Mock.Of<IMediator>(),
+            Mock.Of<IDomainEventCollector>());
+    }
+
+    [Fact]
+    public async Task Handle_NonOwner_ThrowsForbidden_AndDoesNotReindex()
+    {
+        // Arrange — a user with NO RAG access to the game.
+        var gameId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        await using var db = CreateInMemoryDb(nameof(Handle_NonOwner_ThrowsForbidden_AndDoesNotReindex));
+
+        var jobRepo = new Mock<IKbReindexJobRepository>();
+        var unitOfWork = new Mock<IUnitOfWork>();
+        var channel = new KbReindexChannel();
+
+        var ragAccess = new Mock<IRagAccessService>();
+        ragAccess
+            .Setup(s => s.CanAccessRagAsync(userId, gameId, It.IsAny<UserRole>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var handler = new ReindexGameKbCommandHandler(
+            db, jobRepo.Object, channel, unitOfWork.Object, ragAccess.Object,
+            Mock.Of<ILogger<ReindexGameKbCommandHandler>>());
+
+        var command = new ReindexGameKbCommand(GameId: gameId, UserId: userId, UserRole: "User");
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ForbiddenException>(
+            () => handler.Handle(command, TestContext.Current.CancellationToken));
+
+        ragAccess.Verify(
+            s => s.CanAccessRagAsync(userId, gameId, It.IsAny<UserRole>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // No reindex side effects: no job persisted, no work enqueued.
+        jobRepo.Verify(r => r.AddAsync(It.IsAny<KbReindexJob>(), It.IsAny<CancellationToken>()), Times.Never);
+        unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+        channel.Reader.TryRead(out _).Should().BeFalse("no reindex request must be enqueued when access is denied");
+    }
+
+    [Fact]
+    public async Task Handle_Admin_IsAllowed_AndProceeds()
+    {
+        // Arrange — admin passes the access gate; with no indexable PDFs the handler returns a
+        // completed no-op job (proving it proceeded past the gate).
+        var gameId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        await using var db = CreateInMemoryDb(nameof(Handle_Admin_IsAllowed_AndProceeds));
+
+        var jobRepo = new Mock<IKbReindexJobRepository>();
+        var unitOfWork = new Mock<IUnitOfWork>();
+        var channel = new KbReindexChannel();
+
+        var ragAccess = new Mock<IRagAccessService>();
+        ragAccess
+            .Setup(s => s.CanAccessRagAsync(userId, gameId, It.IsAny<UserRole>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var handler = new ReindexGameKbCommandHandler(
+            db, jobRepo.Object, channel, unitOfWork.Object, ragAccess.Object,
+            Mock.Of<ILogger<ReindexGameKbCommandHandler>>());
+
+        var command = new ReindexGameKbCommand(GameId: gameId, UserId: userId, UserRole: "Admin");
+
+        // Act
+        var result = await handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        ragAccess.Verify(
+            s => s.CanAccessRagAsync(userId, gameId, It.IsAny<UserRole>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        result.Should().NotBeNull();
+        result.Status.Should().Be("completed");
+        result.PdfCount.Should().Be(0);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/StreamQaQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/StreamQaQueryHandlerTests.cs
@@ -10,6 +10,7 @@ using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services.Reranking;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using Api.Middleware.Exceptions;
 using Api.Models;
 using Api.Services;
 using Microsoft.Extensions.Logging;
@@ -120,10 +121,101 @@ public class StreamQaQueryHandlerTests
             _promptTemplateServiceMock.Object,
             new InlineCitationMatcherService(),
             _intentClassifierMock.Object,
+            CreatePermissiveRagAccessServiceMock(),
             _loggerMock.Object,
             _fakeTimeProvider
         );
     }
+    // ─── Bug B5: streaming QA per-game RAG access enforcement (IDOR + KB confidentiality) ───
+
+    [Fact]
+    public async Task Handle_AuthenticatedNonOwner_ThrowsForbidden_AndSkipsRetrievalAndLlm()
+    {
+        // Arrange — an authenticated user with NO RAG access to this (non-public) game.
+        var gameId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var query = new StreamQaQuery(
+            gameId.ToString(), "How do I win?", ThreadId: null,
+            DocumentIds: null, ResponseStyle: null, ContinuationContext: null,
+            UserId: userId, UserRole: "User");
+
+        var denyRagAccess = new Mock<IRagAccessService>();
+        denyRagAccess
+            .Setup(s => s.CanAccessRagAsync(userId, gameId, It.IsAny<UserRole>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var handler = CreateHandlerWith(denyRagAccess.Object);
+
+        // Configure the full happy path so that, WERE the guard missing, retrieval + LLM would run —
+        // making a RED failure unambiguous.
+        SetupHappyPathMocks(gameId.ToString(), query.Query);
+
+        // Act
+        Func<Task> act = async () =>
+        {
+            await foreach (var _ in handler.Handle(query, TestContext.Current.CancellationToken))
+            {
+            }
+        };
+
+        // Assert — denial surfaces as ForbiddenException (mirrors non-stream AskQuestion) and NO
+        // retrieval or LLM work happens.
+        await act.Should().ThrowAsync<ForbiddenException>();
+
+        denyRagAccess.Verify(
+            s => s.CanAccessRagAsync(userId, gameId, It.IsAny<UserRole>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _llmServiceMock.Verify(
+            x => x.GenerateCompletionStreamAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "no LLM call must happen when RAG access is denied");
+
+        _keywordSearchServiceMock.Verify(
+            x => x.SearchAsync(It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<List<string>?>(), It.IsAny<string>(), It.IsAny<double>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "no KB retrieval must happen when RAG access is denied");
+
+        _cacheMock.Verify(
+            x => x.GetAsync<QaResponse>(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "not even the cache should be consulted when RAG access is denied");
+    }
+
+    [Fact]
+    public async Task Handle_AuthenticatedOwner_AllowsStreaming()
+    {
+        // Arrange — an authenticated user WITH RAG access proceeds normally.
+        var gameId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var query = new StreamQaQuery(
+            gameId.ToString(), "How do I win?", ThreadId: null,
+            DocumentIds: null, ResponseStyle: null, ContinuationContext: null,
+            UserId: userId, UserRole: "User");
+
+        var allowRagAccess = new Mock<IRagAccessService>();
+        allowRagAccess
+            .Setup(s => s.CanAccessRagAsync(userId, gameId, It.IsAny<UserRole>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var handler = CreateHandlerWith(allowRagAccess.Object);
+        SetupHappyPathMocks(gameId.ToString(), query.Query);
+
+        // Act
+        var events = new List<RagStreamingEvent>();
+        await foreach (var evt in handler.Handle(query, TestContext.Current.CancellationToken))
+        {
+            events.Add(evt);
+        }
+
+        // Assert — the stream completes with no ForbiddenException / error event.
+        allowRagAccess.Verify(
+            s => s.CanAccessRagAsync(userId, gameId, It.IsAny<UserRole>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        events.Should().Contain(e => e.Type == StreamingEventType.Complete);
+        events.Should().NotContain(e => e.Type == StreamingEventType.Error);
+    }
+
     [Fact]
     public async Task Handle_ValidQuery_StreamsCorrectEvents()
     {
@@ -1250,5 +1342,29 @@ public class StreamQaQueryHandlerTests
         var mock = new Mock<IRagAccessService>();
         mock.Setup(s => s.CanAccessRagAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<UserRole>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
         return mock.Object;
+    }
+
+    /// <summary>
+    /// Builds a StreamQaQueryHandler reusing the shared field mocks but with a caller-supplied
+    /// IRagAccessService — used by the Bug B5 access-enforcement tests.
+    /// </summary>
+    private StreamQaQueryHandler CreateHandlerWith(IRagAccessService ragAccessService)
+    {
+        return new StreamQaQueryHandler(
+            _searchQueryHandler,
+            _rerankerMock.Object,
+            _qualityTrackingServiceMock.Object,
+            _chatContextServiceMock.Object,
+            _chatThreadRepositoryMock.Object,
+            _pdfDocumentRepositoryMock.Object,
+            _vectorDocumentRepositoryMock.Object,
+            _llmServiceMock.Object,
+            _cacheMock.Object,
+            _promptTemplateServiceMock.Object,
+            new InlineCitationMatcherService(),
+            _intentClassifierMock.Object,
+            ragAccessService,
+            _loggerMock.Object,
+            _fakeTimeProvider);
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/AskQuestionQueryHandlerPhase2Tests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/AskQuestionQueryHandlerPhase2Tests.cs
@@ -242,6 +242,55 @@ public class AskQuestionQueryHandlerPhase2Tests
     }
 
     // ─────────────────────────────────────────────────────────────────────────
+    // Test 3b (Bug B5 — /agents/qa now threads UserId/UserRole): RAG-access denial
+    // throws ForbiddenException before quota consumption and before any LLM call.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_WhenRagAccessDenied_ThrowsForbiddenException_WithoutQuotaOrLlm()
+    {
+        // Arrange — a non-owner (CanAccessRagAsync=false) with an authenticated identity.
+        var gameId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        SetupDefaultMocks(gameId);
+
+        var denyRagAccess = new Mock<IRagAccessService>();
+        denyRagAccess
+            .Setup(s => s.CanAccessRagAsync(userId, gameId, It.IsAny<UserRole>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var query = new AskQuestionQuery(
+            GameId: gameId,
+            Question: "How does the pawn move?",
+            Language: "en",
+            UserId: userId,
+            UserRole: "User");
+
+        var handler = BuildHandler(ragAccessService: denyRagAccess.Object);
+
+        // Act
+        var act = () => handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Assert — access denial precedes quota + LLM (mirrors the enforcement order at
+        // AskQuestionQueryHandler.cs:137-145, ahead of the quota check at :175).
+        await act.Should().ThrowAsync<ForbiddenException>()
+            .WithMessage("*autorizzato*");
+
+        denyRagAccess.Verify(
+            s => s.CanAccessRagAsync(userId, gameId, It.IsAny<UserRole>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _mockPricingEngine.Verify(
+            p => p.ConsumeQuotaAsync(It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "quota must not be consumed when RAG access is denied");
+        _mockLlmService.Verify(
+            s => s.GenerateCompletionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "LLM must not be called when RAG access is denied");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
     // Test 4: HouseRuleMatcher returns a rule — it is prepended to the user prompt
     // ─────────────────────────────────────────────────────────────────────────
 
@@ -442,7 +491,8 @@ public class AskQuestionQueryHandlerPhase2Tests
     // ─────────────────────────────────────────────────────────────────────────
 
     private AskQuestionQueryHandler BuildHandler(
-        Api.Configuration.LlmQueryComplexityRoutingOptions? routingOverrides = null) =>
+        Api.Configuration.LlmQueryComplexityRoutingOptions? routingOverrides = null,
+        IRagAccessService? ragAccessService = null) =>
         new(
             _searchHandler,
             CreatePassthroughReranker(),
@@ -453,7 +503,7 @@ public class AskQuestionQueryHandlerPhase2Tests
             _mockLlmService.Object,
             _mockPromptTemplateService.Object,
             _mockValidationPipeline.Object,
-            CreatePermissiveRagAccessServiceMock(),
+            ragAccessService ?? CreatePermissiveRagAccessServiceMock(),
             Mock.Of<IRagQualityTracker>(),
             new QueryComplexityAnalyzer(),
             _mockResponseCache.Object,

--- a/apps/api/tests/Api.Tests/Integration/Smoke/KbReindexIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Smoke/KbReindexIntegrationTests.cs
@@ -69,6 +69,13 @@ public sealed class KbReindexIntegrationTests : IAsyncLifetime
             Api.BoundedContexts.KnowledgeBase.Infrastructure.Persistence.KbReindexJobRepository>();
         services.AddSingleton<Api.BoundedContexts.KnowledgeBase.Application.Channels.KbReindexChannel>();
 
+        // Bug B6: ReindexGameKb/RebuildRaptor handlers now enforce per-game RAG access via
+        // IRagAccessService. The base builder omits KnowledgeBase infra, so register it here
+        // (RagAccessService only needs MeepleAiDbContext, already provided by CreateBase).
+        services.AddScoped<
+            Api.BoundedContexts.KnowledgeBase.Application.Services.IRagAccessService,
+            Api.BoundedContexts.KnowledgeBase.Infrastructure.Services.RagAccessService>();
+
         _serviceProvider = services.BuildServiceProvider();
         _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
 
@@ -99,6 +106,10 @@ public sealed class KbReindexIntegrationTests : IAsyncLifetime
             Id = TestGameId,
             Title = "SG2 KB Reindex Test Game",
             CreatedAt = DateTime.UtcNow,
+            // Bug B6: these smoke tests exercise tier gating / cascade / idempotency, not authz.
+            // Mark the game RAG-public so the (non-owner) test user passes the new access gate,
+            // isolating each test to its intended behavior.
+            IsRagPublic = true,
         });
         await _dbContext.SaveChangesAsync(TestCancellationToken);
     }
@@ -187,6 +198,11 @@ public sealed class KbReindexIntegrationTests : IAsyncLifetime
             .ReturnsAsync(TierLimits.FreeTier);
 
         services.AddScoped<ITierEnforcementService>(_ => freeTierMock.Object);
+
+        // Bug B6: RebuildRaptorCommandHandler now depends on IRagAccessService (see InitializeAsync).
+        services.AddScoped<
+            Api.BoundedContexts.KnowledgeBase.Application.Services.IRagAccessService,
+            Api.BoundedContexts.KnowledgeBase.Infrastructure.Services.RagAccessService>();
 
         var freeTierProvider = services.BuildServiceProvider();
         var mediator = freeTierProvider.GetRequiredService<IMediator>();


### PR DESCRIPTION
## Sicurezza — 2 IDOR / authz-gap sulla superficie RAG (da bug-hunt adversariale)

Entrambi chiusi threadando l'identità del chiamante così che i check `IRagAccessService.CanAccessRagAsync` esistenti scattino davvero.

### B5 — IDOR lettura KB QA single-game
`POST /agents/qa` **e** `/agents/qa/stream` costruivano la query **senza** `UserId`/`UserRole` → il check non girava mai: qualsiasi utente autenticato leggeva la KB di qualsiasi gioco non-pubblico (default `IsRagPublic=false`); lo stream lo saltava del tutto.
- `StreamQaQuery` +`UserId`/`UserRole`; `StreamQaQueryHandler` ora enforce `CanAccessRagAsync` (→`ForbiddenException`) **prima** di cache/validazione/retrieval, come `AskQuestionQueryHandler`.
- `AiEndpoints`: threading di `session.Principal!.Subject.Id` + `EffectiveActor.Role` in **entrambi** i path (lo stream e il non-stream `AskQuestionQuery`, il cui check era presente ma **dormiente** per mancanza di identità).
- Verificati **tutti** i siti di costruzione: i 3 caller non-admin (qa, qa/stream, kb/ask) ora threadano l'identità; i 2 admin-gated (`RagDashboard /query/stream`, `RunAgentAutoTest`) sono safe (gli admin bypassano `CanAccessRagAsync`).

### B6 — reindex KB / rebuild RAPTOR senza autorizzazione per-game
`POST /games/{id}/kb/reindex` e `.../raptor/rebuild` facevano solo `RequireSession()` → qualsiasi utente forzava rebuild LLM-cost su qualsiasi gioco e mutava KB altrui (reindex matchava anche `PrivateGameId`). Entrambi gli handler ora iniettano `IRagAccessService` e fanno `CanAccessRagAsync` (→`ForbiddenException`) come **prima** azione, prima del tier-gate / side-effect; i command portano `UserRole`.

## Verifica (TDD, RED→GREEN)
- StreamQaQueryHandler non-owner→`ForbiddenException` + niente retrieval/LLM/cache · AskQuestion non-owner deny (prima di quota+LLM) · nuovi test ReindexGameKb/RebuildRaptor (non-owner→Forbidden, admin→procede).
- Build solution **0 errori** · `~StreamQa|AskQuestion|ReindexGameKb|RebuildRaptor|RagAccess` **68 passed** · `Category=Unit&BoundedContext=KnowledgeBase` **2413 passed** · KbReindex integration **4 passed**.

## Deferred (follow-up)
Lo stream QA non consuma ancora quota (`ConsumeQuotaAsync`) — cambio di billing con proprio test surface, fuori scope da un fix security. Il core (confidenzialità KB + authz) è pienamente chiuso qui.

_Trovati da un bug-hunt adversariale sulla superficie RAG/DocumentProcessing; questi sono i 2 di severità security. Altri finding (RAG-quality, recovery, exc-mapping, NoTracking) in follow-up._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
