### PR TITLE
fix(session-tracking): derive game-session owner from authenticated principal (IDOR)

### DIFF
--- a/apps/api/src/Api/Routing/SessionTracking/SessionCommandEndpoints.cs
+++ b/apps/api/src/Api/Routing/SessionTracking/SessionCommandEndpoints.cs
@@ -37,9 +37,13 @@ internal static class SessionCommandEndpoints
     /// Those are set only by internal MediatR orchestrators (StartGameNight / AttachGamebookCampaign
     /// / the standalone gamebook handler). Binding the command directly let a client send e.g.
     /// <c>skipKbReadinessGate: true</c> to bypass the KB-readiness gate.
+    ///
+    /// <para>Also EXCLUDES <c>UserId</c>: the session owner is derived from the authenticated
+    /// principal in the endpoint, never from the request body. Binding a body-supplied UserId
+    /// was an IDOR (owner spoofing + victim concurrent-session-quota exhaustion) — any authenticated
+    /// caller could create a session owned by an arbitrary victim.</para>
     /// </summary>
     public record CreateSessionRequest(
-        Guid UserId,
         Guid GameId,
         string SessionType,
         DateTime? SessionDate,
@@ -50,12 +54,13 @@ internal static class SessionCommandEndpoints
         GameStateTier StateTier = GameStateTier.Minimal)
     {
         /// <summary>
-        /// Maps to <see cref="CreateSessionCommand"/>, leaving the internal-only flags
+        /// Maps to <see cref="CreateSessionCommand"/> for the given server-derived owner
+        /// <paramref name="userId"/> (the authenticated principal), leaving the internal-only flags
         /// (<c>GamebookCampaignId</c>, <c>SkipGameNightEnvelope</c>, <c>SkipKbReadinessGate</c>)
         /// at their safe defaults (<c>null</c>/<c>false</c>/<c>false</c>).
         /// </summary>
-        public CreateSessionCommand ToCommand() => new(
-            UserId,
+        public CreateSessionCommand ToCommand(Guid userId) => new(
+            userId,
             GameId,
             SessionType,
             SessionDate,
@@ -70,10 +75,20 @@ internal static class SessionCommandEndpoints
     {
         group.MapPost("/game-sessions", async (
             CreateSessionRequest request,
+            HttpContext httpContext,
             IMediator mediator,
             CancellationToken ct) =>
         {
-            var result = await mediator.Send(request.ToCommand(), ct).ConfigureAwait(false);
+            // IDOR guard: derive the session owner from the authenticated principal,
+            // never from the request body — a client must not be able to create a
+            // session owned by (or consume the concurrent-session quota of) another user.
+            var userId = httpContext.User.GetUserId();
+            if (userId == Guid.Empty)
+            {
+                return Results.Unauthorized();
+            }
+
+            var result = await mediator.Send(request.ToCommand(userId), ct).ConfigureAwait(false);
             return Results.Created($"/api/v1/game-sessions/{result.SessionId}", result);
         })
         .RequireAuthenticatedUser()

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Endpoints/CreateSessionEndpointIdorIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Endpoints/CreateSessionEndpointIdorIntegrationTests.cs
@@ -1,0 +1,127 @@
+using System.Net;
+using System.Net.Http.Json;
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SessionTracking;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Endpoints;
+
+/// <summary>
+/// HTTP-layer IDOR test for <c>POST /api/v1/game-sessions</c>.
+/// The endpoint must derive the session owner from the authenticated principal,
+/// NOT from a client-supplied body <c>userId</c>. An attacker who sends a victim's
+/// id in the request body must still own the created session themselves — otherwise
+/// any authenticated user could create sessions owned by (and consume the concurrent-
+/// session quota of) an arbitrary victim (owner spoofing / availability DoS).
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "SessionTracking")]
+public sealed class CreateSessionEndpointIdorIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _attackerClient = null!;
+    private Guid _attackerId;
+    private string _attackerToken = null!;
+    private Guid _victimId;
+    private Guid _gameId;
+
+    public CreateSessionEndpointIdorIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"createsession_idor_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        await db.Database.MigrateAsync();
+
+        (_attackerId, _attackerToken) = await TestSessionHelper.CreateUserSessionAsync(db);
+        (_victimId, _) = await TestSessionHelper.CreateUserSessionAsync(db);
+
+        // Seed a KB-ready SharedGame so the create-session KB-readiness gate (422 when not
+        // ready) passes: a Ready PDF + a completed vector index for that PDF.
+        _gameId = await TestSessionHelper.SeedSharedGameAsync(db, "IDOR Create Game");
+        var pdfId = Guid.NewGuid();
+        db.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = pdfId,
+            SharedGameId = _gameId,
+            FileName = "rulebook.pdf",
+            FilePath = "/uploads/rulebook.pdf",
+            FileSizeBytes = 1024,
+            UploadedByUserId = _attackerId,
+            UploadedAt = DateTime.UtcNow,
+            ProcessingState = "Ready",
+            IsActiveForRag = true,
+        });
+        db.VectorDocuments.Add(new VectorDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            PdfDocumentId = pdfId,
+            SharedGameId = _gameId,
+            IndexingStatus = "completed",
+            ChunkCount = 1,
+            IndexedAt = DateTime.UtcNow,
+        });
+        await db.SaveChangesAsync();
+
+        _attackerClient = _factory.CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _attackerClient?.Dispose();
+        _factory?.Dispose();
+        await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    [Fact(Timeout = 90_000)]
+    public async Task CreateSession_WithSpoofedBodyUserId_OwnsSessionAsAuthenticatedCaller()
+    {
+        // IDOR exploit: the attacker passes the victim's id as the body userId.
+        var body = new
+        {
+            userId = _victimId,
+            gameId = _gameId,
+            sessionType = "Generic",
+            participants = new[] { new { displayName = "Attacker", isOwner = true } },
+        };
+
+        var response = await _attackerClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(
+                HttpMethod.Post, "/api/v1/game-sessions", _attackerToken, body));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created, "a KB-ready game session creation must succeed");
+
+        var result = await response.Content.ReadFromJsonAsync<CreateSessionResult>();
+        result.Should().NotBeNull();
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var session = await db.SessionTrackingSessions
+            .AsNoTracking()
+            .FirstOrDefaultAsync(s => s.Id == result!.SessionId);
+
+        session.Should().NotBeNull();
+        session!.UserId.Should().Be(
+            _attackerId,
+            "the session owner must derive from the authenticated principal, not the client-supplied body userId");
+    }
+}

--- a/apps/api/tests/Api.Tests/Routing/SessionTracking/CreateSessionRequestTests.cs
+++ b/apps/api/tests/Api.Tests/Routing/SessionTracking/CreateSessionRequestTests.cs
@@ -18,14 +18,13 @@ public sealed class CreateSessionRequestTests
     public void ToCommand_LeavesInternalFlagsAtSafeDefaults()
     {
         var request = new SessionCommandEndpoints.CreateSessionRequest(
-            UserId: Guid.NewGuid(),
             GameId: Guid.NewGuid(),
             SessionType: "Standard",
             SessionDate: null,
             Location: null,
             Participants: new List<ParticipantDto>());
 
-        var command = request.ToCommand();
+        var command = request.ToCommand(Guid.NewGuid());
 
         // The internal-only flags are NOT part of the request DTO, so they are structurally
         // unforgeable and must always land on their safe defaults.
@@ -43,7 +42,6 @@ public sealed class CreateSessionRequestTests
         var participants = new List<ParticipantDto> { new() { DisplayName = "Alice", IsOwner = true } };
 
         var request = new SessionCommandEndpoints.CreateSessionRequest(
-            UserId: userId,
             GameId: gameId,
             SessionType: "GameSpecific",
             SessionDate: null,
@@ -52,7 +50,7 @@ public sealed class CreateSessionRequestTests
             GameNightEventId: nightId,
             GuestNames: new[] { "Bob" });
 
-        var command = request.ToCommand();
+        var command = request.ToCommand(userId);
 
         command.UserId.Should().Be(userId);
         command.GameId.Should().Be(gameId);


### PR DESCRIPTION
## Problema (IDOR — broken object-level authorization, OWASP API1/API5)

`POST /api/v1/game-sessions` bind-ava `CreateSessionRequest.UserId` direttamente dal body JSON e lo passava a `CreateSessionCommand` **senza** sovrascriverlo col principal autenticato. Qualsiasi utente autenticato poteva quindi:

- **Owner spoofing**: creare una sessione intestata a una vittima arbitraria (avvelenando `session.UserId`, l'`GameNightEvent.OrganizerId` ad-hoc e `SessionCreatedEvent`).
- **DoS di disponibilità**: consumare/esaurire la quota di sessioni concorrenti della vittima, impedendole di creare le proprie.

`MapCreateSessionEndpoint` era l'unico endpoint user-facing di SessionTracking a NON derivare l'identità dal principal — tutti gli altri (incl. `scores-polymorphic` nello stesso file) già lo fanno.

## Fix (confinato al boundary HTTP)

- L'endpoint deriva l'owner via `httpContext.User.GetUserId()` e risponde `401` se vuoto — **mirror verbatim** del pattern già presente a `SessionCommandEndpoints.cs:185` (`scores-polymorphic`).
- `UserId` rimosso da `CreateSessionRequest`: un valore fornito nel body è ora **strutturalmente ignorato** (System.Text.Json scarta la proprietà extra).
- Gli orchestratori interni MediatR (`StartGameNightSessionCommandHandler`, `AttachGamebookCampaignToGameNightCommandHandler`, `CreateGamebookCampaignHandler`) costruiscono `CreateSessionCommand` **direttamente** (non via DTO) → non impattati.

## Test (TDD)

- **Nuovo** test IDOR d'integrazione HTTP (`CreateSessionEndpointIdorIntegrationTests`): l'attaccante A POSTa `userId=<vittima B>` nel body su un gioco KB-ready → asserisce che la sessione persistita è di proprietà di **A**. Verificato RED (owner=B) → GREEN (owner=A).
- Unit test DTO esistenti (`CreateSessionRequestTests`) aggiornati alla firma `ToCommand(Guid userId)`.
- ✅ 3/3 verde. Build test project pulita, nessuna regressione introdotta dal cambio (verificato con stash).

## Note

- ⚠️ Discovery: rilevati 2 fallimenti **pre-esistenti** su `main-dev` in `CreateSessionCommandAdHocTests` (GameNight status `Published` vs `InProgress`, 409 non lanciato) — **non correlati** a questa PR (falliscono identici con le mie modifiche in stash). Da triageare separatamente.
- Contratto: rimuovere `userId` dal body è un breaking change per eventuali client che lo inviavano — voluto (era la vulnerabilità).

🤖 Generated with [Claude Code](https://claude.com/claude-code)