### PR TITLE
fix(rag): register IPdfExtractorHealthProbe unconditionally — reindex-ready 500 (#3320)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/DependencyInjection/DocumentProcessingServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/DependencyInjection/DocumentProcessingServiceExtensions.cs
@@ -96,6 +96,16 @@ internal static class DocumentProcessingServiceExtensions
         // BGAI-086/087: Configure PDF text extractor based on provider setting
         var extractorProvider = configuration["PdfProcessing:Extractor:Provider"] ?? "Orchestrator";
 
+        // #3269 fix: the bulk re-index C2 gate (BulkReindexReadyCommandHandler) injects
+        // IPdfExtractorHealthProbe UNCONDITIONALLY, so it must be registered regardless of the selected
+        // extractor provider. Previously it was only registered inside RegisterUnstructuredExtractor
+        // (Orchestrator/Unstructured providers), so on Docnet/SmolDocling/fallback the reindex-ready
+        // endpoint 500'd on DI activation. The probe depends only on IHttpClientFactory (always
+        // registered); when the "UnstructuredService" named client is absent (non-Unstructured
+        // providers) the probe degrades to "unhealthy" at runtime, so the gate throws a clear
+        // ConflictException (409) instead of a 500.
+        services.AddScoped<IPdfExtractorHealthProbe, UnstructuredExtractorHealthProbe>();
+
         if (extractorProvider.Equals("Orchestrator", StringComparison.OrdinalIgnoreCase))
         {
             // BGAI-087 + ISSUE-1174: Register all extractors for orchestrator using keyed services
@@ -425,7 +435,8 @@ internal static class DocumentProcessingServiceExtensions
             .AddServiceCallLogging("UnstructuredService");
 
         services.AddScoped<UnstructuredPdfTextExtractor>();
-        services.AddScoped<IPdfExtractorHealthProbe, UnstructuredExtractorHealthProbe>();
+        // IPdfExtractorHealthProbe is now registered unconditionally in AddDocumentProcessingContext
+        // (see the #3269 note there) so the bulk re-index gate resolves under every provider.
     }
 
     /// <summary>

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/DI/ExtractorHealthProbeRegistrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/DI/ExtractorHealthProbeRegistrationTests.cs
@@ -1,0 +1,67 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.DependencyInjection;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
+using Api.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Infrastructure.DI;
+
+/// <summary>
+/// #3269 regression: <see cref="Api.BoundedContexts.DocumentProcessing.Application.Commands.Queue.BulkReindexReadyCommandHandler"/>
+/// injects <see cref="IPdfExtractorHealthProbe"/> UNCONDITIONALLY (the C2 gate that refuses a bulk
+/// re-index against a stale extractor). The registration used to live only inside
+/// <c>RegisterUnstructuredExtractor</c> (Orchestrator/Unstructured providers), so on
+/// Docnet/SmolDocling/fallback the <c>POST /admin/queue/reindex-ready</c> endpoint threw
+/// <see cref="System.InvalidOperationException"/> ("Unable to resolve service for type
+/// IPdfExtractorHealthProbe") → HTTP 500. The probe must now resolve under EVERY provider.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "3269")]
+public sealed class ExtractorHealthProbeRegistrationTests
+{
+    [Theory]
+    [InlineData("Orchestrator")]
+    [InlineData("Unstructured")]
+    [InlineData("SmolDocling")]
+    [InlineData("Docnet")]
+    [InlineData("")] // unknown/unset → code default "Orchestrator", exercised via the ?? fallback path
+    public void AddDocumentProcessingContext_ResolvesHealthProbe_ForEveryProvider(string provider)
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddHttpClient(); // IHttpClientFactory: the probe's only ctor dependency
+
+        var settings = new Dictionary<string, string>
+        {
+            ["PdfProcessing:Extractor:Unstructured:ApiUrl"] = "http://test:8001",
+            ["PdfProcessing:Extractor:SmolDocling:ApiUrl"] = "http://test:8002",
+            ["PdfProcessing:MaxFileSizeBytes"] = "104857600",
+            ["PdfProcessing:Quality:MinimumThreshold"] = "0.80",
+            ["PdfProcessing:Quality:MinCharsPerPage"] = "500"
+        };
+        if (!string.IsNullOrEmpty(provider))
+        {
+            settings["PdfProcessing:Extractor:Provider"] = provider;
+        }
+
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(settings!).Build();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddScoped<ITextChunkingService, TextChunkingService>();
+
+        // Act
+        services.AddDocumentProcessingContext(configuration);
+        using var serviceProvider = services.BuildServiceProvider();
+
+        // Assert: resolves AND constructs (GetRequiredService activates the ctor) under every provider.
+        var probe = serviceProvider.GetRequiredService<IPdfExtractorHealthProbe>();
+        probe.Should().BeOfType<UnstructuredExtractorHealthProbe>(
+            "the bulk re-index C2 gate injects IPdfExtractorHealthProbe regardless of the selected provider");
+    }
+}


### PR DESCRIPTION
## Cosa
Fixa un bug reale che fa **500** l'endpoint `POST /admin/queue/reindex-ready` (motore del re-index big-bang SP3 #3269) su ogni ambiente con extractor provider ≠ Unstructured/Orchestrator.

## Root cause
`BulkReindexReadyCommandHandler` inietta `IPdfExtractorHealthProbe` (C2 gate anti flat-chunking) incondizionatamente, ma la registrazione DI viveva **solo** dentro `RegisterUnstructuredExtractor` (provider Orchestrator/Unstructured). Con `Docnet`/`SmolDocling`/fallback il probe è irrisolvibile → `InvalidOperationException` → 500.

**Scoperto sul campo** eseguendo il re-index big-bang su staging, dove `appsettings.json:212` imposta `Provider=Docnet` di default (il corpus è rimasto intatto — il 500 avviene prima di ogni enqueue).

## Fix
Registrazione incondizionata di `IPdfExtractorHealthProbe` in `AddDocumentProcessingContext` (rimossa dal ramo condizionale). Il probe dipende solo da `IHttpClientFactory`; con provider non-Unstructured il named client manca → il probe **degrada a unhealthy** a runtime → il gate lancia `ConflictException` (409) chiaro invece di un 500 opaco.

## Test
`ExtractorHealthProbeRegistrationTests` — Theory su tutti i provider (`Orchestrator`/`Unstructured`/`SmolDocling`/`Docnet`/unset): 11/11 verdi (5 nuovi + 6 esistenti `OrchestratorDICircularDependency`). Senza il fix, il caso `Docnet`/`SmolDocling` fallisce la risoluzione.

## Config gap (follow-up, non in questa PR)
`Provider=Docnet` di default → la pipeline heading-aware (Unstructured) **non è attiva** in nessun ambiente. Il re-index heading-aware di #3269 richiede `Provider=Unstructured`/`Orchestrator`. È una decisione di config/policy del team.

Fixes #3320
Refs #3269 #3266

🤖 Generated with [Claude Code](https://claude.com/claude-code)
