### PR TITLE
fix(session-tracking): IDOR authz on write-command endpoints

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/CompleteGameNightSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/CompleteGameNightSessionCommandHandler.cs
@@ -85,7 +85,11 @@ internal sealed class CompleteGameNightSessionCommandHandler : ICommandHandler<C
             // (_diaryStream.Publish + _syncService.PublishEventAsync) fire before CommitTransactionAsync,
             // so a rare commit failure leaves phantom broadcasts — clients self-correct on the next
             // poll. See must-fix #5 in the C4 spec (2026-07-05-issue-2634-c4-winner-completa-design.md).
-            await _mediator.Send(new FinalizeSessionCommand(trackingSessionId, finalRanks), cancellationToken).ConfigureAwait(false);
+            // RequestedBy = session.UserId: this is a trusted internal orchestration path. The caller's
+            // authority was already enforced above (organizer check, line 49) — the FinalizeSessionCommand
+            // IDOR guard targets direct HTTP callers, so we finalize on behalf of the tracking session's
+            // owner to avoid spuriously blocking a legitimate game-night completion.
+            await _mediator.Send(new FinalizeSessionCommand(trackingSessionId, finalRanks, session.UserId), cancellationToken).ConfigureAwait(false);
 
             commitStarted = true;
             await _unitOfWork.CommitTransactionAsync(cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/AddNoteCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/AddNoteCommand.cs
@@ -8,7 +8,8 @@ public record AddNoteCommand(
     string NoteType, // 'Private' | 'Shared' | 'Template'
     string? TemplateKey,
     string Content,
-    bool IsHidden
+    bool IsHidden,
+    Guid RequestedBy // IDOR guard: authenticated caller — must be the session owner or a participant.
 ) : IRequest<AddNoteResult>;
 
 public record AddNoteResult(

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/AddNoteCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/AddNoteCommandHandler.cs
@@ -36,6 +36,15 @@ public class AddNoteCommandHandler : IRequestHandler<AddNoteCommand, AddNoteResu
         var session = await _sessionRepository.GetByIdAsync(request.SessionId, cancellationToken).ConfigureAwait(false)
             ?? throw new NotFoundException($"Session {request.SessionId} not found");
 
+        // IDOR guard (security review high-priority): only the session owner or a registered
+        // (User-linked) participant may add notes. Mirrors UpdateSessionScoresCommandHandler.
+        if (session.UserId != request.RequestedBy &&
+            !session.Participants.Any(p => p.UserId == request.RequestedBy))
+        {
+            throw new ForbiddenException(
+                $"User {request.RequestedBy} is not authorized to add notes to session {request.SessionId}.");
+        }
+
         // Verify participant exists in session
         _ = session.Participants.FirstOrDefault(p => p.Id == request.ParticipantId)
             ?? throw new NotFoundException($"Participant {request.ParticipantId} not found in session");

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/AddParticipantCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/AddParticipantCommand.cs
@@ -5,7 +5,8 @@ namespace Api.BoundedContexts.SessionTracking.Application.Commands;
 public record AddParticipantCommand(
     Guid SessionId,
     string DisplayName,
-    Guid? UserId
+    Guid? UserId,
+    Guid RequestedBy // IDOR guard: authenticated caller — must be the session owner or a participant.
 ) : IRequest<AddParticipantResult>;
 
 public record AddParticipantResult(

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/AddParticipantCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/AddParticipantCommandHandler.cs
@@ -32,6 +32,15 @@ public class AddParticipantCommandHandler : IRequestHandler<AddParticipantComman
         var session = await _sessionRepository.GetByIdAsync(request.SessionId, cancellationToken).ConfigureAwait(false)
             ?? throw new NotFoundException($"Session {request.SessionId} not found");
 
+        // IDOR guard (security review high-priority): only the session owner or a registered
+        // (User-linked) participant may add participants. Mirrors UpdateSessionScoresCommandHandler.
+        if (session.UserId != request.RequestedBy &&
+            !session.Participants.Any(p => p.UserId == request.RequestedBy))
+        {
+            throw new ForbiddenException(
+                $"User {request.RequestedBy} is not authorized to add participants to session {request.SessionId}.");
+        }
+
         if (session.Status == SessionStatus.Finalized)
         {
             throw new ConflictException("Cannot add participant to finalized session");

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/FinalizeSessionCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/FinalizeSessionCommand.cs
@@ -4,7 +4,8 @@ namespace Api.BoundedContexts.SessionTracking.Application.Commands;
 
 public record FinalizeSessionCommand(
     Guid SessionId,
-    Dictionary<Guid, int> FinalRanks // participantId → rank
+    Dictionary<Guid, int> FinalRanks, // participantId → rank
+    Guid RequestedBy // IDOR guard: authenticated caller — must be the session owner or a participant.
 ) : IRequest<FinalizeSessionResult>;
 
 public record FinalizeSessionResult(

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/FinalizeSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/FinalizeSessionCommandHandler.cs
@@ -51,6 +51,17 @@ public class FinalizeSessionCommandHandler : IRequestHandler<FinalizeSessionComm
         var session = await _sessionRepository.GetByIdAsync(request.SessionId, cancellationToken).ConfigureAwait(false)
             ?? throw new NotFoundException($"Session {request.SessionId} not found");
 
+        // IDOR guard (security review high-priority): only the session owner or a registered
+        // (User-linked) participant may finalize. Finalizing destroys the live session and triggers
+        // the KB cleanup + game-night link-close cascade, so this must run before any state mutation.
+        // Mirrors UpdateSessionScoresCommandHandler.
+        if (session.UserId != request.RequestedBy &&
+            !session.Participants.Any(p => p.UserId == request.RequestedBy))
+        {
+            throw new ForbiddenException(
+                $"User {request.RequestedBy} is not authorized to finalize session {request.SessionId}.");
+        }
+
         if (session.Status != SessionStatus.Active && session.Status != SessionStatus.Paused)
         {
             throw new ConflictException($"Cannot finalize session with status {session.Status}");

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/RollDiceCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/RollDiceCommand.cs
@@ -9,7 +9,8 @@ public record RollDiceCommand(
     Guid SessionId,
     Guid ParticipantId,
     string Formula,
-    string? Label = null
+    string? Label,
+    Guid RequestedBy // IDOR guard: authenticated caller — must be the session owner or a participant.
 ) : IRequest<RollDiceResult>;
 
 /// <summary>

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/RollDiceCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/RollDiceCommandHandler.cs
@@ -38,6 +38,15 @@ public class RollDiceCommandHandler : IRequestHandler<RollDiceCommand, RollDiceR
         var session = await _sessionRepository.GetByIdAsync(request.SessionId, cancellationToken).ConfigureAwait(false)
             ?? throw new NotFoundException($"Session {request.SessionId} not found");
 
+        // IDOR guard (security review high-priority): only the session owner or a registered
+        // (User-linked) participant may roll dice. Mirrors UpdateSessionScoresCommandHandler.
+        if (session.UserId != request.RequestedBy &&
+            !session.Participants.Any(p => p.UserId == request.RequestedBy))
+        {
+            throw new ForbiddenException(
+                $"User {request.RequestedBy} is not authorized to roll dice in session {request.SessionId}.");
+        }
+
         if (session.Status != SessionStatus.Active)
         {
             throw new ConflictException($"Cannot roll dice in session with status {session.Status}");

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/UpdateScoreCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/UpdateScoreCommand.cs
@@ -8,7 +8,8 @@ public record UpdateScoreCommand(
     Guid ParticipantId,
     int? RoundNumber,
     string? Category,
-    decimal ScoreValue
+    decimal ScoreValue,
+    Guid RequestedBy // IDOR guard: authenticated caller — must be the session owner or a participant.
 ) : IRequest<UpdateScoreResult>;
 
 public record UpdateScoreResult(

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/UpdateScoreCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/UpdateScoreCommandHandler.cs
@@ -35,6 +35,15 @@ public class UpdateScoreCommandHandler : IRequestHandler<UpdateScoreCommand, Upd
         var session = await _sessionRepository.GetByIdAsync(request.SessionId, cancellationToken).ConfigureAwait(false)
             ?? throw new NotFoundException($"Session {request.SessionId} not found");
 
+        // IDOR guard (security review high-priority): only the session owner or a registered
+        // (User-linked) participant may update scores. Mirrors UpdateSessionScoresCommandHandler.
+        if (session.UserId != request.RequestedBy &&
+            !session.Participants.Any(p => p.UserId == request.RequestedBy))
+        {
+            throw new ForbiddenException(
+                $"User {request.RequestedBy} is not authorized to update scores for session {request.SessionId}.");
+        }
+
         if (session.Status != SessionStatus.Active)
         {
             throw new ConflictException($"Cannot update score for session with status {session.Status}");

--- a/apps/api/src/Api/Routing/SessionTracking/SessionCommandEndpoints.cs
+++ b/apps/api/src/Api/Routing/SessionTracking/SessionCommandEndpoints.cs
@@ -118,6 +118,7 @@ internal static class SessionCommandEndpoints
         .Produces(200)
         .Produces(400)
         .Produces(401)
+        .Produces(403)
         .Produces(404);
     }
 
@@ -135,6 +136,7 @@ internal static class SessionCommandEndpoints
     private static async Task<IResult> HandleUpdateScoreLegacy(
         Guid sessionId,
         UpdateScoreCommand command,
+        HttpContext httpContext,
         IMediator mediator,
         HttpResponse response,
         CancellationToken ct)
@@ -145,7 +147,16 @@ internal static class SessionCommandEndpoints
             return Results.BadRequest(new { error = "Session ID mismatch" });
         }
 
-        var result = await mediator.Send(command, ct).ConfigureAwait(false);
+        // IDOR guard: derive the caller identity from the authenticated principal and
+        // authoritatively override any body-supplied RequestedBy. The handler verifies the
+        // caller is the session owner or a registered participant.
+        var userId = httpContext.User.GetUserId();
+        if (userId == Guid.Empty)
+        {
+            return Results.Unauthorized();
+        }
+
+        var result = await mediator.Send(command with { RequestedBy = userId }, ct).ConfigureAwait(false);
 
         // RFC 8594 deprecation signalling — set AFTER the command succeeds so the
         // headers do not leak onto error responses produced by exception middleware.
@@ -209,6 +220,7 @@ internal static class SessionCommandEndpoints
         group.MapPost("/game-sessions/{sessionId:guid}/participants", async (
             Guid sessionId,
             AddParticipantCommand command,
+            HttpContext httpContext,
             IMediator mediator,
             CancellationToken ct) =>
         {
@@ -217,7 +229,16 @@ internal static class SessionCommandEndpoints
                 return Results.BadRequest(new { error = "Session ID mismatch" });
             }
 
-            var result = await mediator.Send(command, ct).ConfigureAwait(false);
+            // IDOR guard: derive the caller identity from the authenticated principal and
+            // authoritatively override any body-supplied RequestedBy. The handler verifies the
+            // caller is the session owner or a registered participant.
+            var userId = httpContext.User.GetUserId();
+            if (userId == Guid.Empty)
+            {
+                return Results.Unauthorized();
+            }
+
+            var result = await mediator.Send(command with { RequestedBy = userId }, ct).ConfigureAwait(false);
             return Results.Created($"/api/v1/sessions/{sessionId}/participants/{result.ParticipantId}", result);
         })
         .RequireAuthenticatedUser()
@@ -227,6 +248,7 @@ internal static class SessionCommandEndpoints
         .Produces(201)
         .Produces(400)
         .Produces(401)
+        .Produces(403)
         .Produces(404);
     }
 
@@ -235,6 +257,7 @@ internal static class SessionCommandEndpoints
         group.MapPost("/game-sessions/{sessionId:guid}/notes", async (
             Guid sessionId,
             AddNoteCommand command,
+            HttpContext httpContext,
             IMediator mediator,
             CancellationToken ct) =>
         {
@@ -243,7 +266,16 @@ internal static class SessionCommandEndpoints
                 return Results.BadRequest(new { error = "Session ID mismatch" });
             }
 
-            var result = await mediator.Send(command, ct).ConfigureAwait(false);
+            // IDOR guard: derive the caller identity from the authenticated principal and
+            // authoritatively override any body-supplied RequestedBy. The handler verifies the
+            // caller is the session owner or a registered participant.
+            var userId = httpContext.User.GetUserId();
+            if (userId == Guid.Empty)
+            {
+                return Results.Unauthorized();
+            }
+
+            var result = await mediator.Send(command with { RequestedBy = userId }, ct).ConfigureAwait(false);
             return Results.Created($"/api/v1/sessions/{sessionId}/notes/{result.NoteId}", result);
         })
         .RequireAuthenticatedUser()
@@ -253,6 +285,7 @@ internal static class SessionCommandEndpoints
         .Produces(201)
         .Produces(400)
         .Produces(401)
+        .Produces(403)
         .Produces(404);
     }
 
@@ -261,6 +294,7 @@ internal static class SessionCommandEndpoints
         group.MapPost("/game-sessions/{sessionId:guid}/finalize", async (
             Guid sessionId,
             FinalizeSessionCommand command,
+            HttpContext httpContext,
             IMediator mediator,
             HttpResponse response,
             CancellationToken ct) =>
@@ -270,7 +304,16 @@ internal static class SessionCommandEndpoints
                 return Results.BadRequest(new { error = "Session ID mismatch" });
             }
 
-            var result = await mediator.Send(command, ct).ConfigureAwait(false);
+            // IDOR guard: derive the caller identity from the authenticated principal and
+            // authoritatively override any body-supplied RequestedBy. The handler verifies the
+            // caller is the session owner or a registered participant.
+            var userId = httpContext.User.GetUserId();
+            if (userId == Guid.Empty)
+            {
+                return Results.Unauthorized();
+            }
+
+            var result = await mediator.Send(command with { RequestedBy = userId }, ct).ConfigureAwait(false);
 
             // Invariante #13 (#1896 WP2 T4): non-blocking warning header for FE toast when
             // a draft+live session coexist in the same GameNightEvent. The operation itself
@@ -289,6 +332,7 @@ internal static class SessionCommandEndpoints
         .Produces(200)
         .Produces(400)
         .Produces(401)
+        .Produces(403)
         .Produces(404);
     }
 
@@ -297,6 +341,7 @@ internal static class SessionCommandEndpoints
         group.MapPost("/game-sessions/{sessionId:guid}/dice", async (
             Guid sessionId,
             RollDiceCommand command,
+            HttpContext httpContext,
             IMediator mediator,
             CancellationToken ct) =>
         {
@@ -305,7 +350,16 @@ internal static class SessionCommandEndpoints
                 return Results.BadRequest(new { error = "Session ID mismatch" });
             }
 
-            var result = await mediator.Send(command, ct).ConfigureAwait(false);
+            // IDOR guard: derive the caller identity from the authenticated principal and
+            // authoritatively override any body-supplied RequestedBy. The handler verifies the
+            // caller is the session owner or a registered participant.
+            var userId = httpContext.User.GetUserId();
+            if (userId == Guid.Empty)
+            {
+                return Results.Unauthorized();
+            }
+
+            var result = await mediator.Send(command with { RequestedBy = userId }, ct).ConfigureAwait(false);
             return Results.Created($"/api/v1/game-sessions/{sessionId}/dice/{result.DiceRollId}", result);
         })
         .RequireAuthenticatedUser()
@@ -316,6 +370,7 @@ internal static class SessionCommandEndpoints
         .Produces(201)
         .Produces(400)
         .Produces(401)
+        .Produces(403)
         .Produces(404)
         .Produces(409);
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/FinalizeSessionDiaryTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/FinalizeSessionDiaryTests.cs
@@ -192,7 +192,7 @@ public sealed class FinalizeSessionDiaryTests : IAsyncLifetime
 
         // Act — finalize the session with the owner as winner.
         var result = await _finalizeHandler!.Handle(
-            new FinalizeSessionCommand(createResult.SessionId, finalRanks),
+            new FinalizeSessionCommand(createResult.SessionId, finalRanks, userId),
             TestCancellationToken);
 
         // Assert — command result echoes the winner.
@@ -278,7 +278,7 @@ public sealed class FinalizeSessionDiaryTests : IAsyncLifetime
 
         // Act
         var result = await _finalizeHandler!.Handle(
-            new FinalizeSessionCommand(createResult.SessionId, finalRanks),
+            new FinalizeSessionCommand(createResult.SessionId, finalRanks, userId),
             TestCancellationToken);
 
         // Assert — no winner in the command result.

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/PauseResumeSessionTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/PauseResumeSessionTests.cs
@@ -405,7 +405,7 @@ public sealed class PauseResumeSessionTests : IAsyncLifetime
         var finalizeHandler = BuildFinalizeHandler();
 
         await finalizeHandler.Handle(
-            new FinalizeSessionCommand(created.SessionId, new Dictionary<Guid, int> { [ownerParticipantId] = 1 }),
+            new FinalizeSessionCommand(created.SessionId, new Dictionary<Guid, int> { [ownerParticipantId] = 1 }, userId),
             TestCancellationToken);
 
         _dbContext.ChangeTracker.Clear();
@@ -444,7 +444,7 @@ public sealed class PauseResumeSessionTests : IAsyncLifetime
         var finalizeHandler = BuildFinalizeHandler();
 
         await finalizeHandler.Handle(
-            new FinalizeSessionCommand(created.SessionId, new Dictionary<Guid, int> { [ownerParticipantId] = 1 }),
+            new FinalizeSessionCommand(created.SessionId, new Dictionary<Guid, int> { [ownerParticipantId] = 1 }, userId),
             TestCancellationToken);
 
         _dbContext.ChangeTracker.Clear();

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/AddNoteCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/AddNoteCommandHandlerTests.cs
@@ -52,10 +52,34 @@ public class AddNoteCommandHandlerTests
         _sessionRepoMock.Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((Session?)null);
 
-        var command = new AddNoteCommand(sessionId, Guid.NewGuid(), "Shared", null, "Test note", false);
+        var command = new AddNoteCommand(sessionId, Guid.NewGuid(), "Shared", null, "Test note", false, Guid.NewGuid());
 
         // Act & Assert
         await Assert.ThrowsAsync<NotFoundException>(
             () => handler.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_CallerNotOwnerOrParticipant_ThrowsForbiddenException()
+    {
+        // Arrange — session owned by someone else; caller is neither owner nor participant (IDOR).
+        var handler = new AddNoteCommandHandler(
+            _sessionRepoMock.Object, _context,
+            _unitOfWorkMock.Object, _syncServiceMock.Object);
+
+        var ownerId = Guid.NewGuid();
+        var attackerId = Guid.NewGuid();
+        var session = Session.Create(ownerId, Guid.NewGuid(), SessionType.Generic);
+
+        _sessionRepoMock.Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var command = new AddNoteCommand(
+            session.Id, session.Participants.First().Id, "Shared", null, "Test note", false, attackerId);
+
+        // Act & Assert — IDOR guard rejects before any note is persisted.
+        await Assert.ThrowsAsync<ForbiddenException>(
+            () => handler.Handle(command, CancellationToken.None));
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/AddParticipantCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/AddParticipantCommandHandlerTests.cs
@@ -29,11 +29,12 @@ public class AddParticipantCommandHandlerTests
     public async Task Handle_ValidRequest_AddsParticipantAndReturnsResult()
     {
         // Arrange
-        var session = Session.Create(Guid.NewGuid(), Guid.NewGuid(), SessionType.Generic);
+        var userId = Guid.NewGuid();
+        var session = Session.Create(userId, Guid.NewGuid(), SessionType.Generic);
         _sessionRepoMock.Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(session);
 
-        var command = new AddParticipantCommand(session.Id, "Alice", Guid.NewGuid());
+        var command = new AddParticipantCommand(session.Id, "Alice", Guid.NewGuid(), userId);
 
         // Act
         var result = await _handler.Handle(command, CancellationToken.None);
@@ -53,7 +54,7 @@ public class AddParticipantCommandHandlerTests
         _sessionRepoMock.Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((Session?)null);
 
-        var command = new AddParticipantCommand(sessionId, "Bob", null);
+        var command = new AddParticipantCommand(sessionId, "Bob", null, Guid.NewGuid());
 
         // Act & Assert
         await Assert.ThrowsAsync<NotFoundException>(
@@ -64,16 +65,37 @@ public class AddParticipantCommandHandlerTests
     public async Task Handle_FinalizedSession_ThrowsConflictException()
     {
         // Arrange
-        var session = Session.Create(Guid.NewGuid(), Guid.NewGuid(), SessionType.Generic);
+        var userId = Guid.NewGuid();
+        var session = Session.Create(userId, Guid.NewGuid(), SessionType.Generic);
         session.Finalize();
 
         _sessionRepoMock.Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(session);
 
-        var command = new AddParticipantCommand(session.Id, "Charlie", null);
+        var command = new AddParticipantCommand(session.Id, "Charlie", null, userId);
 
         // Act & Assert
         await Assert.ThrowsAsync<ConflictException>(
             () => _handler.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_CallerNotOwnerOrParticipant_ThrowsForbiddenException()
+    {
+        // Arrange — session owned by someone else; caller is neither owner nor participant (IDOR).
+        var ownerId = Guid.NewGuid();
+        var attackerId = Guid.NewGuid();
+        var session = Session.Create(ownerId, Guid.NewGuid(), SessionType.Generic);
+
+        _sessionRepoMock.Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var command = new AddParticipantCommand(session.Id, "Injected", null, attackerId);
+
+        // Act & Assert — IDOR guard rejects before any participant is added.
+        await Assert.ThrowsAsync<ForbiddenException>(
+            () => _handler.Handle(command, CancellationToken.None));
+        _sessionRepoMock.Verify(r => r.UpdateAsync(It.IsAny<Session>(), It.IsAny<CancellationToken>()), Times.Never);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/FinalizeSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/FinalizeSessionCommandHandlerTests.cs
@@ -52,7 +52,7 @@ public class FinalizeSessionCommandHandlerTests
         _sessionRepoMock.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((Session?)null);
 
-        var command = new FinalizeSessionCommand(Guid.NewGuid(), new Dictionary<Guid, int>());
+        var command = new FinalizeSessionCommand(Guid.NewGuid(), new Dictionary<Guid, int>(), Guid.NewGuid());
 
         // Act & Assert
         await Assert.ThrowsAsync<NotFoundException>(
@@ -63,13 +63,14 @@ public class FinalizeSessionCommandHandlerTests
     public async Task Handle_AlreadyFinalized_ThrowsConflictException()
     {
         // Arrange
-        var session = Session.Create(Guid.NewGuid(), Guid.NewGuid(), SessionType.Generic);
+        var userId = Guid.NewGuid();
+        var session = Session.Create(userId, Guid.NewGuid(), SessionType.Generic);
         session.Finalize();
 
         _sessionRepoMock.Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(session);
 
-        var command = new FinalizeSessionCommand(session.Id, new Dictionary<Guid, int>());
+        var command = new FinalizeSessionCommand(session.Id, new Dictionary<Guid, int>(), userId);
 
         // Act & Assert
         await Assert.ThrowsAsync<ConflictException>(
@@ -91,7 +92,7 @@ public class FinalizeSessionCommandHandlerTests
             .ReturnsAsync(Enumerable.Empty<ScoreEntry>());
 
         var ranks = new Dictionary<Guid, int> { { participantId, 1 } };
-        var command = new FinalizeSessionCommand(session.Id, ranks);
+        var command = new FinalizeSessionCommand(session.Id, ranks, userId);
 
         // Act
         var result = await _handler.Handle(command, CancellationToken.None);
@@ -100,6 +101,30 @@ public class FinalizeSessionCommandHandlerTests
         Assert.NotNull(result);
         _sessionRepoMock.Verify(r => r.UpdateAsync(session, It.IsAny<CancellationToken>()), Times.Once);
         _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_CallerNotOwnerOrParticipant_ThrowsForbiddenException()
+    {
+        // Arrange — session owned by someone else; the caller is neither owner nor participant (IDOR).
+        var ownerId = Guid.NewGuid();
+        var attackerId = Guid.NewGuid();
+        var session = Session.Create(ownerId, Guid.NewGuid(), SessionType.Generic);
+        var participantId = session.Participants.First().Id;
+
+        _sessionRepoMock.Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var command = new FinalizeSessionCommand(
+            session.Id,
+            new Dictionary<Guid, int> { { participantId, 1 } },
+            attackerId);
+
+        // Act & Assert — IDOR guard rejects before any state mutation.
+        await Assert.ThrowsAsync<ForbiddenException>(
+            () => _handler.Handle(command, CancellationToken.None));
+        _sessionRepoMock.Verify(r => r.UpdateAsync(It.IsAny<Session>(), It.IsAny<CancellationToken>()), Times.Never);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 
     // ── Invariante #13 (#1896 WP2 T4) — LiveActiveWarning ─────────────────────
@@ -168,7 +193,7 @@ public class FinalizeSessionCommandHandlerTests
             .ReturnsAsync(Enumerable.Empty<ScoreEntry>());
 
         var ranks = new Dictionary<Guid, int> { { participantId, 1 } };
-        var command = new FinalizeSessionCommand(sessionBeingFinalized.Id, ranks);
+        var command = new FinalizeSessionCommand(sessionBeingFinalized.Id, ranks, userId);
 
         // Act
         var result = await _handler.Handle(command, CancellationToken.None);
@@ -212,7 +237,7 @@ public class FinalizeSessionCommandHandlerTests
             .ReturnsAsync(Enumerable.Empty<ScoreEntry>());
 
         var ranks = new Dictionary<Guid, int> { { participantId, 1 } };
-        var command = new FinalizeSessionCommand(sessionBeingFinalized.Id, ranks);
+        var command = new FinalizeSessionCommand(sessionBeingFinalized.Id, ranks, userId);
 
         // Act
         var result = await _handler.Handle(command, CancellationToken.None);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/RollDiceCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/RollDiceCommandHandlerTests.cs
@@ -34,7 +34,7 @@ public class RollDiceCommandHandlerTests
         _sessionRepoMock.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((Session?)null);
 
-        var command = new RollDiceCommand(Guid.NewGuid(), Guid.NewGuid(), "2d6");
+        var command = new RollDiceCommand(Guid.NewGuid(), Guid.NewGuid(), "2d6", null, Guid.NewGuid());
 
         // Act & Assert
         await Assert.ThrowsAsync<NotFoundException>(
@@ -45,13 +45,14 @@ public class RollDiceCommandHandlerTests
     public async Task Handle_FinalizedSession_ThrowsConflictException()
     {
         // Arrange
-        var session = Session.Create(Guid.NewGuid(), Guid.NewGuid(), SessionType.Generic);
+        var userId = Guid.NewGuid();
+        var session = Session.Create(userId, Guid.NewGuid(), SessionType.Generic);
         session.Finalize();
 
         _sessionRepoMock.Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(session);
 
-        var command = new RollDiceCommand(session.Id, session.Participants.First().Id, "1d20");
+        var command = new RollDiceCommand(session.Id, session.Participants.First().Id, "1d20", null, userId);
 
         // Act & Assert
         await Assert.ThrowsAsync<ConflictException>(
@@ -62,11 +63,12 @@ public class RollDiceCommandHandlerTests
     public async Task Handle_ParticipantNotInSession_ThrowsNotFoundException()
     {
         // Arrange
-        var session = Session.Create(Guid.NewGuid(), Guid.NewGuid(), SessionType.Generic);
+        var userId = Guid.NewGuid();
+        var session = Session.Create(userId, Guid.NewGuid(), SessionType.Generic);
         _sessionRepoMock.Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(session);
 
-        var command = new RollDiceCommand(session.Id, Guid.NewGuid(), "1d6");
+        var command = new RollDiceCommand(session.Id, Guid.NewGuid(), "1d6", null, userId);
 
         // Act & Assert
         await Assert.ThrowsAsync<NotFoundException>(
@@ -84,7 +86,7 @@ public class RollDiceCommandHandlerTests
         _sessionRepoMock.Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(session);
 
-        var command = new RollDiceCommand(session.Id, participantId, "2d6", "Attack roll");
+        var command = new RollDiceCommand(session.Id, participantId, "2d6", "Attack roll", userId);
 
         // Act
         var result = await _handler.Handle(command, CancellationToken.None);
@@ -95,5 +97,25 @@ public class RollDiceCommandHandlerTests
         Assert.Equal(2, result.Rolls.Length);
         _diceRollRepoMock.Verify(r => r.AddAsync(It.IsAny<DiceRoll>(), It.IsAny<CancellationToken>()), Times.Once);
         _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_CallerNotOwnerOrParticipant_ThrowsForbiddenException()
+    {
+        // Arrange — session owned by someone else; caller is neither owner nor participant (IDOR).
+        var ownerId = Guid.NewGuid();
+        var attackerId = Guid.NewGuid();
+        var session = Session.Create(ownerId, Guid.NewGuid(), SessionType.Generic);
+
+        _sessionRepoMock.Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var command = new RollDiceCommand(
+            session.Id, session.Participants.First().Id, "1d6", null, attackerId);
+
+        // Act & Assert — IDOR guard rejects before any dice roll is persisted.
+        await Assert.ThrowsAsync<ForbiddenException>(
+            () => _handler.Handle(command, CancellationToken.None));
+        _diceRollRepoMock.Verify(r => r.AddAsync(It.IsAny<DiceRoll>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/UpdateScoreCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/UpdateScoreCommandHandlerTests.cs
@@ -34,7 +34,7 @@ public class UpdateScoreCommandHandlerTests
         _sessionRepoMock.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((Session?)null);
 
-        var command = new UpdateScoreCommand(Guid.NewGuid(), Guid.NewGuid(), 1, null, 10m);
+        var command = new UpdateScoreCommand(Guid.NewGuid(), Guid.NewGuid(), 1, null, 10m, Guid.NewGuid());
 
         // Act & Assert
         await Assert.ThrowsAsync<NotFoundException>(
@@ -45,13 +45,14 @@ public class UpdateScoreCommandHandlerTests
     public async Task Handle_FinalizedSession_ThrowsConflictException()
     {
         // Arrange
-        var session = Session.Create(Guid.NewGuid(), Guid.NewGuid(), SessionType.Generic);
+        var userId = Guid.NewGuid();
+        var session = Session.Create(userId, Guid.NewGuid(), SessionType.Generic);
         session.Finalize();
 
         _sessionRepoMock.Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(session);
 
-        var command = new UpdateScoreCommand(session.Id, session.Participants.First().Id, 1, null, 10m);
+        var command = new UpdateScoreCommand(session.Id, session.Participants.First().Id, 1, null, 10m, userId);
 
         // Act & Assert
         await Assert.ThrowsAsync<ConflictException>(
@@ -62,14 +63,35 @@ public class UpdateScoreCommandHandlerTests
     public async Task Handle_ParticipantNotInSession_ThrowsNotFoundException()
     {
         // Arrange
-        var session = Session.Create(Guid.NewGuid(), Guid.NewGuid(), SessionType.Generic);
+        var userId = Guid.NewGuid();
+        var session = Session.Create(userId, Guid.NewGuid(), SessionType.Generic);
         _sessionRepoMock.Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(session);
 
-        var command = new UpdateScoreCommand(session.Id, Guid.NewGuid(), 1, null, 10m);
+        var command = new UpdateScoreCommand(session.Id, Guid.NewGuid(), 1, null, 10m, userId);
 
         // Act & Assert
         await Assert.ThrowsAsync<NotFoundException>(
             () => _handler.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_CallerNotOwnerOrParticipant_ThrowsForbiddenException()
+    {
+        // Arrange — session owned by someone else; caller is neither owner nor participant (IDOR).
+        var ownerId = Guid.NewGuid();
+        var attackerId = Guid.NewGuid();
+        var session = Session.Create(ownerId, Guid.NewGuid(), SessionType.Generic);
+
+        _sessionRepoMock.Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var command = new UpdateScoreCommand(
+            session.Id, session.Participants.First().Id, 1, null, 10m, attackerId);
+
+        // Act & Assert — IDOR guard rejects before any score is persisted.
+        await Assert.ThrowsAsync<ForbiddenException>(
+            () => _handler.Handle(command, CancellationToken.None));
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Validators/FinalizeSessionCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Validators/FinalizeSessionCommandValidatorTests.cs
@@ -24,7 +24,8 @@ public class FinalizeSessionCommandValidatorTests
 
         var command = new FinalizeSessionCommand(
             SessionId: Guid.NewGuid(),
-            FinalRanks: ranks
+            FinalRanks: ranks,
+            RequestedBy: Guid.NewGuid()
         );
 
         // Act
@@ -47,7 +48,8 @@ public class FinalizeSessionCommandValidatorTests
 
         var command = new FinalizeSessionCommand(
             SessionId: Guid.NewGuid(),
-            FinalRanks: ranks
+            FinalRanks: ranks,
+            RequestedBy: Guid.NewGuid()
         );
 
         // Act
@@ -71,7 +73,8 @@ public class FinalizeSessionCommandValidatorTests
 
         var command = new FinalizeSessionCommand(
             SessionId: Guid.NewGuid(),
-            FinalRanks: ranks
+            FinalRanks: ranks,
+            RequestedBy: Guid.NewGuid()
         );
 
         // Act
@@ -88,7 +91,8 @@ public class FinalizeSessionCommandValidatorTests
         // Arrange
         var command = new FinalizeSessionCommand(
             SessionId: Guid.NewGuid(),
-            FinalRanks: new Dictionary<Guid, int>()
+            FinalRanks: new Dictionary<Guid, int>(),
+            RequestedBy: Guid.NewGuid()
         );
 
         // Act

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Validators/UpdateScoreCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Validators/UpdateScoreCommandValidatorTests.cs
@@ -20,7 +20,8 @@ public class UpdateScoreCommandValidatorTests
             ParticipantId: Guid.NewGuid(),
             RoundNumber: 1,
             Category: "Main",
-            ScoreValue: 50
+            ScoreValue: 50,
+            RequestedBy: Guid.NewGuid()
         );
 
         // Act
@@ -39,7 +40,8 @@ public class UpdateScoreCommandValidatorTests
             ParticipantId: Guid.NewGuid(),
             RoundNumber: null,
             Category: null,
-            ScoreValue: 50
+            ScoreValue: 50,
+            RequestedBy: Guid.NewGuid()
         );
 
         // Act
@@ -59,7 +61,8 @@ public class UpdateScoreCommandValidatorTests
             ParticipantId: Guid.NewGuid(),
             RoundNumber: null,
             Category: null,
-            ScoreValue: 100000 // exceeds max
+            ScoreValue: 100000, // exceeds max
+            RequestedBy: Guid.NewGuid()
         );
 
         // Act
@@ -79,7 +82,8 @@ public class UpdateScoreCommandValidatorTests
             ParticipantId: Guid.NewGuid(),
             RoundNumber: 0, // invalid
             Category: null,
-            ScoreValue: 50
+            ScoreValue: 50,
+            RequestedBy: Guid.NewGuid()
         );
 
         // Act
@@ -99,7 +103,8 @@ public class UpdateScoreCommandValidatorTests
             ParticipantId: Guid.NewGuid(),
             RoundNumber: null,
             Category: new string('A', 51), // exceeds 50 chars
-            ScoreValue: 50
+            ScoreValue: 50,
+            RequestedBy: Guid.NewGuid()
         );
 
         // Act

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Endpoints/SessionCommandEndpointsIdorIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Endpoints/SessionCommandEndpointsIdorIntegrationTests.cs
@@ -1,0 +1,310 @@
+using System.Net;
+using System.Net.Http.Json;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SessionTracking;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Endpoints;
+
+/// <summary>
+/// HTTP-layer IDOR tests for the SessionTracking write-command endpoints
+/// (<c>SessionCommandEndpoints</c>): finalize, roll dice, add note, add participant,
+/// and the legacy per-participant score update.
+///
+/// <para>Threat model: a <c>sessionId</c> is discoverable via unauthenticated read paths
+/// (<c>GET /game-sessions/code/{code}</c>, <c>/scoreboard</c>). Before this fix any
+/// authenticated user could finalize (destroying the victim's live session and triggering
+/// the KB cleanup + game-night link close cascade), inject scores/notes/participants, or
+/// roll dice on a session they neither own nor participate in.</para>
+///
+/// <para>The endpoints MUST derive the acting identity from the authenticated principal and
+/// the handlers MUST reject a caller who is neither the session owner nor a registered
+/// (User-linked) participant with HTTP 403. This mirrors the existing IDOR guard on
+/// <c>UpdateSessionScoresCommandHandler</c> (PUT /scores-polymorphic).</para>
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "SessionTracking")]
+[Trait("Concern", "Security")]
+public sealed class SessionCommandEndpointsIdorIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _ownerClient = null!;
+    private HttpClient _attackerClient = null!;
+    private HttpClient _memberClient = null!;
+    private string _ownerToken = null!;
+    private string _attackerToken = null!;
+    private string _memberToken = null!;
+    private Guid _ownerId;
+    private Guid _memberId;
+    private Guid _sessionId;
+    private Guid _ownerParticipantId;
+    private Guid _memberParticipantId;
+
+    public SessionCommandEndpointsIdorIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"sessioncmd_idor_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        await db.Database.MigrateAsync();
+
+        (_ownerId, _ownerToken) = await TestSessionHelper.CreateUserSessionAsync(db);
+        (_, _attackerToken) = await TestSessionHelper.CreateUserSessionAsync(db);
+        (_memberId, _memberToken) = await TestSessionHelper.CreateUserSessionAsync(db);
+
+        var gameId = await TestSessionHelper.SeedSharedGameAsync(db, "IDOR Command Game");
+
+        // Seed an Active SessionTracking session owned by the owner, with the owner AND a
+        // second User-linked member as participants. The member exercises the "participant"
+        // authorization clause; the attacker is neither owner nor participant.
+        _sessionId = Guid.NewGuid();
+        _ownerParticipantId = Guid.NewGuid();
+        _memberParticipantId = Guid.NewGuid();
+
+        db.SessionTrackingSessions.Add(new SessionEntity
+        {
+            Id = _sessionId,
+            UserId = _ownerId,
+            GameId = gameId,
+            Status = "Active",
+            SessionCode = Guid.NewGuid().ToString("N")[..6].ToUpperInvariant(),
+            SessionType = "Generic",
+            SessionDate = DateTime.UtcNow.AddMinutes(-30),
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = _ownerId,
+            Participants = new List<ParticipantEntity>
+            {
+                new()
+                {
+                    Id = _ownerParticipantId,
+                    SessionId = _sessionId,
+                    UserId = _ownerId,
+                    DisplayName = "Owner",
+                    IsOwner = true,
+                    JoinOrder = 1,
+                    CreatedAt = DateTime.UtcNow,
+                },
+                new()
+                {
+                    Id = _memberParticipantId,
+                    SessionId = _sessionId,
+                    UserId = _memberId,
+                    DisplayName = "Member",
+                    IsOwner = false,
+                    JoinOrder = 2,
+                    CreatedAt = DateTime.UtcNow,
+                },
+            },
+        });
+        await db.SaveChangesAsync();
+
+        _ownerClient = _factory.CreateClient();
+        _attackerClient = _factory.CreateClient();
+        _memberClient = _factory.CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _ownerClient?.Dispose();
+        _attackerClient?.Dispose();
+        _memberClient?.Dispose();
+        _factory?.Dispose();
+        await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    private string BaseUrl => $"/api/v1/game-sessions/{_sessionId}";
+
+    private object FinalizeBody => new
+    {
+        sessionId = _sessionId,
+        finalRanks = new Dictionary<Guid, int>
+        {
+            [_ownerParticipantId] = 1,
+            [_memberParticipantId] = 2,
+        },
+    };
+
+    private object DiceBody(Guid participantId) => new
+    {
+        sessionId = _sessionId,
+        participantId,
+        formula = "1d6",
+        label = (string?)null,
+    };
+
+    private object NoteBody(Guid participantId) => new
+    {
+        sessionId = _sessionId,
+        participantId,
+        noteType = "Shared",
+        templateKey = (string?)null,
+        content = "note content",
+        isHidden = false,
+    };
+
+    private object AddParticipantBody => new
+    {
+        sessionId = _sessionId,
+        displayName = "Injected Player",
+        userId = (Guid?)null,
+    };
+
+    private object ScoreBody(Guid participantId) => new
+    {
+        sessionId = _sessionId,
+        participantId,
+        roundNumber = 1,
+        category = (string?)null,
+        scoreValue = 10m,
+    };
+
+    // ── Finalize ──────────────────────────────────────────────────────────────
+
+    [Fact(Timeout = 90_000)]
+    public async Task Finalize_AsAttacker_IsForbidden()
+    {
+        var response = await _attackerClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(
+                HttpMethod.Post, $"{BaseUrl}/finalize", _attackerToken, FinalizeBody));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "a non-owner/non-participant must not finalize (destroy) another user's session");
+    }
+
+    [Fact(Timeout = 90_000)]
+    public async Task Finalize_AsOwner_Succeeds()
+    {
+        var response = await _ownerClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(
+                HttpMethod.Post, $"{BaseUrl}/finalize", _ownerToken, FinalizeBody));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK,
+            "the session owner must be allowed to finalize");
+    }
+
+    // ── Roll dice ─────────────────────────────────────────────────────────────
+
+    [Fact(Timeout = 90_000)]
+    public async Task RollDice_AsAttacker_IsForbidden()
+    {
+        var response = await _attackerClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(
+                HttpMethod.Post, $"{BaseUrl}/dice", _attackerToken, DiceBody(_ownerParticipantId)));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "a non-owner/non-participant must not roll dice in another user's session");
+    }
+
+    [Fact(Timeout = 90_000)]
+    public async Task RollDice_AsOwner_Succeeds()
+    {
+        var response = await _ownerClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(
+                HttpMethod.Post, $"{BaseUrl}/dice", _ownerToken, DiceBody(_ownerParticipantId)));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created,
+            "the session owner must be allowed to roll dice");
+    }
+
+    // ── Add note ──────────────────────────────────────────────────────────────
+
+    [Fact(Timeout = 90_000)]
+    public async Task AddNote_AsAttacker_IsForbidden()
+    {
+        var response = await _attackerClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(
+                HttpMethod.Post, $"{BaseUrl}/notes", _attackerToken, NoteBody(_ownerParticipantId)));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "a non-owner/non-participant must not add notes to another user's session");
+    }
+
+    [Fact(Timeout = 90_000)]
+    public async Task AddNote_AsOwner_Succeeds()
+    {
+        var response = await _ownerClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(
+                HttpMethod.Post, $"{BaseUrl}/notes", _ownerToken, NoteBody(_ownerParticipantId)));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created,
+            "the session owner must be allowed to add notes");
+    }
+
+    [Fact(Timeout = 90_000)]
+    public async Task AddNote_AsMemberParticipant_Succeeds()
+    {
+        // Exercises the "registered participant" authorization clause: the member is not the
+        // owner but is a User-linked participant, so they must be allowed to act.
+        var response = await _memberClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(
+                HttpMethod.Post, $"{BaseUrl}/notes", _memberToken, NoteBody(_memberParticipantId)));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created,
+            "a registered (User-linked) participant must be allowed to add notes");
+    }
+
+    // ── Add participant ───────────────────────────────────────────────────────
+
+    [Fact(Timeout = 90_000)]
+    public async Task AddParticipant_AsAttacker_IsForbidden()
+    {
+        var response = await _attackerClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(
+                HttpMethod.Post, $"{BaseUrl}/participants", _attackerToken, AddParticipantBody));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "a non-owner/non-participant must not add participants to another user's session");
+    }
+
+    [Fact(Timeout = 90_000)]
+    public async Task AddParticipant_AsOwner_Succeeds()
+    {
+        var response = await _ownerClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(
+                HttpMethod.Post, $"{BaseUrl}/participants", _ownerToken, AddParticipantBody));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created,
+            "the session owner must be allowed to add participants");
+    }
+
+    // ── Legacy update score ───────────────────────────────────────────────────
+
+    [Fact(Timeout = 90_000)]
+    public async Task UpdateScore_AsAttacker_IsForbidden()
+    {
+        var response = await _attackerClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(
+                HttpMethod.Put, $"{BaseUrl}/scores", _attackerToken, ScoreBody(_ownerParticipantId)));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "a non-owner/non-participant must not inject scores into another user's session");
+    }
+
+    [Fact(Timeout = 90_000)]
+    public async Task UpdateScore_AsOwner_Succeeds()
+    {
+        var response = await _ownerClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(
+                HttpMethod.Put, $"{BaseUrl}/scores", _ownerToken, ScoreBody(_ownerParticipantId)));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK,
+            "the session owner must be allowed to update scores");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Integration/FinalizeSessionSingleDispatchIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Integration/FinalizeSessionSingleDispatchIntegrationTests.cs
@@ -130,7 +130,7 @@ public sealed class FinalizeSessionSingleDispatchIntegrationTests : IAsyncLifeti
         var finalRanks = new Dictionary<Guid, int> { [participantId] = 1 };
 
         // Act
-        var result = await mediator.Send(new FinalizeSessionCommand(sessionId, finalRanks), TestCancellationToken);
+        var result = await mediator.Send(new FinalizeSessionCommand(sessionId, finalRanks, userId), TestCancellationToken);
 
         // Assert — single dispatch
         result.Should().NotBeNull();
@@ -160,7 +160,7 @@ public sealed class FinalizeSessionSingleDispatchIntegrationTests : IAsyncLifeti
         var finalRanks = new Dictionary<Guid, int> { [participantId] = 1 };
 
         // Act
-        await mediator.Send(new FinalizeSessionCommand(sessionId, finalRanks), TestCancellationToken);
+        await mediator.Send(new FinalizeSessionCommand(sessionId, finalRanks, userId), TestCancellationToken);
 
         // Assert — full payload
         captured.Should().NotBeNull("spy handler must have been called");


### PR DESCRIPTION
## Summary

Fixes a **HIGH-severity IDOR** on the five SessionTracking write-command endpoints in `apps/api/src/Api/Routing/SessionTracking/SessionCommandEndpoints.cs`:

- `POST /game-sessions/{id}/finalize`
- `POST /game-sessions/{id}/dice`
- `POST /game-sessions/{id}/notes`
- `POST /game-sessions/{id}/participants`
- `PUT  /game-sessions/{id}/scores` (legacy)

None verified that the caller owned or participated in the session. A `sessionId` is discoverable via the unauthenticated read paths (`GET /game-sessions/code/{code}`, `/scoreboard`), so any authenticated user could **finalize a victim's live session** (which destroys it and triggers the KB-cleanup + game-night link-close cascade), inject scores/notes/participants, or roll dice on a session they neither own nor participate in.

## Fix

Mirrors the existing IDOR guard on `UpdateSessionScoresCommandHandler` (`PUT /scores-polymorphic`):

1. **Commands** — added a required `Guid RequestedBy` to the 5 commands (`FinalizeSessionCommand`, `RollDiceCommand`, `AddNoteCommand`, `AddParticipantCommand`, `UpdateScoreCommand`).
2. **Endpoints** — each derives the caller from the authenticated principal (`httpContext.User.GetUserId()`), returns `401` on `Guid.Empty`, then sends `command with { RequestedBy = userId }` so a body-supplied value **cannot forge the identity**; each now declares `.Produces(403)`.
3. **Handlers** — each, immediately after loading the session (before any status check or state mutation), throws `ForbiddenException` (403) when `session.UserId != RequestedBy && !session.Participants.Any(p => p.UserId == RequestedBy)`.
4. **Internal orchestrator** — `CompleteGameNightSessionCommandHandler` passes `session.UserId` as `RequestedBy` (organizer authority is already enforced there), so game-night completion is never spuriously blocked.

## Test plan

- **New HTTP IDOR integration suite** `SessionCommandEndpointsIdorIntegrationTests` — attacker → `403`, owner → success, registered (User-linked) participant → success, across all 5 endpoints.
- **Handler-level `Forbidden` unit tests** added to the 5 handler test classes (fail-closed, assert no persistence side-effect).
- Verified **RED** (attacker got `2xx` before the fix) → **GREEN** after.
- `dotnet test --filter Category=Unit` → **20762 passed, 0 failed**.
- The one locally-failing integration test (`Resume_Paused_ReactivatesAndAutoPausesOthersInNight`) fails **identically on clean `main-dev`** (pre-existing `NpgsqlRetryingExecutionStrategy` local issue, unrelated to this change; untouched handler).

## Out of scope (follow-up)

An adversarial review confirmed the **same IDOR class** on other SessionTracking write endpoints, left for a separate PR (per scope discipline):

- `SessionToolsEndpoints` — random tools (timer start/pause/resume/reset mutate shared state + broadcast SSE; coin/wheel are effectively harmless).
- `SessionCardDeckEndpoints` — create/shuffle/draw/discard.
- `SessionPlayerActionsEndpoints` — `UploadSessionMedia` + `SendSessionChatMessage` (the other player-action endpoints in that file already derive identity from the principal).

`SessionNotesEndpoints` (private notes) is already identity-scoped from the principal (#3263) and is **not** a gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
