### PR TITLE
fix(rag): reranker HttpClient targets RERANKER_URL + honors configured timeout

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/DependencyInjection/KnowledgeBaseServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/DependencyInjection/KnowledgeBaseServiceExtensions.cs
@@ -582,20 +582,36 @@ internal static class KnowledgeBaseServiceExtensions
     }
 
     /// <summary>
-    /// Resolves the reranker service base URL. Prefers the <c>Reranking:BaseUrl</c> config key, then
-    /// falls back to the <c>RERANKER_URL</c> env var that every compose file sets
+    /// Resolves the reranker service base URL. Prefers an explicit <c>Reranking:BaseUrl</c> config key,
+    /// then falls back to the <c>RERANKER_URL</c> env var that every compose file sets
     /// (compose.{dev,staging,prod}.yml), and finally to localhost for local <c>dotnet run</c>.
     /// <para>
     /// Before the <c>RERANKER_URL</c> fallback existed the client targeted <c>localhost:8003</c> in
     /// every deployed environment (which set <c>RERANKER_URL</c>, not <c>Reranking:BaseUrl</c>), so
     /// cross-encoder reranking silently failed and every RAG query degraded to the vector-dominated
-    /// fusion fallback.
+    /// fusion fallback. NOTE: for the <c>RERANKER_URL</c> fallback to fire, <c>appsettings.json</c>
+    /// MUST NOT define a <c>Reranking:BaseUrl</c> default — a non-empty default there would shadow the
+    /// env var in every environment (issue #3334). Empty/whitespace values are treated as absent so a
+    /// blank override (<c>RERANKER_URL=</c> or <c>Reranking__BaseUrl=</c>) falls through instead of
+    /// producing <c>new Uri("")</c>.
     /// </para>
     /// </summary>
-    internal static string ResolveRerankerBaseUrl(IConfiguration config) =>
-        config["Reranking:BaseUrl"]
-        ?? config["RERANKER_URL"]
-        ?? "http://localhost:8003";
+    internal static string ResolveRerankerBaseUrl(IConfiguration config)
+    {
+        var explicitBaseUrl = config["Reranking:BaseUrl"];
+        if (!string.IsNullOrWhiteSpace(explicitBaseUrl))
+        {
+            return explicitBaseUrl;
+        }
+
+        var rerankerUrl = config["RERANKER_URL"];
+        if (!string.IsNullOrWhiteSpace(rerankerUrl))
+        {
+            return rerankerUrl;
+        }
+
+        return "http://localhost:8003";
+    }
 
     private static void AddCachingServices(IServiceCollection services, IConfiguration? configuration)
     {

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/DependencyInjection/KnowledgeBaseServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/DependencyInjection/KnowledgeBaseServiceExtensions.cs
@@ -553,9 +553,13 @@ internal static class KnowledgeBaseServiceExtensions
         services.AddHttpClient<ICrossEncoderReranker, CrossEncoderRerankerClient>((sp, client) =>
         {
             var config = sp.GetRequiredService<IConfiguration>();
-            var baseUrl = config["Reranking:BaseUrl"] ?? "http://localhost:8003";
-            client.BaseAddress = new Uri(baseUrl);
-            client.Timeout = TimeSpan.FromSeconds(10);
+            client.BaseAddress = new Uri(ResolveRerankerBaseUrl(config));
+            // Timeout is governed per-request by RerankerClientOptions.TimeoutMs (each call in
+            // CrossEncoderRerankerClient wraps a CancellationTokenSource.CancelAfter(TimeoutMs);
+            // IsHealthyAsync uses its own 5s CTS). The previous hardcoded 10s HttpClient.Timeout
+            // silently capped that option — raising Reranking:TimeoutMs above 10s had no effect —
+            // so defer entirely to the per-request token.
+            client.Timeout = System.Threading.Timeout.InfiniteTimeSpan;
         });
 
         // Options configuration - use provided configuration or defer to runtime resolution
@@ -576,6 +580,22 @@ internal static class KnowledgeBaseServiceExtensions
         // Application Services - Resilient Retrieval with Reranking
         services.AddScoped<IRerankedRetrievalService, ResilientRetrievalService>();
     }
+
+    /// <summary>
+    /// Resolves the reranker service base URL. Prefers the <c>Reranking:BaseUrl</c> config key, then
+    /// falls back to the <c>RERANKER_URL</c> env var that every compose file sets
+    /// (compose.{dev,staging,prod}.yml), and finally to localhost for local <c>dotnet run</c>.
+    /// <para>
+    /// Before the <c>RERANKER_URL</c> fallback existed the client targeted <c>localhost:8003</c> in
+    /// every deployed environment (which set <c>RERANKER_URL</c>, not <c>Reranking:BaseUrl</c>), so
+    /// cross-encoder reranking silently failed and every RAG query degraded to the vector-dominated
+    /// fusion fallback.
+    /// </para>
+    /// </summary>
+    internal static string ResolveRerankerBaseUrl(IConfiguration config) =>
+        config["Reranking:BaseUrl"]
+        ?? config["RERANKER_URL"]
+        ?? "http://localhost:8003";
 
     private static void AddCachingServices(IServiceCollection services, IConfiguration? configuration)
     {

--- a/apps/api/src/Api/appsettings.Integration.json
+++ b/apps/api/src/Api/appsettings.Integration.json
@@ -9,9 +9,6 @@
     "LocalServiceUrl": "http://localhost:18000",
     "EnableFallback": false
   },
-  "Reranking": {
-    "BaseUrl": "http://localhost:18003"
-  },
   "AI": {
     "Comment": "AiProviderSettings (health check, circuit breaker). OllamaLlmClient reads root-level OllamaUrl, not this path.",
     "Providers": {

--- a/apps/api/src/Api/appsettings.json
+++ b/apps/api/src/Api/appsettings.json
@@ -387,8 +387,7 @@
     ]
   },
   "Reranking": {
-    "Comment": "ADR-016 Phase 4: Cross-encoder reranking service configuration",
-    "BaseUrl": "http://localhost:8003",
+    "Comment": "ADR-016 Phase 4: Cross-encoder reranking service configuration. BaseUrl is intentionally NOT defaulted here: a localhost default would shadow the RERANKER_URL env var that every compose file sets (KnowledgeBaseServiceExtensions.ResolveRerankerBaseUrl resolves Reranking:BaseUrl -> RERANKER_URL -> localhost). See issue #3334.",
     "TimeoutMs": 5000,
     "RetryCount": 2,
     "RetryDelayMs": 100

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Infrastructure/DependencyInjection/RerankerBaseUrlResolutionTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Infrastructure/DependencyInjection/RerankerBaseUrlResolutionTests.cs
@@ -104,35 +104,39 @@ public class RerankerBaseUrlResolutionTests
     }
 
     [Fact]
-    public void AppsettingsJson_DoesNotDefineRerankingBaseUrl_SoRerankerUrlFallbackFires()
+    public void NoAppsettingsFile_DefinesRerankingBaseUrl_SoRerankerUrlFallbackFiresInEveryEnvironment()
     {
         // Regression guard for #3334: the original fix was defeated because appsettings.json defined
         // Reranking:BaseUrl="http://localhost:8003", which is loaded in every environment and shadowed
         // the RERANKER_URL fallback (config["Reranking:BaseUrl"] was never null → the ?? branch was dead
-        // code → the reranker kept targeting localhost in staging/prod). This asserts the real
-        // appsettings.json does NOT reintroduce that shadowing default, and that with it layered under a
-        // RERANKER_URL env value the resolution correctly returns the env value.
-        var appsettingsPath = Path.Combine(AppContext.BaseDirectory, "appsettings.json");
-        if (!File.Exists(appsettingsPath))
+        // code → the reranker kept targeting localhost). A sweep also found the SAME shadow in
+        // appsettings.Integration.json. This guard scans ALL appsettings*.json shipped next to the Api
+        // assembly and asserts none reintroduces a shadowing Reranking:BaseUrl, in any environment.
+        var appsettingsFiles = Directory
+            .GetFiles(AppContext.BaseDirectory, "appsettings*.json", SearchOption.TopDirectoryOnly);
+
+        // Api's appsettings*.json are copied next to Api.dll and flow into the test output. If the build
+        // layout ever changes, fail loudly rather than silently skip — this guard is the whole point.
+        appsettingsFiles.Should().NotBeEmpty(
+            $"appsettings*.json must be present in {AppContext.BaseDirectory}; the regression guard cannot run without them.");
+
+        foreach (var file in appsettingsFiles)
         {
-            // Api's appsettings.json is copied next to Api.dll and flows into the test output. If the
-            // build layout ever changes, fail loudly rather than silently skip — this guard is the whole
-            // point of the test.
-            Assert.Fail($"appsettings.json not found at {appsettingsPath}; the regression guard cannot run.");
+            var config = new ConfigurationBuilder().AddJsonFile(file, optional: false).Build();
+            string.IsNullOrWhiteSpace(config["Reranking:BaseUrl"]).Should().BeTrue(
+                $"{Path.GetFileName(file)} must not define Reranking:BaseUrl — a non-blank value shadows the "
+                + "RERANKER_URL env fallback in that environment (#3334).");
         }
 
+        // End-to-end: the base appsettings.json layered under a RERANKER_URL env value must resolve to
+        // the env value, exactly as staging/prod do.
         var layered = new ConfigurationBuilder()
-            .AddJsonFile(appsettingsPath, optional: false)
+            .AddJsonFile(Path.Combine(AppContext.BaseDirectory, "appsettings.json"), optional: false)
             .AddInMemoryCollection(new Dictionary<string, string?>(StringComparer.Ordinal)
             {
                 ["RERANKER_URL"] = "http://reranker-service:8003",
             })
             .Build();
-
-        // The appsettings layer must not supply a shadowing default...
-        string.IsNullOrWhiteSpace(layered["Reranking:BaseUrl"]).Should().BeTrue(
-            "appsettings.json must not define Reranking:BaseUrl or it shadows the RERANKER_URL env fallback (#3334)");
-        // ...so the RERANKER_URL env value wins end-to-end, as it does in staging/prod.
         KnowledgeBaseServiceExtensions.ResolveRerankerBaseUrl(layered)
             .Should().Be("http://reranker-service:8003");
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Infrastructure/DependencyInjection/RerankerBaseUrlResolutionTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Infrastructure/DependencyInjection/RerankerBaseUrlResolutionTests.cs
@@ -73,4 +73,67 @@ public class RerankerBaseUrlResolutionTests
             act.Should().NotThrow();
         }
     }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ResolveRerankerBaseUrl_TreatsBlankBaseUrlAsAbsent_FallsThroughToRerankerUrl(string blank)
+    {
+        // A present-but-blank Reranking:BaseUrl (e.g. env override Reranking__BaseUrl=) must NOT be
+        // treated as an explicit value — otherwise new Uri("") throws at container build. It falls
+        // through to RERANKER_URL.
+        var config = Config(
+            ("Reranking:BaseUrl", blank),
+            ("RERANKER_URL", "http://reranker-service:8003"));
+
+        KnowledgeBaseServiceExtensions.ResolveRerankerBaseUrl(config)
+            .Should().Be("http://reranker-service:8003");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ResolveRerankerBaseUrl_TreatsBlankRerankerUrlAsAbsent_FallsBackToLocalhost(string blank)
+    {
+        // Blanking RERANKER_URL (a common "disable via empty value" pattern) must fall back to
+        // localhost, not produce new Uri("").
+        var config = Config(("RERANKER_URL", blank));
+
+        KnowledgeBaseServiceExtensions.ResolveRerankerBaseUrl(config)
+            .Should().Be("http://localhost:8003");
+    }
+
+    [Fact]
+    public void AppsettingsJson_DoesNotDefineRerankingBaseUrl_SoRerankerUrlFallbackFires()
+    {
+        // Regression guard for #3334: the original fix was defeated because appsettings.json defined
+        // Reranking:BaseUrl="http://localhost:8003", which is loaded in every environment and shadowed
+        // the RERANKER_URL fallback (config["Reranking:BaseUrl"] was never null → the ?? branch was dead
+        // code → the reranker kept targeting localhost in staging/prod). This asserts the real
+        // appsettings.json does NOT reintroduce that shadowing default, and that with it layered under a
+        // RERANKER_URL env value the resolution correctly returns the env value.
+        var appsettingsPath = Path.Combine(AppContext.BaseDirectory, "appsettings.json");
+        if (!File.Exists(appsettingsPath))
+        {
+            // Api's appsettings.json is copied next to Api.dll and flows into the test output. If the
+            // build layout ever changes, fail loudly rather than silently skip — this guard is the whole
+            // point of the test.
+            Assert.Fail($"appsettings.json not found at {appsettingsPath}; the regression guard cannot run.");
+        }
+
+        var layered = new ConfigurationBuilder()
+            .AddJsonFile(appsettingsPath, optional: false)
+            .AddInMemoryCollection(new Dictionary<string, string?>(StringComparer.Ordinal)
+            {
+                ["RERANKER_URL"] = "http://reranker-service:8003",
+            })
+            .Build();
+
+        // The appsettings layer must not supply a shadowing default...
+        string.IsNullOrWhiteSpace(layered["Reranking:BaseUrl"]).Should().BeTrue(
+            "appsettings.json must not define Reranking:BaseUrl or it shadows the RERANKER_URL env fallback (#3334)");
+        // ...so the RERANKER_URL env value wins end-to-end, as it does in staging/prod.
+        KnowledgeBaseServiceExtensions.ResolveRerankerBaseUrl(layered)
+            .Should().Be("http://reranker-service:8003");
+    }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Infrastructure/DependencyInjection/RerankerBaseUrlResolutionTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Infrastructure/DependencyInjection/RerankerBaseUrlResolutionTests.cs
@@ -1,0 +1,76 @@
+using Api.BoundedContexts.KnowledgeBase.Infrastructure.DependencyInjection;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Infrastructure.DependencyInjection;
+
+/// <summary>
+/// Guards <see cref="KnowledgeBaseServiceExtensions.ResolveRerankerBaseUrl"/> — the seam that decides
+/// which URL the cross-encoder reranker HttpClient targets.
+/// <para>
+/// Regression context: the DI wiring read only <c>Reranking:BaseUrl</c> and fell back to
+/// <c>localhost:8003</c>. Every deployed compose file sets <c>RERANKER_URL</c> (not
+/// <c>Reranking:BaseUrl</c>), so in staging/prod the client silently targeted itself, reranking failed,
+/// and every RAG query degraded to the vector-dominated fusion fallback. The <c>RERANKER_URL</c>
+/// fallback restores reachability while keeping <c>Reranking:BaseUrl</c> as an explicit override.
+/// </para>
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public class RerankerBaseUrlResolutionTests
+{
+    private static IConfiguration Config(params (string Key, string Value)[] pairs)
+    {
+        var dict = pairs.ToDictionary(p => p.Key, p => (string?)p.Value, StringComparer.Ordinal);
+        return new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
+    }
+
+    [Fact]
+    public void ResolveRerankerBaseUrl_UsesRerankerUrlEnvVar_WhenBaseUrlKeyAbsent()
+    {
+        // The staging/prod shape: only RERANKER_URL is set (as compose.{staging,prod}.yml do).
+        var config = Config(("RERANKER_URL", "http://reranker-service:8003"));
+
+        KnowledgeBaseServiceExtensions.ResolveRerankerBaseUrl(config)
+            .Should().Be("http://reranker-service:8003");
+    }
+
+    [Fact]
+    public void ResolveRerankerBaseUrl_PrefersExplicitBaseUrlKey_OverRerankerUrl()
+    {
+        var config = Config(
+            ("Reranking:BaseUrl", "http://explicit-override:9000"),
+            ("RERANKER_URL", "http://reranker-service:8003"));
+
+        KnowledgeBaseServiceExtensions.ResolveRerankerBaseUrl(config)
+            .Should().Be("http://explicit-override:9000");
+    }
+
+    [Fact]
+    public void ResolveRerankerBaseUrl_FallsBackToLocalhost_WhenNeitherSet()
+    {
+        var config = Config();
+
+        KnowledgeBaseServiceExtensions.ResolveRerankerBaseUrl(config)
+            .Should().Be("http://localhost:8003");
+    }
+
+    [Fact]
+    public void ResolveRerankerBaseUrl_ReturnsParsableUri()
+    {
+        // The DI lambda feeds the result straight into new Uri(...); a malformed value would throw at
+        // container-build time. Assert the resolved value round-trips through Uri for each source.
+        foreach (var config in new[]
+                 {
+                     Config(("RERANKER_URL", "http://reranker-service:8003")),
+                     Config(("Reranking:BaseUrl", "http://explicit-override:9000")),
+                     Config(),
+                 })
+        {
+            var act = () => new Uri(KnowledgeBaseServiceExtensions.ResolveRerankerBaseUrl(config));
+            act.Should().NotThrow();
+        }
+    }
+}


### PR DESCRIPTION
Closes #3334

## What

The cross-encoder reranker HttpClient read only `Reranking:BaseUrl` (default `localhost:8003`), but every compose file sets `RERANKER_URL`. So in **every deployed environment** the client targeted itself, reranking failed, and every RAG query silently degraded to the vector-dominated fusion fallback. Also `HttpClient.Timeout` was hardcoded to 10s, capping the configured `RerankerClientOptions.TimeoutMs`.

## Changes

- `ResolveRerankerBaseUrl(IConfiguration)` seam: `Reranking:BaseUrl` > `RERANKER_URL` > `localhost:8003`.
- `HttpClient.Timeout = InfiniteTimeSpan` — the per-request CTS (already in `CrossEncoderRerankerClient`) is the single source of truth.
- 4 unit tests (`RerankerBaseUrlResolutionTests`) over resolution precedence + Uri parsability. **GREEN** locally.

## Scope

Restores reranking for well-extracted docs across all envs. Does **not** alone fix the TM "Setup per N giocatori" query — that is blocked upstream by heading mis-detection during extraction (setup text glued into a chunk mislabeled "CARTE") and by CPU reranker latency (>90s for 20 chunks). Those are tracked separately.

## Test

```
dotnet test --filter "FullyQualifiedName~RerankerBaseUrlResolutionTests"
# Passed: 4
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)