### PR TITLE
fix(rag): drop fragment chunks in heading-aware chunking (#3325)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/HeadingAwareChunker.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/HeadingAwareChunker.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.DocumentProcessing.Domain.Services;
 using Api.BoundedContexts.KnowledgeBase.Application.Services.Chunking;
+using Api.Constants;
 using Api.Services;
 
 namespace Api.BoundedContexts.DocumentProcessing.Application.Services;
@@ -36,6 +37,48 @@ internal static class HeadingAwareChunker
             .ChunkDocumentAsync(extractedDocument, config: null, cancellationToken)
             .ConfigureAwait(false);
 
-        return HierarchicalChunkMapper.ToDocumentChunks(hierarchicalChunks);
+        var chunks = HierarchicalChunkMapper.ToDocumentChunks(hierarchicalChunks);
+
+        // #3269 fragment filter: drop decorative/vertical-text artefacts ("A N", "N",
+        // "I L E X Y R F") that unstructured emits as bogus Title elements on complex-layout PDFs.
+        // They pollute retrieval — a query token like "N" ("N giocatori") matches such micro-chunks
+        // with a very high ts_rank (short chunk => high normalized rank), burying the real section
+        // chunk. Keep only chunks whose Text carries a real word (a run of >= MinSubstantiveLetterRun
+        // consecutive letters). The criterion is absolute and monotone across the parent⊇child
+        // hierarchy (a parent concatenates its children), so filtering never orphans a child.
+        return chunks.Where(IsSubstantial).ToList();
+    }
+
+    /// <summary>
+    /// True when <paramref name="chunk"/> carries at least one run of
+    /// <see cref="ChunkingConstants.MinSubstantiveLetterRun"/> consecutive Unicode letters — i.e. one
+    /// real word. Decorative fragments ("A N", "I L E X Y R F", digit/symbol-only runs) have none and
+    /// are dropped. Single scan (no regex) — allocation-free and DoS-safe.
+    /// </summary>
+    internal static bool IsSubstantial(DocumentChunk chunk)
+    {
+        var text = chunk.Text;
+        if (string.IsNullOrEmpty(text))
+        {
+            return false;
+        }
+
+        var run = 0;
+        foreach (var ch in text)
+        {
+            if (char.IsLetter(ch))
+            {
+                if (++run >= ChunkingConstants.MinSubstantiveLetterRun)
+                {
+                    return true;
+                }
+            }
+            else
+            {
+                run = 0;
+            }
+        }
+
+        return false;
     }
 }

--- a/apps/api/src/Api/Constants/ChunkingConstants.cs
+++ b/apps/api/src/Api/Constants/ChunkingConstants.cs
@@ -47,4 +47,16 @@ internal static class ChunkingConstants
     /// E5-base supports 512 tokens * ~4 chars/token = 2048, with a safety buffer applied.
     /// </summary>
     public const int MaxEmbeddingChars = 1800;
+
+    /// <summary>
+    /// Minimum run of consecutive Unicode letters a chunk's text must contain to be indexed (3).
+    /// #3269 fragment filter: heading-aware chunking over noisy <c>unstructured</c> extraction
+    /// (complex PDF layouts with vertical/decorative text) emits bogus micro-chunks such as
+    /// <c>"A N"</c>, <c>"N"</c>, <c>"I L E X Y R F"</c>. A query token like <c>"N"</c> matches these
+    /// with a very high ts_rank (short chunk =&gt; high normalized rank), burying the real section
+    /// chunk. A chunk with no run of this many consecutive letters carries no real word and is
+    /// dropped. The criterion is absolute/monotone across the parent⊇child hierarchy, so filtering
+    /// never orphans a child.
+    /// </summary>
+    public const int MinSubstantiveLetterRun = 3;
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/HeadingAwareChunkerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/HeadingAwareChunkerTests.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.DocumentProcessing.Application.Services;
 using Api.BoundedContexts.DocumentProcessing.Domain.Services;
 using Api.BoundedContexts.KnowledgeBase.Application.Services.Chunking;
 using Api.BoundedContexts.KnowledgeBase.Domain.Chunking;
+using Api.Services;
 using Api.Tests.Constants;
 using FluentAssertions;
 using Moq;
@@ -157,5 +158,59 @@ public class HeadingAwareChunkerTests
         capturedDocument.GameId.Should().Be(GameId);
         capturedDocument.Sections.Should().ContainSingle();
         capturedDocument.Sections[0].Heading.Should().Be("Preparazione");
+    }
+
+    [Fact]
+    public async Task BuildAsync_DropsFragmentChunks_KeepsSubstantiveOnes()
+    {
+        // #3269 fragment filter: decorative/vertical-text artefacts unstructured emits as bogus Title
+        // elements ("A N", "N", "I L E X Y R F", digit-only) must be dropped — a query token like "N"
+        // matches such micro-chunks with a high ts_rank and buries the real section chunk.
+        var substantive = HierarchicalChunk.CreateParent(
+            "6 PREPARAZIONE Di seguito viene descritta la preparazione per il gioco da 2 a 5 giocatori.",
+            Metadata(heading: "Preparazione"));
+        var fragAN = HierarchicalChunk.CreateParent("A N", Metadata(heading: "A N"));
+        var fragN = HierarchicalChunk.CreateParent("N", Metadata(heading: "N"));
+        var fragVertical = HierarchicalChunk.CreateParent("I L E X Y R F", Metadata(heading: null));
+        var fragDigits = HierarchicalChunk.CreateParent("12 34 56 78", Metadata(heading: null));
+
+        var advancedChunkingMock = new Mock<IAdvancedChunkingService>();
+        advancedChunkingMock
+            .Setup(s => s.ChunkDocumentAsync(
+                It.IsAny<ExtractedDocument>(),
+                It.IsAny<ChunkingConfiguration?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<HierarchicalChunk> { substantive, fragAN, fragN, fragVertical, fragDigits });
+
+        // Act
+        var result = await HeadingAwareChunker.BuildAsync(
+            new List<ExtractedElement> { new("Preparazione", 1, "Title") },
+            "flat text",
+            DocumentId,
+            GameId,
+            advancedChunkingMock.Object,
+            CancellationToken.None);
+
+        // Assert — only the substantive chunk survives.
+        result.Should().ContainSingle();
+        result[0].Text.Should().Contain("PREPARAZIONE");
+    }
+
+    [Theory]
+    [InlineData("A N", false)]
+    [InlineData("N", false)]
+    [InlineData("I L E X Y R F", false)]
+    [InlineData("12 34 56 78", false)]
+    [InlineData("", false)]
+    [InlineData("   ", false)]
+    [InlineData("A. B. C.", false)]   // single letters + punctuation, no 3-letter run
+    [InlineData("AZIONI", true)]
+    [InlineData("Preparazione", true)]
+    [InlineData("Da 2 a 5 giocatori", true)]
+    [InlineData("6 PREPARAZIONE Di seguito", true)]
+    public void IsSubstantial_ClassifiesFragmentsVsRealWords(string text, bool expected)
+    {
+        var chunk = new DocumentChunk { Id = Guid.NewGuid(), Text = text };
+        HeadingAwareChunker.IsSubstantial(chunk).Should().Be(expected);
     }
 }


### PR DESCRIPTION
## Cosa
Fixa il collo di bottiglia che, dopo il re-index heading-aware, ancora impediva al RAG di rispondere a *"Setup per N giocatori"* su Terraforming Mars. Scoperto **testando la query RAG end-to-end** sul corpus re-indicizzato.

## Root cause
Il chunking heading-aware (SP2 Slice-D #3269) su estrazione `unstructured` **rumorosa** (PDF con colonne / testo verticale / immagini) crea **chunk-frammento** da testo decorativo estratto come falsi `Title`: `"A N"`, `"N"`, `"I L E X Y R F"` — **92 su 488** chunk `<20 char` per TM. La query contiene il token `"N"` ("N giocatori") → i micro-chunk lo matchano con `ts_rank` altissimo (chunk corto ⇒ rank normalizzato alto) e **dominano il ranking**, nascondendo il chunk sostanziale. Test RAG: risposta *"not available"* + sources `"A N"`/`"N"`, **nonostante** il chunk `PREPARAZIONE` (1242 char, "…preparazione per il gioco standard da 2 a 5 giocatori…") esista.

## Fix
`.Where(IsSubstantial)` in `HeadingAwareChunker.BuildAsync` — chokepoint unico dei 4 ingest path. `IsSubstantial` = il `Text` contiene un run di **≥3 lettere consecutive** (una parola reale). Scan singolo, no-regex.

**Integrità gerarchia:** il criterio è **assoluto e monotono** sulla relazione parent⊇child (il parent concatena i figli): se un parent è scartato, i figli sono già sotto soglia → nessun orfano. `ParentChunkId` è comunque un riferimento soft nullable.

## Test
`HeadingAwareChunkerTests` — end-to-end (5 chunk in ingresso, solo `PREPARAZIONE` sopravvive) + Theory 11 casi di `IsSubstantial` (`"A N"`/`"N"`/`"I L E X Y R F"`/digit-only → drop; `"AZIONI"`/`"Preparazione"` → keep). **15/15 verdi**.

## Nota operativa
Richiede un **re-index** per avere effetto sui corpora esistenti (il re-index staging in corso usa il codice pre-fix; andrà rifatto dopo il deploy di questo fix).

Fixes #3325
Refs #3269 #3266

🤖 Generated with [Claude Code](https://claude.com/claude-code)
