### PR TITLE
fix(docproc): map ProcessingJob queue-state guards to ConflictException (409)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Entities/ProcessingJob.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Entities/ProcessingJob.cs
@@ -73,7 +73,7 @@ public sealed class ProcessingJob : AggregateRoot<Guid>
         if (userId == Guid.Empty)
             throw new ArgumentException("UserId is required.", nameof(userId));
         if (currentQueueSize >= MaxQueueSize)
-            throw new InvalidOperationException($"Queue is full. Maximum {MaxQueueSize} jobs allowed.");
+            throw new ConflictException($"Queue is full. Maximum {MaxQueueSize} jobs allowed.");
 
         var now = (timeProvider ?? TimeProvider.System).GetUtcNow();
         return new ProcessingJob(pdfDocumentId, userId, priority, now);
@@ -174,7 +174,7 @@ public sealed class ProcessingJob : AggregateRoot<Guid>
     public void Cancel(TimeProvider? timeProvider = null)
     {
         if (Status != JobStatus.Queued && Status != JobStatus.Processing)
-            throw new InvalidOperationException($"Cannot cancel job with status '{Status}'.");
+            throw new ConflictException($"Cannot cancel job with status '{Status}'.");
 
         var now = (timeProvider ?? TimeProvider.System).GetUtcNow();
         Status = JobStatus.Cancelled;
@@ -217,7 +217,7 @@ public sealed class ProcessingJob : AggregateRoot<Guid>
     public void UpdatePriority(int newPriority)
     {
         if (Status != JobStatus.Queued)
-            throw new InvalidOperationException($"Cannot change priority of job with status '{Status}'. Only Queued jobs can be reordered.");
+            throw new ConflictException($"Cannot change priority of job with status '{Status}'. Only Queued jobs can be reordered.");
 
         var oldPriority = Priority;
         Priority = newPriority;

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/Queue/BumpPriorityCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/Queue/BumpPriorityCommandHandlerTests.cs
@@ -65,7 +65,7 @@ public sealed class SetPriorityCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_ProcessingJob_ThrowsInvalidOperation()
+    public async Task Handle_ProcessingJob_ThrowsConflictException()
     {
         // Arrange: Create a job and start it so it's Processing
         var job = ProcessingJob.Create(Guid.NewGuid(), Guid.NewGuid(), (int)ProcessingPriority.Normal, 0);
@@ -76,8 +76,8 @@ public sealed class SetPriorityCommandHandlerTests
             .Setup(r => r.GetByIdAsync(job.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(job);
 
-        // Act & Assert — can only bump queued jobs
+        // Act & Assert — can only bump queued jobs; a non-Queued job is a conflict (409), not 500 (#2568).
         await FluentActions.Invoking(() => _handler.Handle(command, CancellationToken.None))
-            .Should().ThrowAsync<InvalidOperationException>();
+            .Should().ThrowAsync<ConflictException>();
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/Queue/CancelJobCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/Queue/CancelJobCommandHandlerTests.cs
@@ -80,7 +80,7 @@ public sealed class CancelJobCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_CompletedJob_ThrowsInvalidOperationException()
+    public async Task Handle_CompletedJob_ThrowsConflictException()
     {
         // Arrange
         var job = ProcessingJob.Create(Guid.NewGuid(), Guid.NewGuid(), 0, 0, _timeProvider);
@@ -92,8 +92,8 @@ public sealed class CancelJobCommandHandlerTests
             .Setup(r => r.GetByIdAsync(job.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(job);
 
-        // Act & Assert
+        // Act & Assert — cancelling a terminal job is a conflict (HTTP 409), not a 500 (#2568).
         await FluentActions.Invoking(() => _handler.Handle(new CancelJobCommand(job.Id), CancellationToken.None))
-            .Should().ThrowAsync<InvalidOperationException>();
+            .Should().ThrowAsync<ConflictException>();
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/Queue/EnqueuePdfCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/Queue/EnqueuePdfCommandHandlerTests.cs
@@ -98,7 +98,7 @@ public sealed class EnqueuePdfCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_QueueFull_ThrowsInvalidOperationException()
+    public async Task Handle_QueueFull_ThrowsConflictException()
     {
         // Arrange
         var command = new EnqueuePdfCommand(Guid.NewGuid(), Guid.NewGuid());
@@ -116,9 +116,9 @@ public sealed class EnqueuePdfCommandHandlerTests
             .Setup(r => r.CountByStatusAsync(JobStatus.Processing, It.IsAny<CancellationToken>()))
             .ReturnsAsync(10);
 
-        // Act & Assert
+        // Act & Assert — a full-queue state is a conflict (HTTP 409), not a 500 (#2568).
         await FluentActions.Invoking(() => _handler.Handle(command, CancellationToken.None))
-            .Should().ThrowAsync<InvalidOperationException>()
+            .Should().ThrowAsync<ConflictException>()
             .WithMessage("*Queue is full*");
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Domain/Entities/ProcessingJobTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Domain/Entities/ProcessingJobTests.cs
@@ -101,13 +101,13 @@ public sealed class ProcessingJobTests
     }
 
     [Fact]
-    public void Create_WhenQueueIsFull_ThrowsInvalidOperationException()
+    public void Create_WhenQueueIsFull_ThrowsConflictException()
     {
         // Act
         var action = () => ProcessingJob.Create(Guid.NewGuid(), Guid.NewGuid(), 0, ProcessingJob.MaxQueueSize, _timeProvider);
 
-        // Assert
-        action.Should().Throw<InvalidOperationException>()
+        // Assert — a full-queue state is a conflict (HTTP 409), not a 500 (#2568).
+        action.Should().Throw<ConflictException>()
             .WithMessage("*Queue is full*");
     }
 
@@ -428,7 +428,7 @@ public sealed class ProcessingJobTests
     }
 
     [Fact]
-    public void Cancel_WhenCompleted_ThrowsInvalidOperationException()
+    public void Cancel_WhenCompleted_ThrowsConflictException()
     {
         // Arrange
         var job = CreateProcessingJob();
@@ -438,13 +438,13 @@ public sealed class ProcessingJobTests
         // Act
         var action = () => job.Cancel(_timeProvider);
 
-        // Assert
-        action.Should().Throw<InvalidOperationException>()
+        // Assert — cancelling a terminal job is a conflict (HTTP 409), not a 500 (#2568).
+        action.Should().Throw<ConflictException>()
             .WithMessage("*Cannot cancel job*");
     }
 
     [Fact]
-    public void Cancel_WhenFailed_ThrowsInvalidOperationException()
+    public void Cancel_WhenFailed_ThrowsConflictException()
     {
         // Arrange
         var job = CreateProcessingJob();
@@ -454,8 +454,8 @@ public sealed class ProcessingJobTests
         // Act
         var action = () => job.Cancel(_timeProvider);
 
-        // Assert
-        action.Should().Throw<InvalidOperationException>()
+        // Assert — cancelling a terminal job is a conflict (HTTP 409), not a 500 (#2568).
+        action.Should().Throw<ConflictException>()
             .WithMessage("*Cannot cancel job*");
     }
 
@@ -585,7 +585,7 @@ public sealed class ProcessingJobTests
     }
 
     [Fact]
-    public void UpdatePriority_WhenNotQueued_ThrowsInvalidOperationException()
+    public void UpdatePriority_WhenNotQueued_ThrowsConflictException()
     {
         // Arrange
         var job = CreateProcessingJob();
@@ -593,8 +593,8 @@ public sealed class ProcessingJobTests
         // Act
         var action = () => job.UpdatePriority(10);
 
-        // Assert
-        action.Should().Throw<InvalidOperationException>()
+        // Assert — reordering a non-Queued job is a conflict (HTTP 409), not a 500 (#2568).
+        action.Should().Throw<ConflictException>()
             .WithMessage("*Cannot change priority*");
     }
 


### PR DESCRIPTION
## Bug-hunt fix — exception mapping 500→409 (B7/B8/B9)

I guard di dominio su `ProcessingJob` lanciavano `InvalidOperationException`, che il middleware mappa a **HTTP 500** (mappa a 404 solo se il messaggio contiene "not found"), mentre gli endpoint dichiarano `.Produces(409)` e questi sono stati di conflitto → 5xx spuri nelle dashboard + loggati `isUnhandled=true`. (Pitfall repo #2568.)

Fix (un solo root-cause): `ProcessingJob.Create()` (coda piena, B9), `Cancel()` (job terminale, B7), `UpdatePriority()` (job non-Queued, B8) ora lanciano **`ConflictException`** (messaggi invariati) — come già fanno `ProcessingJob.Retry()`/`RemoveFromQueue()` nello stesso aggregate (nessuna violazione di layering, `ConflictException : HttpException`).

## Verifica (TDD, RED→GREEN)
7 assertion esistenti aggiornate (`ProcessingJobTests`, `CancelJobCommandHandlerTests` ×2 guard, `EnqueuePdfCommandHandlerTests`, `BumpPriorityCommandHandlerTests`) da `InvalidOperationException` → `ConflictException` (RED genuino: `ConflictException` non è sottoclasse di `InvalidOperationException`). Filtro mirato **51/51** · `Category=Unit&BoundedContext=DocumentProcessing` **465/465** · build 0 errori.

_Da bug-hunt adversariale RAG/DocumentProcessing. Fa parte del batch quick-win insieme al PR NoTracking+capacity._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
