### PR TITLE
docs: mark retired self-hosted-runner sections obsolete (#3331)

### DIFF
--- a/docs/for-claude/architecture/adr/adr-078-auto-issue-noise-thresholds.md
+++ b/docs/for-claude/architecture/adr/adr-078-auto-issue-noise-thresholds.md
@@ -18,7 +18,7 @@ MeepleAI's CI/CD infrastructure includes several automated workflows that create
 
 3. **`ci-minutes-digest.yml`**: Presumably creates or updates a digest issue with CI minute consumption.
 
-4. **`runner-health-check.yml`** and **`monitor-runner-queue.yml`**: Runner health monitoring — likely emit issues or Slack alerts on runner anomalies.
+4. ~~**`runner-health-check.yml`** and **`monitor-runner-queue.yml`**~~ — **removed 2026-07-28 (#3331 / #3348)**: the self-hosted runner was retired (Option E; all workflows now run on GitHub-hosted), so these runner-health monitors were deleted. Kept here for historical context of the convention.
 
 5. **`validate-secrets.yml`**: Validates secrets configuration — could emit issues on secret drift.
 
@@ -29,7 +29,7 @@ MeepleAI's CI/CD infrastructure includes several automated workflows that create
 - The `dev-auto-revert.yml` uses a failure-mode classification with threshold logic ("would-revert only after 30min continuous red") before taking action — a noise-reduction strategy.
 - The `spec-debt-false-positive-allowlist.json` is an explicit allowlist pattern for suppressing known-false-positive auto-issues.
 
-**Problem space**: as the number of automated monitors grows (security scans, dependency drift, spec debt, seed snapshot freshness, runner health), each generating potential issues, the GitHub issue tracker can be polluted with:
+**Problem space**: as the number of automated monitors grows (security scans, dependency drift, spec debt, seed snapshot freshness), each generating potential issues, the GitHub issue tracker can be polluted with:
 - **Noise issues** (same condition detected on consecutive scans, creating N identical issues).
 - **Burst issues** (a single root cause — e.g. a network blip — causing 10 simultaneous "health check failed" issues across 10 monitors).
 - **Stale issues** (a condition that auto-resolved but the issue remains open, accumulating false backlog).

--- a/docs/for-developers/operations/operations-manual.md
+++ b/docs/for-developers/operations/operations-manual.md
@@ -2786,6 +2786,16 @@ Either failure blocks merge. Bypassing requires an explicit lift comment from
 
 ## 21. Self-Hosted Runner Recovery
 
+> **⚠️ OBSOLETE (2026-07-28, #3331)** — the self-hosted runner was **retired** (Option E):
+> the `RUNNER` repo variable was removed, all workflows now run on GitHub-hosted, and the
+> runner was deregistered + decommissioned on the VPS. The scripts referenced below
+> (`apply-memory-overrides.sh`, `10-memory-limits.conf`, `maintenance.sh`, `monitor.sh`)
+> and the babysitting workflows (`runner-health-check`, `runner-maintenance`,
+> `monitor-runner-queue`) were deleted in #3348. This section is kept as historical
+> reference and as the operational guide **if** a dedicated runner is ever re-introduced
+> (Option D fallback, provisioned from `infra/runner/cloud-init.yml` + `setup-*.sh`). See
+> the [migration plan](../../superpowers/plans/2026-07-28-issue-3331-eliminate-self-hosted-runner.md).
+
 ### Background
 
 A GitHub Actions self-hosted runner (`meepleai-staging`, ARM64, Hetzner CX31)


### PR DESCRIPTION
Follow-up doc cleanup dopo la migrazione E (#3331 chiusa, apparato runner eliminato in #3348).

- **operations-manual §21** "Self-Hosted Runner Recovery": aggiunto un banner **OBSOLETE**. Il runner è stato deregistrato e i suoi script/workflow eliminati; la sezione resta come riferimento storico e come guida per il fallback D (re-provisioning da `infra/runner/cloud-init.yml`).
- **adr-078**: barrato l'esempio `runner-health-check` / `monitor-runner-queue` (rimossi) e tolto "runner health" dall'elenco delle categorie di monitor.

Doc-only. Chiude i residui documentali segnalati alla fine della sessione #3331.

🤖 Generated with [Claude Code](https://claude.com/claude-code)