### PR TITLE
fix(docproc): atomic-claim admin process-pending recovery

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/ProcessPendingPdfs/ProcessPendingPdfsCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/ProcessPendingPdfs/ProcessPendingPdfsCommandHandler.cs
@@ -1,29 +1,42 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.Infrastructure;
+using Api.Infrastructure.Entities;
 using Api.SharedKernel.Application.Interfaces;
-using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
 namespace Api.BoundedContexts.DocumentProcessing.Application.Commands.ProcessPendingPdfs;
 
 /// <summary>
-/// Handler for ProcessPendingPdfsCommand.
-/// Finds all PDFs with status "pending" or "processing" and triggers IndexPdfCommand for each.
-/// Admin operation for fixing stuck PDF processing pipeline.
+/// Handler for ProcessPendingPdfsCommand — the admin "unstick the pipeline" recovery endpoint.
+/// Selects Pending PDFs (plus in-flight PDFs that are STALE per a 30-minute cutoff) and routes each
+/// through the shared pipeline's ATOMIC Pending-only claim
+/// (<see cref="IPdfClaimService.TryClaimPendingAsync"/>), so a document already being processed by a
+/// concurrent worker or sweep is skipped instead of being re-extracted and re-indexed in parallel.
+///
+/// <para>The old handler selected every non-terminal PDF and ran a blind Extract + Index with no
+/// claim, so two concurrent admin sweeps (or a sweep racing the Quartz pipeline) both processed the
+/// SAME in-flight document — duplicating/tearing its text_chunks + pgvector rows (the child tables
+/// have no unique (PdfDocumentId, ChunkIndex) and xmin only guards pdf_documents). Mirrors
+/// StalePdfRecoveryService. Bug-hunt B14 (#3269).</para>
 /// </summary>
 internal sealed class ProcessPendingPdfsCommandHandler : ICommandHandler<ProcessPendingPdfsCommand, ProcessPendingPdfsResult>
 {
+    /// <summary>An in-flight (non-Pending) PDF older than this is considered stale and recoverable.</summary>
+    private static readonly TimeSpan ProcessingStaleness = TimeSpan.FromMinutes(30);
+
     private readonly MeepleAiDbContext _dbContext;
-    private readonly IMediator _mediator;
+    private readonly IPdfProcessingPipelineService _pipeline;
     private readonly ILogger<ProcessPendingPdfsCommandHandler> _logger;
 
     public ProcessPendingPdfsCommandHandler(
         MeepleAiDbContext dbContext,
-        IMediator mediator,
+        IPdfProcessingPipelineService pipeline,
         ILogger<ProcessPendingPdfsCommandHandler> logger)
     {
         _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
-        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+        _pipeline = pipeline ?? throw new ArgumentNullException(nameof(pipeline));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -33,70 +46,95 @@ internal sealed class ProcessPendingPdfsCommandHandler : ICommandHandler<Process
     {
         ArgumentNullException.ThrowIfNull(command);
 
-        // Find all PDFs not in terminal states (Ready/Failed), ordered by priority (Admin first)
-        var readyState = nameof(Api.BoundedContexts.DocumentProcessing.Domain.Enums.PdfProcessingState.Ready);
-        var failedState = nameof(Api.BoundedContexts.DocumentProcessing.Domain.Enums.PdfProcessingState.Failed);
+        var pendingState = nameof(PdfProcessingState.Pending);
+        var uploadingState = nameof(PdfProcessingState.Uploading);
+        var extractingState = nameof(PdfProcessingState.Extracting);
+        var chunkingState = nameof(PdfProcessingState.Chunking);
+        var embeddingState = nameof(PdfProcessingState.Embedding);
+        var indexingState = nameof(PdfProcessingState.Indexing);
+        var processingCutoff = DateTime.UtcNow - ProcessingStaleness;
 
-        var pendingPdfs = await _dbContext.PdfDocuments
-            .Where(p => p.ProcessingState != readyState && p.ProcessingState != failedState)
+        // Recoverable = Pending (any age — this is an explicit admin trigger), OR an in-flight state
+        // ONLY if stale, so we never clobber a document the normal pipeline is actively processing.
+        // Demo mock placeholders (seed/ prefix, no real blob) are excluded: force-processing them
+        // would only fail on the missing blob and flip them to Failed.
+        var candidates = await _dbContext.PdfDocuments
+            .Where(p => !p.FilePath.StartsWith(PdfDocumentEntity.DemoMockFilePathPrefix))
+            .Where(p =>
+                p.ProcessingState == pendingState ||
+                ((p.ProcessingState == uploadingState ||
+                  p.ProcessingState == extractingState ||
+                  p.ProcessingState == chunkingState ||
+                  p.ProcessingState == embeddingState ||
+                  p.ProcessingState == indexingState) && p.UploadedAt < processingCutoff))
             .OrderByDescending(p => p.ProcessingPriority) // Admin > Normal
             .ThenBy(p => p.UploadedAt)
-            .Select(p => new { p.Id, p.FileName, p.ProcessingState })
+            .Select(p => new { p.Id, p.FileName, p.FilePath, p.UploadedByUserId, p.ProcessingState })
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        _logger.LogInformation(
-            "Found {Count} pending PDFs to process",
-            pendingPdfs.Count);
+        _logger.LogInformation("Found {Count} recoverable PDF(s) to process", candidates.Count);
 
         var triggered = 0;
         var failed = 0;
         var pdfIds = new List<string>();
 
-        foreach (var pdf in pendingPdfs)
+        foreach (var pdf in candidates)
         {
             try
             {
-                // Step 1: Extract text if not already done
-                _logger.LogInformation("Extracting text for PDF {PdfId} ({FileName})", pdf.Id, pdf.FileName);
-                var extractCommand = new ExtractPdfTextCommand(pdf.Id);
-                await _mediator.Send(extractCommand, cancellationToken).ConfigureAwait(false);
+                // Stale in-flight docs are reset to Pending first so the pipeline's atomic claim can
+                // pick them up (ProcessAsync only claims Pending). Pending docs are processed as-is.
+                if (!string.Equals(pdf.ProcessingState, pendingState, StringComparison.Ordinal))
+                {
+                    await ResetToPendingAsync(pdf.Id, cancellationToken).ConfigureAwait(false);
+                }
 
-                // Step 2: Index PDF (chunking + embedding)
-                _logger.LogInformation("Indexing PDF {PdfId} ({FileName})", pdf.Id, pdf.FileName);
-                var indexCommand = new IndexPdfCommand(pdf.Id.ToString());
-                await _mediator.Send(indexCommand, cancellationToken).ConfigureAwait(false);
+                // ProcessAsync internally does TryClaimPendingAsync (atomic Pending → Extracting); a
+                // document already claimed by a concurrent worker/sweep is skipped without
+                // corruption — closing the race the old blind Extract + Index left open (B14).
+                await _pipeline.ProcessAsync(pdf.Id, pdf.FilePath, pdf.UploadedByUserId, cancellationToken)
+                    .ConfigureAwait(false);
 
                 triggered++;
                 pdfIds.Add(pdf.Id.ToString());
-
-                _logger.LogInformation(
-                    "Successfully processed PDF {PdfId} ({FileName})",
-                    pdf.Id,
-                    pdf.FileName);
+                _logger.LogInformation("Processed PDF {PdfId} ({FileName})", pdf.Id, pdf.FileName);
             }
+#pragma warning disable CA1031 // Non-blocking: log and continue to the next PDF
             catch (Exception ex)
             {
                 failed++;
-                _logger.LogError(
-                    ex,
-                    "Failed to process PDF {PdfId} ({FileName})",
-                    pdf.Id,
-                    pdf.FileName);
+                _logger.LogError(ex, "Failed to process PDF {PdfId} ({FileName})", pdf.Id, pdf.FileName);
             }
+#pragma warning restore CA1031
         }
 
         _logger.LogInformation(
             "Batch PDF processing completed: {Triggered} triggered, {Failed} failed out of {Total} total",
-            triggered,
-            failed,
-            pendingPdfs.Count);
+            triggered, failed, candidates.Count);
 
         return new ProcessPendingPdfsResult(
-            TotalPending: pendingPdfs.Count,
+            TotalPending: candidates.Count,
             Triggered: triggered,
             Failed: failed,
-            PdfIds: pdfIds
-        );
+            PdfIds: pdfIds);
+    }
+
+    private async Task ResetToPendingAsync(Guid pdfDocumentId, CancellationToken cancellationToken)
+    {
+        var readyState = nameof(PdfProcessingState.Ready);
+        // `.AsTracking()` is required because the production MeepleAiDbContext defaults to NoTracking
+        // (PERF-06); without it the mutation is silently dropped.
+        var pdf = await _dbContext.PdfDocuments
+            .AsTracking()
+            .FirstOrDefaultAsync(p => p.Id == pdfDocumentId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (pdf != null && !string.Equals(pdf.ProcessingState, readyState, StringComparison.Ordinal))
+        {
+            pdf.ProcessingState = nameof(PdfProcessingState.Pending);
+            pdf.ProcessingError = null;
+            await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Commands/ProcessPendingPdfs/ProcessPendingPdfsCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Commands/ProcessPendingPdfs/ProcessPendingPdfsCommandHandlerTests.cs
@@ -1,0 +1,131 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Commands.ProcessPendingPdfs;
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Commands.ProcessPendingPdfs;
+
+/// <summary>
+/// Unit tests for the B14 (#3269) recovery-hardening of <see cref="ProcessPendingPdfsCommandHandler"/>:
+/// the handler now selects only genuinely-recoverable docs (Pending, or in-flight-but-stale) and
+/// routes each through the claim-protected <see cref="IPdfProcessingPipelineService.ProcessAsync"/>
+/// instead of a blind Extract + Index over every non-terminal doc. The atomic Pending-only claim
+/// itself (which makes concurrent sweeps race-safe) lives in RelationalPdfClaimService and is
+/// covered by its own tests; here we pin the selector + reset + routing decisions.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "3269")]
+public sealed class ProcessPendingPdfsCommandHandlerTests : IAsyncLifetime
+{
+    private MeepleAiDbContext _db = default!;
+    private Mock<IPdfProcessingPipelineService> _pipeline = default!;
+    private ProcessPendingPdfsCommandHandler _handler = default!;
+
+    public ValueTask InitializeAsync()
+    {
+        _db = TestDbContextFactory.CreateInMemoryDbContext($"pendingpdfs_{Guid.NewGuid():N}");
+        _pipeline = new Mock<IPdfProcessingPipelineService>();
+        _pipeline
+            .Setup(p => p.ProcessAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _handler = new ProcessPendingPdfsCommandHandler(
+            _db, _pipeline.Object, NullLogger<ProcessPendingPdfsCommandHandler>.Instance);
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _db.Dispose();
+        return ValueTask.CompletedTask;
+    }
+
+    private async Task<Guid> SeedPdfAsync(string state, DateTime uploadedAt, string? filePath = null)
+    {
+        var id = Guid.NewGuid();
+        _db.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = id,
+            FileName = $"{id:N}.pdf",
+            FilePath = filePath ?? $"/tmp/{id:N}.pdf",
+            FileSizeBytes = 1024,
+            ContentType = "application/pdf",
+            UploadedByUserId = Guid.NewGuid(),
+            ProcessingState = state,
+            UploadedAt = uploadedAt,
+        });
+        await _db.SaveChangesAsync();
+        return id;
+    }
+
+    [Fact]
+    public async Task Handle_RecentInFlightDoc_IsSkipped_NotClaimed()
+    {
+        // A doc actively being processed (Embedding, uploaded just now) must NOT be recovered — the
+        // old blind Extract + Index would race the live pipeline and corrupt its chunks.
+        await SeedPdfAsync(nameof(PdfProcessingState.Embedding), DateTime.UtcNow);
+
+        var result = await _handler.Handle(new ProcessPendingPdfsCommand(), CancellationToken.None);
+
+        result.TotalPending.Should().Be(0);
+        result.Triggered.Should().Be(0);
+        _pipeline.Verify(
+            p => p.ProcessAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_PendingDoc_IsProcessedThroughClaimProtectedPipeline()
+    {
+        var id = await SeedPdfAsync(nameof(PdfProcessingState.Pending), DateTime.UtcNow);
+
+        var result = await _handler.Handle(new ProcessPendingPdfsCommand(), CancellationToken.None);
+
+        result.Triggered.Should().Be(1);
+        _pipeline.Verify(
+            p => p.ProcessAsync(id, It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_StaleInFlightDoc_IsResetToPendingThenProcessed()
+    {
+        var id = await SeedPdfAsync(nameof(PdfProcessingState.Indexing), DateTime.UtcNow.AddMinutes(-31));
+
+        var result = await _handler.Handle(new ProcessPendingPdfsCommand(), CancellationToken.None);
+
+        result.Triggered.Should().Be(1);
+        _pipeline.Verify(
+            p => p.ProcessAsync(id, It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        var reloaded = await _db.PdfDocuments.AsNoTracking().FirstAsync(p => p.Id == id);
+        reloaded.ProcessingState.Should().Be(
+            nameof(PdfProcessingState.Pending),
+            "a stale in-flight doc must be reset to Pending so the pipeline's atomic claim can pick it up");
+    }
+
+    [Fact]
+    public async Task Handle_DemoMockPlaceholder_IsExcluded()
+    {
+        await SeedPdfAsync(
+            nameof(PdfProcessingState.Pending),
+            DateTime.UtcNow,
+            filePath: $"{PdfDocumentEntity.DemoMockFilePathPrefix}badsworm/game/rulebook.pdf");
+
+        var result = await _handler.Handle(new ProcessPendingPdfsCommand(), CancellationToken.None);
+
+        result.TotalPending.Should().Be(0);
+        _pipeline.Verify(
+            p => p.ProcessAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/ProcessPendingPdfsRecoveryIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/ProcessPendingPdfsRecoveryIntegrationTests.cs
@@ -1,0 +1,180 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Commands.ProcessPendingPdfs;
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Integration.DocumentProcessing;
+
+/// <summary>
+/// Integration test proving the B14 (#3269) recovery selector + reset run correctly against real
+/// Postgres under the production <c>QueryTrackingBehavior.NoTracking</c> default. Uses a mock
+/// <see cref="IPdfProcessingPipelineService"/> (recording which PDFs it is asked to process) rather
+/// than the heavy real pipeline — the atomic Pending-only claim that makes concurrent sweeps
+/// race-safe lives in RelationalPdfClaimService and is covered by its own suite.
+///
+/// <para>Verifies that <see cref="ProcessPendingPdfsCommandHandler"/> processes Pending docs and
+/// STALE in-flight docs (resetting the latter to Pending first) but NOT recently-in-flight docs
+/// (which the live pipeline is still working on — the old handler raced them) nor demo mock
+/// placeholders.</para>
+/// </summary>
+[Collection("Integration-GroupA")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "3269")]
+public sealed class ProcessPendingPdfsRecoveryIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _isolatedDbConnectionString = string.Empty;
+    private string _databaseName = string.Empty;
+    private MeepleAiDbContext? _dbContext;
+    private IServiceProvider? _serviceProvider;
+    private IMediator? _mediator;
+    private readonly Mock<IPdfProcessingPipelineService> _pipeline = new();
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    private static readonly Guid TestUserId = new("A0000000-0000-0000-0000-0000000B1400");
+    private static readonly Guid TestSharedGameId = new("B0000000-0000-0000-0000-0000000B1400");
+
+    public ProcessPendingPdfsRecoveryIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_processpending_{Guid.NewGuid():N}";
+        _isolatedDbConnectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(
+            _isolatedDbConnectionString, useNoTrackingDefault: true);
+
+        services.AddSingleton<IHttpContextAccessor>(new Mock<IHttpContextAccessor>().Object);
+
+        _pipeline
+            .Setup(p => p.ProcessAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        // Registered last so it wins over any real pipeline registration from CreateBase.
+        services.AddScoped(_ => _pipeline.Object);
+
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
+        _mediator = _serviceProvider.GetRequiredService<IMediator>();
+
+        await TestMigrationHelper.MigrateWithRetryAsync(_dbContext, TestCancellationToken);
+        await SeedBaseAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_dbContext is not null)
+        {
+            await _dbContext.DisposeAsync();
+        }
+        if (_serviceProvider is IAsyncDisposable d)
+        {
+            await d.DisposeAsync();
+        }
+        else
+        {
+            (_serviceProvider as IDisposable)?.Dispose();
+        }
+
+        if (!string.IsNullOrEmpty(_databaseName))
+        {
+            try
+            {
+                await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+            }
+            catch
+            {
+                // Ignore cleanup errors — test isolation already achieved
+            }
+        }
+    }
+
+    private async Task SeedBaseAsync()
+    {
+        _dbContext!.Set<UserEntity>().Add(new UserEntity
+        {
+            Id = TestUserId,
+            Email = "processpending-test@meepleai.test",
+            PasswordHash = "x",
+            DisplayName = "ProcessPending Recovery Test",
+        });
+        _dbContext.Set<SharedGameEntity>().Add(new SharedGameEntity
+        {
+            Id = TestSharedGameId,
+            Title = "ProcessPending Recovery Test Game",
+        });
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+    }
+
+    private async Task<Guid> SeedPdfAsync(string state, DateTime uploadedAt, bool demoMock = false)
+    {
+        var id = Guid.NewGuid();
+        using var seedScope = _serviceProvider!.CreateScope();
+        var seedDb = seedScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        seedDb.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = id,
+            SharedGameId = TestSharedGameId,
+            UploadedByUserId = TestUserId,
+            FileName = $"{id:N}.pdf",
+            FilePath = demoMock
+                ? $"{PdfDocumentEntity.DemoMockFilePathPrefix}badsworm/{id:N}/rulebook.pdf"
+                : $"/tmp/{id:N}.pdf",
+            FileSizeBytes = 1024,
+            ContentType = "application/pdf",
+            ProcessingState = state,
+            UploadedAt = uploadedAt,
+        });
+        await seedDb.SaveChangesAsync(TestCancellationToken);
+        return id;
+    }
+
+    [Fact]
+    public async Task ProcessPending_RecoversPendingAndStale_SkipsRecentInFlightAndDemoMocks()
+    {
+        var pendingId = await SeedPdfAsync(nameof(PdfProcessingState.Pending), DateTime.UtcNow);
+        var recentInFlightId = await SeedPdfAsync(nameof(PdfProcessingState.Embedding), DateTime.UtcNow);
+        var staleInFlightId = await SeedPdfAsync(nameof(PdfProcessingState.Indexing), DateTime.UtcNow.AddMinutes(-31));
+        var demoMockId = await SeedPdfAsync(nameof(PdfProcessingState.Pending), DateTime.UtcNow, demoMock: true);
+
+        var result = await _mediator!.Send(new ProcessPendingPdfsCommand(), TestCancellationToken);
+
+        result.TotalPending.Should().Be(2, "only the Pending doc and the STALE in-flight doc are recoverable");
+
+        // Recovered: Pending (as-is) + stale Indexing (after reset to Pending).
+        _pipeline.Verify(p => p.ProcessAsync(pendingId, It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Once);
+        _pipeline.Verify(p => p.ProcessAsync(staleInFlightId, It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Once);
+
+        // Skipped: recently-in-flight (live pipeline still working) + demo mock placeholder.
+        _pipeline.Verify(p => p.ProcessAsync(recentInFlightId, It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+        _pipeline.Verify(p => p.ProcessAsync(demoMockId, It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+
+        // The stale in-flight doc was reset to Pending in the DB (verified from a fresh scope under
+        // NoTracking) so the pipeline's atomic claim can pick it up; the recent in-flight doc is
+        // untouched.
+        using var verifyScope = _serviceProvider!.CreateScope();
+        var verifyDb = verifyScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var stale = await verifyDb.PdfDocuments.AsNoTracking().FirstAsync(p => p.Id == staleInFlightId, TestCancellationToken);
+        stale.ProcessingState.Should().Be(nameof(PdfProcessingState.Pending), "stale in-flight doc must be reset to Pending");
+
+        var recent = await verifyDb.PdfDocuments.AsNoTracking().FirstAsync(p => p.Id == recentInFlightId, TestCancellationToken);
+        recent.ProcessingState.Should().Be(nameof(PdfProcessingState.Embedding), "a recently-active doc must NOT be reset — the live pipeline owns it");
+    }
+}


### PR DESCRIPTION
## Problem

`ProcessPendingPdfsCommandHandler` (the admin *"unstick the pipeline"* endpoint) selected **every** non-terminal PDF and ran a blind Extract + Index with **no claim**. Two concurrent admin sweeps — or a sweep racing the live Quartz pipeline — both processed the **same** in-flight document, duplicating and tearing its `text_chunks` + pgvector rows (the child tables have no unique `(PdfDocumentId, ChunkIndex)`; `xmin` only guards `pdf_documents`). Every other entry point already goes through the atomic Pending-only claim; this one bypassed it.

Bug-hunt **B14** (recovery-hardening, #3269).

## Fix

Mirror `StalePdfRecoveryService`:
- Select Pending docs **plus** in-flight docs **only when stale** (30-min cutoff), excluding demo mock placeholders (`seed/` prefix).
- Reset stale in-flight docs to `Pending` first.
- Route each through `IPdfProcessingPipelineService.ProcessAsync`, whose internal `TryClaimPendingAsync` (atomic `Pending → Extracting`) **skips** any doc already claimed by a concurrent worker/sweep instead of re-processing it in parallel — closing the race and de-duplicating the pipeline logic.

## Tests

- **4 unit**: skip recent in-flight, process Pending, reset + process stale in-flight, exclude demo mock.
- **Testcontainers**: validates the selector + reset on real Postgres under the `NoTracking` default (Pending + stale recovered, recent in-flight + demo mock skipped, stale doc reset to Pending in DB).
- The atomic-claim concurrency guarantee itself is covered by `RelationalPdfClaimService`'s own suite + `ProcessAsync`'s claim-skip.

## Follow-up (tracked separately)

`LaunchAdminPdfProcessingCommandHandler` has the same claim gap with a smaller blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)