### PR TITLE
chore(infra): reduce staging disk footprint

### DIFF
--- a/docs/for-developers/operations/2026-07-28-staging-disk-footprint-reduction.md
+++ b/docs/for-developers/operations/2026-07-28-staging-disk-footprint-reduction.md
@@ -1,0 +1,92 @@
+# Staging disk footprint reduction — 2026-07-28
+
+**Context**: the CAX21 staging server (8GB RAM, 75GB disk) reached **79% disk usage
+(57G/75G)**. Goal: reduce footprint without upgrading the machine while the app is
+still staging-only (not public). Diagnosis via `docker system df -v` + `du`.
+
+## What was consuming the disk
+
+| Area | Size | Root cause |
+|---|---|---|
+| `unstructured-service` image + container | **10.2GB** | Residual: staging's active PDF extractor is `Docnet` (in-process, `appsettings.json → PdfProcessing:Extractor:Provider=Docnet`). The deploy CI (`--profile ai-essential`) never starts `unstructured` (profile `pdf-cloud-extractors`). The image was built locally by an old profile run. |
+| Drift services (`minio`, `mailpit`, `loki`, `fluent-bit`, `orchestration`) | ~1.4GB + RAM | Started manually / by old profiles; none are in the deploy CI profiles (`ai-essential` / `monitoring-essential`). |
+| `reranker_models` volume | 2.3GB | The reranker model is baked into the image (`HF_HOME=/home/reranker/.cache/huggingface`); the named volume mounted on that same path only duplicated it. |
+| Prometheus TSDB volume | 2.6GB | Retention `60d` / `5GB` — oversized for a non-public staging env. |
+| Container JSON logs | 1.5GB | No global `log-opts` on the host; only `api`/`web`/`cloudflared` set `logging:` in compose. |
+| Runner CI cache (`.nuget`, `_work`, `.cache`) | ~10GB | A self-hosted GitHub Actions runner is co-located on the staging server (see Follow-ups). |
+
+## Actions taken
+
+### 1. Runtime cleanup (executed 2026-07-28) — freed ~13GB, disk 79% → 61%
+
+Removed the residuals that the deploy CI never restarts. **Safe**: none of these are
+in the `ai-essential` / `monitoring-essential` deploy profiles, and they have
+`restart: unless-stopped`, so they must be removed with `rm -f` (not `stop`) to stay
+down across a Docker daemon restart.
+
+```bash
+docker rm -f meepleai-unstructured && docker rmi meepleai-unstructured-service:latest
+docker rm -f meepleai-minio meepleai-minio-init mailpit \
+             meepleai-loki meepleai-fluent-bit meepleai-orchestrator
+docker image prune -af --filter "until=1h"
+```
+
+The 13 remaining containers are exactly the deploy set (api, web, embedding, reranker,
+postgres, redis, prometheus, grafana, alertmanager, cadvisor, node-exporter,
+cloudflared, pg-proxy). To re-enable a service deliberately, use the intended target
+(`make staging-with-tutor` for orchestration, `make logging` for loki/fluent-bit).
+
+### 2. Durable repo fixes (this PR)
+
+- **`infra/docker-compose.yml`** — removed the redundant `reranker_models` volume
+  mount + definition. The model is baked into the image; the mount only duplicated
+  ~2.3GB. `embedding-service` already runs volume-less for the same reason.
+- **`infra/compose.staging.yml`** — Prometheus retention `60d`/`5GB` → `15d`/`1536MB`.
+  Staging is non-public pre-prod; 2 weeks of metrics is plenty. Prod keeps `90d`/`50GB`.
+- **`infra/hetzner/cax31-bootstrap.sh`** — added `/etc/docker/daemon.json` with
+  json-file log rotation (`max-size 10m`, `max-file 3`). New servers now boot with a
+  cap on container logs. Idempotent (does not clobber an existing `daemon.json`).
+
+## Applying the durable fixes to the EXISTING staging server
+
+These fixes land in the repo but two of them need a one-time action on the live server,
+because they do not apply retroactively.
+
+1. **`reranker_models` volume** — after this PR merges and the next deploy recreates the
+   reranker container (now without the mount), reclaim the old volume:
+   ```bash
+   docker volume rm meepleai_reranker_models   # ~2.3GB
+   ```
+   Verify first that the reranker container was recreated without the mount:
+   `docker inspect meepleai-reranker --format '{{json .Mounts}}'` (should be `[]`/no
+   huggingface mount) and that `GET :8003/health` is green.
+
+2. **`daemon.json` log rotation** — the bootstrap change only affects *new* servers.
+   On the existing server, create the file and restart Docker once:
+   ```bash
+   sudo tee /etc/docker/daemon.json >/dev/null <<'EOF'
+   { "log-driver": "json-file", "log-opts": { "max-size": "10m", "max-file": "3" } }
+   EOF
+   sudo systemctl restart docker
+   ```
+   Per Docker docs, log-opts apply to newly created containers only — existing
+   containers keep their current logs until recreated (the next `--force-recreate`
+   deploy covers them). To reclaim existing log bulk immediately:
+   `sudo truncate -s 0 /var/lib/docker/containers/*/*-json.log`.
+
+3. **Prometheus retention** — applies when the prometheus container is recreated on the
+   next deploy. The TSDB volume shrinks gradually as old persistent blocks age past the
+   `1536MB` cap (not instantly).
+
+## Follow-ups (not in this PR)
+
+- **Runner CI co-location (~10GB + RAM contention)** — a self-hosted GitHub Actions
+  runner lives on the staging server. Its caches (`~/.nuget` 4GB, `_work` checkout 3.6GB,
+  `~/.cache` 1.5GB) are rebuilt on every CI run, so a one-time clear only buys temporary
+  headroom. Durable options: (a) move the runner to a dedicated host, (b) add a cron that
+  prunes `~/.nuget`/`~/.cache` when idle, (c) cap the checkout retention. This is the
+  main structural driver of regrowth and should be tracked separately.
+- **Application-level retention gaps** (low impact on this server today, pgdata is <500MB):
+  `game_analytics_events` has no retention job; abandoned chunked-upload sessions
+  (`FindExpiredSessionsAsync` is never invoked) can leave temp `.bin` files + orphan DB
+  rows. Worth a backend cleanup job before production scale.

--- a/infra/compose.staging.yml
+++ b/infra/compose.staging.yml
@@ -322,8 +322,11 @@ services:
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.path=/prometheus'
-      - '--storage.tsdb.retention.time=60d'
-      - '--storage.tsdb.retention.size=5GB'
+      # Staging is a non-public pre-prod env: 2 weeks of metrics is plenty for
+      # debugging and keeps the TSDB volume small (~5GB → ~1.5GB). Whichever
+      # limit triggers first wins. Prod (compose.prod.yml) keeps 90d/50GB.
+      - '--storage.tsdb.retention.time=15d'
+      - '--storage.tsdb.retention.size=1536MB'
       - '--web.enable-lifecycle'
     volumes:
       - ./prometheus.staging.yml:/etc/prometheus/prometheus.yml:ro  # staging-specific labels

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -271,8 +271,12 @@ services:
     container_name: meepleai-reranker
     restart: unless-stopped
     profiles: [ai, ai-essential]
-    volumes:
-      - reranker_models:/home/reranker/.cache/huggingface
+    # No model volume: the reranker model (BAAI/bge-reranker-v2-m3) is baked into
+    # the image at build time under HF_HOME=/home/reranker/.cache/huggingface
+    # (see apps/reranker-service/Dockerfile). A named volume on that same path
+    # only shadowed the baked cache and duplicated ~2.3GB on disk with no benefit
+    # (the model is never fetched at runtime). embedding-service already runs
+    # volume-less for the same reason.
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8003/health"]
       interval: 30s
@@ -628,7 +632,8 @@ volumes:
   # ML Service Model Caches
   ollama_data:
   smoldocling_models:
-  reranker_models:
+  # reranker_models removed: the reranker model is baked into the image, so the
+  # volume only duplicated it on disk (see reranker-service above).
 
   # Temporary Processing Directories
   unstructured_temp:

--- a/infra/hetzner/cax31-bootstrap.sh
+++ b/infra/hetzner/cax31-bootstrap.sh
@@ -30,6 +30,28 @@ echo "==> Install Docker (ARM64)"
 curl -fsSL https://get.docker.com | sh
 systemctl enable --now docker
 
+echo "==> Docker daemon: json-file log rotation (prevent unbounded container logs)"
+# Without a global log-opts default, per-container JSON logs under
+# /var/lib/docker/containers grow unbounded: only api/web/cloudflared set an
+# explicit `logging:` block in compose, so postgres/redis/grafana/prometheus/
+# embedding/reranker/etc. had no cap (disk-full incident #1575). This caps every
+# container at max 3×10MB. Applies to newly created/recreated containers only, so
+# a deploy (--force-recreate) picks it up; existing containers keep their current
+# logs until recreated. Idempotent: leaves an existing daemon.json untouched.
+mkdir -p /etc/docker
+if [ ! -f /etc/docker/daemon.json ]; then
+  cat > /etc/docker/daemon.json <<'DOCKERD_EOF'
+{
+  "log-driver": "json-file",
+  "log-opts": {
+    "max-size": "10m",
+    "max-file": "3"
+  }
+}
+DOCKERD_EOF
+  systemctl restart docker
+fi
+
 echo "==> Install Docker Compose plugin"
 mkdir -p ~/.docker/cli-plugins
 curl -SL https://github.com/docker/compose/releases/latest/download/docker-compose-linux-aarch64 \


### PR DESCRIPTION
## Contesto

Il server staging CAX21 (8GB RAM, 75GB disco) aveva raggiunto **79% di uso disco (57G/75G)**. Obiettivo: ridurre il footprint **senza upgrade macchina** finché l'app è solo staging (non pubblica).

Diagnosi via `docker system df -v` + `du`. Questa PR contiene i **fix durevoli lato repo**; la pulizia runtime dei residui (**~13GB, disco 79% → 61%**) è stata eseguita separatamente sul server (rimozione immagine/container `unstructured` −10.2GB + servizi drift fuori dal profilo di deploy).

## Fix in questa PR

| File | Cambiamento | Effetto |
|---|---|---|
| `infra/docker-compose.yml` | Rimosso mount + definizione ridondanti di `reranker_models` | −2.3GB: il modello è bakato nell'immagine (`HF_HOME=/home/reranker/.cache/huggingface`), il volume lo duplicava. `embedding-service` gira già senza volume per lo stesso motivo. |
| `infra/compose.staging.yml` | Prometheus retention `60d/5GB` → `15d/1536MB` | volume TSDB scende ~2.6GB → ~1.5GB. Prod (`compose.prod.yml`) resta `90d/50GB`. |
| `infra/hetzner/cax31-bootstrap.sh` | Aggiunto `/etc/docker/daemon.json` con log-rotation json-file (`max-size 10m`, `max-file 3`) | tetto ai log container sui **nuovi** server. Solo `api/web/cloudflared` avevano `logging:` in compose; il resto cresceva illimitato (incidente disk-full #1575). Idempotente. |

Sintassi verificata su doc ufficiali Docker/Prometheus. `docker compose config` sulla base non riporta reference dangling dopo la rimozione di `reranker_models`; `bash -n` sul bootstrap OK; `daemon.json` è JSON valido.

## Applicazione al server ESISTENTE

Due fix non sono retroattivi e richiedono un'azione one-time (dettagli nel runbook):

- **`reranker_models`**: dopo merge + deploy (che ricrea il reranker senza mount) → `docker volume rm meepleai_reranker_models` per recuperare i 2.3GB.
- **`daemon.json`**: creare il file + `systemctl restart docker` (il bootstrap copre solo i server nuovi). I log-opts valgono per i container ricreati → il prossimo `--force-recreate` deploy li copre.

## Runbook

[`docs/for-developers/operations/2026-07-28-staging-disk-footprint-reduction.md`](docs/for-developers/operations/2026-07-28-staging-disk-footprint-reduction.md) — include diagnosi completa, comandi di cleanup runtime, apply steps server-side e follow-up.

## Follow-up (non in questa PR)

- 🔴 **Runner CI co-locato (~10GB + RAM contention)**: un self-hosted GitHub Actions runner vive sullo stesso server dello staging; le sue cache (`.nuget` 4GB, `_work` 3.6GB, `.cache` 1.5GB) si rigenerano ad ogni build, quindi un clear una-tantum dà solo respiro temporaneo. È il driver strutturale principale della ricrescita — da tracciare separatamente (spostare il runner / cron di potatura / cap checkout).
- Retention applicativa: `game_analytics_events` senza retention job; sessioni chunked-upload abbandonate (`FindExpiredSessionsAsync` mai invocato). Basso impatto su questo server oggi (pgdata <500MB), ma da valutare prima della scala di produzione.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
