### PR TITLE
chore(#564): Q3 re-triage - fix stale #2029 ref on PDF-language TODOs

### DIFF
--- a/apps/web/src/components/search/SearchFilters.tsx
+++ b/apps/web/src/components/search/SearchFilters.tsx
@@ -242,7 +242,7 @@ export const SearchFilters = React.memo<SearchFiltersProps>(function SearchFilte
         </div>
       </div>
 
-      {/* TODO: Issue #2029 - PDF Language Filter (requires backend support) */}
+      {/* TODO(BE-gated): PDF Language Filter — enable when the backend exposes PDF language metadata */}
       {/* <div className="space-y-2">
         <Label htmlFor="filter-language" className="text-xs">
           PDF Language

--- a/apps/web/src/types/search.ts
+++ b/apps/web/src/types/search.ts
@@ -66,7 +66,7 @@ export interface AgentSearchResult extends BaseSearchResult {
 
 /**
  * PDF search result
- * TODO: Issue #2029 - Add PDF document type when available
+ * TODO(BE-gated): add richer PDF document-type fields when the backend exposes them (no tracking issue yet).
  */
 export interface PdfSearchResult extends BaseSearchResult {
   type: 'pdf';
@@ -74,7 +74,7 @@ export interface PdfSearchResult extends BaseSearchResult {
   fileName: string;
   gameId?: string;
   gameName?: string;
-  language?: string; // TODO: Issue #2029 - Add when PDF language metadata is available
+  language?: string; // TODO(BE-gated): populate when PDF language metadata is exposed by the backend
 }
 
 /**
@@ -97,7 +97,7 @@ export interface SearchFilters {
   dateFrom?: Date;
   dateTo?: Date;
   types?: SearchResultType[];
-  language?: string; // TODO: Issue #2029 - Implement when PDF language is available
+  language?: string; // TODO(BE-gated): implement PDF language filtering when the backend exposes language metadata
 }
 
 /**


### PR DESCRIPTION
## Contesto

Ritual trimestrale TODO/FIXME di **#564** (cadenza Q3, scaduta 2026-07-01). Snapshot completo + fix del solo ref genuinamente difettoso trovato.

## Cosa cambia

4 TODO in `search.ts` (3) + `SearchFilters.tsx` (1) referenziavano **#2029**, che in realtà è una **PR mergiata di mockup-cleanup** (`chore(mockups): #2025 portfolio cleanup`), non l'issue PDF-language che il commento implicava. Nessuna issue reale per PDF-language metadata esiste (feature BE-gated).

Rimosso il ref errato → TODO auto-descrittivi con rationale esplicito `(BE-gated)`, coerente con la disciplina di #564 ("debito tracciato a livello codice, no proliferazione di issue gated").

```diff
- * TODO: Issue #2029 - Add PDF document type when available
+ * TODO(BE-gated): add richer PDF document-type fields when the backend exposes them (no tracking issue yet).
```

## Scope escluso (deliberatamente)

- **Sistema #42xx–#52xx** (#4218 SSE, #4219 metrics/ETA, #4211, #4130): tracker interno non-GitHub usato coerentemente in ~40+ punti per feature reali implementate. **NON toccato** — rimuoverlo sarebbe la "mass action rumorosa" che #564 vieta. Documentato nel commento snapshot su #564.
- TODO gated legittimi (#807-followup CSS alpha, #2389 Block C, #1585-followup): mantenuti (debito sano tracciato a livello codice).

## Verifica

- ✅ `eslint` 0 errori sui 2 file (1 warning preesistente `game.title:139`, non correlato)
- ✅ pre-commit lint-staged + `tsc --noEmit` verdi
- ✅ Solo commenti modificati, nessun cambio di comportamento

Ref: #564