### PR TITLE
fix(ci): drop redundant frontend build from pre-deploy (#3331 OOM)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -153,39 +153,36 @@ PRs targeting `main-staging` receive an automated comment showing:
 
 ## Self-Hosted ARM64 Runner
 
-Workflows use a tiered runner selection strategy to balance cost and concurrency:
+> **⚠️ Reality note (2026-07-28, #3331)** — this section had drifted from the
+> deployed setup:
+> - `ci.yml` runs **entirely on GitHub-hosted `ubuntu-latest`** — its
+>   `select-runner` step hardcodes cloud (`ci.yml:74`). **CI does not use the
+>   self-hosted runner.**
+> - The self-hosted runner is **co-located on the Hetzner staging VPS
+>   (~8GB ARM64)**, sharing the box with the app containers — **not** a dedicated
+>   24GB Oracle VM. Today it runs only the deploy-staging orchestration (SSH),
+>   rollback, e2e, and ops one-offs.
+> - The co-location is being unwound (a build OOM already broke a deploy). See
+>   [ADR-044 § Update 2026-07-28](../../docs/for-claude/architecture/adr/adr-044-self-hosted-arm64-runner.md)
+>   and the #3331 spec. **Do not add build-heavy steps to the self-hosted runner.**
 
-| Branch target | Runner | Rationale |
-|--------------|--------|-----------|
-| `main-dev` | `ubuntu-latest` | High PR concurrency, no queue |
-| `main-staging`, `main` | Self-hosted (ARM64) | Low frequency, saves GH Actions minutes |
-| Deploy workflows | Self-hosted (ARM64) | Always staging/prod, free compute |
-
-**CI (`ci.yml`)** uses dynamic selection via the `changes` job output:
+Workflows that still use the self-hosted runner select it via the static toggle:
 ```yaml
-# In changes job:
-runner: ${{ steps.select-runner.outputs.runner }}
-
-# In downstream jobs:
-runs-on: ${{ needs.changes.outputs.runner }}
+runs-on: ${{ vars.RUNNER && fromJSON(vars.RUNNER) || 'ubuntu-latest' }}
 ```
+- **`vars.RUNNER` set** → self-hosted (co-located staging VPS, label `self-hosted,linux,ARM64`)
+- **`vars.RUNNER` unset** → GitHub-hosted `ubuntu-latest`
 
-**Other workflows** use the static toggle pattern:
-```yaml
-runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
-```
+**Architecture Decision**: [ADR-044](../../docs/for-claude/architecture/adr/adr-044-self-hosted-arm64-runner.md) — read the **2026-07-28 Update** for the current (drift-corrected) reality.
 
-**Architecture Decision**: [ADR-044](../../docs/architecture/adr/adr-044-self-hosted-arm64-runner.md)
-
-### Runner Specs
+### Runner Specs (actual, 2026-07-28)
 
 | Resource | Value |
 |----------|-------|
-| Provider | Oracle Cloud Free Tier |
-| CPU | Ampere A1, 4 OCPUs (ARM64) |
-| Memory | 24 GB |
-| Disk | 200 GB |
-| Max concurrent jobs | 2 (recommended) |
+| Host | Hetzner staging VPS (~8GB ARM64), **co-located with app containers** |
+| Runner dir | `/home/deploy/actions-runner` (user `deploy`) |
+| Memory | `MemoryMax=3G` cgroup cap (systemd override, #2019) |
+| Jobs | deploy-staging orchestration, rollback, e2e, ops one-offs (**not** `ci.yml`) |
 
 ### ARM64 Exclusions
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -372,23 +372,22 @@ jobs:
       # Con questa rimozione la superficie di build .NET sull'host di deploy è 0
       # (Opzione 3 completa): tutta la compilazione .NET è sul cloud.
 
-      - name: Setup Frontend
-        if: needs.detect-changes.outputs.deploy_web == 'true'
-        uses: ./.github/actions/setup-frontend
-        with:
-          working-directory: apps/web
-          frozen-lockfile: 'true'
-
-      - name: Frontend build check
-        if: needs.detect-changes.outputs.deploy_web == 'true'
-        run: |
-          echo "🔨 Verifying frontend compiles..."
-          cd apps/web
-          pnpm build
-          echo "✅ Frontend builds successfully"
-        env:
-          NEXT_PUBLIC_API_BASE: http://localhost:8080
-          NODE_OPTIONS: '--max-old-space-size=4096'
+      # Issue #3331: il "Frontend build check" (pnpm build sull'host) è stato
+      # RIMOSSO — stesso trattamento del Backend build check (#2650, sopra).
+      # Compilare il frontend sul runner self-hosted co-locato (cap
+      # MemoryMax=3G, box staging ~8GB condiviso coi container) va in OOM:
+      # `next build` girava con NODE_OPTIONS=--max-old-space-size=4096 (heap 4GB)
+      # e il worker TypeScript sfondava il cap cgroup 3G → SIGKILL (deploy run
+      # 30334115340, 2026-07-28). La verifica di compilazione frontend è già
+      # coperta, senza toccare l'host di deploy:
+      #   - ci.yml `Build Frontend` (ubuntu-latest) esegue `pnpm build` sul CLOUD
+      #     nella PR verso main-dev: se non compila, la PR non arriva a main-staging;
+      #   - il job `build` sotto (sempre ubuntu-latest) builda l'immagine web reale
+      #     sul cloud: se `next build` fallisce, quel job fallisce e blocca il deploy;
+      #   - lo step "Verify CI passed on this commit" sopra conferma la CI autoritativa.
+      # Con questa rimozione la superficie di build sull'host di deploy è 0
+      # (backend #2650 + frontend #3331): tutta la compilazione è sul cloud.
+      # Vedi ADR-044 (Update 2026-07-28) e docs/superpowers/specs/2026-07-28-spec-panel-3331-cicd-runner.md.
 
   # Build and push Docker images (only changed components).
   # ALWAYS runs on ubuntu-latest (cloud) — never on self-hosted runner.

--- a/docs/for-claude/architecture/adr/adr-044-self-hosted-arm64-runner.md
+++ b/docs/for-claude/architecture/adr/adr-044-self-hosted-arm64-runner.md
@@ -1,6 +1,6 @@
 # ADR-044: Migrate CI/CD to Self-Hosted ARM64 Runner
 
-**Status**: Accepted
+**Status**: Accepted (2026-03-09) — **partially superseded / drifted**, see [Update 2026-07-28](#update-2026-07-28--drift-correction--direction-3331)
 **Date**: 2026-03-09
 **Issue**: #2970 (Epic #2967)
 **Decision Makers**: Engineering Lead
@@ -100,6 +100,24 @@ runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
 1. **Full rollback**: Delete `vars.RUNNER` variable in GitHub org/repo settings → all workflows fall back to `ubuntu-latest` immediately
 2. **Per-workflow rollback**: Hardcode `runs-on: ubuntu-latest` in specific workflow file
 3. **Verification**: Check `runner.name` in workflow logs — GitHub-hosted runners contain "GitHub Actions"
+
+## Update 2026-07-28 — Drift correction & direction (#3331)
+
+The runner topology drifted from this ADR's original design. Recorded here so future decisions start from reality, not the 2026-03 plan.
+
+**Reality vs the original decision:**
+- The active runner is **NOT** the dedicated Oracle Cloud 24GB VM this ADR assumed. It is **co-located on the Hetzner staging VPS (~8GB ARM64)**, sharing the box with the app containers (`/home/deploy/actions-runner`, user `deploy`). The `infra/runner/cloud-init.yml` Oracle recipe was never the live deploy runner.
+- "Migrate ALL workflows to self-hosted" was **not sustained**: `ci.yml`'s `select-runner` hardcodes `ubuntu-latest` (`ci.yml:74`), so the 14,700+ tests already run on GitHub-hosted cloud. The self-hosted runner today executes only the deploy-staging orchestration (SSH), rollback, e2e, and ops one-offs.
+- Heavy compilation was evicted to cloud one incident at a time: backend build (#2650, Roslyn OOM), image build (2026-05-08 swap-thrash), migration SQL gen, build-ai. The `Frontend build check` OOM (2026-07-28, deploy run 30334115340) is the same pattern's latest instance.
+
+**Root cause of the #3331 OOM:** the co-located runner has a `MemoryMax=3G` cgroup cap (`infra/runner/systemd-overrides/10-memory-limits.conf`, #2019) to protect the app containers; the redundant frontend build ran with a 4GB Node heap → SIGKILL. Structural, not bad luck.
+
+**Direction (spec-panel #3331, unanimous across Nygard/Hightower/Fowler/Newman):**
+1. **Done (the PR carrying this update):** removed the redundant `Frontend build check` from `deploy-staging.yml` pre-deploy — it duplicated `ci.yml Build Frontend` (cloud) and the real cloud image build. Build surface on the deploy host is now zero (backend + frontend). This is a tourniquet, **not** a cure — #3331 stays open for the structural fix.
+2. **Gate:** measure actual monthly cloud minutes for `backend-e2e` + `test-performance` on hosted ARM64.
+3. **Before production:** decouple CI from the app box for good — either **eliminate the self-hosted runner** (build on hosted, deploy via SSH from cloud with a scoped `command=`-restricted deploy key; the deploy path is already 100% public-SSH to `STAGING_HOST`) if the heavy suites fit the free/cheap tier, or **move the runner to a dedicated VM** (`cloud-init.yml` already exists as the IaC recipe) if they don't. A CI build OOM must never be able to take down the app it deploys to.
+
+Spec: [`docs/superpowers/specs/2026-07-28-spec-panel-3331-cicd-runner.md`](../../../superpowers/specs/2026-07-28-spec-panel-3331-cicd-runner.md).
 
 ## References
 

--- a/docs/superpowers/specs/2026-07-28-spec-panel-3331-cicd-runner.md
+++ b/docs/superpowers/specs/2026-07-28-spec-panel-3331-cicd-runner.md
@@ -1,0 +1,56 @@
+# Spec-panel #3331 — Co-located CI runner on the staging server
+
+**Date**: 2026-07-28 · **Issue**: [#3331](https://github.com/meepleAi-app/meepleai-monorepo/issues/3331) · **Method**: 4-expert panel (Nygard, Hightower, Fowler, Newman) over a shared technical recon.
+
+## Problem
+
+A self-hosted GitHub Actions runner is **co-located on the Hetzner staging VPS (~8GB ARM64)**, sharing the box with the app containers. On 2026-07-28 the deploy (run `30334115340`) **failed with an OOM**: the pre-deploy `Frontend build check` (`next build` + `tsc`, `NODE_OPTIONS=--max-old-space-size=4096`) ran on this runner and was SIGKILL'd, cascading into a missing migration artifact and a failed deploy job. Worked around with `workflow_dispatch -f skip_tests=true`.
+
+## Recon findings (topology & root cause)
+
+1. **CI no longer uses the self-hosted runner.** `ci.yml`'s `select-runner` hardcodes `ubuntu-latest` (`ci.yml:74`) → the 14,700+ tests already run on cloud. The self-hosted runner today runs only: `deploy-staging` orchestration (detect-changes, pre-deploy-check, snapshot-baseline, deploy-SSH, validate), `rollback`, `e2e`, and ops one-offs.
+2. **Heavy compilation is already on cloud**, evicted one incident at a time: backend build (#2650, Roslyn OOM), image build (2026-05-08 swap-thrash), migration SQL gen, build-ai. The frontend OOM is the same pattern.
+3. **The OOM is structural.** The runner has a `MemoryMax=3G` cgroup cap (`infra/runner/systemd-overrides/10-memory-limits.conf`, #2019) that exists to protect the app containers. A 4GB Node heap cannot fit inside a 3G cap on a shared 8GB box → guaranteed SIGKILL.
+4. **The frontend build check is redundant.** `ci.yml Build Frontend` already ran `pnpm build` on cloud for the PR, and the real web image is built on cloud (`build` job, always `ubuntu-latest`). The pre-deploy local build gates nothing new.
+5. **The deploy does not require co-location.** Every server-touching step (snapshot-baseline, apply-migrations, deploy) reaches `STAGING_HOST` over **public SSH** — it would run identically from a cloud runner. The only host-local step is `df /` (rewritable as `ssh $HOST df /`).
+6. **Doc drift.** ADR-044 / README describe a dedicated **Oracle Cloud 24GB VM** that was never the live runner; reality is the ~8GB co-located Hetzner box. Machine naming is inconsistent (CAX21/CAX31/CX31).
+
+## Options assessed
+
+| Option | Nygard | Hightower | Fowler | Newman | Verdict |
+|---|:---:|:---:|:---:|:---:|---|
+| **A** — remove redundant `Frontend build check` from self-hosted | strong-yes | strong-yes | strong-yes | strong-yes | **Do now, €0** |
+| **E** — eliminate self-hosted: build on hosted + deploy SSH from cloud | strong-yes | strong-yes | yes | conditional | **Preferred endpoint** (after gate) |
+| **D** — dedicated small Hetzner VM (~€5/mo) + ephemeral | fallback | conditional | conditional | yes | Structural fallback |
+| **C** — ephemeral runner on the same box | conditional | conditional | no | no | Solves state accretion, not RAM |
+| **B** — cron prune of runner cache | no | no | conditional | conditional | Already covered; disk not RAM |
+| **F** — lower heap / disable check | strong-no | no | no | no | Fragile symptom-tuning |
+| **G** — ARC / Kubernetes | — | — | — | strong-no | Overkill |
+
+**Panel consensus:** the co-location is a **bulkhead violation** (Nygard) / **availability coupling** (Hightower) / **architectural smell being paid off one incident at a time** (Newman). Every relocation that *didn't* break the deploy proves the co-location was never load-bearing. It must not survive into production — there a CI build OOM killing app containers is unacceptable.
+
+## Decision (sequenced)
+
+### 1. NOW — Option A (done in this PR, €0)
+Removed the redundant `Frontend build check` (+ `Setup Frontend`) from `deploy-staging.yml`'s `pre-deploy-check`, mirroring the Backend build check removal (#2650). Reconciled the doc drift (ADR-044 Update, README reality note). **This is a tourniquet, not a cure — #3331 stays open.**
+
+### 2. GATE — measure before choosing E vs D
+Collect the **actual monthly cloud minutes** for the self-hosted-capable heavy suites (`backend-e2e`, `test-performance`) if run on hosted ARM64 (`ubuntu-24.04-arm`, $0.005–0.008/min). Free tier = 2,000 min/mo. This single number decides the endpoint; do not guess.
+
+### 3. BEFORE PRODUCTION — endpoint
+- **Option E (preferred, 3/4 experts):** eliminate the self-hosted runner. Build/test on GitHub-hosted; run the deploy as a hosted job that SSHes to `STAGING_HOST` with a dedicated deploy key locked via `command=` in `authorized_keys` + a non-root deploy user (optional WireGuard/Tailscale hop). Removes both the failure mode **and** the entire pet apparatus (`runner-maintenance.yml`, `runner-health-check.yml`, memory overrides, disk gate, prune crons). Likely €0 at staging cadence. Re-add the `df /` gate as `ssh $HOST df /`.
+- **Option D (fallback):** if the heavy suites blow the free tier (est. €10–40/mo on cloud), move the runner to a dedicated CAX11 (~€5/mo) provisioned from the existing `cloud-init.yml`, running `--ephemeral`. Keeps cache + self-hosted; re-aligns with ADR-044's original intent. Just a `vars.RUNNER` re-point (reversible).
+
+Both are two-way doors (re-enable self-hosted by setting `vars.RUNNER`).
+
+## Rejected / deferred
+- **B, F**: band-aids that address the wrong axis (disk/heap, not the CI-vs-runtime bulkhead) and give false confidence.
+- **C**: correct hygiene (no state accretion) but does not fix RAM contention; only worth it bundled with D.
+- **G (ARC/k8s)**: overkill for one-person, single-VM, staging-only ops.
+
+## Risks
+- Closing #3331 on Option A alone: the specific OOM disappears but the co-location remains; the next heavy pre-deploy step re-triggers the class. **A is necessary-but-not-sufficient.**
+- E's cost is not automatically €0 — `backend-e2e`/`test-performance` on cloud could cost €10–40/mo and forfeit persistent Docker/pnpm cache. Measure first (the gate).
+- E secret handling: scope the deploy key (`command=`, non-root user, pinned `known_hosts`).
+- Don't delete `cloud-init.yml` — it is the IaC for the D fallback. Supersede ADR-044 by recording the decision, not by removing the recipe.
+- Before finalizing, verify GitHub → Settings → Actions → Runners so a stale-registered Oracle runner isn't left in the inventory.


### PR DESCRIPTION
## Problema (#3331)

Il deploy staging del 2026-07-28 (run 30334115340) e' **fallito per OOM**: lo step `Frontend build check` del `pre-deploy-check` (`deploy-staging.yml`) esegue `next build` con heap 4GB sul **runner self-hosted co-locato** sul server staging, il cui servizio systemd ha un cap cgroup `MemoryMax=3G` (#2019, per proteggere i container dell'app) → SIGKILL → deploy interrotto.

## Fix (Opzione A del spec-panel #3331)

Lo step e' **ridondante**: `ci.yml Build Frontend` builda gia' su cloud nella PR, e l'immagine web reale e' buildata su cloud (job `build`, sempre `ubuntu-latest`). Rimosso, come il Backend build check (#2650). Superficie di build sull'host di deploy ora **zero** (backend + frontend).

+ **Riconciliazione doc drift**: ADR-044 (sezione Update) + README — il runner e' un box Hetzner ~8GB **co-locato**, non una VM Oracle 24GB dedicata; `ci.yml` e' 100% cloud, non self-hosted.
+ **Spec design doc**: `docs/superpowers/specs/2026-07-28-spec-panel-3331-cicd-runner.md` (analisi 4-esperti).

## ⚠️ Tourniquet, non cura

Questo elimina l'OOM specifico a costo zero, ma **#3331 resta aperta**: la co-location CI-vs-app e' il failure mode strutturale. Prossimi passi (dalla spec, consenso unanime):
1. **Gate**: misurare i minuti cloud reali di `backend-e2e` + `test-performance` su hosted ARM64.
2. **Prima della produzione**: eliminare il self-hosted (build su hosted + deploy SSH da cloud) se i test stanno nel free tier, oppure spostare il runner su una VM dedicata (~€5/mese) se sforano.

Verificato: `deploy-staging.yml` YAML valido, `pre-deploy-check` mantiene i 3 step utili (Checkout, disk gate, verify CI passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)