### PR TITLE
fix(health): make orchestration health check conditional (#3339)

### DIFF
--- a/apps/api/src/Api/Infrastructure/Health/Checks/OrchestrationHealthCheck.cs
+++ b/apps/api/src/Api/Infrastructure/Health/Checks/OrchestrationHealthCheck.cs
@@ -7,10 +7,6 @@ namespace Api.Infrastructure.Health.Checks;
 /// </summary>
 public class OrchestrationHealthCheck : IHealthCheck
 {
-#pragma warning disable S1075 // URI should not be hardcoded — default for Docker internal service discovery
-    private const string DefaultOrchestrationUrl = "http://orchestration-service:8004";
-#pragma warning restore S1075
-
     private readonly IConfiguration _configuration;
     private readonly ILogger<OrchestrationHealthCheck> _logger;
     private readonly IHttpClientFactory _httpClientFactory;
@@ -30,10 +26,13 @@ public class OrchestrationHealthCheck : IHealthCheck
         CancellationToken cancellationToken = default)
     {
         var orchestratorUrl = _configuration["ORCHESTRATION_SERVICE_URL"]
-            ?? Environment.GetEnvironmentVariable("ORCHESTRATION_SERVICE_URL")
-            ?? DefaultOrchestrationUrl;
+            ?? Environment.GetEnvironmentVariable("ORCHESTRATION_SERVICE_URL");
         if (string.IsNullOrWhiteSpace(orchestratorUrl))
         {
+            // Registration is gated on ORCHESTRATION_SERVICE_URL (see
+            // HealthCheckServiceExtensions), so this branch is only hit under config
+            // drift. Return Degraded (never Unhealthy) — orchestration is a
+            // NonCritical/Optional service and must not 503 the aggregate /health (#3339).
             return HealthCheckResult.Degraded("Orchestration service not configured");
         }
 
@@ -57,13 +56,17 @@ public class OrchestrationHealthCheck : IHealthCheck
         }
         catch (HttpRequestException ex)
         {
-            _logger.LogError(ex, "Orchestration service health check failed - HTTP request error");
-            return HealthCheckResult.Unhealthy("Orchestration service unavailable", ex);
+            // #3339: orchestration is NonCritical/Optional (compose profile `tutor-agents`,
+            // not the standard deploy). A connection failure must NOT 503 the aggregate
+            // /health — return Degraded, consistent with the timeout branch above and the
+            // Degraded failureStatus/NonCritical registration.
+            _logger.LogWarning(ex, "Orchestration service health check failed - HTTP request error");
+            return HealthCheckResult.Degraded("Orchestration service unavailable", ex);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Orchestration service health check failed - unexpected error");
-            return HealthCheckResult.Unhealthy("Orchestration service check failed", ex);
+            _logger.LogWarning(ex, "Orchestration service health check failed - unexpected error");
+            return HealthCheckResult.Degraded("Orchestration service check failed", ex);
         }
     }
 }

--- a/apps/api/src/Api/Infrastructure/Health/Extensions/HealthCheckServiceExtensions.cs
+++ b/apps/api/src/Api/Infrastructure/Health/Extensions/HealthCheckServiceExtensions.cs
@@ -99,11 +99,21 @@ public static class HealthCheckServiceExtensions
                 timeout: TimeSpan.FromSeconds(5));
         }
 
-        builder.AddCheck<OrchestrationHealthCheck>(
-            "orchestrator",
-            HealthStatus.Degraded,
-            tags: new[] { HealthCheckTags.Ai, HealthCheckTags.NonCritical },
-            timeout: TimeSpan.FromSeconds(5));
+        // Conditional: orchestration (LangGraph) is opt-in — it runs only under the
+        // `tutor-agents` compose profile, not the standard deploy profile. Register the
+        // health check only when ORCHESTRATION_SERVICE_URL is set (mirrors the Ollama
+        // pattern below), so /health does not 503 for an intentionally-not-deployed
+        // service (#3339). Environments that DO run orchestration (dev/prod) set
+        // ORCHESTRATION_SERVICE_URL on the api service.
+        var orchestrationUrl = configuration["ORCHESTRATION_SERVICE_URL"];
+        if (!string.IsNullOrWhiteSpace(orchestrationUrl))
+        {
+            builder.AddCheck<OrchestrationHealthCheck>(
+                "orchestrator",
+                HealthStatus.Degraded,
+                tags: new[] { HealthCheckTags.Ai, HealthCheckTags.NonCritical, HealthCheckTags.Optional },
+                timeout: TimeSpan.FromSeconds(5));
+        }
 
         // Conditional: Ollama is opt-in — register only when OLLAMA_URL is set.
         var ollamaUrl = configuration["OLLAMA_URL"];

--- a/apps/api/tests/Api.Tests/Infrastructure/Health/Extensions/HealthCheckServiceExtensionsTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/Health/Extensions/HealthCheckServiceExtensionsTests.cs
@@ -105,22 +105,45 @@ public sealed class HealthCheckServiceExtensionsTests
         registrations.Any(r => r.Name == "ollama").Should().Be(expected);
     }
 
+    // #3339: orchestration (LangGraph) runs only under the `tutor-agents` compose
+    // profile, not the standard deploy. Its health check must be registered ONLY when
+    // ORCHESTRATION_SERVICE_URL is set (mirrors the Ollama pattern), so an
+    // intentionally-not-deployed orchestration never 503s the aggregate /health.
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData("", false)]
+    [InlineData("   ", false)]
+    [InlineData("http://orchestration-service:8004", true)]
+    public void Orchestration_Is_Registered_Only_When_Url_Is_Set(string? url, bool expected)
+    {
+        var registrations = RegisterAndCollect(new()
+        {
+            ["ORCHESTRATION_SERVICE_URL"] = url,
+            ["PdfProcessing:Extractor:Provider"] = "Docnet" // isolate from PDF provider noise
+        });
+
+        registrations.Any(r => r.Name == "orchestrator").Should().Be(expected);
+    }
+
     [Fact]
     public void Optional_Tag_Is_Applied_To_Conditionally_Registered_Checks()
     {
         var registrations = RegisterAndCollect(new()
         {
             ["PdfProcessing:Extractor:Provider"] = "Orchestrator",
-            ["OLLAMA_URL"] = "http://ollama:11434"
+            ["OLLAMA_URL"] = "http://ollama:11434",
+            ["ORCHESTRATION_SERVICE_URL"] = "http://orchestration-service:8004"
         });
 
         var unstructured = registrations.Single(r => r.Name == "unstructured");
         var smoldocling = registrations.Single(r => r.Name == "smoldocling");
         var ollama = registrations.Single(r => r.Name == "ollama");
+        var orchestrator = registrations.Single(r => r.Name == "orchestrator");
 
         unstructured.Tags.Should().Contain(HealthCheckTags.Optional);
         smoldocling.Tags.Should().Contain(HealthCheckTags.Optional);
         ollama.Tags.Should().Contain(HealthCheckTags.Optional);
+        orchestrator.Tags.Should().Contain(HealthCheckTags.Optional);
     }
 
     [Fact]
@@ -137,10 +160,12 @@ public sealed class HealthCheckServiceExtensionsTests
 
         names.Should().Contain(new[]
         {
-            "openrouter", "embedding", "embedding-dimensions", "reranker", "orchestrator",
+            "openrouter", "embedding", "embedding-dimensions", "reranker",
             "bggapi", "oauth", "smtp", "grafana", "prometheus", "redis-rate-limiting",
             "s3storage", "slack_api", "slack_queue"
         });
-        names.Should().NotContain(new[] { "unstructured", "smoldocling", "ollama" });
+        // #3339: orchestrator is now conditional on ORCHESTRATION_SERVICE_URL (like ollama),
+        // so with the URL unset it must NOT be registered.
+        names.Should().NotContain(new[] { "unstructured", "smoldocling", "ollama", "orchestrator" });
     }
 }

--- a/infra/compose.dev.yml
+++ b/infra/compose.dev.yml
@@ -69,6 +69,9 @@ services:
       RERANKER_URL: http://reranker-service:8003
       UNSTRUCTURED_API_URL: http://unstructured-service:8001
       SMOLDOCLING_API_URL: http://smoldocling-service:8002
+      # #3339: registers the orchestration health check (orchestration-service runs
+      # under `--profile ai`). Without ai it reports Degraded, never 503.
+      ORCHESTRATION_SERVICE_URL: http://orchestration-service:8004
       # Issue #1099: passthrough for CI smoke tests to bypass AuthLogin
       # rate limit (10 req/min/IP) which all smoke tests share a single IP.
       # Empty in local dev → code treats it as disabled flag absent → rate

--- a/infra/compose.prod.yml
+++ b/infra/compose.prod.yml
@@ -86,6 +86,9 @@ services:
       LOCAL_EMBEDDING_URL: http://embedding-service:8000
       Embedding__LocalServiceUrl: http://embedding-service:8000
       RERANKER_URL: http://reranker-service:8003
+      # #3339: prod runs orchestration under `--profile ai`; set the URL so the
+      # orchestration health check is registered and monitored.
+      ORCHESTRATION_SERVICE_URL: http://orchestration-service:8004
       EMBEDDING_MODEL: intfloat/multilingual-e5-base
       Embedding__Model: intfloat/multilingual-e5-base
       Embedding__Dimensions: 768


### PR DESCRIPTION
## Problema (#3339)

Dopo ogni deploy staging standard, `GET /health` (aggregato) tornava **503** anche con l'app perfettamente funzionante (`/health/live` e `/health/ready` = 200). Causa: `OrchestrationHealthCheck` ritornava **`Unhealthy`** su connection-refused, e orchestration-service **non è nel profilo di deploy standard** (gira solo con `--profile tutor-agents`) → dopo ogni deploy sparisce → 503 ricorrente. Scoperto durante la sessione #3330 (rimozione orchestration residuo).

## Fix

Applica il **pattern condizionale già usato dal progetto** per i servizi opt-in (Ollama, n8n, SmolDocling):

- **Registrazione condizionale**: l'health check `orchestrator` viene registrato **solo se `ORCHESTRATION_SERVICE_URL` è settato** (`HealthCheckServiceExtensions`), con tag `Optional`. Non deployato → non registrato → niente 503, niente rumore Degraded permanente.
- **Difesa in profondità**: `OrchestrationHealthCheck` ritorna **`Degraded`** (non `Unhealthy`) su connessione fallita — coerente col branch timeout già esistente e con la registrazione `Degraded`/`NonCritical`. Rimosso il default URL hardcoded.
- **Coordinamento compose**: `ORCHESTRATION_SERVICE_URL` aggiunto all'`api` in `compose.dev.yml` e `compose.prod.yml` (dove orchestration gira con `--profile ai`) per mantenere il monitoring lì. Staging standard resta **senza** URL by design → niente 503.

## Matrice comportamento

| Ambiente | orchestration gira? | URL settato? | health check | /health |
|---|---|---|---|---|
| staging standard | no | no | non registrato | **200** ✅ |
| staging-tutor | sì | no | non registrato | 200 (non monitorato) |
| dev core | no | sì | registrato → Degraded | 200 (b) |
| dev ai / prod | sì | sì | registrato → Healthy | 200 ✅ |

## Test

`HealthCheckServiceExtensionsTests`: nuovo `Orchestration_Is_Registered_Only_When_Url_Is_Set` (theory come Ollama) + `Optional_Tag` esteso + `Always_On` aggiornato (orchestrator ora condizionale). **20/20 pass** in locale.

Chiude #3339.

🤖 Generated with [Claude Code](https://claude.com/claude-code)