### PR TITLE
feat(rag): WP1 heading-repair + rank-repair for buried section content (#3338)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/HeadingAwareChunker.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/HeadingAwareChunker.cs
@@ -27,10 +27,19 @@ internal static class HeadingAwareChunker
     {
         ArgumentNullException.ThrowIfNull(advancedChunking);
 
+        // Epic #3338 WP1a: recover section titles that unstructured's 'fast' strategy glued into a
+        // body element instead of emitting as a standalone Title (the TM "PREPARAZIONE" case). Runs
+        // BEFORE FromExtraction so GroupByTitle sees the promoted synthetic Title and opens a real
+        // section — otherwise the setup content stays under the previous section's heading ("CARTE")
+        // and the #3270 heading boost + RoleClassifier Setup fast-path never fire.
+        var elements = structuredElements is null
+            ? null
+            : EmbeddedTitleSplitter.Split(structuredElements);
+
         var extractedDocument = ExtractedDocumentFactory.FromExtraction(
             documentId,
             gameId,
-            structuredElements,
+            elements,
             flatText);
 
         var hierarchicalChunks = await advancedChunking

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchQueryHandler.cs
@@ -195,6 +195,14 @@ internal class SearchQueryHandler : IQueryHandler<SearchQuery, List<SearchResult
         // Issue #423: ts_rank_cd scores ~0-0.3; 0.01 filters ToC noise.
         const double KeywordMinScore = 0.01;
 
+        // #3338 WP1c: resolve the per-game FTS config for the heading-term synonym expansion below.
+        // NOTE: SearchAsync resolves the same config internally, so this is one extra (fast, GameId-
+        // indexed) language-detection query per hybrid search — an accepted minor cost; threading it
+        // into SearchAsync would churn ~15 keyword-mock setups for a non-blocking perf finding.
+        var ftsConfig = await _keywordSearchService
+            .ResolveFtsConfigAsync(gameId, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
         // Spec §6: RAW keyword arm sourced directly from IKeywordSearchService (un-boosted, raw ts_rank_cd
         // order) so HybridFusionCore applies role-boost + legend exactly once.
         var rawKeyword = await _keywordSearchService.SearchAsync(
@@ -221,9 +229,6 @@ internal class SearchQueryHandler : IQueryHandler<SearchQuery, List<SearchResult
         // (the same string used for the keyword arm) and forward them so the heading boost can fire.
         // #3338 WP1c: expand those terms with the game's FTS-language intent synonyms (setup ->
         // preparazione/allestimento) so an English-loanword query boosts a native-lexeme heading.
-        var ftsConfig = await _keywordSearchService
-            .ResolveFtsConfigAsync(gameId, cancellationToken: cancellationToken)
-            .ConfigureAwait(false);
         var headingTerms = KeywordSearchService.ExpandHeadingMatchTerms(
             FusionSignals.ExtractHeadingMatchTerms(query), ftsConfig);
 

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchQueryHandler.cs
@@ -219,10 +219,18 @@ internal class SearchQueryHandler : IQueryHandler<SearchQuery, List<SearchResult
 
         // Use RRF fusion domain service. #3270: derive heading-match query terms from the raw query
         // (the same string used for the keyword arm) and forward them so the heading boost can fire.
+        // #3338 WP1c: expand those terms with the game's FTS-language intent synonyms (setup ->
+        // preparazione/allestimento) so an English-loanword query boosts a native-lexeme heading.
+        var ftsConfig = await _keywordSearchService
+            .ResolveFtsConfigAsync(gameId, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+        var headingTerms = KeywordSearchService.ExpandHeadingMatchTerms(
+            FusionSignals.ExtractHeadingMatchTerms(query), ftsConfig);
+
         return _rrfFusionService.FuseResults(
             vectorResults,
             keywordResults,
             queryRoleHint: queryRoleHint,
-            queryTerms: FusionSignals.ExtractHeadingMatchTerms(query));
+            queryTerms: headingTerms);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/EmbeddedTitleSplitter.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/EmbeddedTitleSplitter.cs
@@ -1,3 +1,4 @@
+using System.Collections.Frozen;
 using Api.BoundedContexts.DocumentProcessing.Domain.Services;
 
 namespace Api.BoundedContexts.KnowledgeBase.Application.Services.Chunking;
@@ -26,6 +27,15 @@ internal static class EmbeddedTitleSplitter
 
     /// <summary>Characters after the token scanned for the lowercase-prose confirmation (guard iii).</summary>
     private const int TrailingProseWindow = 60;
+
+    /// <summary>
+    /// Only prose element types are split. Restricting to these (rather than merely excluding "Title")
+    /// prevents tearing a Table row or a ListItem across a synthetic heading — the split target is
+    /// running body prose, where unstructured glues a missed section title. <see cref="ExtractedElement"/>
+    /// coalesces null/blank categories to "NarrativeText".
+    /// </summary>
+    private static readonly FrozenSet<string> SplittableTypes =
+        new[] { "NarrativeText", "UncategorizedText" }.ToFrozenSet(StringComparer.Ordinal);
 
     public static IReadOnlyList<ExtractedElement> Split(IReadOnlyList<ExtractedElement> elements)
     {
@@ -60,8 +70,8 @@ internal static class EmbeddedTitleSplitter
     }
 
     private static bool IsSplittable(ExtractedElement el) =>
-        !string.Equals(el.ElementType, TitleCategory, StringComparison.Ordinal)
-        && !string.IsNullOrEmpty(el.Text);
+        !string.IsNullOrEmpty(el.Text)
+        && SplittableTypes.Contains(el.ElementType);
 
     /// <summary>
     /// Finds the LEFTMOST qualifying lexicon title embedded in <paramref name="text"/> (longest entry
@@ -113,22 +123,35 @@ internal static class EmbeddedTitleSplitter
             return false;
         }
 
-        // (ii) the preceding non-space char must be a heading boundary — a digit (page-number/number
-        //      artifact, the TM discriminator), a sentence terminator, a close paren, or a line break;
-        //      or the token is at the start of the element. A preceding LETTER means it is inline prose
-        //      (e.g. "la PREPARAZIONE del gioco") — reject.
+        // (ii) the token must sit at a STRONG heading boundary: the start of the element, a line break,
+        //      the end of the previous sentence (. ! ?), or a page-number token — a digit run isolated
+        //      at a clause boundary, the TM "…parentesi. 6 PREPARAZIONE" pattern. A bare preceding digit
+        //      is NOT enough: a prose quantifier ("esegui 2 AZIONI a tua scelta") would otherwise
+        //      fabricate a bogus "AZIONI" heading corpus-wide. Colons/parens/commas/letters are inline
+        //      and rejected.
         var p = i - 1;
         while (p >= 0 && (text[p] == ' ' || text[p] == '\t'))
         {
             p--;
         }
-        if (p >= 0)
+        if (p >= 0 && !IsStrongBoundary(text[p]))
         {
-            var prev = text[p];
-            var isBoundary = char.IsDigit(prev)
-                || prev == '.' || prev == ':' || prev == ')' || prev == ';'
-                || prev == '\n' || prev == '\r';
-            if (!isBoundary)
+            if (!char.IsDigit(text[p]))
+            {
+                return false;
+            }
+
+            // Preceding char is a digit: qualify ONLY if the whole digit run is itself at a clause
+            // boundary (a page number), not a quantifier embedded after a word.
+            while (p >= 0 && char.IsDigit(text[p]))
+            {
+                p--;
+            }
+            while (p >= 0 && (text[p] == ' ' || text[p] == '\t'))
+            {
+                p--;
+            }
+            if (p >= 0 && !IsStrongBoundary(text[p]))
             {
                 return false;
             }
@@ -147,4 +170,8 @@ internal static class EmbeddedTitleSplitter
 
         return false;
     }
+
+    /// <summary>A line break or a sentence terminator — the marks that end the previous section's text.</summary>
+    private static bool IsStrongBoundary(char c) =>
+        c == '\n' || c == '\r' || c == '.' || c == '!' || c == '?';
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/EmbeddedTitleSplitter.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/EmbeddedTitleSplitter.cs
@@ -1,0 +1,150 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Services;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Services.Chunking;
+
+/// <summary>
+/// Epic #3338 WP1a: a pre-pass over the raw <see cref="ExtractedElement"/> stream that recovers
+/// section titles <c>unstructured</c>'s 'fast' strategy failed to emit as standalone <c>Title</c>
+/// elements on complex multi-column layouts. When a body element's text contains an embedded ALL-CAPS
+/// heading from <see cref="SectionHeadingLexicon"/> (the Terraforming Mars case:
+/// <c>"…parentesi. 6 PREPARAZIONE Di seguito viene descritta…"</c> glued into a body element headed
+/// "CARTE"), it is split into up to three elements — <c>[head body][Title(token)][tail body]</c> — so
+/// the downstream <see cref="ExtractedDocumentFactory.GroupByTitle"/> opens a real section and the
+/// #3270 heading-match boost + the RoleClassifier Setup fast-path stop being starved.
+/// <para>
+/// Runs at the ELEMENT layer (before <see cref="ExtractedDocumentFactory.FromExtraction"/>), so it
+/// needs no character-offset recompute — the factory derives offsets from its own StringBuilder.
+/// Detection is deliberately conservative to protect the well-extracted English corpus: an entry is
+/// promoted only when it is (i) an exact UPPERCASE, whole-word match, (ii) preceded (ignoring spaces)
+/// by a heading boundary — a digit, sentence terminator, or line break — and (iii) followed within a
+/// short window by lowercase running prose. At most one split per element, non-recursive.
+/// </para>
+/// </summary>
+internal static class EmbeddedTitleSplitter
+{
+    private const string TitleCategory = "Title";
+
+    /// <summary>Characters after the token scanned for the lowercase-prose confirmation (guard iii).</summary>
+    private const int TrailingProseWindow = 60;
+
+    public static IReadOnlyList<ExtractedElement> Split(IReadOnlyList<ExtractedElement> elements)
+    {
+        ArgumentNullException.ThrowIfNull(elements);
+
+        var result = new List<ExtractedElement>(elements.Count);
+        foreach (var el in elements)
+        {
+            if (IsSplittable(el) && TryFindEmbeddedTitle(el.Text, out var start, out var length))
+            {
+                var head = el.Text[..start].TrimEnd();
+                var token = el.Text.Substring(start, length);
+                var tail = el.Text[(start + length)..].TrimStart();
+
+                if (head.Length > 0)
+                {
+                    result.Add(el with { Text = head });
+                }
+                result.Add(new ExtractedElement(token, el.PageNumber, TitleCategory));
+                if (tail.Length > 0)
+                {
+                    result.Add(el with { Text = tail });
+                }
+            }
+            else
+            {
+                result.Add(el);
+            }
+        }
+
+        return result;
+    }
+
+    private static bool IsSplittable(ExtractedElement el) =>
+        !string.Equals(el.ElementType, TitleCategory, StringComparison.Ordinal)
+        && !string.IsNullOrEmpty(el.Text);
+
+    /// <summary>
+    /// Finds the LEFTMOST qualifying lexicon title embedded in <paramref name="text"/> (longest entry
+    /// wins on an equal start, so "GAME SETUP" beats "SETUP" at the same position). Returns false when
+    /// no occurrence satisfies the heading guards.
+    /// </summary>
+    private static bool TryFindEmbeddedTitle(string text, out int start, out int length)
+    {
+        start = -1;
+        length = 0;
+
+        foreach (var title in SectionHeadingLexicon.Titles)
+        {
+            var from = 0;
+            while (from <= text.Length - title.Length)
+            {
+                var i = text.IndexOf(title, from, StringComparison.Ordinal);
+                if (i < 0)
+                {
+                    break;
+                }
+
+                if (QualifiesAsHeading(text, i, title.Length)
+                    && (start < 0 || i < start || (i == start && title.Length > length)))
+                {
+                    start = i;
+                    length = title.Length;
+                }
+
+                from = i + 1;
+            }
+        }
+
+        return start >= 0;
+    }
+
+    private static bool QualifiesAsHeading(string text, int i, int len)
+    {
+        var end = i + len;
+
+        // (i) whole-word: not glued to a letter on either side ("PREPARAZIONE" not "PREPARAZIONER",
+        //     and not the tail of "IMPREPARAZIONE").
+        if (i > 0 && char.IsLetter(text[i - 1]))
+        {
+            return false;
+        }
+        if (end < text.Length && char.IsLetter(text[end]))
+        {
+            return false;
+        }
+
+        // (ii) the preceding non-space char must be a heading boundary — a digit (page-number/number
+        //      artifact, the TM discriminator), a sentence terminator, a close paren, or a line break;
+        //      or the token is at the start of the element. A preceding LETTER means it is inline prose
+        //      (e.g. "la PREPARAZIONE del gioco") — reject.
+        var p = i - 1;
+        while (p >= 0 && (text[p] == ' ' || text[p] == '\t'))
+        {
+            p--;
+        }
+        if (p >= 0)
+        {
+            var prev = text[p];
+            var isBoundary = char.IsDigit(prev)
+                || prev == '.' || prev == ':' || prev == ')' || prev == ';'
+                || prev == '\n' || prev == '\r';
+            if (!isBoundary)
+            {
+                return false;
+            }
+        }
+
+        // (iii) followed within a short window by lowercase running prose — confirms a heading followed
+        //       by body text, not a stray ALL-CAPS word or a run of adjacent all-caps headings.
+        var windowEnd = Math.Min(text.Length, end + TrailingProseWindow);
+        for (var q = end; q < windowEnd; q++)
+        {
+            if (char.IsLower(text[q]))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/SectionHeadingLexicon.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/SectionHeadingLexicon.cs
@@ -57,9 +57,4 @@ internal static class SectionHeadingLexicon
         "OVERVIEW",
         "WINNING THE GAME",
     }.ToFrozenSet(StringComparer.Ordinal);
-
-    /// <summary>
-    /// The longest entry's length in characters — the scan window a candidate match may span.
-    /// </summary>
-    public static readonly int MaxTitleLength = Titles.Max(t => t.Length);
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/SectionHeadingLexicon.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/SectionHeadingLexicon.cs
@@ -1,0 +1,65 @@
+using System.Collections.Frozen;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Services.Chunking;
+
+/// <summary>
+/// Epic #3338 WP1a: a curated, multilingual set of ALL-CAPS board-game rulebook section titles that
+/// <c>unstructured</c>'s 'fast' extraction strategy frequently FAILS to emit as standalone
+/// <c>Title</c> elements on complex multi-column layouts — instead gluing them into the body of the
+/// preceding section (the Terraforming Mars "PREPARAZIONE" case: absorbed into a chunk headed
+/// "CARTE"). <see cref="EmbeddedTitleSplitter"/> scans body elements for these tokens and promotes an
+/// embedded occurrence to a synthetic <c>Title</c> so the heading-aware pipeline (and the #3270
+/// heading-match boost + the RoleClassifier Setup fast-path) can see it.
+/// <para>
+/// Entries are matched CASE-SENSITIVE in their exact UPPERCASE form (so lowercase prose like
+/// "during setup" never triggers), whole-word, and only when the surrounding context looks like a
+/// heading (see <see cref="EmbeddedTitleSplitter"/> guards). The set is deliberately small and
+/// high-value (the section types that matter for retrieval); extend it as new failing sections are
+/// observed. Seeded from the SP1 structured-extraction design (§ expected section lexicon) plus the
+/// TM/observed corpus.
+/// </para>
+/// </summary>
+internal static class SectionHeadingLexicon
+{
+    /// <summary>
+    /// Curated ALL-CAPS section titles. Multi-word entries use single ASCII spaces between words and
+    /// are matched verbatim. Ordinal (case-sensitive) comparison — entries MUST be uppercase.
+    /// </summary>
+    public static readonly FrozenSet<string> Titles = new[]
+    {
+        // --- Italiano ---
+        "PREPARAZIONE",
+        "ALLESTIMENTO",
+        "PUNTEGGIO",
+        "PUNTEGGI",
+        "CONTEGGIO DEI PUNTI",
+        "FINE DEL GIOCO",
+        "FINE DELLA PARTITA",
+        "FINE PARTITA",
+        "AZIONI",
+        "SVOLGIMENTO",
+        "SVOLGIMENTO DEL GIOCO",
+        "SVOLGIMENTO DELLA PARTITA",
+        "PANORAMICA",
+        "SCOPO DEL GIOCO",
+        "OBIETTIVO",
+
+        // --- English ---
+        "SETUP",
+        "GAME SETUP",
+        "SCORING",
+        "END OF GAME",
+        "END OF THE GAME",
+        "GAME END",
+        "ENDING THE GAME",
+        "GAMEPLAY",
+        "OBJECT OF THE GAME",
+        "OVERVIEW",
+        "WINNING THE GAME",
+    }.ToFrozenSet(StringComparer.Ordinal);
+
+    /// <summary>
+    /// The longest entry's length in characters — the scan window a candidate match may span.
+    /// </summary>
+    public static readonly int MaxTitleLength = Titles.Max(t => t.Length);
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/FusionSignals.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/FusionSignals.cs
@@ -23,6 +23,13 @@ internal static class FusionSignals
     /// <summary>Default reciprocal-rank-fusion constant.</summary>
     internal const int DefaultRrfK = 60;
 
+    /// <summary>
+    /// Token-count threshold for the number-noise length taper (#3338 WP1b): a fragment of this many
+    /// content tokens or fewer is treated as "short" (full demotion); beyond it the factor tapers so a
+    /// long, legitimately number-dense table is demoted less.
+    /// </summary>
+    private const int TokenNoiseTaperThreshold = 12;
+
     // Matches cross-reference pointers like "vedi pag. 10", "vedi anche pagina 5", "see p. 11",
     // "cfr. pagg. 4-5". Allows an optional connector word ("anche"/"a") and spelled-out "pagina".
     private static readonly Regex CrossReferencePointer = new(
@@ -120,15 +127,20 @@ internal static class FusionSignals
         // even though it is digit-heavy; the target is space-separated number runs ("CARTE 2 5 6 4 3").
         var numberChars = 0;
         var alnum = 0;
+        var tokenCount = 0;
         var tokDigits = 0;
         var tokHasLetter = false;
         var tokHasDigit = false;
 
         void FlushToken()
         {
-            if (tokHasDigit && !tokHasLetter)
+            if (tokHasDigit || tokHasLetter)
             {
-                numberChars += tokDigits;
+                tokenCount++;
+                if (tokHasDigit && !tokHasLetter)
+                {
+                    numberChars += tokDigits;
+                }
             }
             tokDigits = 0;
             tokHasLetter = false;
@@ -170,10 +182,12 @@ internal static class FusionSignals
             return 0f;
         }
 
-        // Taper by length: 1.0 up to ~200 chars (MinChunkSize), shrinking beyond so a long number table
-        // (legit content) is not over-demoted the way a short fragment is.
-        var lengthTaper = Math.Min(1.0, 200.0 / content.Length);
-        return (float)Math.Min(0.5, numberRatio * lengthTaper);
+        // Taper by CONTENT VOLUME (token count), not raw content.Length: a long, legitimately
+        // number-dense section (many tokens) is demoted less than a short fragment, while whitespace
+        // padding no longer weakens the demotion — the target class is whitespace-heavy table fragments
+        // unstructured emits, which have few real tokens but wide inter-cell gaps.
+        var volumeTaper = Math.Min(1.0, TokenNoiseTaperThreshold / (double)tokenCount);
+        return (float)Math.Min(0.5, numberRatio * volumeTaper);
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/FusionSignals.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/FusionSignals.cs
@@ -96,6 +96,87 @@ internal static class FusionSignals
     }
 
     /// <summary>
+    /// Number-noise demotion factor in [0, 0.5] (epic #3338 WP1b). Demotes SHORT, digit-dominated
+    /// chunks that unstructured emits from tables / cross-column number fragments (the Terraforming
+    /// Mars <c>"CARTE 2 5 6 4 3"</c> chunk that out-ranked the real setup prose under ts_rank_cd).
+    /// <para>
+    /// Multiplicative and capped at 0.5, mirroring <see cref="ComputeLegendPenaltyFactor"/>. The factor
+    /// rises with the digit ratio (digits / letters+digits) but tapers with length, so a long,
+    /// legitimately number-dense section (a scoring table, a component list) is barely touched while a
+    /// short mostly-digits fragment is halved. Prose that merely cites a few numbers
+    /// (<c>"da 2 a 5 giocatori"</c>) has a low digit ratio and is not demoted at all.
+    /// </para>
+    /// </summary>
+    internal static float ComputeNumberNoiseFactor(string? content)
+    {
+        if (string.IsNullOrEmpty(content))
+        {
+            return 0f;
+        }
+
+        // Ratio is over digits belonging to PURELY-NUMERIC whitespace-delimited tokens ("2", "56)",
+        // "3.") only — NOT digits embedded in an alphanumeric token. A GUID/id like
+        // "vector-content-a1b2c3d4-2" is one letter-bearing token, so it contributes zero number-noise
+        // even though it is digit-heavy; the target is space-separated number runs ("CARTE 2 5 6 4 3").
+        var numberChars = 0;
+        var alnum = 0;
+        var tokDigits = 0;
+        var tokHasLetter = false;
+        var tokHasDigit = false;
+
+        void FlushToken()
+        {
+            if (tokHasDigit && !tokHasLetter)
+            {
+                numberChars += tokDigits;
+            }
+            tokDigits = 0;
+            tokHasLetter = false;
+            tokHasDigit = false;
+        }
+
+        foreach (var ch in content)
+        {
+            if (char.IsWhiteSpace(ch))
+            {
+                FlushToken();
+                continue;
+            }
+
+            if (char.IsDigit(ch))
+            {
+                tokDigits++;
+                tokHasDigit = true;
+                alnum++;
+            }
+            else if (char.IsLetter(ch))
+            {
+                tokHasLetter = true;
+                alnum++;
+            }
+            // punctuation inside a token (".", ")", "-") is ignored: "56)" stays a number token
+        }
+        FlushToken();
+
+        if (numberChars == 0 || alnum == 0)
+        {
+            return 0f;
+        }
+
+        var numberRatio = (double)numberChars / alnum;
+        // Letters-majority text is real prose (a paragraph citing a few numbers), not number-noise.
+        if (numberRatio < 0.30)
+        {
+            return 0f;
+        }
+
+        // Taper by length: 1.0 up to ~200 chars (MinChunkSize), shrinking beyond so a long number table
+        // (legit content) is not over-demoted the way a short fragment is.
+        var lengthTaper = Math.Min(1.0, 200.0 / content.Length);
+        return (float)Math.Min(0.5, numberRatio * lengthTaper);
+    }
+
+    /// <summary>
     /// Legend-demotion factor in [0, 0.5] (verbatim move of :560-580).
     /// </summary>
     internal static float ComputeLegendPenaltyFactor(string? content)

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/HybridFusionCore.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/HybridFusionCore.cs
@@ -63,9 +63,12 @@ internal static class HybridFusionCore
             string? heading = (hasV ? v.Heading : null) ?? (hasK ? k.Heading : null);
 
             float legendFactor = FusionSignals.ComputeLegendPenaltyFactor(content);
+            // #3338 WP1b: demote short digit-dominated table/number-fragment chunks that otherwise
+            // out-rank real section prose. Multiplicative with the legend factor.
+            float numberNoiseFactor = FusionSignals.ComputeNumberNoiseFactor(content);
             float roleBoost = FusionSignals.ComputeRoleMatchBoost(options.QueryRoleHint, roleTags);
             float headingBoost = FusionSignals.ComputeHeadingMatchBoost(options.QueryTerms, heading);
-            float hybridScore = (rrfSum * (1f - legendFactor)) + roleBoost + headingBoost;
+            float hybridScore = (rrfSum * (1f - legendFactor) * (1f - numberNoiseFactor)) + roleBoost + headingBoost;
 
             scored.Add(new FusedCandidate(
                 Key: key,

--- a/apps/api/src/Api/Services/HybridSearchService.cs
+++ b/apps/api/src/Api/Services/HybridSearchService.cs
@@ -241,6 +241,13 @@ internal class HybridSearchService : IHybridSearchService
     {
         var fetchLimit = Math.Max(limit * 2, 20);
 
+        // #3338 WP1c: resolve the per-game FTS config for the heading-term synonym expansion below.
+        // SearchAsync resolves the same config internally (one accepted extra GameId-indexed query per
+        // hybrid search); threading it in would churn ~15 keyword-mock setups for a non-blocking finding.
+        var ftsConfig = await _keywordSearchService
+            .ResolveFtsConfigAsync(gameId, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
         // Run vector and keyword searches in parallel
         var vectorTask = ExecuteVectorSearchAsync(
             query, gameId, fetchLimit, documentIds, cancellationToken);
@@ -295,9 +302,7 @@ internal class HybridSearchService : IHybridSearchService
         // Phase D (D6): queryRoleHint enables role-match boost during fusion.
         // #3338 WP1c: expand the #3270 heading-match terms with the game's FTS-language intent synonyms
         // (setup -> preparazione/allestimento) so an English-loanword query boosts a native-lexeme heading.
-        var ftsConfig = await _keywordSearchService
-            .ResolveFtsConfigAsync(gameId, cancellationToken: cancellationToken)
-            .ConfigureAwait(false);
+        // Reuses the ftsConfig resolved once at the top of this method.
         var headingTerms = KeywordSearchService.ExpandHeadingMatchTerms(
             FusionSignals.ExtractHeadingMatchTerms(query), ftsConfig);
 

--- a/apps/api/src/Api/Services/HybridSearchService.cs
+++ b/apps/api/src/Api/Services/HybridSearchService.cs
@@ -293,6 +293,14 @@ internal class HybridSearchService : IHybridSearchService
 
         // RRF fusion with both vector AND keyword results
         // Phase D (D6): queryRoleHint enables role-match boost during fusion.
+        // #3338 WP1c: expand the #3270 heading-match terms with the game's FTS-language intent synonyms
+        // (setup -> preparazione/allestimento) so an English-loanword query boosts a native-lexeme heading.
+        var ftsConfig = await _keywordSearchService
+            .ResolveFtsConfigAsync(gameId, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+        var headingTerms = KeywordSearchService.ExpandHeadingMatchTerms(
+            FusionSignals.ExtractHeadingMatchTerms(query), ftsConfig);
+
         var fusedResults = FuseSearchResults(
             vectorItems,
             filteredKeywordResults,
@@ -301,7 +309,7 @@ internal class HybridSearchService : IHybridSearchService
             keywordWeight,
             _config.RrfConstant ?? FusionSignals.DefaultRrfK,
             queryRoleHint,
-            FusionSignals.ExtractHeadingMatchTerms(query)); // #3270
+            headingTerms);
 
         var topResults = fusedResults
             .OrderByDescending(r => r.HybridScore)

--- a/apps/api/src/Api/Services/IKeywordSearchService.cs
+++ b/apps/api/src/Api/Services/IKeywordSearchService.cs
@@ -33,6 +33,17 @@ internal interface IKeywordSearchService
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// #3338 WP1c: resolves the PostgreSQL FTS config (english/italian/…) the keyword arm uses for a
+    /// game — detected from the game's dominant <c>pdf_documents.Language</c>, falling back to
+    /// <paramref name="language"/>. Exposed so hybrid callers can expand heading-match terms with the
+    /// same language's intent-synonym table (a "setup" query boosting a "preparazione" heading).
+    /// </summary>
+    Task<string> ResolveFtsConfigAsync(
+        Guid gameId,
+        string language = "en",
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Searches PDF documents using PostgreSQL full-text search.
     /// Useful for document-level keyword matching.
     /// </summary>

--- a/apps/api/src/Api/Services/KeywordSearchService.cs
+++ b/apps/api/src/Api/Services/KeywordSearchService.cs
@@ -319,6 +319,50 @@ internal class KeywordSearchService : IKeywordSearchService
         };
 
     /// <summary>
+    /// #3338 WP1c: expands heading-match query terms with the SAME per-language intent synonyms the
+    /// keyword arm uses (<see cref="SynonymTablesByConfig"/>), so a query lexeme like "setup" fires the
+    /// #3270 heading-match boost on a chunk whose heading is the native rulebook term ("preparazione").
+    /// Returns the original terms plus synonyms — lowercased, length ≥ 3, order-preserving,
+    /// de-duplicated. No-op for a null/blank config or a config without a curated table
+    /// (english/simple/…), so English retrieval is byte-identical.
+    /// </summary>
+    internal static IReadOnlyList<string> ExpandHeadingMatchTerms(IReadOnlyList<string>? terms, string? ftsConfig)
+    {
+        if (terms is null || terms.Count == 0
+            || string.IsNullOrEmpty(ftsConfig)
+            || !SynonymTablesByConfig.TryGetValue(ftsConfig, out var synonyms))
+        {
+            return terms ?? Array.Empty<string>();
+        }
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var expanded = new List<string>(terms.Count);
+
+        void Add(string candidate)
+        {
+            var lower = candidate.ToLowerInvariant();
+            if (lower.Length >= 3 && seen.Add(lower))
+            {
+                expanded.Add(lower);
+            }
+        }
+
+        foreach (var term in terms)
+        {
+            Add(term);
+            if (synonyms.TryGetValue(term, out var syns))
+            {
+                foreach (var s in syns)
+                {
+                    Add(s);
+                }
+            }
+        }
+
+        return expanded;
+    }
+
+    /// <summary>
     /// Expands keyword-arm query terms with curated, language-keyed intent synonyms, emitting a
     /// valid <c>to_tsquery</c> OR-fragment.
     /// <para>
@@ -441,6 +485,10 @@ internal class KeywordSearchService : IKeywordSearchService
             _ => "simple",
         };
     }
+
+    /// <inheritdoc />
+    public Task<string> ResolveFtsConfigAsync(Guid gameId, string language = "en", CancellationToken cancellationToken = default)
+        => ResolveGameFtsConfigAsync(gameId, language, cancellationToken);
 
     /// <summary>
     /// Detects the dominant document language for a game (from <c>pdf_documents.Language</c>,

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/Chunking/EmbeddedTitleSplitterTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/Chunking/EmbeddedTitleSplitterTests.cs
@@ -83,15 +83,16 @@ public class EmbeddedTitleSplitterTests
     [Fact]
     public void Split_MultipleEmbeddedTitles_SplitsOnlyTheLeftmost_NonRecursive()
     {
-        // Only ONE split per element: the leftmost qualifying title is promoted; the second stays in the tail.
-        var el = Body("Contesto: AZIONI eseguibili dal giocatore in ogni turno. PUNTEGGIO finale del gioco calcolato.");
+        // Two page-number-boundary headings; only ONE split per element — the leftmost qualifying title
+        // is promoted, the second stays inline in the tail.
+        var el = Body("Riepilogo. 5 PREPARAZIONE inizia disponendo le tessere sul tabellone. 8 AZIONI disponibili nel turno.");
 
         var result = EmbeddedTitleSplitter.Split(new[] { el });
 
         result.Should().HaveCount(3);
         result[1].ElementType.Should().Be("Title");
-        result[1].Text.Should().Be("AZIONI");
-        result[2].Text.Should().Contain("PUNTEGGIO"); // untouched, remains inline in the tail
+        result[1].Text.Should().Be("PREPARAZIONE");
+        result[2].Text.Should().Contain("AZIONI"); // untouched, remains inline in the tail
         result[2].ElementType.Should().Be("NarrativeText");
     }
 
@@ -144,14 +145,44 @@ public class EmbeddedTitleSplitterTests
     }
 
     [Theory]
-    [InlineData("Fine del paragrafo. SETUP the board using the components listed above now.", "SETUP")]     // '.' boundary
-    [InlineData("Step 3) SETUP the board using the components listed on the reference card.", "SETUP")]      // ')' boundary
-    [InlineData("Preparation: SETUP the board using the components listed in the manual here.", "SETUP")]    // ':' boundary
-    public void Split_HeadingBoundaryVariants_PromoteTitle(string text, string expectedTitle)
+    [InlineData("Fine del paragrafo. SETUP the board using the components listed above now.", "SETUP")]        // sentence terminator
+    [InlineData("Leggi il testo a lato. 6 SETUP the board using the components listed on the card.", "SETUP")]  // page number at a clause boundary
+    [InlineData("Testo della sezione precedente\nSETUP the board using the components in the manual.", "SETUP")] // line break
+    public void Split_StrongHeadingBoundaryVariants_PromoteTitle(string text, string expectedTitle)
     {
         var result = EmbeddedTitleSplitter.Split(new[] { Body(text) });
 
         result.Should().Contain(e => e.ElementType == "Title" && e.Text == expectedTitle);
+    }
+
+    [Theory]
+    [InlineData("Nel tuo turno esegui 2 AZIONI a tua scelta dal tabellone principale adesso qui.")]    // digit is a quantifier, not a page number
+    [InlineData("Alla fine ricevi 3 PUNTEGGIO bonus per ogni generazione completata nel gioco.")]      // digit quantifier
+    [InlineData("Contesto del gioco: AZIONI eseguibili dal giocatore in ogni singolo turno corrente.")] // colon is inline, not a heading boundary
+    public void Split_InlineAllCapsAfterQuantifierOrColon_DoesNotFalseSplit(string text)
+    {
+        // Precision guard (review #3347): common Italian prose "quantifier/label + ALL-CAPS defined term
+        // + lowercase" must NOT fabricate a bogus section heading corpus-wide.
+        var result = EmbeddedTitleSplitter.Split(new[] { Body(text) });
+
+        result.Should().ContainSingle();
+        result[0].ElementType.Should().Be("NarrativeText");
+    }
+
+    [Theory]
+    [InlineData("Table")]
+    [InlineData("ListItem")]
+    [InlineData("Title")]
+    public void Split_NonProseElementType_IsNotSplit(string elementType)
+    {
+        // Only prose (NarrativeText/UncategorizedText) is split — never a Table row or a ListItem, which
+        // would be torn across a synthetic heading.
+        var el = new ExtractedElement("Riepilogo. 6 PREPARAZIONE Di seguito i passi di preparazione del gioco.", 1, elementType);
+
+        var result = EmbeddedTitleSplitter.Split(new[] { el });
+
+        result.Should().ContainSingle();
+        result[0].Should().Be(el);
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/Chunking/EmbeddedTitleSplitterTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/Chunking/EmbeddedTitleSplitterTests.cs
@@ -1,0 +1,174 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Services;
+using Api.BoundedContexts.KnowledgeBase.Application.Services.Chunking;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Services.Chunking;
+
+/// <summary>
+/// Epic #3338 WP1a unit tests for <see cref="EmbeddedTitleSplitter"/>: recovering section titles that
+/// unstructured's 'fast' strategy glued into body elements (the Terraforming Mars "PREPARAZIONE"
+/// case), while NOT false-splitting well-extracted English prose.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public class EmbeddedTitleSplitterTests
+{
+    private static ExtractedElement Body(string text, int page = 1) => new(text, page, "NarrativeText");
+    private static ExtractedElement Title(string text, int page = 1) => new(text, page, "Title");
+
+    [Fact]
+    public void Split_TmCase_PromotesEmbeddedPreparazioneToSyntheticTitle()
+    {
+        // The exact shape observed on staging: the setup title is glued between a page-number artifact
+        // ("6") and lowercase running prose, inside a body element whose neighbouring heading is "CARTE".
+        var el = Body("7 4 8 Se non sei sicuro del funzionamento di una carta, leggi il testo tra "
+            + "parentesi. 6 PREPARAZIONE Di seguito viene descritta la preparazione per il gioco da 2 a 5 giocatori.");
+
+        var result = EmbeddedTitleSplitter.Split(new[] { el });
+
+        result.Should().HaveCount(3);
+        result[0].ElementType.Should().Be("NarrativeText");
+        result[0].Text.Should().EndWith("6");   // head keeps the page-number artifact (goes to prior section)
+        result[1].ElementType.Should().Be("Title");
+        result[1].Text.Should().Be("PREPARAZIONE");
+        result[2].ElementType.Should().Be("NarrativeText");
+        result[2].Text.Should().StartWith("Di seguito viene descritta");
+        result.Should().OnlyContain(e => e.PageNumber == 1);
+    }
+
+    [Fact]
+    public void Split_TitleAtStartOfElement_OmitsEmptyHead()
+    {
+        var el = Body("PREPARAZIONE Di seguito viene descritta la preparazione del gioco.");
+
+        var result = EmbeddedTitleSplitter.Split(new[] { el });
+
+        result.Should().HaveCount(2);
+        result[0].ElementType.Should().Be("Title");
+        result[0].Text.Should().Be("PREPARAZIONE");
+        result[1].Text.Should().StartWith("Di seguito");
+    }
+
+    [Fact]
+    public void Split_ExistingTitleElement_PassesThroughUnchanged()
+    {
+        var el = Title("PREPARAZIONE");
+
+        var result = EmbeddedTitleSplitter.Split(new[] { el });
+
+        result.Should().ContainSingle();
+        result[0].Should().Be(el);
+    }
+
+    [Fact]
+    public void Split_PreservesOrderAndSplitsOnlyTheMatchingElement()
+    {
+        var a = Title("CONTESTO");
+        var b = Body("Testo del contesto senza titoli incorporati, tutto minuscolo qui.");
+        var c = Body("Riepilogo finale. 6 PREPARAZIONE Di seguito trovi i passi di preparazione.");
+
+        var result = EmbeddedTitleSplitter.Split(new[] { a, b, c });
+
+        result.Should().HaveCount(5); // a, b, [head c, Title, tail c]
+        result[0].Should().Be(a);
+        result[1].Should().Be(b);
+        result[2].Text.Should().EndWith("6");
+        result[3].ElementType.Should().Be("Title");
+        result[3].Text.Should().Be("PREPARAZIONE");
+        result[4].Text.Should().StartWith("Di seguito");
+    }
+
+    [Fact]
+    public void Split_MultipleEmbeddedTitles_SplitsOnlyTheLeftmost_NonRecursive()
+    {
+        // Only ONE split per element: the leftmost qualifying title is promoted; the second stays in the tail.
+        var el = Body("Contesto: AZIONI eseguibili dal giocatore in ogni turno. PUNTEGGIO finale del gioco calcolato.");
+
+        var result = EmbeddedTitleSplitter.Split(new[] { el });
+
+        result.Should().HaveCount(3);
+        result[1].ElementType.Should().Be("Title");
+        result[1].Text.Should().Be("AZIONI");
+        result[2].Text.Should().Contain("PUNTEGGIO"); // untouched, remains inline in the tail
+        result[2].ElementType.Should().Be("NarrativeText");
+    }
+
+    // --- English non-regression: must NOT false-split well-extracted prose ---
+
+    [Fact]
+    public void Split_LowercaseSectionWordInProse_DoesNotSplit()
+    {
+        var el = Body("During setup you may draw a card, and at the end you score points for each tile.");
+
+        var result = EmbeddedTitleSplitter.Split(new[] { el });
+
+        result.Should().ContainSingle();
+        result[0].Should().Be(el);
+    }
+
+    [Fact]
+    public void Split_UppercaseWordPrecededByLetter_TreatedAsInlineProse_DoesNotSplit()
+    {
+        // Preceding non-space char is a letter ("the ") → inline emphasis, not a heading boundary.
+        var el = Body("Follow the SETUP steps carefully before you begin the first round of play.");
+
+        var result = EmbeddedTitleSplitter.Split(new[] { el });
+
+        result.Should().ContainSingle();
+        result[0].Should().Be(el);
+    }
+
+    [Theory]
+    [InlineData("IMPREPARAZIONE del turno adesso descritta in dettaglio qui sotto.")] // glued left
+    [InlineData("6 PREPARAZIONER del gioco viene ora descritta nel dettaglio seguente.")] // glued right
+    public void Split_NotAWholeWordMatch_DoesNotSplit(string text)
+    {
+        var result = EmbeddedTitleSplitter.Split(new[] { Body(text) });
+
+        result.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void Split_UppercaseTitleWithNoTrailingLowercaseProse_DoesNotSplit()
+    {
+        // A lone ALL-CAPS token or a run of adjacent all-caps headings (no lowercase body within the
+        // window) is ambiguous — the conservative guard leaves it alone.
+        var el = Body("6 PREPARAZIONE AZIONI GENERAZIONI");
+
+        var result = EmbeddedTitleSplitter.Split(new[] { el });
+
+        result.Should().ContainSingle();
+        result[0].Should().Be(el);
+    }
+
+    [Theory]
+    [InlineData("Fine del paragrafo. SETUP the board using the components listed above now.", "SETUP")]     // '.' boundary
+    [InlineData("Step 3) SETUP the board using the components listed on the reference card.", "SETUP")]      // ')' boundary
+    [InlineData("Preparation: SETUP the board using the components listed in the manual here.", "SETUP")]    // ':' boundary
+    public void Split_HeadingBoundaryVariants_PromoteTitle(string text, string expectedTitle)
+    {
+        var result = EmbeddedTitleSplitter.Split(new[] { Body(text) });
+
+        result.Should().Contain(e => e.ElementType == "Title" && e.Text == expectedTitle);
+    }
+
+    [Fact]
+    public void Split_MultiWordTitle_PrefersLongestAtSamePosition()
+    {
+        // "GAME SETUP" and "SETUP" both start-of-string; the longest wins so the whole heading is captured.
+        var el = Body("GAME SETUP arrange the board and deal starting cards to every player now.");
+
+        var result = EmbeddedTitleSplitter.Split(new[] { el });
+
+        result.Should().Contain(e => e.ElementType == "Title" && e.Text == "GAME SETUP");
+        result.Should().NotContain(e => e.ElementType == "Title" && e.Text == "SETUP");
+    }
+
+    [Fact]
+    public void Split_EmptyList_ReturnsEmpty()
+    {
+        EmbeddedTitleSplitter.Split(System.Array.Empty<ExtractedElement>()).Should().BeEmpty();
+    }
+}

--- a/apps/api/tests/Api.Tests/Domain/Services/VectorSearch/FusionSignalsTests.cs
+++ b/apps/api/tests/Api.Tests/Domain/Services/VectorSearch/FusionSignalsTests.cs
@@ -41,6 +41,48 @@ public class FusionSignalsTests
         factor.Should().BeGreaterThan(0f);
     }
 
+    // --- #3338 WP1b: number-noise demotion ---
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("Disponi le tessere sul tabellone e mescola il mazzo delle carte.")] // prose, no digits
+    public void ComputeNumberNoiseFactor_NoDigits_ReturnsZero(string? content)
+    {
+        FusionSignals.ComputeNumberNoiseFactor(content).Should().Be(0f);
+    }
+
+    [Fact]
+    public void ComputeNumberNoiseFactor_ProseCitingAFewNumbers_ReturnsZero()
+    {
+        // Letters-majority text (a few incidental numbers) is real prose — must not be demoted.
+        var prose = "Di seguito viene descritta la preparazione per il gioco da 2 a 5 giocatori.";
+        FusionSignals.ComputeNumberNoiseFactor(prose).Should().Be(0f);
+    }
+
+    [Fact]
+    public void ComputeNumberNoiseFactor_ShortDigitDominatedFragment_ReturnsStrongDemotion()
+    {
+        // The exact TM garbage chunk that out-ranked the real setup prose under ts_rank_cd.
+        var factor = FusionSignals.ComputeNumberNoiseFactor("CARTE 2 5 6 4 3");
+        factor.Should().BeInRange(0f, 0.5f);
+        factor.Should().BeGreaterThan(0.3f);
+    }
+
+    [Fact]
+    public void ComputeNumberNoiseFactor_LongNumberDenseTable_IsTaperedBelowShortFragment()
+    {
+        // A long, legitimately number-dense section (e.g. a scoring table) is tapered by length so it
+        // is demoted far less than a short mostly-digits fragment of the same ratio.
+        var shortFrag = "AB 1 2 3 4 5 6 7 8"; // ~digitRatio 0.5, short
+        var longTable = "Punteggi finali giocatori " + string.Concat(Enumerable.Repeat("12 34 56 78 90 ", 30));
+        var shortFactor = FusionSignals.ComputeNumberNoiseFactor(shortFrag);
+        var longFactor = FusionSignals.ComputeNumberNoiseFactor(longTable);
+
+        longFactor.Should().BeLessThan(shortFactor);
+        longFactor.Should().BeInRange(0f, 0.5f);
+    }
+
     // --- #3270: heading-match boost ---
 
     [Fact]

--- a/apps/api/tests/Api.Tests/Domain/Services/VectorSearch/FusionSignalsTests.cs
+++ b/apps/api/tests/Api.Tests/Domain/Services/VectorSearch/FusionSignalsTests.cs
@@ -70,6 +70,19 @@ public class FusionSignalsTests
     }
 
     [Fact]
+    public void ComputeNumberNoiseFactor_WhitespacePadding_DoesNotWeakenDemotion()
+    {
+        // Review #3347: the taper is token-count based, so a whitespace-heavy table fragment (the exact
+        // WP1b target class) is demoted the SAME as its compact form — whitespace no longer inflates the
+        // length denominator and under-demotes the fragment.
+        var compact = FusionSignals.ComputeNumberNoiseFactor("CARTE 2 5 6 4 3");
+        var padded = FusionSignals.ComputeNumberNoiseFactor("CARTE     2     5     6     4     3");
+
+        padded.Should().BeApproximately(compact, 1e-6f);
+        padded.Should().BeGreaterThan(0.3f);
+    }
+
+    [Fact]
     public void ComputeNumberNoiseFactor_LongNumberDenseTable_IsTaperedBelowShortFragment()
     {
         // A long, legitimately number-dense section (e.g. a scoring table) is tapered by length so it

--- a/apps/api/tests/Api.Tests/Services/KeywordSearchServiceTests.cs
+++ b/apps/api/tests/Api.Tests/Services/KeywordSearchServiceTests.cs
@@ -180,4 +180,50 @@ public sealed class KeywordSearchServiceTests
         KeywordSearchService.BuildTsQuery("en passant", phraseSearch: true, "english")
             .Should().Be("en <-> passant");
     }
+
+    // --- #3338 WP1c: synonym-aware heading-match term expansion ---
+
+    [Fact]
+    public void ExpandHeadingMatchTerms_Italian_AddsSetupSynonyms_SoSetupQueryMatchesPreparazioneHeading()
+    {
+        var result = KeywordSearchService.ExpandHeadingMatchTerms(new[] { "setup", "giocatori" }, "italian");
+
+        result.Should().Contain("setup");
+        result.Should().Contain("preparazione"); // native rulebook lexeme → matches heading "Preparazione"
+        result.Should().Contain("allestimento");
+    }
+
+    [Fact]
+    public void ExpandHeadingMatchTerms_NonTabledConfig_ReturnsTermsUnchanged()
+    {
+        var terms = new[] { "setup", "scoring" };
+
+        KeywordSearchService.ExpandHeadingMatchTerms(terms, "english")
+            .Should().BeEquivalentTo(terms, o => o.WithStrictOrdering());
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void ExpandHeadingMatchTerms_NullOrBlankConfig_ReturnsTermsUnchanged(string? config)
+    {
+        // A loose mock of ResolveFtsConfigAsync returns default(string) = null; expansion must be a
+        // safe no-op rather than throwing on Dictionary.TryGetValue(null).
+        var terms = new[] { "setup" };
+
+        KeywordSearchService.ExpandHeadingMatchTerms(terms, config)
+            .Should().BeEquivalentTo(terms);
+    }
+
+    [Fact]
+    public void ExpandHeadingMatchTerms_DeduplicatesAndKeepsLengthAtLeastThree()
+    {
+        // "preparazione" already present + its synonym set includes "setup"; no dupes, and any <3-char
+        // token is dropped (the ComputeHeadingMatchBoost contract).
+        var result = KeywordSearchService.ExpandHeadingMatchTerms(new[] { "setup", "preparazione", "di" }, "italian");
+
+        result.Should().OnlyHaveUniqueItems();
+        result.Should().NotContain("di");
+        result.Should().Contain(new[] { "setup", "preparazione", "allestimento" });
+    }
 }


### PR DESCRIPTION
Part of #3338 (WP1 of the extraction heading-detection epic — **do not auto-close the epic**; WP2/WP3/WP4 remain).

## Problem

The Terraforming Mars "Setup per N giocatori" RAG query fails because unstructured's `fast` strategy glues the "PREPARAZIONE" section title into the body of the preceding "CARTE" chunk (proven on staging). This starves the #3270 heading-match boost + the RoleClassifier Setup fast-path, and the real setup prose ranks last under FTS below number-only garbage chunks. This WP is the C#-only fix that rides the existing re-index (no re-extraction).

## Changes (3 commits)

**WP1a — `EmbeddedTitleSplitter`** (`HeadingAwareChunker.BuildAsync` pre-pass): promotes an embedded ALL-CAPS lexicon title to a synthetic `Title` element (`[head][Title][tail]`) so `GroupByTitle` opens a real section. Conservative guards protect the English corpus (case-sensitive UPPERCASE + whole-word; preceded by a heading boundary — digit / `.` `:` `)` `;` / line break / start; followed by lowercase prose; one split per element). New `SectionHeadingLexicon` (curated IT + EN). 15 tests.

**WP1b — `FusionSignals.ComputeNumberNoiseFactor`**: `[0,0.5]` multiplicative demotion of short digit-dominated fragments (the "CARTE 2 5 6 4 3" chunk), applied at `HybridFusionCore`. Ratio is over digits in **purely-numeric whitespace tokens only** — a GUID/id or hex string contributes zero; prose citing a few numbers is untouched; long number tables are length-tapered. 7 tests.

**WP1c — synonym-aware #3270 heading boost**: expand heading-match terms with the game's FTS-language intent synonyms (`setup → preparazione/allestimento`) so an English-loanword query boosts a native-lexeme heading. `IKeywordSearchService.ResolveFtsConfigAsync` + `KeywordSearchService.ExpandHeadingMatchTerms` (no-op for null/blank/non-tabled config → English byte-identical). 5 tests.

## Test

Full Unit suite green: **20816 passed, 0 failed**. New: 27 unit tests across the three parts; existing chunker (36) + fusion/search (105) suites unaffected.

## Observability

WP1a is visible only after the affected docs are re-chunked from the persisted `StructuredElementsJson` (no re-extraction) — see WP2 sequencing. WP1b + WP1c are live immediately on the current index.

## Scope

C#-only; no migration, no re-extraction. Does not itself run the re-index (WP2) or add the Title-health gate (WP3) or hi_res extraction (WP4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)