### PR TITLE
fix(docproc): resume PDF processing on retry via Pending + enqueue

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/RetryPdfProcessingCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/RetryPdfProcessingCommandHandler.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Commands.Queue;
 using Api.BoundedContexts.DocumentProcessing.Domain.Events;
 using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
 using Api.Middleware.Exceptions;
@@ -62,6 +63,26 @@ internal sealed class RetryPdfProcessingCommandHandler
             // Update via repository (handles mapping and persistence)
             await _pdfRepository.UpdateAsync(pdf, cancellationToken).ConfigureAwait(false);
             await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            // Enqueue the PDF so the pipeline actually reprocesses it. Retry() only resets the
+            // document to Pending; without an enqueue nothing picks it up — both the manual retry
+            // (this handler) and the automatic RetryFailedPdfsJob were dead loops before this fix
+            // (bug-hunt B11, #3269). Best-effort: an active job may already exist (e.g. a concurrent
+            // retry), in which case EnqueuePdfCommand throws ConflictException and the existing job
+            // will reprocess the now-Pending document — mirror ReindexDocumentCommandHandler.
+            try
+            {
+                await _mediator.Send(
+                    new EnqueuePdfCommand(pdf.Id, pdf.UploadedByUserId, Priority: 0),
+                    cancellationToken).ConfigureAwait(false);
+            }
+            catch (ConflictException ex)
+            {
+                _logger.LogInformation(
+                    ex,
+                    "PDF {PdfId} already has an active job; the retry will reprocess via that job",
+                    command.PdfId);
+            }
 
             // Publish domain event
             var retryEvent = new PdfRetryInitiatedEvent(

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Entities/PdfDocument.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Entities/PdfDocument.cs
@@ -423,15 +423,20 @@ internal sealed class PdfDocument : AggregateRoot<Guid>
 
         RetryCount++;
 
-        // Resume from failed state or restart from Extracting
-        var resumeState = FailedAtState ?? PdfProcessingState.Extracting;
-        TransitionTo(resumeState);
+        // Reset to Pending so the pipeline re-claims and re-runs the document from the start.
+        // The pipeline has NO true mid-pipeline resume (ProcessAsync always restarts from Extract),
+        // and only a Pending PDF is claimable by IPdfClaimService.TryClaimPendingAsync. The old
+        // "resume from FailedAtState ?? Extracting" left the document in a non-Pending state that
+        // no runtime rail could claim, so a retry never actually reprocessed (bug-hunt B11, #3269).
+        // Failed → Pending is permitted by ValidateStateTransition (Failed → any recovery state).
+        TransitionTo(PdfProcessingState.Pending);
 
         // Clear error state
         ProcessingError = null;
         ProcessedAt = null;
 
-        // Emit event to trigger pipeline resumption
+        // Emit event to trigger the retry notification. The actual pipeline resumption is driven by
+        // the EnqueuePdfCommand dispatched by RetryPdfProcessingCommandHandler after this returns.
         AddDomainEvent(new PdfRetryInitiatedEvent(Id, RetryCount, UploadedByUserId));
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Domain/Entities/PdfDocumentStateTransitionTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Domain/Entities/PdfDocumentStateTransitionTests.cs
@@ -191,7 +191,7 @@ public class PdfDocumentStateTransitionTests
     }
 
     [Fact]
-    public void TransitionTo_Failed_To_Extracting_Succeeds_DuringRetry()
+    public void TransitionTo_Failed_To_Pending_Succeeds_DuringRetry()
     {
         // Arrange
         var document = CreateTestDocument();
@@ -199,11 +199,11 @@ public class PdfDocumentStateTransitionTests
         document.TransitionTo(PdfProcessingState.Extracting);
         document.MarkAsFailed("Network error", ErrorCategory.Network, PdfProcessingState.Extracting);
 
-        // Act - Retry should allow transition from Failed
+        // Act - Retry resets to Pending (Failed → Pending is permitted; B11 #3269)
         document.Retry();
 
         // Assert
-        document.ProcessingState.Should().Be(PdfProcessingState.Extracting);
+        document.ProcessingState.Should().Be(PdfProcessingState.Pending);
     }
 
     // ===== Invalid Transitions Tests =====

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Domain/Entities/PdfDocumentTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Domain/Entities/PdfDocumentTests.cs
@@ -298,9 +298,28 @@ public class PdfDocumentTests
 
         // Assert
         document.RetryCount.Should().Be(1);
-        document.ProcessingState.Should().Be(PdfProcessingState.Extracting);
+        document.ProcessingState.Should().Be(PdfProcessingState.Pending);
         document.ProcessingError.Should().BeNull();
         document.ProcessedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void Retry_AlwaysResetsToPending_RegardlessOfFailedAtState()
+    {
+        // B11 (#3269): retry must reset the document to Pending — the only state the pipeline's
+        // atomic claim (IPdfClaimService.TryClaimPendingAsync) can pick up — NOT to FailedAtState.
+        // The old "resume from FailedAtState ?? Extracting" left the doc in a non-claimable state
+        // that no runtime rail resumed, so retries never actually reprocessed.
+        var document = CreateTestDocument(LanguageCode.English);
+        document.MarkAsFailed("Chunking blew up", ErrorCategory.Parsing, PdfProcessingState.Chunking);
+
+        document.Retry();
+
+        document.ProcessingState.Should().Be(
+            PdfProcessingState.Pending,
+            "retry resets to Pending regardless of the FailedAtState (here Chunking)");
+        document.RetryCount.Should().Be(1);
+        document.DomainEvents.Should().ContainSingle(e => e is PdfRetryInitiatedEvent);
     }
 
     [Fact]
@@ -335,20 +354,6 @@ public class PdfDocumentTests
         var exception = ((Action)(() => document.Retry())).Should().Throw<InvalidOperationException>().Which;
         exception.Message.Should().Contain("Cannot retry");
         exception.Message.Should().Contain("State=Pending");
-    }
-
-    [Fact]
-    public void Retry_ResumesFromFailedAtState()
-    {
-        // Arrange
-        var document = CreateTestDocument(LanguageCode.English);
-        document.MarkAsFailed("Chunking failed", ErrorCategory.Parsing, PdfProcessingState.Chunking);
-
-        // Act
-        document.Retry();
-
-        // Assert - Should resume from Chunking, not restart from beginning
-        document.ProcessingState.Should().Be(PdfProcessingState.Chunking);
     }
 
     // #2284 follow-up: TD1 — MarkProcessed domain method
@@ -469,22 +474,25 @@ public class PdfDocumentTests
         document.CanRetry().Should().BeTrue();
         document.RetryCount.Should().Be(0);
 
-        // First retry
+        // First retry — resets to Pending (retry restarts the pipeline from the top; B11)
         document.Retry();
         document.RetryCount.Should().Be(1);
-        document.ProcessingState.Should().Be(PdfProcessingState.Extracting);
+        document.ProcessingState.Should().Be(PdfProcessingState.Pending);
         document.ProcessingError.Should().BeNull();
 
         // Second failure
         document.MarkAsFailed("Parsing error", ErrorCategory.Parsing, PdfProcessingState.Chunking);
         document.CanRetry().Should().BeTrue();
 
-        // Second retry
+        // Second retry — again resets to Pending regardless of FailedAtState
         document.Retry();
         document.RetryCount.Should().Be(2);
-        document.ProcessingState.Should().Be(PdfProcessingState.Chunking);
+        document.ProcessingState.Should().Be(PdfProcessingState.Pending);
 
-        // Success path - complete processing through state machine
+        // Success path - the pipeline re-runs from the start (Pending → … → Ready)
+        document.TransitionTo(PdfProcessingState.Uploading);
+        document.TransitionTo(PdfProcessingState.Extracting);
+        document.TransitionTo(PdfProcessingState.Chunking);
         document.TransitionTo(PdfProcessingState.Embedding);
         document.TransitionTo(PdfProcessingState.Indexing);
         document.MarkAsCompleted(10);

--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/RetryPdfProcessingIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/RetryPdfProcessingIntegrationTests.cs
@@ -6,6 +6,7 @@ using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
 using Api.BoundedContexts.DocumentProcessing.Infrastructure.Persistence;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.DocumentProcessing;
 using Api.Infrastructure.Entities.SharedGameCatalog;
 using Api.SharedKernel.Application.Services;
 using Api.SharedKernel.Infrastructure.Persistence;
@@ -53,6 +54,9 @@ public sealed class RetryPdfProcessingIntegrationTests : IAsyncLifetime
         // Register repositories
         services.AddScoped<IUserRepository, UserRepository>();
         services.AddScoped<IPdfDocumentRepository, PdfDocumentRepository>();
+        // Required by EnqueuePdfCommandHandler, which the retry handler now dispatches to resume
+        // the pipeline (B11).
+        services.AddScoped<IProcessingJobRepository, ProcessingJobRepository>();
 
         // Register IProcessingMetricsService (required by PdfStateChangedMetricsEventHandler picked up by MediatR assembly scan)
         var mockMetricsService = new Moq.Mock<Api.BoundedContexts.DocumentProcessing.Application.Services.IProcessingMetricsService>();
@@ -178,16 +182,31 @@ public sealed class RetryPdfProcessingIntegrationTests : IAsyncLifetime
         // Assert
         result.Success.Should().BeTrue($"Expected success but got: {result.Message}");
         result.RetryCount.Should().Be(1);
-        result.CurrentState.Should().Be(PdfProcessingState.Extracting.ToString());
+        result.CurrentState.Should().Be(
+            PdfProcessingState.Pending.ToString(),
+            "retry resets the document to Pending — the only state the pipeline's atomic claim can "
+            + "pick up — not to FailedAtState/Extracting (which no runtime rail could claim; B11)");
 
         // Verify database was updated
         var updatedPdf = await _dbContext.PdfDocuments
+            .AsNoTracking()
             .FirstOrDefaultAsync(p => p.Id == pdfId, TestCancellationToken);
 
         updatedPdf.Should().NotBeNull();
         updatedPdf.RetryCount.Should().Be(1);
-        updatedPdf.ProcessingState.Should().Be(PdfProcessingState.Extracting.ToString());
+        updatedPdf.ProcessingState.Should().Be(PdfProcessingState.Pending.ToString());
         updatedPdf.ProcessingError.Should().BeNull();
+
+        // The crux of B11: the retry must actually enqueue a job so the pipeline reprocesses.
+        // Before the fix nothing was enqueued and the document stalled forever.
+        var enqueuedJob = await _dbContext.Set<ProcessingJobEntity>()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(
+                j => j.PdfDocumentId == pdfId && j.Status == JobStatus.Queued.ToString(),
+                TestCancellationToken);
+        enqueuedJob.Should().NotBeNull(
+            "RetryPdfProcessingCommandHandler must dispatch EnqueuePdfCommand so the pipeline "
+            + "reprocesses the now-Pending document");
     }
 
     [Fact]
@@ -378,7 +397,10 @@ public sealed class RetryPdfProcessingIntegrationTests : IAsyncLifetime
         var command1 = new RetryPdfProcessingCommand(pdfId, userId);
         var result1 = await mediator.Send(command1, TestCancellationToken);
 
-        // Simulate another failure
+        // Simulate the pipeline failing again after the first retry (in production the enqueued
+        // job would run and re-fail). Reset to Failed so the second retry is eligible (CanRetry
+        // requires Failed). The job enqueued by retry #1 stays Queued, so retry #2's enqueue will
+        // hit the idempotent "already queued" ConflictException (tolerated by the handler).
         var pdf = await _dbContext.PdfDocuments.FindAsync(new object[] { pdfId }, TestCancellationToken);
         pdf!.ProcessingState = PdfProcessingState.Failed.ToString();
         pdf.ProcessingError = "Error 2";
@@ -397,9 +419,9 @@ public sealed class RetryPdfProcessingIntegrationTests : IAsyncLifetime
         result2.Success.Should().BeTrue();
         result2.RetryCount.Should().Be(2);
 
-        // Verify final state
+        // Verify final state: retry always resets to Pending (never FailedAtState/Chunking; B11).
         var finalPdf = await _dbContext.PdfDocuments.FindAsync(new object[] { pdfId }, TestCancellationToken);
         finalPdf!.RetryCount.Should().Be(2);
-        finalPdf.ProcessingState.Should().Be(PdfProcessingState.Chunking.ToString());
+        finalPdf.ProcessingState.Should().Be(PdfProcessingState.Pending.ToString());
     }
 }


### PR DESCRIPTION
## Problem

Both **manual** retry (`RetryPdfProcessingCommandHandler`) and **automatic** retry (`RetryFailedPdfsJob`, same command) never actually reprocessed a Failed PDF:

- `PdfDocument.Retry()` transitioned to `FailedAtState ?? Extracting` — a state **no runtime rail could claim**. The pipeline's atomic claim only picks up `Pending` PDFs and always restarts from Extract (there is no true mid-pipeline resume), so the document sat in a non-claimable limbo forever.
- The handler only `Publish`ed `PdfRetryInitiatedEvent` (a notification) — **nothing enqueued** the PDF. The API answered *"Retry N initiated"* while the document was stuck.

The existing integration test even hand-forced the doc back to Failed with `// Simulate another failure` because nothing moved it — the missing resumption in plain sight. Bug-hunt **B11** (recovery-hardening, #3269).

## Fix

- **Domain**: `PdfDocument.Retry()` now transitions to `Pending` (Failed → Pending is a permitted recovery transition; it is the only state the pipeline can claim). Keeps `RetryCount++` / `CanRetry()` / the notification event.
- **Application**: after persisting the reset, the handler dispatches `EnqueuePdfCommand(Priority 0)`, tolerating the idempotent *"already queued"* `ConflictException` (mirrors `ReindexDocumentCommandHandler`). One fix repairs both retry loops.

## Tests

- New domain guard: `Retry_AlwaysResetsToPending_RegardlessOfFailedAtState`.
- `RetryPdfProcessingIntegrationTests` updated: asserts `Pending` + that a **Queued job is actually enqueued**.
- Existing domain tests updated to the Pending resume semantics (full-cycle now re-runs from the top); superseded `Retry_ResumesFromFailedAtState` removed; state-transition test renamed to `…Failed_To_Pending…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)