### PR TITLE
fix(docproc): persist NoTracking Ready/VectorDoc writes + bulk-reindex cap

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/IndexPdfCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/IndexPdfCommandHandler.cs
@@ -264,8 +264,14 @@ internal class IndexPdfCommandHandler : ICommandHandler<IndexPdfCommand, Indexin
         }
 
         // Check if already indexed (for idempotency)
+        // .AsTracking() overrides the global QueryTrackingBehavior.NoTracking default (mirrors the
+        // tracked `pdf` load above). Without it this existing VectorDocument is detached, so the
+        // "reset to processing" write below AND the terminal MarkIndexingFailedAsync write are silent
+        // no-ops — a failed re-index would leave the VectorDocument 'completed' with stale embeddings
+        // while the PDF is Failed (divergent tables).
         var pdfGuid = Guid.Parse(pdfId);
         var existingVectorDoc = await _db.Set<VectorDocumentEntity>()
+            .AsTracking()
             .FirstOrDefaultAsync(v => v.PdfDocumentId == pdfGuid, cancellationToken).ConfigureAwait(false);
 
         if (existingVectorDoc != null)

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/Queue/BulkReindexFailedCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/Queue/BulkReindexFailedCommandHandler.cs
@@ -37,9 +37,14 @@ internal sealed class BulkReindexFailedCommandHandler
 
         // Fix: check available capacity before re-enqueuing to avoid exceeding MaxQueueSize.
         // ProcessingJob.Create() enforces the cap but Retry() does not, so we enforce it here.
+        // The real cap is (Queued + Processing < MaxQueueSize), so BOTH in-flight statuses must
+        // be subtracted — otherwise with Processing jobs present we over-enqueue past the cap.
+        // Mirrors BulkReindexReadyCommandHandler's exact (Queued + Processing) computation.
         var currentQueuedCount = await _jobRepository.CountByStatusAsync(
             JobStatus.Queued, cancellationToken).ConfigureAwait(false);
-        var availableSlots = ProcessingJob.MaxQueueSize - currentQueuedCount;
+        var currentProcessingCount = await _jobRepository.CountByStatusAsync(
+            JobStatus.Processing, cancellationToken).ConfigureAwait(false);
+        var availableSlots = ProcessingJob.MaxQueueSize - (currentQueuedCount + currentProcessingCount);
 
         var enqueued = 0;
         var skipped = 0;

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/EventHandlers/VectorDocumentReadyStateHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/EventHandlers/VectorDocumentReadyStateHandler.cs
@@ -40,7 +40,13 @@ internal sealed class VectorDocumentReadyStateHandler
             return;
         }
 
+        // .AsTracking() overrides the global QueryTrackingBehavior.NoTracking default (PERF-06,
+        // InfrastructureServiceExtensions.cs). Without it the entity is detached and the
+        // ProcessingState=Ready + IndexerVersion writes below are a silent no-op at SaveChangesAsync,
+        // making this compensating handler dead. Mirrors ExtractPdfTextCommandHandler /
+        // IndexPdfCommandHandler (#3288-class fix).
         var pdfEntity = await _dbContext.PdfDocuments
+            .AsTracking()
             .FirstOrDefaultAsync(p => p.Id == evt.PdfDocumentId, cancellationToken)
             .ConfigureAwait(false);
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/Queue/BulkReindexFailedCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/Queue/BulkReindexFailedCommandHandlerTests.cs
@@ -102,6 +102,47 @@ public sealed class BulkReindexFailedCommandHandlerTests
     }
 
     [Fact]
+    public async Task Handle_QueueFullViaProcessingJobs_CountsProcessingAndSkipsAll()
+    {
+        // Queue is full via in-flight Processing jobs, with 0 Queued. This proves Processing is
+        // counted toward the capacity guard: the real cap enforced by ProcessingJob.Create is
+        // (Queued + Processing < MaxQueueSize), so if this handler subtracted only Queued from
+        // MaxQueueSize, availableSlots would be the full MaxQueueSize and every retryable failed
+        // job would be re-enqueued past the real cap. Mirrors BulkReindexReadyCommandHandler's
+        // Handle_QueueFullViaProcessingJobs_CountsProcessingAndSkipsAll.
+        _jobRepoMock
+            .Setup(r => r.CountByStatusAsync(JobStatus.Queued, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
+        _jobRepoMock
+            .Setup(r => r.CountByStatusAsync(JobStatus.Processing, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ProcessingJob.MaxQueueSize);
+
+        var jobs = new List<ProcessingJob>();
+        for (var i = 0; i < 3; i++)
+        {
+            var job = CreateFailedJob();
+            _jobRepoMock
+                .Setup(r => r.ExistsByPdfDocumentIdAsync(job.PdfDocumentId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(false);
+            jobs.Add(job);
+        }
+        _jobRepoMock
+            .Setup(r => r.GetAllByStatusAsync(JobStatus.Failed, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(jobs);
+
+        var result = await _handler.Handle(
+            new BulkReindexFailedCommand(Guid.NewGuid()), CancellationToken.None);
+
+        result.EnqueuedCount.Should().Be(0);
+        result.SkippedCount.Should().Be(3);
+        result.Errors.Should().HaveCount(3);
+        result.Errors.Should().OnlyContain(e => e.Reason == "Queue is at maximum capacity");
+        _jobRepoMock.Verify(
+            r => r.UpdateAsync(It.IsAny<ProcessingJob>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
     public async Task Handle_MixedJobs_ReportsCorrectCounts()
     {
         var retryableJob = CreateFailedJob();

--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/IndexPdfVectorDocNoTrackingPersistenceIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/IndexPdfVectorDocNoTrackingPersistenceIntegrationTests.cs
@@ -1,0 +1,216 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Commands;
+using Api.BoundedContexts.DocumentProcessing.Application.DTOs;
+using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Application.Services.Chunking;
+using Api.BoundedContexts.KnowledgeBase.Domain.Services;
+using Api.Configuration;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.KnowledgeBase;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Services;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Npgsql;
+using Xunit;
+
+namespace Api.Tests.Integration.DocumentProcessing;
+
+/// <summary>
+/// Regression for the <see cref="IndexPdfCommandHandler"/> failed-reindex NoTracking silent no-op.
+///
+/// On the re-index path, <c>ValidateAndPreparePdfForIndexingAsync</c> loads the pre-existing
+/// <see cref="VectorDocumentEntity"/> via a bare <c>_db.Set&lt;VectorDocumentEntity&gt;().FirstOrDefaultAsync(...)</c>
+/// (no <c>.AsTracking()</c>). The DbContext defaults to <c>QueryTrackingBehavior.NoTracking</c>
+/// (PERF-06), so the entity is detached — the "reset to processing" write AND the terminal
+/// <c>MarkIndexingFailedAsync</c> write ("failed") are both silent no-ops. Net effect: when a
+/// re-index fails, the VectorDocument stays <c>completed</c> with stale embeddings while the PDF is
+/// Failed — divergent tables.
+///
+/// <para>The existing <c>IndexPdfIntegrationTests</c> misses this because it builds its DbContext via
+/// <c>IntegrationServiceCollectionBuilder.CreateBase(conn)</c> WITHOUT <c>useNoTrackingDefault: true</c>,
+/// leaving EF Core's track-by-default behavior in place (which masks the bug). This suite explicitly
+/// opts into the production NoTracking default.</para>
+/// </summary>
+[Collection("Integration-GroupA")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "DocumentProcessing")]
+public sealed class IndexPdfVectorDocNoTrackingPersistenceIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = string.Empty;
+    private IServiceProvider? _serviceProvider;
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    public IndexPdfVectorDocNoTrackingPersistenceIntegrationTests(SharedTestcontainersFixture fixture)
+        => _fixture = fixture;
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"indexpdf_vecdoc_notracking_{Guid.NewGuid():N}";
+        var conn = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        // CRUX: useNoTrackingDefault: true reproduces the production QueryTrackingBehavior.NoTracking
+        // default. Without it the test DbContext would track-by-default and mask the bug.
+        var services = IntegrationServiceCollectionBuilder.CreateBase(conn, useNoTrackingDefault: true);
+
+        // Real chunking stack so ChunkAndEmbedTextAsync produces genuine chunks before the
+        // (deliberately failing) embedding step drives execution to MarkIndexingFailedAsync.
+        services.AddSingleton<ITextChunkingService, TextChunkingService>();
+        services.AddScoped<ChunkingStrategySelector>();
+        services.AddScoped<IAdvancedChunkingService, AdvancedChunkingService>();
+
+        _serviceProvider = services.BuildServiceProvider();
+
+        var db = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            try
+            {
+                await db.Database.MigrateAsync(TestCancellationToken);
+                break;
+            }
+            catch (NpgsqlException) when (attempt < 2)
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(500), TestCancellationToken);
+            }
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_serviceProvider is IAsyncDisposable asyncDisposable)
+            await asyncDisposable.DisposeAsync();
+        else
+            (_serviceProvider as IDisposable)?.Dispose();
+
+        if (!string.IsNullOrEmpty(_databaseName))
+        {
+            try { await _fixture.DropIsolatedDatabaseAsync(_databaseName); }
+            catch { /* ignore cleanup errors */ }
+        }
+    }
+
+    private static IOptions<IndexingSettings> IndexingSettings() =>
+        Options.Create(new IndexingSettings { EmbeddingBatchSize = 100 });
+
+    [Fact(DisplayName = "IndexPdfCommandHandler marks the existing VectorDocument failed under NoTracking when reindex embedding fails")]
+    public async Task Handle_FailedReindexUnderNoTracking_MarksExistingVectorDocumentFailed()
+    {
+        var pdfId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        // Arrange — seed user, game, a Ready PDF with extracted text, and an EXISTING VectorDocument
+        // in the "completed" state (the re-index scenario). Seed via its own scope so the entities
+        // are not left tracked in the context the handler will later query (matches production
+        // isolation and avoids EF "already tracked" harness artifacts).
+        await using (var seedScope = _serviceProvider!.CreateAsyncScope())
+        {
+            var seedDb = seedScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            seedDb.Users.Add(new UserEntity
+            {
+                Id = userId,
+                Email = $"indexpdf-notrk-{userId:N}@meepleai.test",
+                DisplayName = "IndexPdf NoTracking Test",
+                Role = "Editor",
+                CreatedAt = DateTime.UtcNow,
+            });
+            seedDb.SharedGames.Add(new SharedGameEntity
+            {
+                Id = gameId,
+                Title = "IndexPdf NoTracking Test Game",
+                CreatedAt = DateTime.UtcNow,
+            });
+            seedDb.PdfDocuments.Add(new PdfDocumentEntity
+            {
+                Id = pdfId,
+                SharedGameId = gameId,
+                UploadedByUserId = userId,
+                FileName = "reindex.pdf",
+                FilePath = $"/test/{pdfId:N}.pdf",
+                FileSizeBytes = 1024,
+                ContentType = "application/pdf",
+                UploadedAt = DateTime.UtcNow,
+                PageCount = 3,
+                ProcessingState = "Ready",
+                ExtractedText = "Setup the board.\n\nDeal cards to each player.\n\nScore points at the end.",
+            });
+            seedDb.Set<VectorDocumentEntity>().Add(new VectorDocumentEntity
+            {
+                Id = Guid.NewGuid(),
+                PdfDocumentId = pdfId,
+                GameId = gameId,
+                SharedGameId = gameId,
+                ChunkCount = 5,
+                TotalCharacters = 100,
+                IndexedAt = DateTime.UtcNow,
+                IndexingStatus = "completed",
+                IndexingError = null,
+                EmbeddingModel = "test-embedding-model",
+                EmbeddingDimensions = 768,
+            });
+            await seedDb.SaveChangesAsync(TestCancellationToken);
+        }
+
+        // Act — run the handler with a FAILING embedding service so execution reaches
+        // MarkIndexingFailedAsync on the existing VectorDocument. Handler built against a fresh
+        // NoTracking-default context resolved from the act scope.
+        var embeddingMock = new Mock<IEmbeddingService>();
+        embeddingMock.Setup(e => e.GetEmbeddingDimensions()).Returns(768);
+        embeddingMock.Setup(e => e.GetModelName()).Returns("test-embedding-model");
+        embeddingMock
+            .Setup(e => e.GenerateEmbeddingsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EmbeddingResult
+            {
+                Success = false,
+                Embeddings = new List<float[]>(),
+                ErrorMessage = "simulated embedding failure",
+            });
+
+        IndexingResultDto result;
+        using (var actScope = _serviceProvider!.CreateScope())
+        {
+            var actDb = actScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var handler = new IndexPdfCommandHandler(
+                actDb,
+                actScope.ServiceProvider.GetRequiredService<IAdvancedChunkingService>(),
+                embeddingMock.Object,
+                NullLogger<IndexPdfCommandHandler>.Instance,
+                IndexingSettings(),
+                Mock.Of<ISemanticResponseCache>(),
+                Mock.Of<IPdfIndexingPipeline>());
+
+            result = await handler.Handle(new IndexPdfCommand(pdfId.ToString()), TestCancellationToken);
+        }
+
+        // Sanity: the handler reported the embedding failure.
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(PdfIndexingErrorCode.EmbeddingFailed);
+
+        // Assert — fresh NoTracking read: the existing VectorDocument must have flipped to "failed".
+        using (var verifyScope = _serviceProvider!.CreateScope())
+        {
+            var verifyDb = verifyScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var vectorDoc = await verifyDb.Set<VectorDocumentEntity>()
+                .AsNoTracking()
+                .FirstAsync(v => v.PdfDocumentId == pdfId, TestCancellationToken);
+
+            vectorDoc.IndexingStatus.Should().Be(
+                "failed",
+                "IndexPdfCommandHandler must load the existing VectorDocument .AsTracking() so a failed "
+                + "re-index actually marks it failed — under the NoTracking default the mutation is a silent "
+                + "no-op, leaving the VectorDocument 'completed' with stale embeddings while the PDF failed.");
+            vectorDoc.IndexingError.Should().NotBeNullOrEmpty(
+                "the embedding failure message must be recorded on the VectorDocument");
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/VectorDocumentReadyStateNoTrackingPersistenceIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/VectorDocumentReadyStateNoTrackingPersistenceIntegrationTests.cs
@@ -1,0 +1,132 @@
+using Api.BoundedContexts.DocumentProcessing.Application.EventHandlers;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.SharedKernel.Application.IntegrationEvents;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Api.Tests.Integration.DocumentProcessing;
+
+/// <summary>
+/// Regression for the <see cref="VectorDocumentReadyStateHandler"/> NoTracking silent no-op.
+///
+/// The compensating handler loads the PdfDocument via a bare
+/// <c>_dbContext.PdfDocuments.FirstOrDefaultAsync(...)</c> (no <c>.AsTracking()</c>). The DbContext
+/// defaults to <c>QueryTrackingBehavior.NoTracking</c> (PERF-06,
+/// <c>InfrastructureServiceExtensions.cs</c>), so the returned entity is detached — the whole point
+/// of the handler (set <c>ProcessingState=Ready</c> + stamp <c>IndexerVersion</c> then
+/// <c>SaveChangesAsync</c>) is a guaranteed no-op and the PDF is never advanced to Ready after vector
+/// indexing completes.
+///
+/// The existing Category=Unit <c>VectorDocumentReadyStateHandlerTests</c> misses this because
+/// <c>TestDbContextFactory</c> uses the EF Core in-memory provider with default track-all semantics.
+/// This test runs against real Postgres via Testcontainers with the production NoTracking default, so
+/// the mutation must actually persist.
+/// </summary>
+[Collection("Integration-GroupD")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "DocumentProcessing")]
+public sealed class VectorDocumentReadyStateNoTrackingPersistenceIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _databaseName = $"vecdoc_ready_notracking_{Guid.NewGuid():N}";
+    private WebApplicationFactory<Program> _factory = null!;
+
+    public VectorDocumentReadyStateNoTrackingPersistenceIntegrationTests(SharedTestcontainersFixture fixture)
+        => _fixture = fixture;
+
+    public async ValueTask InitializeAsync()
+    {
+        var conn = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        await TestcontainersWaitHelpers.WaitForPostgresReadyAsync(conn);
+        _factory = IntegrationWebApplicationFactory.Create(conn);
+        using var scope = _factory.Services.CreateScope();
+        await scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>().Database.MigrateAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_factory != null) await _factory.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    [Fact(DisplayName = "VectorDocumentReadyStateHandler persists ProcessingState=Ready + IndexerVersion under NoTracking (real DB)")]
+    public async Task Handle_UnderProductionNoTrackingDefault_PersistsReadyStateAndIndexerVersion()
+    {
+        var pdfId = Guid.NewGuid();
+
+        // Arrange — seed a user (FK) and a PDF stuck in the Indexing state, via one scope.
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var userId = Guid.NewGuid();
+            db.Users.Add(new UserEntity
+            {
+                Id = userId,
+                Email = $"vecdoc-ready-{userId:N}@meepleai.test",
+                DisplayName = "VecDoc Ready Test",
+                Role = "user",
+                CreatedAt = DateTime.UtcNow,
+            });
+            db.PdfDocuments.Add(new PdfDocumentEntity
+            {
+                Id = pdfId,
+                FileName = "rules.pdf",
+                FilePath = $"pdfs/{pdfId:N}/rules.pdf",
+                FileSizeBytes = 1024,
+                ContentType = "application/pdf",
+                UploadedByUserId = userId,
+                UploadedAt = DateTime.UtcNow,
+                ProcessingState = nameof(PdfProcessingState.Indexing),
+                IndexerVersion = null,
+                Language = "en",
+            });
+            await db.SaveChangesAsync();
+        }
+
+        // Act — invoke the handler against a fresh NoTracking DbContext resolved from the container.
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var handler = new VectorDocumentReadyStateHandler(
+                scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>(),
+                NullLogger<VectorDocumentReadyStateHandler>.Instance);
+
+            var evt = new VectorDocumentReadyIntegrationEvent
+            {
+                DocumentId = Guid.NewGuid(),
+                GameId = Guid.NewGuid(),
+                ChunkCount = 42,
+                PdfDocumentId = pdfId,
+                UploadedByUserId = Guid.NewGuid(),
+                FileName = "rules.pdf",
+                CurrentProcessingState = nameof(PdfProcessingState.Indexing),
+            };
+
+            await handler.Handle(evt, CancellationToken.None);
+        }
+
+        // Assert — fresh NoTracking read; the compensating writes must have actually persisted.
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var entity = await db.PdfDocuments.AsNoTracking().FirstAsync(x => x.Id == pdfId);
+
+            entity.ProcessingState.Should().Be(
+                nameof(PdfProcessingState.Ready),
+                "VectorDocumentReadyStateHandler must load PdfDocuments .AsTracking() so the compensating "
+                + "ProcessingState=Ready write is persisted under the NoTracking default (silent no-op otherwise)");
+            entity.IndexerVersion.Should().Be(
+                IndexerVersionRegistry.Current.Version,
+                "the compensating Ready transition must also stamp the current IndexerVersion (#3269)");
+        }
+    }
+}


### PR DESCRIPTION
## Bug-hunt fixes — NoTracking silent no-op (B1/B2) + capacity undercount (B15)

### B1 — VectorDocumentReadyStateHandler compensating write dead
`VectorDocumentReadyStateHandler` caricava `PdfDocuments` senza `.AsTracking()` (default globale NoTracking, PERF-06) → i write `ProcessingState=Ready` + `IndexerVersion` + SaveChanges erano un no-op silenzioso: l'handler safety-net non poteva assolvere il suo scopo (classe #3288). Fix: `.AsTracking()`.

### B2 — Failed re-index non marca VectorDocument failed
`IndexPdfCommandHandler` caricava `existingVectorDoc` senza `.AsTracking()` → il reset "to processing" e `MarkIndexingFailedAsync` erano no-op: un reindex fallito lasciava il VectorDocument `completed` con embedding stale mentre il PDF era Failed (tabelle divergenti). Fix: `.AsTracking()` (mirror del load `pdf` tracked nello stesso file).

### B15 — BulkReindexFailed capacity undercount
`availableSlots = MaxQueueSize - Queued` ignorava i job `Processing`; il cap reale (`ProcessingJob.Create`) è `Queued + Processing < MaxQueueSize` → over-enqueue oltre il cap con job in-flight. Fix: `MaxQueueSize - (Queued + Processing)` (mirror di `BulkReindexReadyCommandHandler`).

## Verifica (TDD, RED→GREEN)
- B1/B2: nuovi test d'integrazione **Testcontainers NoTracking** (contesto NoTracking fresco che prova la persistenza) — RED senza `.AsTracking()` (stato resta `Indexing`/`completed`) → GREEN. (La suite `IndexPdfIntegrationTests` esistente usa `CreateBase` *senza* NoTracking → mascherava B2: per questo è shippato.)
- B15: unit test con `Processing=MaxQueueSize` → 0 enqueued.
- Filtro mirato 8/8 · `Category=Unit&BoundedContext=DocumentProcessing` **465/465** · build 0 errori.

_Da bug-hunt adversariale RAG/DocumentProcessing. Batch quick-win insieme al PR ConflictException (#3311)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
