### PR TITLE
fix(docproc): make reindex reset+enqueue atomic (no phantom strand)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/Queue/BulkReindexReadyCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/Queue/BulkReindexReadyCommandHandler.cs
@@ -75,11 +75,12 @@ internal sealed class BulkReindexReadyCommandHandler
 
         // Pace against the queue cap: ReindexDocumentCommand fans out to EnqueuePdfCommand →
         // ProcessingJob.Create, whose guard rejects when Queued + Processing >= MaxQueueSize and
-        // throws a plain InvalidOperationException that ReindexDocumentCommandHandler swallows
-        // AFTER already resetting the PDF to Pending — a phantom success that leaves the doc broken.
-        // We MUST mirror EnqueuePdfCommandHandler's EXACT capacity computation (Queued + Processing)
-        // so we never dispatch beyond the real cap. Remaining docs are skipped with a retryable
-        // error so the admin can re-run to drain the rest as the queue empties.
+        // throws a ConflictException. ReindexDocumentCommandHandler now rolls back its destructive
+        // reset on that failure (issue #3269 B10) instead of leaving a phantom success, but we still
+        // pace here so we don't dispatch reindexes that would only be rolled back. We MUST mirror
+        // EnqueuePdfCommandHandler's EXACT capacity computation (Queued + Processing) so we never
+        // dispatch beyond the real cap. Remaining docs are skipped with a retryable error so the
+        // admin can re-run to drain the rest as the queue empties.
         var queuedCount = await _jobRepository
             .CountByStatusAsync(JobStatus.Queued, cancellationToken)
             .ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/ReindexDocumentCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/ReindexDocumentCommandHandler.cs
@@ -85,7 +85,14 @@ internal sealed class ReindexDocumentCommandHandler : ICommandHandler<ReindexDoc
             _dbContext.TextChunks.RemoveRange(chunks);
         }
 
-        // Reset state + scrive la versione risolta.
+        // Stage the destructive reset (chunk delete + field mutations) but DO NOT commit it on its
+        // own. The reset MUST commit atomically with the new ProcessingJob: the old code saved the
+        // reset first and then swallowed any enqueue failure (queue full / transient) in a broad
+        // catch — a phantom success that left the PDF reset-to-Pending with its chunks deleted but
+        // no job to reprocess it, stranding the document (bug-hunt B10, #3269; B4 amplifies it by
+        // stamping IndexerVersion=target so no recovery selector re-picks the strand). EnqueuePdfCommand
+        // shares this scoped DbContext, so wrapping both in one explicit transaction makes the reset
+        // + job commit together — or not at all.
         pdf.ProcessingState = nameof(PdfProcessingState.Pending);
         pdf.ProcessedAt = null;
         pdf.ProcessingError = null;
@@ -94,38 +101,57 @@ internal sealed class ReindexDocumentCommandHandler : ICommandHandler<ReindexDoc
         pdf.FailedAtState = null;
         pdf.IndexerVersion = resolvedVersion;
 
-        try
+        // The production Npgsql context uses a retrying execution strategy, which forbids
+        // user-initiated transactions unless they run inside the strategy's executed delegate so a
+        // transient-failure retry re-runs the WHOLE transaction as one retriable unit.
+        var strategy = _dbContext.Database.CreateExecutionStrategy();
+        await strategy.ExecuteAsync(async () =>
         {
-            await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-        }
-        catch (DbUpdateConcurrencyException ex)
-        {
-            MeepleAiMetrics.RecordPdfConcurrencyConflict(
-                nameof(ReindexDocumentCommandHandler),
-                MeepleAiMetrics.PdfConcurrencyCategories.A);
-            _logger.LogWarning(ex,
-                "Concurrency conflict on PdfDocument {PdfId} in {Handler} (Category A)",
-                command.PdfId, nameof(ReindexDocumentCommandHandler));
-            throw new ConflictException(
-                $"Document {command.PdfId} was modified by another concurrent operation; please retry.");
-        }
+            using var transaction = await _dbContext.Database
+                .BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                // Persist the reset within the transaction (not yet committed).
+                await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
-        // Enqueue Quartz.
-        try
-        {
-            var userId = pdf.UploadedByUserId;
-            await _mediator.Send(
-                new EnqueuePdfCommand(command.PdfId, userId, Priority: 0),
-                cancellationToken).ConfigureAwait(false);
-            _logger.LogInformation(
-                "Reindexed PDF {PdfId} with version {IndexerVersion} enqueued for processing",
-                command.PdfId, resolvedVersion);
-        }
-#pragma warning disable CA1031 // Best-effort enqueue
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Could not enqueue reindexed PDF {PdfId} (may already be queued)", command.PdfId);
-        }
-#pragma warning restore CA1031
+                // Enqueue within the SAME transaction — EnqueuePdfCommandHandler's SaveChanges runs
+                // on the shared DbContext under this ambient transaction, so the job is staged
+                // alongside the reset and both commit together below.
+                await _mediator.Send(
+                    new EnqueuePdfCommand(command.PdfId, pdf.UploadedByUserId, Priority: 0),
+                    cancellationToken).ConfigureAwait(false);
+
+                await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+
+                _logger.LogInformation(
+                    "Reindexed PDF {PdfId} with version {IndexerVersion} enqueued for processing",
+                    command.PdfId, resolvedVersion);
+            }
+            catch (DbUpdateConcurrencyException ex)
+            {
+                await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                MeepleAiMetrics.RecordPdfConcurrencyConflict(
+                    nameof(ReindexDocumentCommandHandler),
+                    MeepleAiMetrics.PdfConcurrencyCategories.A);
+                _logger.LogWarning(ex,
+                    "Concurrency conflict on PdfDocument {PdfId} in {Handler} (Category A)",
+                    command.PdfId, nameof(ReindexDocumentCommandHandler));
+                throw new ConflictException(
+                    $"Document {command.PdfId} was modified by another concurrent operation; please retry.");
+            }
+            catch (ConflictException ex)
+            {
+                // Queue full, or an active job already exists for this PDF. The transaction rolls
+                // back, so the destructive reset is undone — the document stays in its pre-reindex
+                // state with its chunks intact (no strand). Surface a retryable 409 instead of the
+                // old phantom success. In the BulkReindexReadyCommandHandler fan-out this is caught
+                // per-document and the batch continues with the remaining candidates.
+                await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                _logger.LogWarning(ex,
+                    "Could not enqueue reindex for PDF {PdfId} (queue full or already queued); reset rolled back",
+                    command.PdfId);
+                throw;
+            }
+        }).ConfigureAwait(false);
     }
 }

--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/ReindexDocumentPersistsResetIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/ReindexDocumentPersistsResetIntegrationTests.cs
@@ -1,10 +1,14 @@
 using Api.BoundedContexts.DocumentProcessing.Application.Commands;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.BoundedContexts.DocumentProcessing.Domain.Entities;
 using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
 using Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects;
 using Api.BoundedContexts.DocumentProcessing.Infrastructure.Persistence;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.DocumentProcessing;
 using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Middleware.Exceptions;
 using Api.Tests.Constants;
 using Api.Tests.Infrastructure;
 using FluentAssertions;
@@ -239,5 +243,88 @@ public sealed class ReindexDocumentPersistsResetIntegrationTests : IAsyncLifetim
             .Where(tc => tc.PdfDocumentId == pdfId)
             .ToListAsync(TestCancellationToken);
         remainingChunks.Should().BeEmpty("all TextChunks for the document must be deleted on reindex");
+    }
+
+    /// <summary>
+    /// Fills the processing queue to <see cref="ProcessingJob.MaxQueueSize"/> with Queued jobs (all
+    /// pointing at one throwaway PDF) so the next <c>EnqueuePdfCommand → ProcessingJob.Create</c>
+    /// hits the capacity guard and throws <see cref="ConflictException"/>. Seeded via an isolated
+    /// scope so the rows are committed before the reindex runs.
+    /// </summary>
+    private async Task SaturateQueueAsync()
+    {
+        using var seedScope = _serviceProvider!.CreateScope();
+        var seedDb = seedScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var fillerPdfId = Guid.NewGuid();
+        seedDb.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = fillerPdfId,
+            SharedGameId = TestSharedGameId,
+            UploadedByUserId = TestUserId,
+            FileName = $"filler-{fillerPdfId:N}.pdf",
+            FilePath = $"/tmp/{fillerPdfId:N}.pdf",
+            FileSizeBytes = 1024,
+            ContentType = "application/pdf",
+            ProcessingState = "Pending",
+            UploadedAt = DateTime.UtcNow,
+        });
+
+        for (var i = 0; i < ProcessingJob.MaxQueueSize; i++)
+        {
+            seedDb.Set<ProcessingJobEntity>().Add(new ProcessingJobEntity
+            {
+                Id = Guid.NewGuid(),
+                PdfDocumentId = fillerPdfId,
+                UserId = TestUserId,
+                Status = nameof(JobStatus.Queued),
+                Priority = (int)ProcessingPriority.Normal,
+                CreatedAt = DateTimeOffset.UtcNow,
+                RetryCount = 0,
+                MaxRetries = 3,
+            });
+        }
+
+        await seedDb.SaveChangesAsync(TestCancellationToken);
+    }
+
+    [Fact]
+    public async Task Reindex_WhenQueueFull_RollsBackReset_NoPhantomStrand()
+    {
+        var pdfId = await SeedReadyPdfWithChunksAsync(); // Ready, IndexerVersion "v1.0", 2 chunks
+        await SaturateQueueAsync();                      // queue at MaxQueueSize → enqueue will fail
+
+        var act = () => _mediator!.Send(
+            new ReindexDocumentCommand(pdfId, IndexerVersionRegistry.Current.Version),
+            TestCancellationToken);
+
+        // (a) The failed enqueue surfaces as a retryable conflict — never a phantom success.
+        await act.Should().ThrowAsync<ConflictException>();
+
+        // Verify from a fresh scope: the destructive reset was ROLLED BACK.
+        using var verifyScope = _serviceProvider!.CreateScope();
+        var verifyDb = verifyScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var reloaded = await verifyDb.PdfDocuments
+            .AsNoTracking()
+            .FirstAsync(p => p.Id == pdfId, TestCancellationToken);
+        // (b) PDF untouched: still Ready, still v1.0 (B4 — NOT stamped to the target, so recovery
+        // selectors still see it), chunks intact.
+        reloaded.ProcessingState.Should().Be(
+            "Ready", "the destructive reset must roll back when the enqueue fails (no phantom strand)");
+        reloaded.IndexerVersion.Should().Be(
+            "v1.0", "IndexerVersion must NOT be stamped to the target on a rolled-back reindex (B4)");
+
+        var chunks = await verifyDb.TextChunks
+            .AsNoTracking()
+            .Where(tc => tc.PdfDocumentId == pdfId)
+            .ToListAsync(TestCancellationToken);
+        chunks.Should().HaveCount(2, "the chunk delete must roll back with the reset — no data loss");
+
+        // (c) No ProcessingJob was created for the target PDF (the fan-out left no strand).
+        var jobForPdf = await verifyDb.Set<ProcessingJobEntity>()
+            .AsNoTracking()
+            .AnyAsync(j => j.PdfDocumentId == pdfId, TestCancellationToken);
+        jobForPdf.Should().BeFalse("a rolled-back reindex must not leave an orphan job for the PDF");
     }
 }

--- a/apps/api/tests/Api.Tests/Unit/DocumentProcessing/ReindexDocumentCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/DocumentProcessing/ReindexDocumentCommandHandlerTests.cs
@@ -149,4 +149,26 @@ public sealed class ReindexDocumentCommandHandlerTests : IAsyncLifetime
             It.Is<EnqueuePdfCommand>(c => c.PdfDocumentId == pdf.Id),
             It.IsAny<CancellationToken>()), Times.Once);
     }
+
+    [Fact]
+    public async Task Handle_EnqueueThrowsConflict_RethrowsInsteadOfPhantomSuccess()
+    {
+        // B10 (#3269): the old handler committed the destructive reset and then SWALLOWED any
+        // enqueue failure (queue full / transient) in a broad catch — a phantom success that left
+        // the PDF reset-to-Pending with its chunks gone but no job to reprocess it. The handler
+        // must now surface the failure (rolled back) so the caller gets a retryable 409.
+        // NOTE: this asserts only the THROW. Proving the reset is actually rolled back needs a real
+        // transaction — the InMemory provider has none — so the rollback is covered by
+        // ReindexDocumentPersistsResetIntegrationTests (queue-saturation scenario).
+        var pdf = await SeedPdfAsync(indexerVersion: "v1.0");
+
+        _mediator.Setup(m => m.Send(It.IsAny<EnqueuePdfCommand>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ConflictException("Queue is full. Maximum 100 jobs allowed."));
+
+        var handler = CreateHandler();
+
+        var act = () => handler.Handle(new ReindexDocumentCommand(pdf.Id, "v1.1"), CancellationToken.None);
+
+        await act.Should().ThrowAsync<ConflictException>().WithMessage("*Queue is full*");
+    }
 }


### PR DESCRIPTION
## Problem

`ReindexDocumentCommandHandler` committed its **destructive reset** (chunk delete + state → `Pending` + `IndexerVersion` stamp) **first**, then enqueued in a separate step whose failure was swallowed by a broad catch — a **phantom success** that left the PDF reset-to-Pending with its chunks gone but **no job** to reprocess it, stranding the document. **B4** amplified it: the reset-time `IndexerVersion = target` stamp meant no recovery selector re-picked the strand.

Bug-hunt **B10 + B4** (recovery-hardening, #3269).

## Fix

Wrap the reset + `EnqueuePdfCommand` in one explicit transaction (via `CreateExecutionStrategy` so it composes with the production Npgsql retry strategy — which otherwise forbids user transactions). `EnqueuePdfCommand` shares the scoped `DbContext`, so its `SaveChanges` stages the job under the **same** transaction; both commit together or roll back together.

On queue-full / already-queued `ConflictException` (or a transient / concurrency error) the reset **rolls back** and the handler rethrows a retryable **409** — never a phantom success. With the strand now impossible, the reset-time version stamp is safe (**B4 subsumed**). Also fixes the now-stale phantom-success comment in `BulkReindexReadyCommandHandler`.

## Tests

- Unit: `Handle_EnqueueThrowsConflict_RethrowsInsteadOfPhantomSuccess` (throw, not swallow).
- **Testcontainers**: `Reindex_WhenQueueFull_RollsBackReset_NoPhantomStrand` — saturates the queue to `MaxQueueSize`, then proves the reset **fully rolls back** (PDF still `Ready` + `v1.0` + 2 chunks intact) and **no orphan job** is left for the PDF.
- Bulk fan-out + version integration suites still green (transactional reindex works in the shared-context loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)