### PR TITLE
chore(infra): pin staging extractor to Unstructured + raise unstructured memory to 3G

### DIFF
--- a/infra/compose.staging.yml
+++ b/infra/compose.staging.yml
@@ -103,6 +103,13 @@ services:
       # Services may not be running in minimal profile, but URLs must pass validation.
       PdfProcessing__Extractor__SmolDocling__ApiUrl: "http://smoldocling-service:8002"
       PdfProcessing__Extractor__Unstructured__ApiUrl: "http://unstructured-service:8001"
+      # Staging uses the heading-aware Unstructured extractor (appsettings default is "Docnet",
+      # which produces flat, headingless chunks — see epic 3338). This env pins staging to
+      # Unstructured for RAG-quality re-indexing. DEPLOY PRECONDITION: the deploying command MUST
+      # bring up the `pdf-cloud-extractors` profile (unstructured-service), otherwise every PDF
+      # ingest fails with "Failed to connect to Unstructured service". Coordinate the merge+deploy
+      # of this line with the WP2 corpus re-index (do not deploy while unstructured-service is down).
+      PdfProcessing__Extractor__Provider: "Unstructured"
     volumes:
       - ./secrets:/app/infra/secrets:ro
       # F4: persisted DataProtection key ring (see DATAPROTECTION__KEYSPATH above).
@@ -246,7 +253,10 @@ services:
       resources:
         limits:
           cpus: '1.0'
-          memory: 1G
+          # 1G was OOM-killed under the SP3 bulk re-index (2026-07-28): 63/135 PDFs failed with
+          # "Resource temporarily unavailable" because the service died mid-run. 'fast' strategy on
+          # large multi-column PDFs (up to ~62 MB) exceeds 1G. Bumped to 3G (server has ~4.9G free).
+          memory: 3G
         reservations:
           cpus: '0.5'
           memory: 512M

--- a/infra/compose.staging.yml
+++ b/infra/compose.staging.yml
@@ -249,13 +249,20 @@ services:
   unstructured-service:
     profiles: [pdf-cloud-extractors]
     restart: always
+    # mem_limit (v2 syntax) is the ONLY memory cap `docker compose up` honors — the deploy.resources
+    # block below is ignored outside swarm/`--compatibility`, so the earlier 1G bump had no effect and
+    # the OOM recurred. 3G bounds a single 'fast' extraction; with the re-index run at concurrency=1 the
+    # host (7.5G total) stays clear. If a PDF needs >3G the container is killed (restart: always) and
+    # only that PDF fails — the host never OOMs.
+    mem_limit: 3g
+    mem_reservation: 512m
     deploy:
       resources:
         limits:
           cpus: '1.0'
-          # 1G was OOM-killed under the SP3 bulk re-index (2026-07-28): 63/135 PDFs failed with
-          # "Resource temporarily unavailable" because the service died mid-run. 'fast' strategy on
-          # large multi-column PDFs (up to ~62 MB) exceeds 1G. Bumped to 3G (server has ~4.9G free).
+          # NB: deploy.resources.limits is swarm-only (ignored by `docker compose up`) — kept for
+          # documentation / future swarm. The effective cap is `mem_limit` above. 1G here OOM-killed
+          # the SP3 bulk re-index (2026-07-28): 63/135 PDFs failed "Resource temporarily unavailable".
           memory: 3G
         reservations:
           cpus: '0.5'


### PR DESCRIPTION
Closes #3340

> **DRAFT — do not merge standalone.** The `Provider: Unstructured` line requires the `pdf-cloud-extractors` profile to be up at deploy time. Merge + deploy must be coordinated with the WP2 corpus re-index of the extraction epic (issue 3338), NOT while `unstructured-service` is down — otherwise every PDF ingest on staging fails.

## What

Staging silently ran the **Docnet** extractor (the `appsettings.json` default) after the runtime `/tmp` compose override was lost on an API container recreation — degrading RAG ingestion to flat, headingless chunks. And `unstructured-service` had a **1G** memory limit that was OOM-killed under the SP3 bulk re-index (63/135 PDFs failed "Resource temporarily unavailable").

## Changes (`compose.staging.yml`, staging-only)

- API env: `PdfProcessing__Extractor__Provider: "Unstructured"`.
- `unstructured-service` memory limit `1G` → `3G` (server has ~4.9G free; `fast` strategy on ~62 MB multi-column PDFs exceeds 1G).

## Why draft / why not re-process the 65 Failed now

The 65 currently-Failed PDFs are intentionally left for the **post-WP1** quality re-index (extraction epic issue 3338, WP2). Re-processing now would run `fast` and reproduce the same heading mis-detection the epic fixes — double work. This PR only makes the config permanent + fixes the OOM so the eventual re-index succeeds.

Does not touch the global `appsettings` default or prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)