### PR TITLE
fix(session-sync): stabilize SSE connection vs inline-callback churn

### DIFF
--- a/apps/web/src/lib/domain-hooks/__tests__/useSessionSync.test.ts
+++ b/apps/web/src/lib/domain-hooks/__tests__/useSessionSync.test.ts
@@ -7,10 +7,45 @@
  * These unit tests verify hook initialization and basic structure.
  */
 
-import { renderHook } from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { useSessionSync } from '../useSessionSync';
+
+/**
+ * EventSource mock that records every constructed instance so a test can assert
+ * how many times `new EventSource(...)` ran. Mirrors the pattern used in
+ * useTurnOrder.test.ts (Vitest v4: assign the class directly, no `vi.fn` wrap).
+ */
+interface TrackedEventSourceInstance {
+  url: string;
+  withCredentials: boolean;
+  onopen: (() => void) | null;
+  onerror: (() => void) | null;
+  close: ReturnType<typeof vi.fn>;
+  addEventListener: ReturnType<typeof vi.fn>;
+  removeEventListener: ReturnType<typeof vi.fn>;
+  readyState: number;
+}
+
+let trackedEventSourceInstances: TrackedEventSourceInstance[] = [];
+
+class TrackedEventSource {
+  url: string;
+  withCredentials: boolean;
+  onopen: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  close = vi.fn();
+  addEventListener = vi.fn();
+  removeEventListener = vi.fn();
+  readyState = 0; // CONNECTING
+
+  constructor(url: string, options?: { withCredentials?: boolean }) {
+    this.url = url;
+    this.withCredentials = options?.withCredentials ?? false;
+    trackedEventSourceInstances.push(this as TrackedEventSourceInstance);
+  }
+}
 
 describe('useSessionSync', () => {
   const mockSessionId = 'session-123';
@@ -122,5 +157,41 @@ describe('useSessionSync', () => {
     unmount();
 
     expect(mockClose).toHaveBeenCalled();
+  });
+
+  it('creates the EventSource only once when re-rendered with unstable inline callbacks (#P3 churn)', () => {
+    // Mirrors the real consumer (toolkit/[sessionId]/_content.tsx): fresh inline
+    // callback identities on every render. With the churn bug, each re-render
+    // recreates `connect`, so the mount effect tears down and re-opens the SSE
+    // stream — dropping in-flight pause/resume/finalize/score events and
+    // flickering `isConnected`.
+    trackedEventSourceInstances = [];
+    global.EventSource = TrackedEventSource as unknown as typeof EventSource;
+
+    const { rerender } = renderHook(() =>
+      useSessionSync({
+        sessionId: mockSessionId,
+        onScoreUpdate: () => {},
+        onPaused: () => {},
+        onResumed: () => {},
+        onFinalized: () => {},
+        onError: () => {},
+      })
+    );
+
+    expect(trackedEventSourceInstances).toHaveLength(1);
+
+    // onopen flips isConnected → an internal re-render in which the consumer's
+    // inline callbacks are re-created with new identities.
+    act(() => {
+      trackedEventSourceInstances[0]?.onopen?.();
+    });
+
+    // Explicit parent re-render with brand-new inline callback identities.
+    rerender();
+
+    // Exactly one EventSource must ever be constructed for a stable
+    // (sessionId, apiBaseUrl) pair.
+    expect(trackedEventSourceInstances).toHaveLength(1);
   });
 });

--- a/apps/web/src/lib/domain-hooks/useSessionSync.ts
+++ b/apps/web/src/lib/domain-hooks/useSessionSync.ts
@@ -124,51 +124,70 @@ export function useSessionSync(options: UseSessionSyncOptions): SessionSyncState
   const maxReconnectAttempts = 5;
   const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
+  // Keep the latest callbacks in refs so the SSE connection is NOT torn down and
+  // re-established when a consumer passes fresh inline callbacks on every render
+  // (e.g. toolkit/[sessionId]/_content.tsx). Without this, `handleEvent` → `connect`
+  // → the mount effect all get new identities each render, closing and re-opening
+  // the EventSource in a self-sustaining loop that drops in-flight events and
+  // flickers `isConnected`. Mirrors the ref pattern in useTurnOrder.
+  const onScoreUpdateRef = useRef(onScoreUpdate);
+  const onPausedRef = useRef(onPaused);
+  const onResumedRef = useRef(onResumed);
+  const onFinalizedRef = useRef(onFinalized);
+  const onErrorRef = useRef(onError);
+  const onTurnAdvancedRef = useRef(onTurnAdvanced);
+
+  useEffect(() => {
+    onScoreUpdateRef.current = onScoreUpdate;
+    onPausedRef.current = onPaused;
+    onResumedRef.current = onResumed;
+    onFinalizedRef.current = onFinalized;
+    onErrorRef.current = onError;
+    onTurnAdvancedRef.current = onTurnAdvanced;
+  });
+
   /**
    * Handle SSE event
    */
-  const handleEvent = useCallback(
-    (event: MessageEvent<string>) => {
-      try {
-        const parsedEvent: SessionEvent = JSON.parse(event.data);
+  const handleEvent = useCallback((event: MessageEvent<string>) => {
+    try {
+      const parsedEvent: SessionEvent = JSON.parse(event.data);
 
-        switch (parsedEvent.type) {
-          case SessionEventType.ScoreUpdatedEvent: {
-            const data = parsedEvent.data as ScoreUpdatedEventData;
-            const scoreEntry = {
-              ...data.scoreEntry,
-              timestamp: new Date(data.scoreEntry.timestamp),
-            };
+      switch (parsedEvent.type) {
+        case SessionEventType.ScoreUpdatedEvent: {
+          const data = parsedEvent.data as ScoreUpdatedEventData;
+          const scoreEntry = {
+            ...data.scoreEntry,
+            timestamp: new Date(data.scoreEntry.timestamp),
+          };
 
-            setScores(prev => [...prev, scoreEntry]);
-            onScoreUpdate?.(scoreEntry);
-            break;
-          }
-
-          case SessionEventType.SessionPausedEvent: {
-            onPaused?.();
-            break;
-          }
-
-          case SessionEventType.SessionResumedEvent: {
-            onResumed?.();
-            break;
-          }
-
-          case SessionEventType.SessionFinalizedEvent: {
-            onFinalized?.();
-            break;
-          }
+          setScores(prev => [...prev, scoreEntry]);
+          onScoreUpdateRef.current?.(scoreEntry);
+          break;
         }
-      } catch (err) {
-        logger.error(
-          `[useSessionSync] Event parsing error: ${event.data}`,
-          err instanceof Error ? err : undefined
-        );
+
+        case SessionEventType.SessionPausedEvent: {
+          onPausedRef.current?.();
+          break;
+        }
+
+        case SessionEventType.SessionResumedEvent: {
+          onResumedRef.current?.();
+          break;
+        }
+
+        case SessionEventType.SessionFinalizedEvent: {
+          onFinalizedRef.current?.();
+          break;
+        }
       }
-    },
-    [onScoreUpdate, onPaused, onResumed, onFinalized]
-  );
+    } catch (err) {
+      logger.error(
+        `[useSessionSync] Event parsing error: ${event.data}`,
+        err instanceof Error ? err : undefined
+      );
+    }
+  }, []);
 
   /**
    * Connect to SSE stream
@@ -195,7 +214,7 @@ export function useSessionSync(options: UseSessionSyncOptions): SessionSyncState
 
         const errorObj = new Error('SSE connection failed');
         setError(errorObj);
-        onError?.(errorObj);
+        onErrorRef.current?.(errorObj);
 
         // Auto-reconnect with exponential backoff
         if (reconnectAttemptsRef.current < maxReconnectAttempts) {
@@ -221,26 +240,25 @@ export function useSessionSync(options: UseSessionSyncOptions): SessionSyncState
         eventSource.addEventListener(eventType, handleEvent);
       });
 
-      // Listen to turn-order toolkit events (Issue #4975)
-      if (onTurnAdvanced) {
-        eventSource.addEventListener('session:toolkit', (event: MessageEvent<string>) => {
-          try {
-            const payload = JSON.parse(event.data) as TurnAdvancedPayload;
-            onTurnAdvanced(payload);
-          } catch (err) {
-            logger.error('[useSessionSync] session:toolkit parse error:', err);
-          }
-        });
-      }
+      // Listen to turn-order toolkit events (Issue #4975). Always registered; the
+      // callback is invoked through a ref so `connect` stays stable across renders.
+      eventSource.addEventListener('session:toolkit', (event: MessageEvent<string>) => {
+        try {
+          const payload = JSON.parse(event.data) as TurnAdvancedPayload;
+          onTurnAdvancedRef.current?.(payload);
+        } catch (err) {
+          logger.error('[useSessionSync] session:toolkit parse error:', err);
+        }
+      });
 
       eventSourceRef.current = eventSource;
     } catch (err) {
       const errorObj = err instanceof Error ? err : new Error('Failed to create EventSource');
       setError(errorObj);
       setIsConnected(false);
-      onError?.(errorObj);
+      onErrorRef.current?.(errorObj);
     }
-  }, [sessionId, apiBaseUrl, handleEvent, onError, onTurnAdvanced]);
+  }, [sessionId, apiBaseUrl, handleEvent]);
 
   /**
    * Disconnect SSE stream


### PR DESCRIPTION
## Problema (P3 — HIGH, real-time)

`apps/web/src/lib/domain-hooks/useSessionSync.ts` ricostruiva l'`EventSource` ad **ogni render** quando il consumer passa callback inline non memoizzate — è il caso reale in `toolkit/[sessionId]/_content.tsx:242-259` (5 callback inline).

Catena del bug:
- `handleEvent` (deps sulle callback) → nuova identità ogni render
- `connect` (dep su `handleEvent`) → nuova identità ogni render
- l'effetto di mount (deps `[connect, disconnect]`) → **ri-esegue ad ogni render**: il cleanup chiude l'`EventSource` + `setIsConnected(false)`, il body ne apre uno nuovo + `onopen` → `setIsConnected(true)` → toggle → re-render → **loop auto-sostenuto**.

Al primo `score_update` lo store Zustand cambia → re-render → `EventSource` distrutto/ricreato: ogni `pause`/`resume`/`finalize`/`score` in arrivo durante il teardown è **perso**, e l'indicatore `isConnected` flickera.

## Fix

Mirror del pattern già presente in-repo (`useTurnOrder`): le callback vivono in ref sincronizzate ogni render.

1. 6 ref (`onScoreUpdateRef`/`onPausedRef`/`onResumedRef`/`onFinalizedRef`/`onErrorRef`/`onTurnAdvancedRef`) sincronizzate via un singolo `useEffect` (`ref.current = cb`).
2. `handleEvent` invoca via ref → deps `[]` (stabile).
3. `connect` legge `*Ref.current` → deps `[sessionId, apiBaseUrl, handleEvent]`.

`handleEvent` è ora stabile, quindi `connect` resta stabile per `(sessionId, apiBaseUrl)`: l'`EventSource` è creato **una sola volta** per sessione. `handleEvent` è incluso nelle deps di `connect` perché `react-hooks/exhaustive-deps` è a livello **`error`** — essendo stabile non reintroduce churn. Il listener `session:toolkit` è ora sempre registrato e protetto dal ref (come in `useTurnOrder`).

## Test (TDD)

Nuovo test in `useSessionSync.test.ts`: renderizza con callback inline instabili, fa `onopen` + forza un re-render, e asserisce che il costruttore `EventSource` sia chiamato **esattamente una volta**.

- **RED** (codice buggato): `expected length 1 but got 4`
- **GREEN** (fix): 1

## Verifica

- `pnpm test` — `useSessionSync` 6/6 ✅ · intera cartella `domain-hooks` 250/250 ✅
- `pnpm typecheck` — 0 errori ✅
- `pnpm lint` — 0 errori (100 warning pre-esistenti, sotto il budget `--max-warnings=510`, nessuno nei file toccati) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
