### PR TITLE
fix(docproc): reset PDF to Pending on bulk-reindex-failed re-queue

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/Queue/BulkReindexFailedCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/Queue/BulkReindexFailedCommandHandler.cs
@@ -2,8 +2,10 @@ using Api.BoundedContexts.DocumentProcessing.Application.Commands.Queue;
 using Api.BoundedContexts.DocumentProcessing.Domain.Entities;
 using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
+using Api.Infrastructure;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
 
 namespace Api.BoundedContexts.DocumentProcessing.Application.Commands.Queue;
 
@@ -18,13 +20,16 @@ internal sealed class BulkReindexFailedCommandHandler
 {
     private readonly IProcessingJobRepository _jobRepository;
     private readonly IUnitOfWork _unitOfWork;
+    private readonly MeepleAiDbContext _dbContext;
 
     public BulkReindexFailedCommandHandler(
         IProcessingJobRepository jobRepository,
-        IUnitOfWork unitOfWork)
+        IUnitOfWork unitOfWork,
+        MeepleAiDbContext dbContext)
     {
         _jobRepository = jobRepository ?? throw new ArgumentNullException(nameof(jobRepository));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
     }
 
     public async Task<BulkReindexResult> Handle(
@@ -85,6 +90,30 @@ internal sealed class BulkReindexFailedCommandHandler
                 // Set priority to Low for bulk reindex
                 job.UpdatePriority((int)ProcessingPriority.Low);
                 await _jobRepository.UpdateAsync(job, cancellationToken).ConfigureAwait(false);
+
+                // Reset the underlying PDF to Pending so the worker's atomic Pending-only claim
+                // (IPdfClaimService.TryClaimPendingAsync) can pick it up. Re-queuing the job alone
+                // is a phantom success: the pipeline claims only Pending PDFs, so a Failed PDF is
+                // skipped and the job is marked Completed WITHOUT reprocessing. Mirrors the reset in
+                // ReindexDocumentCommandHandler (and every other recovery path). IndexerVersion is a
+                // provenance label (ADR-086) and is deliberately left untouched. `.AsTracking()` is
+                // required because the production MeepleAiDbContext defaults to NoTracking (PERF-06);
+                // without it the mutation is silently dropped. Persisted by the SaveChangesAsync
+                // below, in the same unit of work as the job update.
+                var pdf = await _dbContext.PdfDocuments
+                    .AsTracking()
+                    .FirstOrDefaultAsync(p => p.Id == job.PdfDocumentId, cancellationToken)
+                    .ConfigureAwait(false);
+                if (pdf is not null)
+                {
+                    pdf.ProcessingState = nameof(PdfProcessingState.Pending);
+                    pdf.ProcessingError = null;
+                    pdf.ProcessedAt = null;
+                    pdf.RetryCount = 0;
+                    pdf.ErrorCategory = null;
+                    pdf.FailedAtState = null;
+                }
+
                 enqueued++;
             }
             catch (Exception ex)

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/Queue/BulkReindexFailedCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/Queue/BulkReindexFailedCommandHandlerTests.cs
@@ -2,8 +2,10 @@ using Api.BoundedContexts.DocumentProcessing.Application.Commands.Queue;
 using Api.BoundedContexts.DocumentProcessing.Domain.Entities;
 using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
+using Api.Infrastructure;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
 using FluentAssertions;
 using Moq;
 using Xunit;
@@ -15,13 +17,15 @@ public sealed class BulkReindexFailedCommandHandlerTests
 {
     private readonly Mock<IProcessingJobRepository> _jobRepoMock = new();
     private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
+    private readonly MeepleAiDbContext _dbContext = TestDbContextFactory.CreateInMemoryDbContext();
     private readonly BulkReindexFailedCommandHandler _handler;
 
     public BulkReindexFailedCommandHandlerTests()
     {
         _handler = new BulkReindexFailedCommandHandler(
             _jobRepoMock.Object,
-            _unitOfWorkMock.Object);
+            _unitOfWorkMock.Object,
+            _dbContext);
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/BulkReindexFailedResetsPdfIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/BulkReindexFailedResetsPdfIntegrationTests.cs
@@ -1,0 +1,236 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Commands.Queue;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Persistence;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Services;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.DocumentProcessing;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Integration.DocumentProcessing;
+
+/// <summary>
+/// Integration test proving <see cref="BulkReindexFailedCommandHandler"/> resets the underlying
+/// PdfDocument to <c>Pending</c> (not just re-queues the ProcessingJob) so the reprocessing loop
+/// actually closes. Issue #3269 recovery-hardening (bug-hunt B12).
+///
+/// <para><b>The bug this guards against:</b> the handler re-queues each Failed ProcessingJob
+/// (Failed → Queued, Low priority) but never touches the <c>pdf_documents</c> row, which stays
+/// <c>Failed</c>. The Quartz worker then dequeues the Queued job and calls
+/// <see cref="RelationalPdfClaimService.TryClaimPendingAsync"/>, whose atomic
+/// <c>UPDATE ... WHERE processing_state = 'Pending'</c> matches 0 rows for a Failed PDF — the
+/// pipeline logs "not in Pending state, skipping" and returns WITHOUT reprocessing, so the job is
+/// marked Completed while the PDF is silently never re-indexed (a phantom "reindex succeeded").
+/// Every sibling recovery path (<see cref="Api.BoundedContexts.DocumentProcessing.Application.Commands.ReindexDocumentCommandHandler"/>,
+/// and the <c>BulkReindexReadyCommandHandler</c> fan-out) resets the PDF to Pending; this handler
+/// was the outlier.</para>
+///
+/// <para>The pure-mock unit suite (<c>BulkReindexFailedCommandHandlerTests</c>) never constructs a
+/// PdfDocument and asserts only on the job, so it cannot catch this — a Testcontainers test that
+/// exercises the real claim SQL is the only faithful reproduction. It also runs under the
+/// production <c>QueryTrackingBehavior.NoTracking</c> default so a missing <c>.AsTracking()</c>
+/// on the reset query would still be caught.</para>
+/// </summary>
+[Collection("Integration-GroupA")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "3269")]
+public sealed class BulkReindexFailedResetsPdfIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _isolatedDbConnectionString = string.Empty;
+    private string _databaseName = string.Empty;
+    private MeepleAiDbContext? _dbContext;
+    private IServiceProvider? _serviceProvider;
+    private IMediator? _mediator;
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    private static readonly Guid TestUserId = new("A0000000-0000-0000-0000-0000000B1200");
+    private static readonly Guid TestSharedGameId = new("B0000000-0000-0000-0000-0000000B1200");
+
+    public BulkReindexFailedResetsPdfIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_bulkfailed_reset_{Guid.NewGuid():N}";
+        _isolatedDbConnectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        // useNoTrackingDefault: true reproduces the production QueryTrackingBehavior.NoTracking
+        // default, so a missing `.AsTracking()` on the PDF reset query would drop the mutation.
+        var services = IntegrationServiceCollectionBuilder.CreateBase(
+            _isolatedDbConnectionString, useNoTrackingDefault: true);
+
+        services.AddSingleton<IHttpContextAccessor>(new Mock<IHttpContextAccessor>().Object);
+        services.AddScoped<IPdfDocumentRepository, PdfDocumentRepository>();
+        services.AddScoped<IProcessingJobRepository, ProcessingJobRepository>();
+
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
+        _mediator = _serviceProvider.GetRequiredService<IMediator>();
+
+        await TestMigrationHelper.MigrateWithRetryAsync(_dbContext, TestCancellationToken);
+        await SeedBaseAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_dbContext is not null)
+        {
+            await _dbContext.DisposeAsync();
+        }
+        if (_serviceProvider is IAsyncDisposable d)
+        {
+            await d.DisposeAsync();
+        }
+        else
+        {
+            (_serviceProvider as IDisposable)?.Dispose();
+        }
+
+        if (!string.IsNullOrEmpty(_databaseName))
+        {
+            try
+            {
+                await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+            }
+            catch
+            {
+                // Ignore cleanup errors — test isolation already achieved
+            }
+        }
+    }
+
+    private async Task SeedBaseAsync()
+    {
+        _dbContext!.Set<UserEntity>().Add(new UserEntity
+        {
+            Id = TestUserId,
+            Email = "bulkfailed-reset-test@meepleai.test",
+            PasswordHash = "x",
+            DisplayName = "BulkReindexFailed Reset Test",
+        });
+        _dbContext.Set<SharedGameEntity>().Add(new SharedGameEntity
+        {
+            Id = TestSharedGameId,
+            Title = "BulkReindexFailed Reset Test Game",
+        });
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+    }
+
+    /// <summary>
+    /// Seeds a Failed PdfDocument (with non-default reset-target fields so a dropped mutation is
+    /// observable) plus a matching Failed ProcessingJob (retryable: RetryCount 0 &lt; MaxRetries 3).
+    /// Seeds via its own fresh scope, deliberately separate from the one the mediator will use,
+    /// mirroring the isolation of a real prior request's DbContext (see
+    /// ReindexDocumentPersistsResetIntegrationTests for the rationale).
+    /// </summary>
+    private async Task<Guid> SeedFailedPdfWithFailedJobAsync()
+    {
+        var pdfId = Guid.NewGuid();
+
+        using var seedScope = _serviceProvider!.CreateScope();
+        var seedDb = seedScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        seedDb.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = pdfId,
+            SharedGameId = TestSharedGameId,
+            UploadedByUserId = TestUserId,
+            FileName = $"bulkfailed-{pdfId:N}.pdf",
+            FilePath = $"/tmp/{pdfId:N}.pdf",
+            FileSizeBytes = 1024,
+            ContentType = "application/pdf",
+            ProcessingState = "Failed",
+            UploadedAt = DateTime.UtcNow,
+            IndexerVersion = "v1.0",
+            ProcessedAt = DateTime.UtcNow.AddMinutes(-5),
+            ProcessingError = "boom — extractor timed out",
+            RetryCount = 2,
+            ErrorCategory = "Network",
+            FailedAtState = "Chunking",
+        });
+
+        seedDb.Set<ProcessingJobEntity>().Add(new ProcessingJobEntity
+        {
+            Id = Guid.NewGuid(),
+            PdfDocumentId = pdfId,
+            UserId = TestUserId,
+            Status = "Failed",
+            Priority = (int)ProcessingPriority.Normal,
+            CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-10),
+            CompletedAt = DateTimeOffset.UtcNow.AddMinutes(-5),
+            ErrorMessage = "boom — extractor timed out",
+            RetryCount = 0,
+            MaxRetries = 3,
+        });
+
+        await seedDb.SaveChangesAsync(TestCancellationToken);
+        return pdfId;
+    }
+
+    [Fact]
+    public async Task BulkReindexFailed_ResetsPdfToPending_SoTheWorkerCanClaimAndReprocess()
+    {
+        var pdfId = await SeedFailedPdfWithFailedJobAsync();
+
+        var result = await _mediator!.Send(
+            new BulkReindexFailedCommand(TestUserId), TestCancellationToken);
+
+        result.EnqueuedCount.Should().Be(1, "the single retryable Failed job must be re-queued");
+
+        // Verify from a FRESH, independent scope + AsNoTracking read — simulates what the Quartz
+        // worker observes on the next tick.
+        using var verifyScope = _serviceProvider!.CreateScope();
+        var verifyDb = verifyScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        // (a) The job is re-queued at Low priority.
+        var job = await verifyDb.Set<ProcessingJobEntity>()
+            .AsNoTracking()
+            .FirstAsync(j => j.PdfDocumentId == pdfId, TestCancellationToken);
+        job.Status.Should().Be(nameof(JobStatus.Queued), "Retry() moves the job back to Queued");
+        job.Priority.Should().Be((int)ProcessingPriority.Low, "bulk reindex re-queues at Low priority");
+
+        // (b) The PDF row is reset to Pending — the crux. Without this the worker's Pending-only
+        // atomic claim never matches and the reprocess silently no-ops.
+        var pdf = await verifyDb.PdfDocuments
+            .AsNoTracking()
+            .FirstAsync(p => p.Id == pdfId, TestCancellationToken);
+        pdf.ProcessingState.Should().Be(
+            "Pending",
+            "BulkReindexFailedCommandHandler must reset the PDF to Pending (like every sibling "
+            + "recovery path) — re-queuing the job alone is a phantom success because the pipeline "
+            + "only claims Pending PDFs.");
+        pdf.ProcessingError.Should().BeNull("the stale error must be cleared on re-queue");
+        pdf.ProcessedAt.Should().BeNull("ProcessedAt must be cleared on re-queue");
+        pdf.RetryCount.Should().Be(0, "the PDF retry counter must reset on re-queue");
+        pdf.ErrorCategory.Should().BeNull("ErrorCategory must be cleared on re-queue");
+        pdf.FailedAtState.Should().BeNull("FailedAtState must be cleared on re-queue");
+        pdf.IndexerVersion.Should().Be(
+            "v1.0", "IndexerVersion is a provenance label and must NOT be touched by the re-queue");
+
+        // (c) Prove the loop actually closes: the worker's atomic Pending-only claim now succeeds.
+        using var claimScope = _serviceProvider!.CreateScope();
+        var claimDb = claimScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var claimService = new RelationalPdfClaimService(claimDb);
+        var claimed = await claimService.TryClaimPendingAsync(pdfId, TestCancellationToken);
+        claimed.Should().BeTrue(
+            "after the reset the PDF is Pending, so the worker's atomic claim (Pending → Extracting) "
+            + "wins and reprocessing proceeds; before the fix it would return false and the PDF "
+            + "would stay Failed forever.");
+    }
+}


### PR DESCRIPTION
## Problem

`BulkReindexFailedCommandHandler` re-queued each Failed `ProcessingJob` (Failed → Queued, Low priority) but never touched the `pdf_documents` row, which stayed **Failed**. The Quartz worker then dequeues the job and calls `IPdfClaimService.TryClaimPendingAsync`, whose atomic `UPDATE ... WHERE processing_state='Pending'` matches **0 rows** for a Failed PDF — so the pipeline skips it and marks the job Completed **without reprocessing** (a phantom "reindex succeeded"). Every sibling recovery path resets the PDF to Pending; this handler was the outlier.

Bug-hunt **B12** (recovery-hardening, #3269).

## Fix

Inject `MeepleAiDbContext` and, for each re-queued job, reset the underlying PDF to `Pending` (clearing `ProcessingError`/`ProcessedAt`/`RetryCount`/`ErrorCategory`/`FailedAtState`, leaving `IndexerVersion` as a provenance label per ADR-086), persisted in the same unit of work. `.AsTracking()` is required under the production `QueryTrackingBehavior.NoTracking` default (PERF-06).

Builds on **PR #3317** — the re-queue path itself was throwing `DbUpdateConcurrencyException` before that root fix, so this reset was untestable end-to-end until now.

## Tests

- New Testcontainers test `BulkReindexFailedResetsPdfIntegrationTests` — proves the PDF becomes `Pending` and the worker's atomic `TryClaimPendingAsync` then succeeds (returns true; before the fix it returned false and the PDF stayed Failed forever).
- Existing unit suite updated for the new `MeepleAiDbContext` dependency; still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)