### PR TITLE
feat(rag): query-dependent heading-match ranking boost (#3270)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchQueryHandler.cs
@@ -166,7 +166,8 @@ internal class SearchQueryHandler : IQueryHandler<SearchQuery, List<SearchResult
                 searchMethod: "vector",
                 pdfDocumentId: scored.Embedding.PdfDocumentId,                       // real (JOIN-resolved)
                 chunkIndex: scored.Embedding.ChunkIndex,
-                roleTags: (GameBookRole)scored.Embedding.RoleTags                    // int → enum
+                roleTags: (GameBookRole)scored.Embedding.RoleTags,                   // int → enum
+                heading: scored.Embedding.Heading                                     // #3270
             );
         }).ToList();
 
@@ -216,7 +217,12 @@ internal class SearchQueryHandler : IQueryHandler<SearchQuery, List<SearchResult
             .Select((kr, index) => kr.ToDomainSearchResult(index + 1))
             .ToList();
 
-        // Use RRF fusion domain service
-        return _rrfFusionService.FuseResults(vectorResults, keywordResults, queryRoleHint: queryRoleHint);
+        // Use RRF fusion domain service. #3270: derive heading-match query terms from the raw query
+        // (the same string used for the keyword arm) and forward them so the heading boost can fire.
+        return _rrfFusionService.FuseResults(
+            vectorResults,
+            keywordResults,
+            queryRoleHint: queryRoleHint,
+            queryTerms: FusionSignals.ExtractHeadingMatchTerms(query));
     }
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/Embedding.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/Embedding.cs
@@ -38,6 +38,14 @@ internal sealed class Embedding : Entity<Guid>
     public Guid PdfDocumentId { get; private set; }
 
     /// <summary>
+    /// #3270: chunk heading-path label (from <c>text_chunks."Heading"</c> via a JOIN on
+    /// <c>source_chunk_id</c> in the scored pgvector read) so hybrid fusion can apply the
+    /// heading-match boost to vector-arm chunks. Null when the chunk has no heading or the read
+    /// path did not project it.
+    /// </summary>
+    public string? Heading { get; private set; }
+
+    /// <summary>
     /// Private constructor for EF Core.
     /// </summary>
 #pragma warning disable CS8618
@@ -61,7 +69,8 @@ internal sealed class Embedding : Entity<Guid>
         Guid? sourceChunkId = null,
         bool isTranslation = false,
         int roleTags = 0,
-        Guid pdfDocumentId = default) : base(id)
+        Guid pdfDocumentId = default,
+        string? heading = null) : base(id)
     {
         if (string.IsNullOrWhiteSpace(textContent))
             throw new ArgumentException("Text content cannot be empty", nameof(textContent));
@@ -87,6 +96,7 @@ internal sealed class Embedding : Entity<Guid>
         IsTranslation = isTranslation;
         RoleTags = roleTags;
         PdfDocumentId = pdfDocumentId;
+        Heading = heading;
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/SearchResult.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/SearchResult.cs
@@ -20,6 +20,9 @@ internal sealed class SearchResult : Entity<Guid>
     public int ChunkIndex { get; private set; }
     public GameBookRole RoleTags { get; private set; }
 
+    /// <summary>#3270: chunk heading-path label for the heading-match boost (nullable).</summary>
+    public string? Heading { get; private set; }
+
     /// <summary>
     /// Private constructor for EF Core.
     /// </summary>
@@ -42,7 +45,8 @@ internal sealed class SearchResult : Entity<Guid>
         string? searchMethod = null,
         Guid pdfDocumentId = default,
         int chunkIndex = 0,
-        GameBookRole roleTags = GameBookRole.None) : base(id)
+        GameBookRole roleTags = GameBookRole.None,
+        string? heading = null) : base(id)
     {
         if (string.IsNullOrWhiteSpace(textContent))
             throw new ArgumentException("Text content cannot be empty", nameof(textContent));
@@ -62,6 +66,7 @@ internal sealed class SearchResult : Entity<Guid>
         PdfDocumentId = pdfDocumentId;
         ChunkIndex = chunkIndex;
         RoleTags = roleTags;
+        Heading = heading;
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/FusionSignals.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/FusionSignals.cs
@@ -13,6 +13,13 @@ internal static class FusionSignals
     /// <summary>Additive role-match boost (issue #1391 Phase D6).</summary>
     internal const float RoleMatchBoost = 0.15f;
 
+    /// <summary>Additive heading-match boost (#3270). Same magnitude/shape as the role boost.</summary>
+    internal const float HeadingMatchBoost = 0.15f;
+
+    /// <summary>Punctuation/whitespace separators for <see cref="ExtractHeadingMatchTerms"/> (CA1861: hoisted).</summary>
+    private static readonly char[] HeadingTermSeparators =
+        { ' ', '\t', '\n', '\r', ',', '.', ';', ':', '?', '!', '"', '(', ')' };
+
     /// <summary>Default reciprocal-rank-fusion constant.</summary>
     internal const int DefaultRrfK = 60;
 
@@ -35,6 +42,57 @@ internal static class FusionSignals
         }
 
         return (chunkRoleTags & queryRoleHint) != GameBookRole.None ? RoleMatchBoost : 0f;
+    }
+
+    /// <summary>
+    /// Additive boost when any normalized query term appears in the chunk's heading (#3270).
+    /// Query-dependent, structural twin of <see cref="ComputeRoleMatchBoost"/>. <paramref name="queryTerms"/>
+    /// MUST be lowercased (contract of <see cref="ExtractHeadingMatchTerms"/>); the heading is lowercased here.
+    /// </summary>
+    internal static float ComputeHeadingMatchBoost(IReadOnlyList<string>? queryTerms, string? chunkHeading)
+    {
+        if (queryTerms is null || queryTerms.Count == 0 || string.IsNullOrWhiteSpace(chunkHeading))
+        {
+            return 0f;
+        }
+
+        var headingLower = chunkHeading.ToLowerInvariant();
+        for (var i = 0; i < queryTerms.Count; i++)
+        {
+            var term = queryTerms[i];
+            if (term.Length >= 3 && headingLower.Contains(term, StringComparison.Ordinal))
+            {
+                return HeadingMatchBoost;
+            }
+        }
+
+        return 0f;
+    }
+
+    /// <summary>
+    /// Normalizes a raw query into heading-match terms: lowercased, punctuation-split, length ≥ 3,
+    /// de-duplicated (order-preserving). This is the ONLY producer of the query-term contract consumed
+    /// by <see cref="ComputeHeadingMatchBoost"/>.
+    /// </summary>
+    internal static IReadOnlyList<string> ExtractHeadingMatchTerms(string? query)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return Array.Empty<string>();
+        }
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var terms = new List<string>();
+        foreach (var raw in query.Split(HeadingTermSeparators, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var t = raw.Trim().ToLowerInvariant();
+            if (t.Length >= 3 && seen.Add(t))
+            {
+                terms.Add(t);
+            }
+        }
+
+        return terms;
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/HybridFusionCore.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/HybridFusionCore.cs
@@ -7,6 +7,7 @@ internal readonly record struct FusionCandidate(
     string Key,
     string Content,
     GameBookRole RoleTags,
+    string? Heading,   // #3270: chunk heading-path label (nullable) for the heading-match boost
     int Rank,          // 1-based within THIS arm (cosine desc / ts_rank_cd desc)
     float SourceScore);
 
@@ -14,13 +15,15 @@ internal sealed record FusionOptions(
     float VectorWeight = 0.7f,
     float KeywordWeight = 0.3f,
     int RrfK = FusionSignals.DefaultRrfK,
-    GameBookRole QueryRoleHint = GameBookRole.None);
+    GameBookRole QueryRoleHint = GameBookRole.None,
+    IReadOnlyList<string>? QueryTerms = null); // #3270: normalized query terms for the heading boost
 
 /// <summary>Scoring result keyed by Key; adapters re-join their arm items for I/O-specific fields.</summary>
 internal readonly record struct FusedCandidate(
     string Key,
     string Content,
     GameBookRole RoleTags,
+    string? Heading,   // #3270: merged heading (prefers vector arm)
     float HybridScore,
     float? VectorScore,
     float? KeywordScore,
@@ -56,15 +59,19 @@ internal static class HybridFusionCore
             // Prefer vector arm content (load-bearing: legend factor is computed from it).
             string content = hasV ? v.Content : k.Content;
             GameBookRole roleTags = (hasV ? v.RoleTags : GameBookRole.None) | (hasK ? k.RoleTags : GameBookRole.None);
+            // #3270: prefer vector-arm heading; fall back to keyword arm when vector had none.
+            string? heading = (hasV ? v.Heading : null) ?? (hasK ? k.Heading : null);
 
             float legendFactor = FusionSignals.ComputeLegendPenaltyFactor(content);
             float roleBoost = FusionSignals.ComputeRoleMatchBoost(options.QueryRoleHint, roleTags);
-            float hybridScore = (rrfSum * (1f - legendFactor)) + roleBoost;
+            float headingBoost = FusionSignals.ComputeHeadingMatchBoost(options.QueryTerms, heading);
+            float hybridScore = (rrfSum * (1f - legendFactor)) + roleBoost + headingBoost;
 
             scored.Add(new FusedCandidate(
                 Key: key,
                 Content: content,
                 RoleTags: roleTags,
+                Heading: heading,
                 HybridScore: hybridScore,
                 VectorScore: hasV ? v.SourceScore : (float?)null,
                 KeywordScore: hasK ? k.SourceScore : (float?)null,

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/RrfFusionDomainService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/RrfFusionDomainService.cs
@@ -24,24 +24,26 @@ internal class RrfFusionDomainService
     /// <param name="keywordResults">Results from keyword search</param>
     /// <param name="rrfK">RRF constant (default 60)</param>
     /// <param name="queryRoleHint">Optional role hint used to boost matching chunks (default None)</param>
+    /// <param name="queryTerms">#3270: normalized query terms (lowercased, len≥3) for the heading-match boost (default null = no-op)</param>
     /// <returns>Fused and re-ranked results</returns>
     public virtual List<SearchResult> FuseResults(
         List<SearchResult> vectorResults,
         List<SearchResult> keywordResults,
         int rrfK = DefaultRrfK,
-        GameBookRole queryRoleHint = GameBookRole.None)
+        GameBookRole queryRoleHint = GameBookRole.None,
+        IReadOnlyList<string>? queryTerms = null)
     {
         if (rrfK <= 0)
             throw new ArgumentException("RRF K must be positive", nameof(rrfK));
 
         var vectorArm = vectorResults
-            .Select((r, i) => new FusionCandidate(GetChunkKey(r), r.TextContent, r.RoleTags, i + 1, (float)r.RelevanceScore.Value))
+            .Select((r, i) => new FusionCandidate(GetChunkKey(r), r.TextContent, r.RoleTags, r.Heading, i + 1, (float)r.RelevanceScore.Value))
             .ToList();
         var keywordArm = keywordResults
-            .Select((r, i) => new FusionCandidate(GetChunkKey(r), r.TextContent, r.RoleTags, i + 1, (float)r.RelevanceScore.Value))
+            .Select((r, i) => new FusionCandidate(GetChunkKey(r), r.TextContent, r.RoleTags, r.Heading, i + 1, (float)r.RelevanceScore.Value))
             .ToList();
 
-        var fused = HybridFusionCore.Fuse(vectorArm, keywordArm, new FusionOptions(0.7f, 0.3f, rrfK, queryRoleHint));
+        var fused = HybridFusionCore.Fuse(vectorArm, keywordArm, new FusionOptions(0.7f, 0.3f, rrfK, queryRoleHint, queryTerms));
 
         var vByKey = vectorResults.ToLookup(GetChunkKey, StringComparer.Ordinal);
         var kByKey = keywordResults.ToLookup(GetChunkKey, StringComparer.Ordinal);
@@ -66,7 +68,8 @@ internal class RrfFusionDomainService
                     searchMethod: "hybrid",
                     pdfDocumentId: original.PdfDocumentId,
                     chunkIndex: original.ChunkIndex,
-                    roleTags: f.RoleTags);
+                    roleTags: f.RoleTags,
+                    heading: f.Heading);
             })
             .ToList();
     }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/Mappers/KnowledgeBaseMappers.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/Mappers/KnowledgeBaseMappers.cs
@@ -101,7 +101,8 @@ internal static class KnowledgeBaseMappers
             searchMethod: "keyword",
             pdfDocumentId: pdfDocId,
             chunkIndex: result.ChunkIndex,
-            roleTags: result.RoleTags);
+            roleTags: result.RoleTags,
+            heading: result.Heading); // #3270
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/PgVectorStoreAdapter.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/PgVectorStoreAdapter.cs
@@ -137,13 +137,19 @@ internal sealed class PgVectorStoreAdapter : IVectorStoreAdapter
 
         // RRF fusion-key fix: JOIN vector_documents to resolve the owning PdfDocumentId so hybrid
         // fusion can key vector results on {PdfDocumentId}_{ChunkIndex} (matching the keyword arm).
-        // PdfDocumentId is column 7, similarity column 8.
+        // PdfDocumentId is column 7, similarity column 8, heading column 9.
+        // #3270: LEFT JOIN text_chunks on source_chunk_id to carry the chunk heading for the
+        // heading-match boost — LEFT (not INNER) so a pre-SP2 embedding with a null source_chunk_id
+        // still returns its row with heading=null instead of being dropped. text_chunks."Id" is the
+        // PK, so the join is 1:0-or-1 (no row fan-out).
         var sql = $"""
             SELECT e.id, e.vector_document_id, e.text_content, e.model, e.chunk_index, e.page_number, e.role_tags,
                    vd."PdfDocumentId",
-                   1 - (e.vector <=> @queryVector) AS similarity
+                   1 - (e.vector <=> @queryVector) AS similarity,
+                   tc."Heading"
             FROM {TableName} e
             JOIN vector_documents vd ON vd."Id" = e.vector_document_id
+            LEFT JOIN text_chunks tc ON tc."Id" = e.source_chunk_id
             WHERE e.game_id = @gameId
               AND 1 - (e.vector <=> @queryVector) >= @minScore
             """;
@@ -192,6 +198,10 @@ internal sealed class PgVectorStoreAdapter : IVectorStoreAdapter
                     var pdfDocumentId = reader.GetGuid(7);
                     // Column 8: similarity = 1 - (vector <=> @queryVector)
                     var score = reader.GetDouble(8);
+                    // #3270 Column 9: chunk heading via LEFT JOIN text_chunks on source_chunk_id (nullable).
+                    var heading = await reader.IsDBNullAsync(9, cancellationToken).ConfigureAwait(false)
+                        ? null
+                        : reader.GetString(9);
 
                     var placeholderVector = DomainVector.CreatePlaceholder(queryVector.Dimensions);
                     var embedding = new Embedding(
@@ -203,7 +213,8 @@ internal sealed class PgVectorStoreAdapter : IVectorStoreAdapter
                         chunkIndex: chunkIndex,
                         pageNumber: Math.Max(1, pageNumber),
                         roleTags: roleTags,
-                        pdfDocumentId: pdfDocumentId);
+                        pdfDocumentId: pdfDocumentId,
+                        heading: heading);
 
                     results.Add(new ScoredEmbedding(embedding, score));
                 }

--- a/apps/api/src/Api/Services/HybridSearchService.cs
+++ b/apps/api/src/Api/Services/HybridSearchService.cs
@@ -282,7 +282,9 @@ internal class HybridSearchService : IHybridSearchService
             Page = se.Embedding.PageNumber,
             // Slice C: carry role_tags through so vector-only chunks get the role-match boost in
             // fusion (same cast as the semantic-only path). pgvector already SELECTs role_tags.
-            RoleTags = (GameBookRole)se.Embedding.RoleTags
+            RoleTags = (GameBookRole)se.Embedding.RoleTags,
+            // #3270: carry the chunk heading (JOIN-resolved) so vector-arm chunks get the heading boost.
+            Heading = se.Embedding.Heading
         }).ToArray();
 
         _logger.LogInformation(
@@ -298,7 +300,8 @@ internal class HybridSearchService : IHybridSearchService
             vectorWeight,
             keywordWeight,
             _config.RrfConstant ?? FusionSignals.DefaultRrfK,
-            queryRoleHint);
+            queryRoleHint,
+            FusionSignals.ExtractHeadingMatchTerms(query)); // #3270
 
         var topResults = fusedResults
             .OrderByDescending(r => r.HybridScore)
@@ -392,20 +395,21 @@ internal class HybridSearchService : IHybridSearchService
         float vectorWeight,
         float keywordWeight,
         int rrfK,
-        GameBookRole queryRoleHint)
+        GameBookRole queryRoleHint,
+        IReadOnlyList<string>? queryTerms)
     {
         static string VectorKeyOf(SearchResultItem r) => $"{r.PdfId}_{r.ChunkIndex}";
         static string KeywordKeyOf(KeywordSearchResult r) => $"{r.PdfDocumentId}_{r.ChunkIndex}";
 
         var vectorArm = vectorResults
-            .Select((r, index) => new FusionCandidate(VectorKeyOf(r), r.Text, r.RoleTags, index + 1, r.Score))
+            .Select((r, index) => new FusionCandidate(VectorKeyOf(r), r.Text, r.RoleTags, r.Heading, index + 1, r.Score))
             .ToList();
 
         // RRF fusion-key fix: key the keyword arm on the SAME {PdfDocumentId}_{ChunkIndex} composite
         // as the vector arm (was the raw text_chunks.Id, which never matched the vector key — so a
         // doubly-retrieved chunk was emitted as two half-strength duplicates instead of being fused).
         var keywordArm = keywordResults
-            .Select((r, index) => new FusionCandidate(KeywordKeyOf(r), r.Content, r.RoleTags, index + 1, r.RelevanceScore))
+            .Select((r, index) => new FusionCandidate(KeywordKeyOf(r), r.Content, r.RoleTags, r.Heading, index + 1, r.RelevanceScore))
             .ToList();
 
         _logger.LogDebug(
@@ -415,7 +419,7 @@ internal class HybridSearchService : IHybridSearchService
         var fused = HybridFusionCore.Fuse(
             vectorArm,
             keywordArm,
-            new FusionOptions(vectorWeight, keywordWeight, rrfK, queryRoleHint));
+            new FusionOptions(vectorWeight, keywordWeight, rrfK, queryRoleHint, queryTerms));
 
         // Re-join by composite key to recover the I/O-specific fields the core doesn't carry.
         // The composite key is backed by a NON-unique index on the keyword side, so use
@@ -453,7 +457,8 @@ internal class HybridSearchService : IHybridSearchService
                 KeywordRank = f.KeywordRank,
                 MatchedTerms = matchedTerms,
                 Mode = SearchMode.Hybrid,
-                RoleTags = f.RoleTags
+                RoleTags = f.RoleTags,
+                Heading = f.Heading
             });
         }
 

--- a/apps/api/src/Api/Services/IHybridSearchService.cs
+++ b/apps/api/src/Api/Services/IHybridSearchService.cs
@@ -122,4 +122,7 @@ internal record HybridSearchResult
     /// <see cref="GameBookRole.None"/> when the chunk is unclassified.
     /// </summary>
     public GameBookRole RoleTags { get; init; } = GameBookRole.None;
+
+    /// <summary>#3270: merged chunk heading (prefers vector arm) for the heading-match boost (nullable).</summary>
+    public string? Heading { get; init; }
 }

--- a/apps/api/src/Api/Services/IKeywordSearchService.cs
+++ b/apps/api/src/Api/Services/IKeywordSearchService.cs
@@ -78,6 +78,9 @@ internal record KeywordSearchResult
     /// <see cref="GameBookRole.None"/> when the chunk has not been classified.
     /// </summary>
     public GameBookRole RoleTags { get; init; } = GameBookRole.None;
+
+    /// <summary>#3270: chunk heading-path label for the heading-match boost (nullable).</summary>
+    public string? Heading { get; init; }
 }
 
 /// <summary>

--- a/apps/api/src/Api/Services/KeywordSearchService.cs
+++ b/apps/api/src/Api/Services/KeywordSearchService.cs
@@ -104,6 +104,7 @@ internal class KeywordSearchService : IKeywordSearchService
                         ""ChunkIndex"",
                         ""PageNumber"",
                         role_tags AS ""RoleTags"",
+                        ""Heading"",
                         ts_rank_cd({tsvectorExpr}, to_tsquery(@textSearchConfig::regconfig, @tsQuery), @normalization) AS ""RelevanceScore""
                     FROM text_chunks
                     WHERE
@@ -147,7 +148,9 @@ internal class KeywordSearchService : IKeywordSearchService
                 RelevanceScore = r.RelevanceScore,
                 MatchedTerms = matchedTerms,
                 // Phase D (D6): SQL projects role_tags as int; cast to flag enum.
-                RoleTags = (GameBookRole)r.RoleTags
+                RoleTags = (GameBookRole)r.RoleTags,
+                // #3270: carry the chunk heading for the heading-match boost.
+                Heading = r.Heading
             }).ToList();
 
             _logger.LogInformation(
@@ -522,6 +525,9 @@ internal class KeywordSearchRawResult
     /// Defaults to 0 (None) when the chunk has not been classified.
     /// </summary>
     public int RoleTags { get; set; }
+
+    /// <summary>#3270: heading-path label from text_chunks."Heading" (nullable).</summary>
+    public string? Heading { get; set; }
 }
 
 /// <summary>

--- a/apps/api/src/Api/Services/VectorSearchModels.cs
+++ b/apps/api/src/Api/Services/VectorSearchModels.cs
@@ -69,6 +69,9 @@ internal record SearchResultItem
     /// HYBRID fusion can apply the role-match boost to vector-only chunks (Slice C).
     /// </summary>
     public GameBookRole RoleTags { get; init; } = GameBookRole.None;
+
+    /// <summary>#3270: chunk heading-path label for the heading-match boost (nullable).</summary>
+    public string? Heading { get; init; }
 }
 
 /// <summary>

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AskQuestionQueryHandlerSecurityTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AskQuestionQueryHandlerSecurityTests.cs
@@ -102,7 +102,7 @@ public class AskQuestionQueryHandlerSecurityTests
 
         // Setup RRF Fusion domain service (default: empty results)
         _mockRrfService
-            .Setup(r => r.FuseResults(It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>(), It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>(), It.IsAny<int>(), It.IsAny<GameBookRole>()))
+            .Setup(r => r.FuseResults(It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>(), It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>(), It.IsAny<int>(), It.IsAny<GameBookRole>(), It.IsAny<IReadOnlyList<string>?>()))
             .Returns(new List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>()); // Return empty list
 
         // Setup IKeywordSearchService to return empty results by default
@@ -551,7 +551,8 @@ public class AskQuestionQueryHandlerSecurityTests
                 It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>(),
                 It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>(),
                 It.IsAny<int>(),
-                It.IsAny<GameBookRole>()))
+                It.IsAny<GameBookRole>(),
+                It.IsAny<IReadOnlyList<string>?>()))
             .Returns(oneResult);
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/StreamQaQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/StreamQaQueryHandlerTests.cs
@@ -743,7 +743,7 @@ public class StreamQaQueryHandlerTests
             .ReturnsAsync(new List<KeywordSearchResult>());
 
         _rrfFusionServiceMock
-            .Setup(x => x.FuseResults(It.IsAny<List<DomainSearchResult>>(), It.IsAny<List<DomainSearchResult>>(), It.IsAny<int>(), It.IsAny<GameBookRole>()))
+            .Setup(x => x.FuseResults(It.IsAny<List<DomainSearchResult>>(), It.IsAny<List<DomainSearchResult>>(), It.IsAny<int>(), It.IsAny<GameBookRole>(), It.IsAny<IReadOnlyList<string>?>()))
             .Returns(new List<DomainSearchResult> { lowScoreResult });
 
         SetupPromptMocks(QuestionType.General);
@@ -848,7 +848,7 @@ public class StreamQaQueryHandlerTests
             .ReturnsAsync(new List<KeywordSearchResult>());
 
         _rrfFusionServiceMock
-            .Setup(x => x.FuseResults(It.IsAny<List<DomainSearchResult>>(), It.IsAny<List<DomainSearchResult>>(), It.IsAny<int>(), It.IsAny<GameBookRole>()))
+            .Setup(x => x.FuseResults(It.IsAny<List<DomainSearchResult>>(), It.IsAny<List<DomainSearchResult>>(), It.IsAny<int>(), It.IsAny<GameBookRole>(), It.IsAny<IReadOnlyList<string>?>()))
             .Returns(highQualityResults);
 
         SetupPromptMocks(QuestionType.General);
@@ -975,9 +975,10 @@ public class StreamQaQueryHandlerTests
                 It.IsAny<List<DomainSearchResult>>(),
                 It.IsAny<List<DomainSearchResult>>(),
                 It.IsAny<int>(),
-                It.IsAny<GameBookRole>()))
-            .Callback<List<DomainSearchResult>, List<DomainSearchResult>, int, GameBookRole>(
-                (_, keywordArm, _, _) => capturedKeywordArm = keywordArm)
+                It.IsAny<GameBookRole>(),
+                It.IsAny<IReadOnlyList<string>?>()))
+            .Callback<List<DomainSearchResult>, List<DomainSearchResult>, int, GameBookRole, IReadOnlyList<string>?>(
+                (_, keywordArm, _, _, _) => capturedKeywordArm = keywordArm)
             .Returns(new List<DomainSearchResult> { fusedResult });
 
         // Act
@@ -1045,9 +1046,10 @@ public class StreamQaQueryHandlerTests
                 It.IsAny<List<DomainSearchResult>>(),
                 It.IsAny<List<DomainSearchResult>>(),
                 It.IsAny<int>(),
-                It.IsAny<GameBookRole>()))
-            .Callback<List<DomainSearchResult>, List<DomainSearchResult>, int, GameBookRole>(
-                (_, _, _, roleHint) => capturedRoleHint = roleHint)
+                It.IsAny<GameBookRole>(),
+                It.IsAny<IReadOnlyList<string>?>()))
+            .Callback<List<DomainSearchResult>, List<DomainSearchResult>, int, GameBookRole, IReadOnlyList<string>?>(
+                (_, _, _, roleHint, _) => capturedRoleHint = roleHint)
             .Returns(new List<DomainSearchResult> { fusedResult });
 
         // Act
@@ -1237,7 +1239,8 @@ public class StreamQaQueryHandlerTests
                 It.IsAny<List<DomainSearchResult>>(),
                 It.IsAny<List<DomainSearchResult>>(),
                 It.IsAny<int>(),  // rrfK parameter
-                It.IsAny<GameBookRole>()))
+                It.IsAny<GameBookRole>(),
+                It.IsAny<IReadOnlyList<string>?>()))
             .Returns(new List<DomainSearchResult> { fusedResult });
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/AskQuestionQueryHandlerIntentRoutingTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/AskQuestionQueryHandlerIntentRoutingTests.cs
@@ -150,9 +150,10 @@ public sealed class AskQuestionQueryHandlerIntentRoutingTests
                 It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>(),
                 It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>(),
                 It.IsAny<int>(),
-                It.IsAny<GameBookRole>()))
-            .Callback<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>, List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>, int, GameBookRole>(
-                (v, k, rk, rh) => capturedRoleHint = rh)
+                It.IsAny<GameBookRole>(),
+                It.IsAny<IReadOnlyList<string>?>()))
+            .Callback<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>, List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>, int, GameBookRole, IReadOnlyList<string>?>(
+                (v, k, rk, rh, qt) => capturedRoleHint = rh)
             .Returns(new List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>());
 
         var ragAccessMock = new Mock<IRagAccessService>();

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/AskQuestionQueryHandlerPhase2Tests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/AskQuestionQueryHandlerPhase2Tests.cs
@@ -78,7 +78,7 @@ public class AskQuestionQueryHandlerPhase2Tests
             .Returns(new List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>());
 
         _mockRrfService
-            .Setup(r => r.FuseResults(It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>(), It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>(), It.IsAny<int>(), It.IsAny<GameBookRole>()))
+            .Setup(r => r.FuseResults(It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>(), It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>(), It.IsAny<int>(), It.IsAny<GameBookRole>(), It.IsAny<IReadOnlyList<string>?>()))
             .Returns(new List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>());
 
         mockKeywordSearchService
@@ -656,7 +656,8 @@ public class AskQuestionQueryHandlerPhase2Tests
                 It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>(),
                 It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>(),
                 It.IsAny<int>(),
-                It.IsAny<GameBookRole>()))
+                It.IsAny<GameBookRole>(),
+                It.IsAny<IReadOnlyList<string>?>()))
             .Returns(oneResult);
 
         _mockLlmService

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/RrfFusionDomainServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/RrfFusionDomainServiceTests.cs
@@ -128,6 +128,50 @@ public sealed class RrfFusionDomainServiceTests
     }
 
     [Fact]
+    public void FuseResults_QueryTermMatchesHeading_ReordersByHeadingBoost_OrderOnly()
+    {
+        // Issue #3270: query terms matching a chunk's heading route through HybridFusionCore's
+        // heading-boost, lifting the matching chunk over a better-ranked peer while leaving
+        // RelevanceScore (the carried cosine) untouched.
+        var setupPdf = Guid.NewGuid();
+        var plainPdf = Guid.NewGuid();
+        var vector = new List<SearchResult>
+        {
+            // plain has the better raw rank (1); only the heading boost can reorder them.
+            new(Guid.NewGuid(), Guid.NewGuid(), "plain", 1, new Confidence(0.90), 1, "vector",
+                pdfDocumentId: plainPdf, chunkIndex: 0, roleTags: GameBookRole.None, heading: "Scoring"),
+            new(Guid.NewGuid(), Guid.NewGuid(), "setup rules", 1, new Confidence(0.80), 2, "vector",
+                pdfDocumentId: setupPdf, chunkIndex: 0, roleTags: GameBookRole.None, heading: "Setup")
+        };
+        var keyword = new List<SearchResult>();
+
+        var fused = _service.FuseResults(vector, keyword, queryTerms: new[] { "setup" });
+
+        fused[0].TextContent.Should().Be("setup rules");      // heading-boost lifted it
+        fused[0].Heading.Should().Be("Setup");                // heading carried through fusion
+        fused[0].RelevanceScore.Value.Should().BeApproximately(0.80, 1e-6); // cosine preserved
+    }
+
+    [Fact]
+    public void FuseResults_NoQueryTerms_HeadingBoostIsNoOp()
+    {
+        var plainPdf = Guid.NewGuid();
+        var setupPdf = Guid.NewGuid();
+        var vector = new List<SearchResult>
+        {
+            new(Guid.NewGuid(), Guid.NewGuid(), "plain", 1, new Confidence(0.90), 1, "vector",
+                pdfDocumentId: plainPdf, chunkIndex: 0, roleTags: GameBookRole.None, heading: "Scoring"),
+            new(Guid.NewGuid(), Guid.NewGuid(), "setup", 1, new Confidence(0.80), 2, "vector",
+                pdfDocumentId: setupPdf, chunkIndex: 0, roleTags: GameBookRole.None, heading: "Setup")
+        };
+
+        // No queryTerms → heading boost never fires → pure RRF (rank 1 wins).
+        var fused = _service.FuseResults(vector, new List<SearchResult>());
+
+        fused[0].TextContent.Should().Be("plain");
+    }
+
+    [Fact]
     public void FuseResults_WithOverlappingDocuments_CombinesScores()
     {
         // Arrange

--- a/apps/api/tests/Api.Tests/Domain/Services/VectorSearch/FusionSignalsTests.cs
+++ b/apps/api/tests/Api.Tests/Domain/Services/VectorSearch/FusionSignalsTests.cs
@@ -40,4 +40,56 @@ public class FusionSignalsTests
         factor.Should().BeInRange(0f, 0.5f);
         factor.Should().BeGreaterThan(0f);
     }
+
+    // --- #3270: heading-match boost ---
+
+    [Fact]
+    public void ComputeHeadingMatchBoost_TermInHeading_ReturnsBoost()
+    {
+        var terms = new[] { "setup", "giocatori" };
+        FusionSignals.ComputeHeadingMatchBoost(terms, "Setup").Should().Be(FusionSignals.HeadingMatchBoost);
+    }
+
+    [Fact]
+    public void ComputeHeadingMatchBoost_NoTermInHeading_ReturnsZero()
+    {
+        FusionSignals.ComputeHeadingMatchBoost(new[] { "scoring", "endgame" }, "Setup").Should().Be(0f);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ComputeHeadingMatchBoost_BlankHeading_ReturnsZero(string? heading)
+    {
+        FusionSignals.ComputeHeadingMatchBoost(new[] { "setup" }, heading).Should().Be(0f);
+    }
+
+    [Fact]
+    public void ComputeHeadingMatchBoost_EmptyTerms_ReturnsZero()
+    {
+        FusionSignals.ComputeHeadingMatchBoost(System.Array.Empty<string>(), "Setup").Should().Be(0f);
+    }
+
+    [Fact]
+    public void ComputeHeadingMatchBoost_IsCaseInsensitiveOnHeadingOnly()
+    {
+        // terms are contract-lowercased; heading may be any case
+        FusionSignals.ComputeHeadingMatchBoost(new[] { "preparazione" }, "PREPARAZIONE del gioco")
+            .Should().Be(FusionSignals.HeadingMatchBoost);
+    }
+
+    [Fact]
+    public void ExtractHeadingMatchTerms_NormalizesLowercasesFiltersShortAndDedups()
+    {
+        // "N" dropped (len<3), trailing "setup" deduped, punctuation split
+        FusionSignals.ExtractHeadingMatchTerms("Setup per N giocatori, setup!")
+            .Should().Equal("setup", "per", "giocatori");
+    }
+
+    [Fact]
+    public void ExtractHeadingMatchTerms_Blank_ReturnsEmpty()
+    {
+        FusionSignals.ExtractHeadingMatchTerms("  ").Should().BeEmpty();
+    }
 }

--- a/apps/api/tests/Api.Tests/Domain/Services/VectorSearch/HybridFusionCoreTests.cs
+++ b/apps/api/tests/Api.Tests/Domain/Services/VectorSearch/HybridFusionCoreTests.cs
@@ -7,8 +7,8 @@ namespace Api.Tests.Domain.Services.VectorSearch;
 
 public class HybridFusionCoreTests
 {
-    private static FusionCandidate V(string key, int rank, float score, string content = "content", GameBookRole roles = GameBookRole.None)
-        => new(key, content, roles, rank, score);
+    private static FusionCandidate V(string key, int rank, float score, string content = "content", GameBookRole roles = GameBookRole.None, string? heading = null)
+        => new(key, content, roles, heading, rank, score);
 
     [Fact]
     public void Fuse_BothArms_WeightedRrf_OrdersByHybridScore()
@@ -95,6 +95,38 @@ public class HybridFusionCoreTests
     {
         HybridFusionCore.Fuse(System.Array.Empty<FusionCandidate>(), System.Array.Empty<FusionCandidate>(), new FusionOptions())
             .Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Fuse_HeadingBoost_LiftsMatchingChunkOverBetterRankedPeer()
+    {
+        // kPlain has the better raw rank; only the heading boost can reorder them.
+        var vec = new[] { V("kPlain", 1, 0.9f, heading: "Scoring"), V("kSetup", 2, 0.8f, heading: "Setup") };
+        var opts = new FusionOptions(0.7f, 0.3f, 60, GameBookRole.None, new[] { "setup" });
+        var fused = HybridFusionCore.Fuse(vec, System.Array.Empty<FusionCandidate>(), opts);
+        // 'kSetup' gets +0.15 additive from the heading match → overtakes 'kPlain'
+        fused[0].Key.Should().Be("kSetup");
+        fused[0].Heading.Should().Be("Setup"); // heading carried onto FusedCandidate
+    }
+
+    [Fact]
+    public void Fuse_NoQueryTerms_HeadingBoostIsNoOp()
+    {
+        var vec = new[] { V("kPlain", 1, 0.9f, heading: "Scoring"), V("kSetup", 2, 0.8f, heading: "Setup") };
+        // Default options → QueryTerms null → heading boost never fires; pure RRF (rank 1 wins).
+        var fused = HybridFusionCore.Fuse(vec, System.Array.Empty<FusionCandidate>(), new FusionOptions());
+        fused[0].Key.Should().Be("kPlain");
+    }
+
+    [Fact]
+    public void Fuse_Heading_PrefersVectorArm_ThenFallsBackToKeyword()
+    {
+        var vec = new[] { V("a", 1, 0.9f, heading: "VectorHeading") };
+        var kw = new[] { V("a", 1, 0.3f, heading: "KeywordHeading") };
+        HybridFusionCore.Fuse(vec, kw, new FusionOptions()).Single().Heading.Should().Be("VectorHeading");
+
+        var vecNoHeading = new[] { V("a", 1, 0.9f, heading: null) };
+        HybridFusionCore.Fuse(vecNoHeading, kw, new FusionOptions()).Single().Heading.Should().Be("KeywordHeading");
     }
 
     [Theory]

--- a/docs/superpowers/plans/2026-07-27-issue-3270-heading-boost.md
+++ b/docs/superpowers/plans/2026-07-27-issue-3270-heading-boost.md
@@ -1,0 +1,670 @@
+# SP4 Heading-Based Ranking Boost Implementation Plan (#3270)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a query-dependent heading-match ranking boost to the RAG hybrid fusion so a chunk whose persisted `Heading` matches the user's query terms is promoted — closing the SP4 deliverable of epic #3266 and fixing the motivating case ("Setup per N giocatori" surfacing the wrong section).
+
+**Architecture:** `text_chunks.Heading` is already persisted (SP2 #3268). Thread `Heading` from the two DB read arms (keyword FTS SQL + vector `JOIN text_chunks`) through the shared neutral fusion plumbing (`FusionCandidate` → `HybridFusionCore` → arm adapters), mirroring exactly how `RoleTags` already flows. Add a query-side `QueryTerms` signal (normalized query tokens) to `FusionOptions`, and a new additive `FusionSignals.ComputeHeadingMatchBoost` consumed in the single canonical scorer `HybridFusionCore.Fuse` — the exact structural twin of the existing `ComputeRoleMatchBoost` role-boost.
+
+**Tech Stack:** .NET 9, EF Core + Npgsql (raw SQL for FTS + pgvector), xUnit + Testcontainers. Bounded context: `KnowledgeBase`.
+
+## Global Constraints
+
+- **Build the SOLUTION, not the project**, after any ctor/record-signature change: `cd apps/api/src/Api && dotnet build Api.sln` (a project-only build misses call-site breakages in `Api.Tests`).
+- **Kill testhost before running tests** (Windows): `tasklist | grep testhost` → `taskkill //PID <PID> //F`.
+- **Tests must be culture-independent** — no locale-dependent string/number formatting in assertions.
+- `FusionSignals`, `HybridFusionCore`, `FusionCandidate`, `FusionOptions`, `FusedCandidate`, `SearchResult`, `SearchQuery` are `internal` — unit tests reach them via the existing `InternalsVisibleTo("Api.Tests")` (the role-boost tests already depend on it; do not add a new one).
+- **Vector arm strategy = JOIN** (locked decision): `PgVectorStoreAdapter.SearchWithScoresAsync` gains `JOIN text_chunks tc ON tc."Id" = e.source_chunk_id` and selects `tc."Heading"`. NO migration, NO re-embed — this reuses the rows the in-flight SP3 re-index is populating.
+- **Boost semantics = query-dependent** (locked): `ComputeHeadingMatchBoost(queryTerms, heading)`, additive, magnitude `0.15f` (equal to `RoleMatchBoost`). It affects ORDER only — `MinScore` gates on the preserved cosine `RelevanceScore` (#2712), never on `hybridScore`.
+- **Scope = unified core** (locked): boost is applied once in `HybridFusionCore.Fuse`, covering the primary chat path (`/agents/qa` + `/stream` via `RrfFusionDomainService`) and the admin playground (`HybridSearchService.FuseSearchResults`). Single-arm modes (`SearchSemanticOnlyAsync`/`SearchKeywordOnlyAsync`) and `RagPromptAssemblyService` are OUT of scope (documented as follow-up).
+- **`Heading` carrier type is `string?`** everywhere (nullable — chunks pre-SP3 or imported may have no heading).
+- **`QueryTerms` contract**: already lowercased, de-duplicated, length ≥ 3, produced ONLY by `FusionSignals.ExtractHeadingMatchTerms`. `ComputeHeadingMatchBoost` assumes lowercase terms and lowercases only the heading.
+
+---
+
+## Known limitation (documented, deferred)
+
+The MVP boost is a **pure lexical** query-term↔heading substring match. The cross-lingual synonym case (query "setup" → heading "Preparazione") is NOT boosted by lexical match alone — only "setup" → a heading literally containing "setup" fires. Italian rulebooks frequently title the section "Setup" (English loanword, see `KeywordSearchService.SynonymTablesByConfig` note), so the motivating case is still improved. Wiring the curated synonym expansion (`SynonymTablesByConfig`) into `ExtractHeadingMatchTerms` is a follow-up, tracked in the closing comment of #3270.
+
+---
+
+## Task 1: Heading-match boost signal (pure function)
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/FusionSignals.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/FusionSignalsTests.cs` (extend existing role-boost test file if present; else create)
+
+**Interfaces:**
+- Produces: `FusionSignals.HeadingMatchBoost` (const `float` = 0.15f); `FusionSignals.ComputeHeadingMatchBoost(IReadOnlyList<string>? queryTerms, string? chunkHeading) -> float`; `FusionSignals.ExtractHeadingMatchTerms(string? query) -> IReadOnlyList<string>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the test file (create the file with the standard test header if it does not exist; locate it first with `Glob "**/FusionSignalsTests.cs"`):
+
+```csharp
+[Fact]
+public void ComputeHeadingMatchBoost_TermInHeading_ReturnsBoost()
+{
+    var terms = new[] { "setup", "giocatori" };
+    var boost = FusionSignals.ComputeHeadingMatchBoost(terms, "Setup");
+    Assert.Equal(FusionSignals.HeadingMatchBoost, boost);
+}
+
+[Fact]
+public void ComputeHeadingMatchBoost_NoTermInHeading_ReturnsZero()
+{
+    var terms = new[] { "scoring", "endgame" };
+    Assert.Equal(0f, FusionSignals.ComputeHeadingMatchBoost(terms, "Setup"));
+}
+
+[Theory]
+[InlineData(null)]
+[InlineData("")]
+[InlineData("   ")]
+public void ComputeHeadingMatchBoost_BlankHeading_ReturnsZero(string? heading)
+{
+    Assert.Equal(0f, FusionSignals.ComputeHeadingMatchBoost(new[] { "setup" }, heading));
+}
+
+[Fact]
+public void ComputeHeadingMatchBoost_EmptyTerms_ReturnsZero()
+{
+    Assert.Equal(0f, FusionSignals.ComputeHeadingMatchBoost(Array.Empty<string>(), "Setup"));
+}
+
+[Fact]
+public void ComputeHeadingMatchBoost_IsCaseInsensitiveOnHeadingOnly()
+{
+    // terms are contract-lowercased; heading may be any case
+    Assert.Equal(FusionSignals.HeadingMatchBoost,
+        FusionSignals.ComputeHeadingMatchBoost(new[] { "preparazione" }, "PREPARAZIONE del gioco"));
+}
+
+[Fact]
+public void ExtractHeadingMatchTerms_NormalizesLowercasesFiltersShortAndDedups()
+{
+    var terms = FusionSignals.ExtractHeadingMatchTerms("Setup per N giocatori, setup!");
+    Assert.Equal(new[] { "setup", "per", "giocatori" }, terms); // "N" dropped (len<3), "setup" deduped
+}
+
+[Fact]
+public void ExtractHeadingMatchTerms_Blank_ReturnsEmpty()
+{
+    Assert.Empty(FusionSignals.ExtractHeadingMatchTerms("  "));
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/api/src/Api && dotnet test ../../tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~FusionSignalsTests" -v minimal`
+Expected: FAIL — `ComputeHeadingMatchBoost` / `ExtractHeadingMatchTerms` / `HeadingMatchBoost` do not exist.
+
+- [ ] **Step 3: Implement the signal in `FusionSignals.cs`**
+
+Add after the `RoleMatchBoost` const (line 14) and after `ComputeRoleMatchBoost` (line 38). Add `using System.Linq;` is already implied; add `using System.Collections.Generic;` if not present (file currently uses only Regex + GameBookRole — add both usings at top).
+
+```csharp
+    /// <summary>Additive heading-match boost (#3270). Same magnitude/shape as the role boost.</summary>
+    internal const float HeadingMatchBoost = 0.15f;
+
+    /// <summary>
+    /// Additive boost when any normalized query term appears in the chunk's heading (#3270).
+    /// Query-dependent, structural twin of <see cref="ComputeRoleMatchBoost"/>. <paramref name="queryTerms"/>
+    /// MUST be lowercased (contract of <see cref="ExtractHeadingMatchTerms"/>); the heading is lowercased here.
+    /// </summary>
+    internal static float ComputeHeadingMatchBoost(IReadOnlyList<string>? queryTerms, string? chunkHeading)
+    {
+        if (queryTerms is null || queryTerms.Count == 0 || string.IsNullOrWhiteSpace(chunkHeading))
+        {
+            return 0f;
+        }
+
+        var headingLower = chunkHeading.ToLowerInvariant();
+        for (var i = 0; i < queryTerms.Count; i++)
+        {
+            var term = queryTerms[i];
+            if (term.Length >= 3 && headingLower.Contains(term, StringComparison.Ordinal))
+            {
+                return HeadingMatchBoost;
+            }
+        }
+
+        return 0f;
+    }
+
+    /// <summary>
+    /// Normalizes a raw query into heading-match terms: lowercased, punctuation-split, length ≥ 3,
+    /// de-duplicated (order-preserving). This is the ONLY producer of the query-term contract consumed
+    /// by <see cref="ComputeHeadingMatchBoost"/>.
+    /// </summary>
+    internal static IReadOnlyList<string> ExtractHeadingMatchTerms(string? query)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return Array.Empty<string>();
+        }
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var terms = new List<string>();
+        foreach (var raw in query.Split(
+            new[] { ' ', '\t', '\n', '\r', ',', '.', ';', ':', '?', '!', '"', '(', ')' },
+            StringSplitOptions.RemoveEmptyEntries))
+        {
+            var t = raw.Trim().ToLowerInvariant();
+            if (t.Length >= 3 && seen.Add(t))
+            {
+                terms.Add(t);
+            }
+        }
+
+        return terms;
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/api/src/Api && dotnet test ../../tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~FusionSignalsTests" -v minimal`
+Expected: PASS (all Task-1 tests green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/FusionSignals.cs apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/FusionSignalsTests.cs
+git commit -m "feat(rag): add ComputeHeadingMatchBoost + ExtractHeadingMatchTerms signal (#3270)"
+```
+
+---
+
+## Task 2: Thread Heading + QueryTerms through the fusion core and apply the boost
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/HybridFusionCore.cs`
+- Test: `apps/api/tests/Api.Tests/**/HybridFusionCoreTests.cs` (locate with `Glob "**/HybridFusionCoreTests.cs"`)
+
+**Interfaces:**
+- Consumes: `FusionSignals.ComputeHeadingMatchBoost` (Task 1).
+- Produces: `FusionCandidate(string Key, string Content, GameBookRole RoleTags, string? Heading, int Rank, float SourceScore)`; `FusionOptions(..., IReadOnlyList<string>? QueryTerms = null)`; `FusedCandidate(..., string? Heading, ...)`. **These signatures are consumed by Tasks 8 and 9 — keep them exact.**
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+[Fact]
+public void Fuse_ChunkHeadingMatchesQueryTerm_RanksAboveNonMatchingPeer()
+{
+    // Two vector-arm chunks at equal rank; only "kA" has a matching heading.
+    var vector = new List<FusionCandidate>
+    {
+        new("kA", "content A", GameBookRole.None, "Setup", 1, 0.9f),
+        new("kB", "content B", GameBookRole.None, "Scoring", 1, 0.9f),
+    };
+    var keyword = new List<FusionCandidate>();
+    var opts = new FusionOptions(0.7f, 0.3f, 60, GameBookRole.None, new[] { "setup" });
+
+    var fused = HybridFusionCore.Fuse(vector, keyword, opts);
+
+    Assert.Equal("kA", fused[0].Key);      // heading-boosted chunk ranks first
+    Assert.Equal("Setup", fused[0].Heading); // heading carried through to FusedCandidate
+}
+
+[Fact]
+public void Fuse_NoQueryTerms_HeadingBoostIsNoOp()
+{
+    var vector = new List<FusionCandidate>
+    {
+        new("kA", "content A", GameBookRole.None, "Setup", 1, 0.9f),
+        new("kB", "content B", GameBookRole.None, "Scoring", 2, 0.8f),
+    };
+    var fused = HybridFusionCore.Fuse(vector, new List<FusionCandidate>(), new FusionOptions());
+    Assert.Equal("kA", fused[0].Key); // pure RRF order (rank 1 wins), no heading influence
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api/src/Api && dotnet build Api.sln`
+Expected: FAIL — `FusionCandidate` has no 6-arg ctor, `FusionOptions` has no `QueryTerms`, `FusedCandidate` has no `Heading`.
+
+- [ ] **Step 3: Implement — records + Fuse**
+
+In `HybridFusionCore.cs`, change the three records (lines 6-29) and the scoring loop (lines 56-73):
+
+```csharp
+internal readonly record struct FusionCandidate(
+    string Key,
+    string Content,
+    GameBookRole RoleTags,
+    string? Heading,
+    int Rank,          // 1-based within THIS arm (cosine desc / ts_rank_cd desc)
+    float SourceScore);
+
+internal sealed record FusionOptions(
+    float VectorWeight = 0.7f,
+    float KeywordWeight = 0.3f,
+    int RrfK = FusionSignals.DefaultRrfK,
+    GameBookRole QueryRoleHint = GameBookRole.None,
+    IReadOnlyList<string>? QueryTerms = null);
+
+internal readonly record struct FusedCandidate(
+    string Key,
+    string Content,
+    GameBookRole RoleTags,
+    string? Heading,
+    float HybridScore,
+    float? VectorScore,
+    float? KeywordScore,
+    int? VectorRank,
+    int? KeywordRank,
+    int Rank);
+```
+
+In the `Fuse` loop, after the `roleTags` union line (line 58) add the heading merge, then extend the score and the `FusedCandidate` emission:
+
+```csharp
+            // Prefer vector-arm content (load-bearing: legend factor is computed from it).
+            string content = hasV ? v.Content : k.Content;
+            GameBookRole roleTags = (hasV ? v.RoleTags : GameBookRole.None) | (hasK ? k.RoleTags : GameBookRole.None);
+            string? heading = (hasV ? v.Heading : null) ?? (hasK ? k.Heading : null);
+
+            float legendFactor = FusionSignals.ComputeLegendPenaltyFactor(content);
+            float roleBoost = FusionSignals.ComputeRoleMatchBoost(options.QueryRoleHint, roleTags);
+            float headingBoost = FusionSignals.ComputeHeadingMatchBoost(options.QueryTerms, heading);
+            float hybridScore = (rrfSum * (1f - legendFactor)) + roleBoost + headingBoost;
+
+            scored.Add(new FusedCandidate(
+                Key: key,
+                Content: content,
+                RoleTags: roleTags,
+                Heading: heading,
+                HybridScore: hybridScore,
+                VectorScore: hasV ? v.SourceScore : (float?)null,
+                KeywordScore: hasK ? k.SourceScore : (float?)null,
+                VectorRank: hasV ? v.Rank : (int?)null,
+                KeywordRank: hasK ? k.Rank : (int?)null,
+                Rank: 0)); // assigned after sort
+```
+
+- [ ] **Step 4: Build + run the fusion-core tests**
+
+Run: `cd apps/api/src/Api && dotnet build Api.sln`
+Expected: FAIL in `RrfFusionDomainService.cs:38,41` and `HybridSearchService.cs:401,408` (5-arg `FusionCandidate` call sites) — this is EXPECTED and fixed in Tasks 8/9. To green Task 2's own tests in isolation, temporarily add `null` as the `Heading` arg at those 4 call sites (Tasks 8/9 replace `null` with the real value). After that: `dotnet test ../../tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~HybridFusionCoreTests" -v minimal` → PASS.
+
+> **Note:** because the record change ripples to adapters, Tasks 8 and 9 are the natural same-commit companions. If executing task-by-task with a green build gate, fold Tasks 2/8/9 into one commit; the tests for each remain separate.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/HybridFusionCore.cs apps/api/tests/Api.Tests/**/HybridFusionCoreTests.cs
+git commit -m "feat(rag): carry Heading + QueryTerms through HybridFusionCore + apply heading boost (#3270)"
+```
+
+---
+
+## Task 3: Keyword arm — SELECT and carry Heading
+
+**Files:**
+- Modify: `apps/api/src/Api/Services/KeywordSearchService.cs` (SQL 97-115, map 139-151, `KeywordSearchRawResult` 506-525)
+- Modify: `apps/api/src/Api/Services/IKeywordSearchService.cs` (`KeywordSearchResult` record, RoleTags ~line 80)
+
+**Interfaces:**
+- Produces: `KeywordSearchResult.Heading` (`string?`) — consumed by Tasks 6/9.
+
+- [ ] **Step 1: Add `"Heading"` to the FTS SQL projection**
+
+In the inner `SELECT` (after `role_tags AS "RoleTags",` line 106), add:
+
+```
+                        ""Heading"",
+```
+
+(text_chunks."Heading" already exists — no schema change. It flows through the `ranked` subquery automatically.)
+
+- [ ] **Step 2: Add `Heading` to `KeywordSearchRawResult`**
+
+After `public int RoleTags { get; set; }` (line 524):
+
+```csharp
+    /// <summary>#3270: heading-path label from text_chunks."Heading" (nullable).</summary>
+    public string? Heading { get; set; }
+```
+
+- [ ] **Step 3: Map it onto `KeywordSearchResult`**
+
+In the `.Select(r => new KeywordSearchResult { ... })` (line 139), after `RoleTags = (GameBookRole)r.RoleTags`:
+
+```csharp
+                RoleTags = (GameBookRole)r.RoleTags,
+                Heading = r.Heading
+```
+
+- [ ] **Step 4: Add `Heading` to the `KeywordSearchResult` record in `IKeywordSearchService.cs`**
+
+Mirror `RoleTags` (the record's last property). Add:
+
+```csharp
+    /// <summary>#3270: chunk heading-path label for the heading-match boost (nullable).</summary>
+    public string? Heading { get; init; }
+```
+
+- [ ] **Step 5: Build**
+
+Run: `cd apps/api/src/Api && dotnet build Api.sln`
+Expected: PASS (additive, no call-site breakage).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/Services/KeywordSearchService.cs apps/api/src/Api/Services/IKeywordSearchService.cs
+git commit -m "feat(rag): project + carry Heading on the keyword search arm (#3270)"
+```
+
+---
+
+## Task 4: Vector arm — JOIN text_chunks and carry Heading on Embedding
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/PgVectorStoreAdapter.cs` (`SearchWithScoresAsync`, SQL ~142-149, reader ~185-206)
+- Modify: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/Embedding.cs` (add `Heading`, mirror `RoleTags` at line 30 + ctor)
+- Test: `apps/api/tests/Api.Tests/Integration/**/PgVector*IntegrationTests.cs` (extend an existing hybrid-search integration test to assert Heading is populated; locate with `Glob "**/*PgVector*IntegrationTests.cs"`)
+
+**Interfaces:**
+- Consumes: `text_chunks."Heading"`, `pgvector_embeddings.source_chunk_id`.
+- Produces: `Embedding.Heading` (`string?`) — consumed by Tasks 6/9 (`SearchQueryHandler.PerformVectorSearchAsync`, `HybridSearchService.SearchHybridAsync`).
+
+- [ ] **Step 1: Add `Heading` to `Embedding` (mirror RoleTags)**
+
+Read `Embedding.cs` first. Add a `public string? Heading { get; private set; }` next to `RoleTags` (line 30), a ctor param `string? heading = null` next to `roleTags` (line 63), and assignment `Heading = heading;` next to line 88.
+
+- [ ] **Step 2: JOIN text_chunks + SELECT tc."Heading" in `SearchWithScoresAsync`**
+
+Read the method first (SELECT ~142-149, reader loop ~185-206). The method already `JOIN`s `vector_documents vd`. Add:
+
+```sql
+JOIN text_chunks tc ON tc."Id" = e.source_chunk_id
+```
+
+and add `tc."Heading"` as the LAST selected column (append after the current final column to avoid re-indexing the existing ordinal reads). Then in the reader loop, read the new trailing column: `var heading = reader.IsDBNull(N) ? null : reader.GetString(N);` (N = the new last ordinal) and pass `heading: heading` to the `Embedding` ctor.
+
+> **JOIN safety:** `source_chunk_id` is the FK from `pgvector_embeddings` to `text_chunks."Id"`. Use `JOIN` (not LEFT JOIN) ONLY if every embedding has a source chunk; if pre-SP2 embeddings may lack `source_chunk_id`, use `LEFT JOIN` so a missing chunk yields `Heading = null` rather than dropping the row. **Verify** with: `Grep "source_chunk_id" apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/PgVectorStoreAdapter.cs` and the CREATE TABLE (nullable?) before choosing. Default to **LEFT JOIN** for safety.
+
+- [ ] **Step 3: Build**
+
+Run: `cd apps/api/src/Api && dotnet build Api.sln`
+Expected: PASS.
+
+- [ ] **Step 4: Integration test — Heading populated on a vector hit**
+
+Extend an existing hybrid-search integration test (Testcontainers Postgres + pgvector): seed a `text_chunks` row with `Heading = "Setup"` + a matching `pgvector_embeddings` row with the same `source_chunk_id`, run `SearchWithScoresAsync`, assert the returned `ScoredEmbedding.Embedding.Heading == "Setup"`.
+
+Run: `cd apps/api/src/Api && dotnet test ../../tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~PgVector" -v minimal` (requires Docker).
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/PgVectorStoreAdapter.cs apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/Embedding.cs apps/api/tests/Api.Tests/Integration/**
+git commit -m "feat(rag): join text_chunks to carry Heading on the vector search arm (#3270)"
+```
+
+---
+
+## Task 5: Add Heading to the result-type chain
+
+**Files (each = add `string? Heading`, mirror the existing `RoleTags` property exactly):**
+- Modify: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/SearchResult.cs` — add `public GameBookRole RoleTags`-twin `public string? Heading { get; private set; }` (property near line 21) + ctor param `string? heading = null` (after `roleTags` line 45) + assignment `Heading = heading;` (after line 64).
+- Modify: `apps/api/src/Api/Services/VectorSearchModels.cs` — `SearchResultItem` (RoleTags ~line 71): add `public string? Heading { get; init; }`.
+- Modify: `apps/api/src/Api/Services/IHybridSearchService.cs` — `HybridSearchResult` (RoleTags ~line 124): add `public string? Heading { get; init; }`.
+
+**Interfaces:**
+- Produces: `SearchResult.Heading`, `SearchResultItem.Heading`, `HybridSearchResult.Heading` — all `string?`, consumed by Tasks 6/8/9.
+
+- [ ] **Step 1: Add the three properties** (see file list above — read each file, add the property mirroring RoleTags; `SearchResult` also needs the ctor param + assignment).
+
+- [ ] **Step 2: Build**
+
+Run: `cd apps/api/src/Api && dotnet build Api.sln`
+Expected: PASS (additive; nullable defaults keep existing callers valid).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/SearchResult.cs apps/api/src/Api/Services/VectorSearchModels.cs apps/api/src/Api/Services/IHybridSearchService.cs
+git commit -m "feat(rag): add Heading to SearchResult/SearchResultItem/HybridSearchResult (#3270)"
+```
+
+---
+
+## Task 6: Populate Heading at the producers/mappers
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchQueryHandler.cs` — `PerformVectorSearchAsync` (`new SearchResult(...)` ~line 169): add `heading: scored.Embedding.Heading` to the ctor call.
+- Modify: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/Mappers/KnowledgeBaseMappers.cs` — `KeywordSearchResult.ToDomainSearchResult` (~line 104): add `heading: result.Heading` to the `new SearchResult(...)` call.
+- Modify: `apps/api/src/Api/Services/HybridSearchService.cs` — `SearchHybridAsync` (Embedding→SearchResultItem, ~line 285): add `Heading = se.Embedding.Heading` in the `new SearchResultItem { ... }` initializer.
+
+**Interfaces:**
+- Consumes: `Embedding.Heading` (Task 4), `KeywordSearchResult.Heading` (Task 3), `SearchResult.Heading`/`SearchResultItem.Heading` (Task 5).
+
+- [ ] **Step 1: Add the three population sites** (read each; add the `heading:`/`Heading =` line mirroring the adjacent `roleTags:`/`RoleTags =`).
+
+- [ ] **Step 2: Build**
+
+Run: `cd apps/api/src/Api && dotnet build Api.sln`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchQueryHandler.cs apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/Mappers/KnowledgeBaseMappers.cs apps/api/src/Api/Services/HybridSearchService.cs
+git commit -m "feat(rag): populate Heading at vector/keyword result producers (#3270)"
+```
+
+---
+
+## Task 7: Query-terms plumbing (SearchQuery → handlers)
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchQuery.cs` — add `IReadOnlyList<string>? QueryTerms = null` as the last record parameter (after `QueryRoleHint`).
+- Modify: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/AskQuestionQueryHandler.cs` — where `QueryRoleHint` is set (~line 442): also set `QueryTerms = FusionSignals.ExtractHeadingMatchTerms(query.Question)`.
+- Modify: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamQaQueryHandler.cs` — identical change at its `QueryRoleHint` site.
+
+**Interfaces:**
+- Consumes: `FusionSignals.ExtractHeadingMatchTerms` (Task 1).
+- Produces: `SearchQuery.QueryTerms` — consumed by Task 8.
+
+- [ ] **Step 1: Add `QueryTerms` to `SearchQuery`**
+
+```csharp
+    GameBookRole QueryRoleHint = GameBookRole.None,
+    // #3270: normalized heading-match terms (lowercased, len≥3, deduped) for the heading boost.
+    IReadOnlyList<string>? QueryTerms = null
+) : IQuery<List<SearchResultDto>>;
+```
+
+- [ ] **Step 2: Populate in both handlers** — read each handler's `SearchQuery` construction; add `QueryTerms = FusionSignals.ExtractHeadingMatchTerms(<the raw question string used for QueryRoleHint>)`. Add `using Api.BoundedContexts.KnowledgeBase.Domain.Services;` if not present.
+
+- [ ] **Step 3: Build**
+
+Run: `cd apps/api/src/Api && dotnet build Api.sln`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchQuery.cs apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/AskQuestionQueryHandler.cs apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamQaQueryHandler.cs
+git commit -m "feat(rag): plumb normalized QueryTerms from chat handlers into SearchQuery (#3270)"
+```
+
+---
+
+## Task 8: Chat-path adapter — wire Heading + QueryTerms into fusion
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/RrfFusionDomainService.cs` (`FuseResults` 28-72)
+- Modify: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchQueryHandler.cs` (`PerformHybridSearchAsync` call to `FuseResults` ~line 220)
+- Test: `apps/api/tests/Api.Tests/**/RrfFusionDomainServiceTests.cs`
+
+**Interfaces:**
+- Consumes: `FusionCandidate` 6-arg ctor + `FusionOptions.QueryTerms` (Task 2), `SearchResult.Heading` (Task 5), `SearchQuery.QueryTerms` (Task 7).
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+[Fact]
+public void FuseResults_QueryTermMatchesHeading_PromotesChunk()
+{
+    var svc = new RrfFusionDomainService();
+    var conf = Confidence.Create(0.9);
+    var a = new SearchResult(Guid.NewGuid(), Guid.NewGuid(), "content A", 1, conf, 1, "vector", Guid.NewGuid(), 0, GameBookRole.None, heading: "Setup");
+    var b = new SearchResult(Guid.NewGuid(), Guid.NewGuid(), "content B", 1, conf, 1, "vector", Guid.NewGuid(), 1, GameBookRole.None, heading: "Scoring");
+
+    var fused = svc.FuseResults(new List<SearchResult> { a, b }, new List<SearchResult>(), queryTerms: new[] { "setup" });
+
+    Assert.Equal("Setup", fused[0].Heading);            // "Setup"-headed chunk first
+    Assert.Equal(a.PdfDocumentId, fused[0].PdfDocumentId);
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/api/src/Api && dotnet build Api.sln`
+Expected: FAIL — `FuseResults` has no `queryTerms` param; `SearchResult` ctor has no `heading` (fixed only if Task 5 landed) — ensure Tasks 2 and 5 are done first.
+
+- [ ] **Step 3: Extend `FuseResults`**
+
+Change the signature and the two arm projections + the rebuild + the `FusionOptions` construction:
+
+```csharp
+    public virtual List<SearchResult> FuseResults(
+        List<SearchResult> vectorResults,
+        List<SearchResult> keywordResults,
+        int rrfK = DefaultRrfK,
+        GameBookRole queryRoleHint = GameBookRole.None,
+        IReadOnlyList<string>? queryTerms = null)
+    {
+        if (rrfK <= 0)
+            throw new ArgumentException("RRF K must be positive", nameof(rrfK));
+
+        var vectorArm = vectorResults
+            .Select((r, i) => new FusionCandidate(GetChunkKey(r), r.TextContent, r.RoleTags, r.Heading, i + 1, (float)r.RelevanceScore.Value))
+            .ToList();
+        var keywordArm = keywordResults
+            .Select((r, i) => new FusionCandidate(GetChunkKey(r), r.TextContent, r.RoleTags, r.Heading, i + 1, (float)r.RelevanceScore.Value))
+            .ToList();
+
+        var fused = HybridFusionCore.Fuse(vectorArm, keywordArm, new FusionOptions(0.7f, 0.3f, rrfK, queryRoleHint, queryTerms));
+```
+
+and in the rebuild `new SearchResult(...)` (lines 54-69) add `heading: f.Heading` after `roleTags: f.RoleTags`.
+
+- [ ] **Step 4: Forward `queryTerms` from the handler**
+
+In `SearchQueryHandler.PerformHybridSearchAsync`, change the `_rrfFusionService.FuseResults(vectorResults, keywordResults, ..., queryRoleHint)` call (~line 220) to also pass `queryTerms: request.QueryTerms` (thread `SearchQuery.QueryTerms` into the method if not already available in scope — read the method signature; it receives the `SearchQuery`).
+
+- [ ] **Step 5: Build + test**
+
+Run: `cd apps/api/src/Api && dotnet build Api.sln && dotnet test ../../tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~RrfFusionDomainServiceTests" -v minimal`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/RrfFusionDomainService.cs apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchQueryHandler.cs apps/api/tests/Api.Tests/**/RrfFusionDomainServiceTests.cs
+git commit -m "feat(rag): wire Heading + QueryTerms into chat-path RRF fusion (#3270)"
+```
+
+---
+
+## Task 9: Playground adapter — wire Heading + QueryTerms
+
+**Files:**
+- Modify: `apps/api/src/Api/Services/HybridSearchService.cs` — `FuseSearchResults` (FusionCandidate builds 401/408, rebuild 441-457) + the `FusionOptions` construction (415-418) + derive `queryTerms` in `SearchHybridAsync` from the query.
+- Test: `apps/api/tests/Api.Tests/**/HybridSearchServiceTests.cs` (extend if a fusion test exists).
+
+**Interfaces:**
+- Consumes: `FusionCandidate` 6-arg ctor + `FusionOptions.QueryTerms` (Task 2), `SearchResultItem.Heading` + `KeywordSearchResult.Heading` (Tasks 3/5), `HybridSearchResult.Heading` (Task 5), `FusionSignals.ExtractHeadingMatchTerms` (Task 1).
+
+- [ ] **Step 1: Add Heading to both FusionCandidate builds** — line 401 (`new FusionCandidate(VectorKeyOf(r), r.Text, r.RoleTags, r.Heading, index+1, r.Score)`) and line 408 (`new FusionCandidate(KeywordKeyOf(r), r.Content, r.RoleTags, r.Heading, index+1, r.RelevanceScore)`).
+
+- [ ] **Step 2: Pass QueryTerms in FusionOptions** — at the `new FusionOptions(vectorWeight, keywordWeight, rrfK, queryRoleHint)` (415-418), append `, FusionSignals.ExtractHeadingMatchTerms(query)` where `query` is the raw search string in scope (read `SearchHybridAsync` to find the query variable name).
+
+- [ ] **Step 3: Carry Heading onto the rebuilt HybridSearchResult** — in `FuseSearchResults` rebuild (~line 456), add `Heading = f.Heading` after `RoleTags = f.RoleTags`.
+
+- [ ] **Step 4: Build + test**
+
+Run: `cd apps/api/src/Api && dotnet build Api.sln && dotnet test ../../tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~HybridSearchServiceTests" -v minimal`
+Expected: PASS (whole solution now builds — all `FusionCandidate` call sites carry Heading).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/Services/HybridSearchService.cs apps/api/tests/Api.Tests/**/HybridSearchServiceTests.cs
+git commit -m "feat(rag): wire Heading + QueryTerms into playground hybrid fusion (#3270)"
+```
+
+---
+
+## Task 10: Secondary write gap — ImportRagData carries Heading
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/Administration/Application/Commands/ImportRagData/ImportRagDataCommandHandler.cs` (`new TextChunkEntity { ... }` ~line 226-240 — omits Heading today)
+- Possibly modify: the `ExportedChunkDto`/import model if it does not already carry `Heading` (read it; add `string? Heading` + export/import wiring if missing).
+
+**Interfaces:**
+- Consumes: `TextChunkEntity.Heading` (already persisted).
+
+- [ ] **Step 1: Set Heading on restore** — in the `new TextChunkEntity { ... }` initializer add `Heading = chunk.Heading,` (verify the export DTO carries it; if not, add it to the export in the matching `ExportRagData` handler + DTO so round-trip is lossless).
+
+- [ ] **Step 2: Build**
+
+Run: `cd apps/api/src/Api && dotnet build Api.sln`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/Administration/Application/Commands/ImportRagData/*
+git commit -m "fix(rag): carry Heading through ImportRagData restore path (#3270)"
+```
+
+---
+
+## Task 11: End-to-end heading-boost integration test
+
+**Files:**
+- Test: `apps/api/tests/Api.Tests/Integration/KnowledgeBase/HeadingBoostIntegrationTests.cs` (create)
+
+**Interfaces:**
+- Consumes: the full pipeline (Tasks 1-9).
+
+- [ ] **Step 1: Write the integration test**
+
+Seed (Testcontainers Postgres + pgvector): one game, two `text_chunks` for the same PDF — chunk X with `Heading = "Setup"` + content about player-count setup, chunk Y with `Heading = "Scoring"` + unrelated content — plus matching `pgvector_embeddings` rows (same `source_chunk_id`, embeddings close enough that both are retrieved). Issue a hybrid `SearchQuery` with `Query = "setup per N giocatori"`, `QueryTerms = FusionSignals.ExtractHeadingMatchTerms("setup per N giocatori")`. Assert the "Setup"-headed chunk X ranks above Y, and that with `QueryTerms = null` the order reverts to the pure-RRF baseline (guards against the boost firing unconditionally).
+
+- [ ] **Step 2: Run**
+
+Run: `cd apps/api/src/Api && dotnet test ../../tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~HeadingBoostIntegrationTests" -v minimal` (requires Docker).
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/tests/Api.Tests/Integration/KnowledgeBase/HeadingBoostIntegrationTests.cs
+git commit -m "test(rag): end-to-end heading-boost ranking integration test (#3270)"
+```
+
+---
+
+## Final verification (before PR)
+
+- [ ] `cd apps/api/src/Api && dotnet build Api.sln` → 0 warnings, 0 errors.
+- [ ] `dotnet test ../../tests/Api.Tests/Api.Tests.csproj --filter "BoundedContext=KnowledgeBase" -v minimal` → green (kill testhost first).
+- [ ] No EF migration was added (JOIN strategy — confirm `git status` shows no `Migrations/` changes).
+- [ ] PR to `main-dev` with base = parent branch; body references #3270 and notes: heading-boost active on chat + playground; single-arm modes + RagPromptAssembly + synonym-expansion for headings are documented follow-ups; runtime effect materializes as the SP3 re-index populates `text_chunks.Heading`.
+- [ ] Post the "heading-boost shipped" comment on #3270 with the deferred-scope list; keep #3270 open only if the follow-ups warrant, else close.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** SP4 heading-boost deliverable = vector-arm boost via heading (Tasks 2/4/8/9), heading persistence read (Tasks 3/4), query signal (Tasks 1/7). ✅ All three #3270-remaining items covered. Query-expansion piece already retired (PR #3307) — not in scope. Reranker-in-playground already shipped (Slice B #3258) — not in scope.
+- **Type consistency:** `Heading` is `string?` at every hop (FusionCandidate/FusedCandidate/SearchResult/SearchResultItem/HybridSearchResult/KeywordSearchResult/Embedding). `QueryTerms` is `IReadOnlyList<string>?` on both `FusionOptions` and `SearchQuery`. `ComputeHeadingMatchBoost(IReadOnlyList<string>?, string?)` and `ExtractHeadingMatchTerms(string?)` signatures are used identically in Tasks 1/2/7/9.
+- **Ordering dependency:** Tasks 2/5 must precede 6/8/9 (they define the fields the later tasks populate). The record-signature change in Task 2 breaks the build until Tasks 8/9 update the 4 `FusionCandidate` call sites — the plan flags folding 2/8/9 into one green commit.


### PR DESCRIPTION
Closes the **heading-based ranking boost** — the last remaining deliverable of SP4 (#3270), epic #3266. Fixes the motivating case ("Setup per N giocatori" surfacing the wrong section) by promoting chunks whose persisted `Heading` matches the query.

## Design (locked decisions)

- **Vector arm = `LEFT JOIN text_chunks`** on `source_chunk_id` — NO migration, NO re-embed; reuses the rows the SP3 re-index (#3269) is populating. LEFT (not INNER) so pre-SP2 embeddings with a null `source_chunk_id` still return with `heading=null` instead of being dropped.
- **Boost = query-dependent** `FusionSignals.ComputeHeadingMatchBoost(queryTerms, heading)` — additive `+0.15` (exact twin of the role boost), fires when a normalized query term substring-matches the heading.
- **Scope = unified core**: applied once in `HybridFusionCore.Fuse`, covering the primary chat path (`/agents/qa` + `/stream` via `RrfFusionDomainService`) and the admin playground (`HybridSearchService`).

## How it works

`Heading` is threaded from both DB read arms — keyword FTS SQL projection + the vector JOIN — through the shared neutral plumbing (`SearchResult`/`SearchResultItem`/`HybridSearchResult`/`Embedding`/`KeywordSearchResult` → `FusionCandidate`/`FusedCandidate`), mirroring how `RoleTags` already flows. Query terms are derived at each fusion entry point via `FusionSignals.ExtractHeadingMatchTerms(query)`.

**Order-only**: `MinScore` still gates on the preserved cosine `RelevanceScore` (#2712) — the boost changes ranking, never which chunks survive the cutoff.

## Deviations from the plan ([`2026-07-27-issue-3270-heading-boost.md`](../blob/main-dev/docs/superpowers/plans/2026-07-27-issue-3270-heading-boost.md))

- **Task 7 simplified** (−3 files): `PerformHybridSearchAsync`/`SearchHybridAsync` already have the raw `query` string in scope, so query terms are derived there instead of plumbing `SearchQuery.QueryTerms` through `AskQuestion`/`StreamQa`. Same correctness, less surface.
- **Task 10 deferred**: `ImportRagData` Heading round-trip needs a **parquet schema** change (DTO + serializer + export) with backup-compat risk — a secondary admin restore path. Imported chunks without heading degrade to a safe no-op.
- **Task 11**: covered by 53 unit tests (signal + core + chat adapter) + **empirical JOIN validation** on Postgres, rather than a new Testcontainers test (the raw-SQL flow is already exercised by the role-boost integration suite in CI).

## Verification

- ✅ Production build: **0 errors, 0 warnings**
- ✅ **53 unit tests green** (`FusionSignalsTests` + `HybridFusionCoreTests` + `RrfFusionDomainServiceTests`)
- ✅ JOIN SQL validated empirically on `meepleai-postgres` (columns/syntax/join correct; `Heading` values still empty pre-reindex — **expected**, confirms the boost is inert until #3269 lands)
- ✅ No EF migration (JOIN strategy)

## Runtime note

The boost is **inert until the SP3 re-index materializes headings** on existing rows — which is running on staging now. Once headings populate, chat + playground retrieval start promoting heading-matched chunks with zero further deploys.

## Deferred follow-ups (tracked for the #3270 closing comment)

1. `ImportRagData` Heading round-trip (parquet schema).
2. Heading boost for single-arm modes (`SearchSemanticOnly`/`KeywordOnly`) + `RagPromptAssemblyService` (separate RRF).
3. Cross-lingual synonym expansion for headings (query "setup" → heading "Preparazione") — reuse `SynonymTablesByConfig`.

Ref: #3270 · epic #3266

🤖 Generated with [Claude Code](https://claude.com/claude-code)