### PR TITLE
fix(gamenight): reconcile children in UpdateAsync (fix child-loss)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/GameNightEventRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/GameNightEventRepository.cs
@@ -1,3 +1,4 @@
+using System.Linq.Expressions;
 using System.Text.Json;
 using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
 using Api.BoundedContexts.GameManagement.Domain.Enums;
@@ -156,14 +157,152 @@ internal class GameNightEventRepository : RepositoryBase, IGameNightEventReposit
         await DbContext.GameNightEvents.AddAsync(entity, cancellationToken).ConfigureAwait(false);
     }
 
-    public Task UpdateAsync(GameNightEvent gameNight, CancellationToken cancellationToken = default)
+    /// <summary>
+    /// Persists mutations to an existing aggregate by RECONCILING its child collections
+    /// (<see cref="GameNightRsvpEntity"/>, <see cref="GameNightSessionEntity"/>) rather than
+    /// re-attaching the whole graph with <c>DbSet.Update()</c>. Votes are handled by dedicated
+    /// methods and are intentionally left untouched here (see the body for the xmin rationale).
+    ///
+    /// <para>The old detached full-graph <c>.Update()</c> marked every child with a set key as
+    /// <c>Modified</c>. A child added since the load (its Id is a fresh <c>Guid.NewGuid()</c>) then
+    /// became an <c>UPDATE</c> against a nonexistent row → 0 rows affected →
+    /// <see cref="DbUpdateConcurrencyException"/> and a silent rollback (invitees lost;
+    /// start-session mis-mapped to a false <c>MAX_LIVE_SESSIONS_EXCEEDED</c> 409). It also collided
+    /// with the already-tracked instance on the <c>FindByLinkedSessionIdAsync</c> path (EF identity
+    /// conflict) — the same failure the reminder job had to work around (#2720).</para>
+    ///
+    /// <para>This mirrors <see cref="LiveSessionRepository"/>: the root is attached as
+    /// <c>Modified</c> (detached load) or updated in place via <c>SetValues</c> (tracked load) so the
+    /// round-tripped <c>xmin</c> concurrency token still drives the <c>WHERE</c> clause (Issue
+    /// #2703); each child is then Added / Modified / Deleted against its DB-resident rows.</para>
+    /// </summary>
+    public async Task UpdateAsync(GameNightEvent gameNight, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(gameNight);
         CollectDomainEvents(gameNight);
 
-        var entity = MapToPersistence(gameNight);
-        DbContext.GameNightEvents.Update(entity);
-        return Task.CompletedTask;
+        var snapshot = MapToPersistence(gameNight);
+
+        // Capture child rows before the root snapshot is (possibly) stripped of its collections.
+        // NB: Votes are intentionally NOT reconciled here — see the ReconcileChildrenAsync calls below.
+        var snapshotRsvps = snapshot.Rsvps.ToList();
+        var snapshotSessions = snapshot.Sessions.ToList();
+
+        // ── Root: reconcile against the change tracker so we never attach a second instance ──
+        var trackedRoot = DbContext.ChangeTracker.Entries<GameNightEventEntity>()
+            .FirstOrDefault(e => e.Entity.Id == gameNight.Id)?.Entity;
+
+        if (trackedRoot == null)
+        {
+            // Detached load (GetByIdAsync / GetByLinkedSessionIdAsync — 13 of 14 callers): attach the
+            // root scalar-only as Modified. EF emits UPDATE ... WHERE id = @id AND xmin = @original
+            // because the snapshot carries the round-tripped xmin token.
+            snapshot.Rsvps.Clear();
+            snapshot.Sessions.Clear();
+            snapshot.Votes.Clear();
+            DbContext.Entry(snapshot).State = EntityState.Modified;
+        }
+        else
+        {
+            // Tracked load (SessionStartedHandler via FindByLinkedSessionIdAsync): copy scalars onto
+            // the already-tracked root so EF keeps its loaded OriginalValues (xmin) for the WHERE.
+            DbContext.Entry(trackedRoot).CurrentValues.SetValues(snapshot);
+        }
+
+        // ── Child collections: Added (new) / Modified (existing) / Deleted (removed) ──
+        // Mind the FK asymmetry: Rsvp keys back via EventId, Session via GameNightEventId.
+        // RSVPs and Sessions mutate ONLY through this aggregate + UpdateAsync, and the forced-Modified
+        // root above always advances xmin, so a concurrent aggregate write loses the xmin race and
+        // rolls back before it can wrongly delete a sibling's row — the Delete branch is safe for them.
+        // (No domain method removes an RSVP/Session today, so the Delete branch is defensive/unexercised
+        // — kept to mirror LiveSessionRepository and to stay correct if such a mutation is added later.)
+        await ReconcileChildrenAsync(
+            snapshotRsvps, r => r.Id, r => r.EventId == gameNight.Id,
+            id => new GameNightRsvpEntity { Id = id, EventId = gameNight.Id },
+            cancellationToken).ConfigureAwait(false);
+
+        await ReconcileChildrenAsync(
+            snapshotSessions, s => s.Id, s => s.GameNightEventId == gameNight.Id,
+            id => new GameNightSessionEntity { Id = id, GameNightEventId = gameNight.Id },
+            cancellationToken).ConfigureAwait(false);
+
+        // Votes are deliberately excluded: they are persisted by the dedicated AddVoteAsync /
+        // RemoveVoteAsync / SetVotingWinnerAsync paths, which touch a single vote row WITHOUT
+        // advancing the root xmin. A concurrently-cast vote is therefore invisible to a stale-snapshot
+        // UpdateAsync; reconciling votes here (with a Delete branch) would silently drop it. UpdateAsync
+        // leaves vote rows untouched — the vote lifecycle lives entirely on those dedicated methods.
+    }
+
+    /// <summary>
+    /// Reconciles one child collection of the aggregate against its DB-resident rows: children new
+    /// since the load are <c>Added</c>, existing ones <c>Modified</c>, and rows no longer present are
+    /// <c>Deleted</c>. This is what keeps a NEW child (Id already assigned via <c>Guid.NewGuid()</c>
+    /// in the domain) from being wrongly marked <c>Modified</c> — an UPDATE against a nonexistent row.
+    /// </summary>
+    private async Task ReconcileChildrenAsync<TChild>(
+        IReadOnlyList<TChild> snapshotChildren,
+        Expression<Func<TChild, Guid>> idSelector,
+        Expression<Func<TChild, bool>> foreignKeyFilter,
+        Func<Guid, TChild> deletedStubFactory,
+        CancellationToken cancellationToken)
+        where TChild : class
+    {
+        var idOf = idSelector.Compile();
+
+        var existingIds = (await DbContext.Set<TChild>()
+            .AsNoTracking()
+            .Where(foreignKeyFilter)
+            .Select(idSelector)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false))
+            .ToHashSet();
+
+        foreach (var child in snapshotChildren)
+        {
+            var id = idOf(child);
+            AttachOrUpdate(child, id, existingIds.Contains(id)
+                ? EntityState.Modified
+                : EntityState.Added);
+        }
+
+        // Delete rows the domain dropped.
+        var snapshotIds = snapshotChildren.Select(idOf).ToHashSet();
+        foreach (var removedId in existingIds.Where(id => !snapshotIds.Contains(id)))
+        {
+            AttachOrUpdate(deletedStubFactory(removedId), removedId, EntityState.Deleted);
+        }
+    }
+
+    /// <summary>
+    /// Attaches <paramref name="snapshotEntity"/> with the given <paramref name="targetState"/>,
+    /// correctly handling the case where an entity with the same key is already tracked (e.g. a child
+    /// loaded via <c>Include</c> on the tracked-root path): it updates that entry in place instead of
+    /// attaching a duplicate, which would throw an EF identity conflict. Mirrors
+    /// <see cref="LiveSessionRepository"/>.AttachOrUpdate.
+    /// </summary>
+    private void AttachOrUpdate<TChild>(TChild snapshotEntity, Guid id, EntityState targetState)
+        where TChild : class
+    {
+        var existingEntry = DbContext.ChangeTracker.Entries<TChild>()
+            .FirstOrDefault(e => e.Property("Id").CurrentValue is Guid g && g == id);
+
+        if (existingEntry != null)
+        {
+            if (targetState == EntityState.Modified)
+            {
+                existingEntry.CurrentValues.SetValues(snapshotEntity);
+                existingEntry.State = EntityState.Modified;
+            }
+            else if (targetState == EntityState.Deleted)
+            {
+                existingEntry.State = EntityState.Deleted;
+            }
+            // Added is a no-op when the entity is already tracked.
+        }
+        else
+        {
+            DbContext.Entry(snapshotEntity).State = targetState;
+        }
     }
 
     public Task DeleteAsync(GameNightEvent gameNight, CancellationToken cancellationToken = default)
@@ -203,9 +342,10 @@ internal class GameNightEventRepository : RepositoryBase, IGameNightEventReposit
         Guid sessionId, CancellationToken cancellationToken = default)
     {
         // AsNoTracking — the go-live orchestrator (GoLiveSessionCommandHandler) mutates the
-        // returned aggregate and persists via the detached UpdateAsync full-remap + .Update()
-        // pattern (mirrors GetByIdAsync feeding StartGameNightSessionCommandHandler). Loading it
-        // tracked (as FindByLinkedSessionIdAsync does) would collide with that fresh-entity Update.
+        // returned aggregate and persists it through the detached branch of UpdateAsync's child
+        // reconciliation (mirrors GetByIdAsync feeding StartGameNightSessionCommandHandler). The
+        // tracked branch (used by FindByLinkedSessionIdAsync) is equally supported now; this loader
+        // simply stays detached so its callers keep the cheaper AsNoTracking read.
         var entity = await DbContext.GameNightEvents
             .AsNoTracking()
             .Include(e => e.Rsvps)

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/GameNightEventChildReconciliationIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/GameNightEventChildReconciliationIntegrationTests.cs
@@ -1,0 +1,310 @@
+using Api.BoundedContexts.GameManagement.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.GameManagement;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Integration.GameManagement;
+
+/// <summary>
+/// Integration tests proving that <see cref="GameNightEventRepository.UpdateAsync"/> reconciles the
+/// aggregate's child collections (<c>game_night_rsvps</c>, <c>game_night_sessions</c>) instead of
+/// re-mapping the whole graph and calling a detached <c>DbSet.Update()</c>.
+///
+/// <para><b>The bug (P2 — GameNight UpdateAsync child-loss):</b> the previous <c>UpdateAsync</c> did
+/// <c>MapToPersistence(gameNight)</c> (a brand-new graph where every child already carries a
+/// <c>Guid.NewGuid()</c> Id) followed by <c>DbContext.GameNightEvents.Update(entity)</c>. On a
+/// disconnected graph EF marks every child with a set key as <c>Modified</c>, so a NEW child
+/// (invitee / session added since the load) becomes an <c>UPDATE</c> against a row that does not
+/// exist → 0 rows affected → <see cref="DbUpdateConcurrencyException"/> and a full rollback. The
+/// in-memory provider used by the unit tests upserts silently and never reproduces this — only a
+/// real relational provider (Postgres) does.</para>
+///
+/// <para>Two production symptoms this reproduces:
+/// <list type="bullet">
+///   <item><c>InviteToGameNightCommandHandler</c> — the added invitees are silently rolled back.</item>
+///   <item><c>StartGameNightSessionCommandHandler</c> — the aggregate save ALWAYS throws
+///         <see cref="DbUpdateConcurrencyException"/>, which the handler mis-maps to
+///         <c>MaxLiveSessionsExceededException</c> (a false 409 "max live sessions") so the session
+///         is never linked to the night.</item>
+/// </list></para>
+///
+/// <para>These tests fail on origin/main-dev (child rows lost / concurrency exception / EF identity
+/// conflict on the tracked-root path) and pass once <c>UpdateAsync</c> reconciles child state
+/// (Added / Modified / Deleted) the way <see cref="LiveSessionRepository"/> already does.</para>
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "gamenight-update-child-loss")]
+public sealed class GameNightEventChildReconciliationIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = null!;
+    private string _connectionString = null!;
+    private MeepleAiDbContext _dbContext = null!;
+
+    public GameNightEventChildReconciliationIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"gamenight_childrecon_{Guid.NewGuid():N}";
+        _connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        _dbContext = _fixture.CreateDbContext(_connectionString);
+        await _dbContext.Database.MigrateAsync(TestCancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _dbContext.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    private GameNightEventRepository CreateRepository(MeepleAiDbContext dbContext) =>
+        new(dbContext, Mock.Of<IDomainEventCollector>(), Mock.Of<ILogger<GameNightEventRepository>>());
+
+    /// <summary>Seeds a persisted Published night with no children and returns its id.</summary>
+    private async Task<Guid> SeedPublishedEventAsync()
+    {
+        var eventId = Guid.NewGuid();
+        _dbContext.GameNightEvents.Add(new GameNightEventEntity
+        {
+            Id = eventId,
+            OrganizerId = Guid.NewGuid(),
+            Title = "Boardgame Night",
+            ScheduledAt = DateTimeOffset.UtcNow.AddDays(3),
+            GameIdsJson = "[]",
+            Status = "Published",
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        });
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+        return eventId;
+    }
+
+    /// <summary>
+    /// Seeds a persisted Published night that already has one Pending session linked to
+    /// <paramref name="sessionId"/> (so <c>FindByLinkedSessionIdAsync</c> can load it TRACKED).
+    /// </summary>
+    private async Task<Guid> SeedPublishedEventWithSessionAsync(Guid sessionId)
+    {
+        var eventId = Guid.NewGuid();
+        _dbContext.GameNightEvents.Add(new GameNightEventEntity
+        {
+            Id = eventId,
+            OrganizerId = Guid.NewGuid(),
+            Title = "Boardgame Night",
+            ScheduledAt = DateTimeOffset.UtcNow.AddDays(3),
+            GameIdsJson = "[]",
+            Status = "Published",
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Sessions =
+            {
+                new GameNightSessionEntity
+                {
+                    Id = Guid.NewGuid(),
+                    GameNightEventId = eventId,
+                    SessionId = sessionId,
+                    GameId = Guid.NewGuid(),
+                    GameTitle = "Catan",
+                    PlayOrder = 1,
+                    Status = "Pending"
+                }
+            }
+        });
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+        return eventId;
+    }
+
+    /// <summary>
+    /// Detached-root path (the 13 <c>GetByIdAsync</c> callers). Reload a persisted night, add a NEW
+    /// invitee AND a NEW session, then <c>UpdateAsync</c> + <c>SaveChanges</c>. Both new child rows
+    /// must exist afterwards. Before the fix, the detached <c>.Update()</c> marks the new children
+    /// <c>Modified</c> → the <c>SaveChanges</c> throws <see cref="DbUpdateConcurrencyException"/> and
+    /// nothing is persisted.
+    /// </summary>
+    [Fact(DisplayName = "UpdateAsync persists a new invitee AND a new session added after a detached reload")]
+    public async Task UpdateAsync_DetachedRoot_AddInviteeAndSession_PersistsNewChildRows()
+    {
+        // ── Arrange ─────────────────────────────────────────────────────────────
+        var eventId = await SeedPublishedEventAsync();
+        var inviteeId = Guid.NewGuid();
+        var trackingSessionId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+
+        await using var dbWrite = _fixture.CreateDbContext(_connectionString);
+        var repo = CreateRepository(dbWrite);
+
+        var night = await repo.GetByIdAsync(eventId, TestCancellationToken);
+        night.Should().NotBeNull();
+
+        // ── Act: add a brand-new invitee and a brand-new session, then persist ──
+        night!.AddInvitees(new List<Guid> { inviteeId });
+        night.AddSession(trackingSessionId, gameId, "Wingspan");
+
+        await repo.UpdateAsync(night, TestCancellationToken);
+        // Pre-fix: the detached graph marks both new children Modified → this throws
+        // DbUpdateConcurrencyException (UPDATE affected 0 rows) and rolls the whole write back.
+        await dbWrite.SaveChangesAsync(TestCancellationToken);
+
+        // ── Assert: reload from a fresh context; both new child rows survive ──
+        await using var dbVerify = _fixture.CreateDbContext(_connectionString);
+
+        var rsvpRows = await dbVerify.GameNightRsvps
+            .AsNoTracking()
+            .CountAsync(r => r.EventId == eventId && r.UserId == inviteeId, TestCancellationToken);
+        rsvpRows.Should().Be(1, "the invitee added after reload must be inserted, not lost");
+
+        var sessionRows = await dbVerify.GameNightSessions
+            .AsNoTracking()
+            .CountAsync(s => s.GameNightEventId == eventId && s.SessionId == trackingSessionId, TestCancellationToken);
+        sessionRows.Should().Be(1, "the session added after reload must be inserted, not lost");
+    }
+
+    /// <summary>
+    /// Reproduces the <c>StartGameNightSessionCommandHandler</c> false-409: the handler adds a
+    /// session and starts it (Pending → InProgress) then persists via <c>UpdateAsync</c>. Before the
+    /// fix, that save ALWAYS throws <see cref="DbUpdateConcurrencyException"/> (the new session row is
+    /// marked Modified), which the handler mis-maps to a "max live sessions" 409 even on the very
+    /// first, uncontended start. This test proves the repository operation succeeds and persists the
+    /// InProgress session, so the concurrency exception (hence the false 409) no longer fires.
+    /// </summary>
+    [Fact(DisplayName = "UpdateAsync persists an InProgress session on first start without a false concurrency conflict")]
+    public async Task UpdateAsync_DetachedRoot_StartSession_PersistsInProgressSession_NoFalseConflict()
+    {
+        // ── Arrange ─────────────────────────────────────────────────────────────
+        var eventId = await SeedPublishedEventAsync();
+        var trackingSessionId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+
+        await using var dbWrite = _fixture.CreateDbContext(_connectionString);
+        var repo = CreateRepository(dbWrite);
+
+        var night = await repo.GetByIdAsync(eventId, TestCancellationToken);
+        night.Should().NotBeNull();
+
+        // ── Act: mirror the handler — add a session, start it, persist ──
+        night!.AddSession(trackingSessionId, gameId, "Catan");
+        night.StartCurrentSession(); // Pending → InProgress
+
+        await repo.UpdateAsync(night, TestCancellationToken);
+
+        // The uncontended first start must NOT surface as a concurrency conflict.
+        Func<Task> act = async () => await dbWrite.SaveChangesAsync(TestCancellationToken);
+        await act.Should().NotThrowAsync<DbUpdateConcurrencyException>(
+            "the first, uncontended start-session save must not raise the concurrency exception the " +
+            "handler mis-maps to a false MAX_LIVE_SESSIONS_EXCEEDED 409");
+
+        // ── Assert: the session is persisted and live ──
+        await using var dbVerify = _fixture.CreateDbContext(_connectionString);
+        var session = await dbVerify.GameNightSessions
+            .AsNoTracking()
+            .SingleAsync(s => s.GameNightEventId == eventId && s.SessionId == trackingSessionId, TestCancellationToken);
+        session.Status.Should().Be("InProgress", "the started session must persist as InProgress");
+    }
+
+    /// <summary>
+    /// Tracked-root path (the single <c>SessionStartedHandler</c> caller, which loads via
+    /// <c>FindByLinkedSessionIdAsync</c> — TRACKED + Include). Adding a NEW child on an
+    /// already-tracked root and persisting via <c>UpdateAsync</c> must not raise an EF identity
+    /// conflict (the pre-fix full-graph re-map + <c>DbSet.Update()</c> collides with the tracked
+    /// instance — the same failure the reminder job worked around, #2720). The new invitee row must
+    /// persist and the pre-existing session must remain intact.
+    /// </summary>
+    [Fact(DisplayName = "UpdateAsync on a tracked root (FindByLinkedSessionId) persists a new invitee without an identity conflict")]
+    public async Task UpdateAsync_TrackedRoot_ViaFindByLinkedSession_AddInvitee_PersistsWithoutIdentityConflict()
+    {
+        // ── Arrange: a Published night with one Pending session ──
+        var trackingSessionId = Guid.NewGuid();
+        var eventId = await SeedPublishedEventWithSessionAsync(trackingSessionId);
+        var inviteeId = Guid.NewGuid();
+
+        await using var dbWrite = _fixture.CreateDbContext(_connectionString);
+        var repo = CreateRepository(dbWrite);
+
+        // TRACKED load — the caller (SessionStartedHandler) needs change-tracking end-to-end.
+        var night = await repo.FindByLinkedSessionIdAsync(trackingSessionId, TestCancellationToken);
+        night.Should().NotBeNull();
+
+        // ── Act: mutate a tracked root (new child) and persist ──
+        night!.AddInvitees(new List<Guid> { inviteeId });
+
+        await repo.UpdateAsync(night, TestCancellationToken);
+        await dbWrite.SaveChangesAsync(TestCancellationToken);
+
+        // ── Assert: the new invitee row exists and the original session is untouched ──
+        await using var dbVerify = _fixture.CreateDbContext(_connectionString);
+
+        var rsvpRows = await dbVerify.GameNightRsvps
+            .AsNoTracking()
+            .CountAsync(r => r.EventId == eventId && r.UserId == inviteeId, TestCancellationToken);
+        rsvpRows.Should().Be(1, "the invitee added on a tracked root must be inserted");
+
+        var sessionRows = await dbVerify.GameNightSessions
+            .AsNoTracking()
+            .CountAsync(s => s.GameNightEventId == eventId && s.SessionId == trackingSessionId, TestCancellationToken);
+        sessionRows.Should().Be(1, "the pre-existing session must survive the update");
+    }
+
+    /// <summary>
+    /// Guards a subtle data-loss trap in child reconciliation: votes are managed by the DEDICATED
+    /// <c>AddVoteAsync</c> / <c>RemoveVoteAsync</c> paths, which insert/delete a single vote row
+    /// WITHOUT touching the aggregate root — so casting a vote does NOT advance the root's xmin.
+    /// A concurrently-cast vote is therefore invisible to a stale-snapshot <c>UpdateAsync</c>. If
+    /// <c>UpdateAsync</c> reconciled votes with a Delete branch, that unrelated scalar update would
+    /// silently DELETE the concurrently-cast vote (it appears in the DB but not in the loaded
+    /// snapshot). <c>UpdateAsync</c> must therefore leave vote rows untouched.
+    /// </summary>
+    [Fact(DisplayName = "UpdateAsync must not delete a vote row added concurrently (absent from the loaded snapshot)")]
+    public async Task UpdateAsync_DoesNotDeleteConcurrentlyAddedVote()
+    {
+        // ── Arrange: seed a Published night, then load it (snapshot has zero votes) ──
+        var eventId = await SeedPublishedEventAsync();
+
+        await using var dbWrite = _fixture.CreateDbContext(_connectionString);
+        var repo = CreateRepository(dbWrite);
+
+        var night = await repo.GetByIdAsync(eventId, TestCancellationToken);
+        night.Should().NotBeNull();
+
+        // A vote is cast from another context AFTER the snapshot was loaded (the AddVoteAsync path
+        // inserts only the vote row and never advances the root xmin).
+        var voteId = Guid.NewGuid();
+        await using (var dbVote = _fixture.CreateDbContext(_connectionString))
+        {
+            dbVote.GameNightVotes.Add(new GameNightVoteEntity
+            {
+                Id = voteId,
+                EventId = eventId,
+                VoterUserId = Guid.NewGuid(),
+                CandidateGameId = Guid.NewGuid(),
+                CreatedAt = DateTimeOffset.UtcNow
+            });
+            await dbVote.SaveChangesAsync(TestCancellationToken);
+        }
+
+        // ── Act: an unrelated scalar update on the stale aggregate ──
+        night!.Update("Renamed Night", null, night.ScheduledAt, null, null, null);
+        await repo.UpdateAsync(night, TestCancellationToken);
+        await dbWrite.SaveChangesAsync(TestCancellationToken);
+
+        // ── Assert: the concurrently-cast vote must survive the unrelated update ──
+        await using var dbVerify = _fixture.CreateDbContext(_connectionString);
+        var voteRows = await dbVerify.GameNightVotes
+            .AsNoTracking()
+            .CountAsync(v => v.Id == voteId, TestCancellationToken);
+        voteRows.Should().Be(1, "UpdateAsync must not delete vote rows it never manages");
+    }
+}


### PR DESCRIPTION
## Problema (P2 — GameNight `UpdateAsync` child-loss, HIGH data-integrity)

`GameNightEventRepository.UpdateAsync` ricostruiva l'intero grafo dell'aggregato con `MapToPersistence` e chiamava `DbContext.GameNightEvents.Update(entity)`. Su un grafo **disconnesso** EF marca ogni figlio con chiave non-default come `Modified`, quindi un figlio **nuovo** (aggiunto dopo il load, con `Id = Guid.NewGuid()`) diventava un `UPDATE` su una riga inesistente → **0 righe** → `DbUpdateConcurrencyException` + rollback.

L'InMemory dei test unit fa upsert silenzioso e **non** catturava il bug — solo Postgres lo rivela.

Sintomi in produzione:
- **`InviteToGameNightCommandHandler`** → gli invitati venivano silenziosamente rollbackati.
- **`StartGameNightSessionCommandHandler`** → l'`UpdateAsync` falliva **sempre**; il `catch (DbUpdateConcurrencyException)` mis-mappava a `MaxLiveSessionsExceededException` → **falso 409 "max live sessions"**, sessione mai linkata.
- **Path tracked** (`FindByLinkedSessionIdAsync` → `SessionStartedHandler`): il `.Update()` su entity fresca collideva con l'istanza già tracciata → **EF identity conflict** (la stessa collisione #2720 che il reminder job aveva dovuto aggirare).

## Fix

Riconciliazione delle collezioni figlie (`Added`/`Modified`/`Deleted`) invece di ri-attaccare il grafo intero, **rispecchiando `LiveSessionRepository`**:

- **Root**: attaccato come `Modified` (load detached, 13/14 chiamanti) oppure aggiornato via `SetValues` sul root già tracciato (`SessionStartedHandler`) → in entrambi i casi lo **xmin** round-trip continua a guidare la clausola `WHERE` (#2703).
- **RSVP / Session**: riconciliati per `Id` (attenzione all'asimmetria FK: `EventId` per Rsvp, `GameNightEventId` per Session). Il ramo Delete è sicuro perché questi figli mutano solo tramite l'aggregato+`UpdateAsync`, che fa sempre bump dell'xmin del root.
- **Votes: esclusi deliberatamente.** Sono persistiti dai metodi dedicati `AddVoteAsync`/`RemoveVoteAsync`/`SetVotingWinnerAsync`, che **non** fanno bump dell'xmin del root; riconciliarli con un ramo Delete cancellerebbe un voto castato concorrentemente (invisibile allo snapshot stale). Un test dedicato lo prova.

Il `catch (DbUpdateConcurrencyException) → MaxLiveSessionsExceededException` in `StartGameNightSessionCommandHandler` è **mantenuto**: dopo il fix scatta solo su una xmin race **genuina** (design WS1 DEC-5, asserito da 3 unit test). Rimuoverlo è fuori scope e regredirebbe il contratto del blocked-modal 409.

## Test (TDD)

4 nuovi test Testcontainers-Postgres in `GameNightEventChildReconciliationIntegrationTests.cs` — **RED** sull'implementazione `.Update()`, **GREEN** dopo il fix:

1. `UpdateAsync_DetachedRoot_AddInviteeAndSession_PersistsNewChildRows` — invitee + session nuovi persistiti (root detached).
2. `UpdateAsync_DetachedRoot_StartSession_PersistsInProgressSession_NoFalseConflict` — primo start persiste la sessione `InProgress` senza il falso 409.
3. `UpdateAsync_TrackedRoot_ViaFindByLinkedSession_AddInvitee_PersistsWithoutIdentityConflict` — nuovo invitee su root tracciato senza identity conflict.
4. `UpdateAsync_DoesNotDeleteConcurrentlyAddedVote` — un voto castato concorrentemente sopravvive a un `UpdateAsync` con snapshot stale.

Regressione verificata verde: **470 unit test GameNight** (inclusi i 3 handler test del catch) + i 2 integration esistenti (`GameNightEventConcurrencyTests` xmin + `GameNightEventPublishRsvpIntegrationTests` rsvp).

## Follow-up noto (pre-esistente, NON introdotto qui)

`MapToPersistence` omette la colonna entity-only `TestRunId`, quindi ogni `UpdateAsync` riuscito azzera `test_run_id` su root + figli riconciliati (`CleanupTestEntitiesCommand` cerca per quella colonna). Il vecchio `.Update()` lo azzerava già su ogni update riuscito — questo cambio non lo introduce, ma lo porta anche sui path child-adding. Raccomandato un fix dedicato che fa round-trip di `TestRunId` come `LiveSessionRepository` fa con `TotalPausedDurationMs`. Impatto: solo hygiene E2E, non dati di produzione.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
