### PR TITLE
feat(rag): WP3 Title-health metric + TM canonical query + WP4 go/no-go (#3338)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/EmbeddedTitleSplitter.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/EmbeddedTitleSplitter.cs
@@ -150,7 +150,12 @@ internal static class EmbeddedTitleSplitter
         return hasLetter;
     }
 
-    private static bool ContainsLexiconTitle(string text)
+    /// <summary>
+    /// True when <paramref name="text"/> contains a curated <see cref="SectionHeadingLexicon"/> section
+    /// title as an exact UPPERCASE whole word. Shared with <see cref="TitleHealthMetric"/> (WP3 canonical
+    /// coverage) so the "is this a known section type" predicate has a single definition.
+    /// </summary>
+    internal static bool ContainsLexiconTitle(string text)
     {
         foreach (var title in SectionHeadingLexicon.Titles)
         {

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/TitleHealthMetric.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/TitleHealthMetric.cs
@@ -1,0 +1,140 @@
+using Api.Constants;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Services.Chunking;
+
+/// <summary>
+/// Epic #3338 WP3: a per-game extraction-quality signal computed from the section HEADINGS a game's
+/// chunks carry (<c>text_chunks.Heading</c>) — what retrieval actually sees. It measures how many
+/// distinct headings are plausible section titles (vs. the garbage unstructured's 'fast' strategy
+/// emits on complex layouts — spaced single letters "I L E X Y R F", single chars "D", symbol/number
+/// noise "(14%), Oceani") and how many curated canonical section types are present. Its purpose is the
+/// WP3 regression guard (a well-extracted game's health must not drop after a WP1/WP4 change) and the
+/// WP4 go/no-go read-out (a residual IT cohort below the band threshold triggers hi_res extraction).
+/// <para>Pure and allocation-light — no I/O; the caller supplies the game's chunk headings.</para>
+/// </summary>
+internal static class TitleHealthMetric
+{
+    /// <summary>
+    /// A section title is short (real ones observed: "PLANCE DEI GIOCATORI"=20, "SVOLGIMENTO DELLA
+    /// PARTITA"=25). Longer strings are running headers, copyright/URL lines
+    /// ("© 2016 FryxGames www.fryxgames.se/…") or prose bleed.
+    /// </summary>
+    private const int MaxPlausibleHeadingLength = 40;
+
+    /// <summary>Minimum fraction of non-space characters that must be letters for a heading to be plausible.</summary>
+    private const double MinLetterFraction = 0.6;
+
+    private const double GreenThreshold = 0.80;
+    private const double YellowThreshold = 0.50;
+
+    /// <param name="DistinctHeadings">Distinct non-blank headings across the game's chunks.</param>
+    /// <param name="PlausibleHeadings">How many of those look like real section titles.</param>
+    /// <param name="PlausibleFraction">PlausibleHeadings / DistinctHeadings (0 when there are none).</param>
+    /// <param name="CanonicalCoverage">How many curated <see cref="SectionHeadingLexicon"/> section types appear.</param>
+    /// <param name="Band">green ≥ 0.80 · yellow ≥ 0.50 · red otherwise — the WP4 go/no-go band.</param>
+    public readonly record struct TitleHealthResult(
+        int DistinctHeadings,
+        int PlausibleHeadings,
+        double PlausibleFraction,
+        int CanonicalCoverage,
+        string Band);
+
+    public static TitleHealthResult Compute(IEnumerable<string?> chunkHeadings)
+    {
+        ArgumentNullException.ThrowIfNull(chunkHeadings);
+
+        var distinct = chunkHeadings
+            .Where(h => !string.IsNullOrWhiteSpace(h))
+            .Select(h => h!.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        var plausible = distinct.Count(IsPlausibleHeading);
+        var fraction = distinct.Count == 0 ? 0.0 : (double)plausible / distinct.Count;
+        var canonical = CountCanonicalCoverage(distinct);
+        var band = fraction >= GreenThreshold ? "green"
+            : fraction >= YellowThreshold ? "yellow"
+            : "red";
+
+        return new TitleHealthResult(distinct.Count, plausible, fraction, canonical, band);
+    }
+
+    /// <summary>
+    /// True when a heading looks like a real section title: 2–80 chars, carrying a real word (a run of
+    /// ≥ <see cref="ChunkingConstants.MinSubstantiveLetterRun"/> consecutive letters, so "D", "S U",
+    /// "I L E X Y R F" are rejected) and dominantly letters (≥ 60 % of non-space chars, so "(14%), Oceani"
+    /// and "© 2016 FryxGames" are rejected). Measures title-LIKENESS, not section-correctness — a real
+    /// word fragment like "Dato" counts as plausible; the target is gross extraction garbage.
+    /// </summary>
+    internal static bool IsPlausibleHeading(string? heading)
+    {
+        if (string.IsNullOrWhiteSpace(heading))
+        {
+            return false;
+        }
+
+        var t = heading.Trim();
+        if (t.Length < 2 || t.Length > MaxPlausibleHeadingLength)
+        {
+            return false;
+        }
+
+        var run = 0;
+        var letters = 0;
+        var nonSpace = 0;
+        var hasWord = false;
+        foreach (var ch in t)
+        {
+            if (!char.IsWhiteSpace(ch))
+            {
+                nonSpace++;
+            }
+
+            if (char.IsLetter(ch))
+            {
+                letters++;
+                if (++run >= ChunkingConstants.MinSubstantiveLetterRun)
+                {
+                    hasWord = true;
+                }
+            }
+            else
+            {
+                run = 0;
+            }
+        }
+
+        return hasWord && nonSpace > 0 && (double)letters / nonSpace >= MinLetterFraction;
+    }
+
+    private static int CountCanonicalCoverage(IEnumerable<string> headings)
+    {
+        var upperHeadings = headings.Select(h => h.ToUpperInvariant()).ToList();
+        var covered = 0;
+        foreach (var title in SectionHeadingLexicon.Titles)
+        {
+            if (upperHeadings.Any(h => ContainsWholeWord(h, title)))
+            {
+                covered++;
+            }
+        }
+        return covered;
+    }
+
+    private static bool ContainsWholeWord(string text, string word)
+    {
+        var i = text.IndexOf(word, StringComparison.Ordinal);
+        while (i >= 0)
+        {
+            var leftOk = i == 0 || !char.IsLetter(text[i - 1]);
+            var end = i + word.Length;
+            var rightOk = end >= text.Length || !char.IsLetter(text[end]);
+            if (leftOk && rightOk)
+            {
+                return true;
+            }
+            i = text.IndexOf(word, i + 1, StringComparison.Ordinal);
+        }
+        return false;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/TitleHealthMetric.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/TitleHealthMetric.cs
@@ -30,7 +30,7 @@ internal static class TitleHealthMetric
     /// <param name="DistinctHeadings">Distinct non-blank headings across the game's chunks.</param>
     /// <param name="PlausibleHeadings">How many of those look like real section titles.</param>
     /// <param name="PlausibleFraction">PlausibleHeadings / DistinctHeadings (0 when there are none).</param>
-    /// <param name="CanonicalCoverage">How many curated <see cref="SectionHeadingLexicon"/> section types appear.</param>
+    /// <param name="CanonicalCoverage">Distinct PLAUSIBLE headings that match a curated <see cref="SectionHeadingLexicon"/> section word (counted per-heading, so a heading is credited once regardless of how many overlapping lexicon entries it matches).</param>
     /// <param name="Band">green ≥ 0.80 · yellow ≥ 0.50 · red otherwise — the WP4 go/no-go band.</param>
     public readonly record struct TitleHealthResult(
         int DistinctHeadings,
@@ -51,7 +51,12 @@ internal static class TitleHealthMetric
 
         var plausible = distinct.Count(IsPlausibleHeading);
         var fraction = distinct.Count == 0 ? 0.0 : (double)plausible / distinct.Count;
-        var canonical = CountCanonicalCoverage(distinct);
+        // Per-heading (not per-lexicon-entry) and gated on plausibility: a heading is a "canonical
+        // section" once when it is a plausible title carrying a lexicon word — so an overlapping entry
+        // ("SVOLGIMENTO" ⊂ "SVOLGIMENTO DEL GIOCO") is not double-counted, and a garbage heading that
+        // merely embeds a lexicon token ("3 4 SETUP 9%") does not credit coverage.
+        var canonical = distinct.Count(h =>
+            IsPlausibleHeading(h) && EmbeddedTitleSplitter.ContainsLexiconTitle(h.ToUpperInvariant()));
         var band = fraction >= GreenThreshold ? "green"
             : fraction >= YellowThreshold ? "yellow"
             : "red";
@@ -60,7 +65,7 @@ internal static class TitleHealthMetric
     }
 
     /// <summary>
-    /// True when a heading looks like a real section title: 2–80 chars, carrying a real word (a run of
+    /// True when a heading looks like a real section title: 2–40 chars, carrying a real word (a run of
     /// ≥ <see cref="ChunkingConstants.MinSubstantiveLetterRun"/> consecutive letters, so "D", "S U",
     /// "I L E X Y R F" are rejected) and dominantly letters (≥ 60 % of non-space chars, so "(14%), Oceani"
     /// and "© 2016 FryxGames" are rejected). Measures title-LIKENESS, not section-correctness — a real
@@ -105,36 +110,5 @@ internal static class TitleHealthMetric
         }
 
         return hasWord && nonSpace > 0 && (double)letters / nonSpace >= MinLetterFraction;
-    }
-
-    private static int CountCanonicalCoverage(IEnumerable<string> headings)
-    {
-        var upperHeadings = headings.Select(h => h.ToUpperInvariant()).ToList();
-        var covered = 0;
-        foreach (var title in SectionHeadingLexicon.Titles)
-        {
-            if (upperHeadings.Any(h => ContainsWholeWord(h, title)))
-            {
-                covered++;
-            }
-        }
-        return covered;
-    }
-
-    private static bool ContainsWholeWord(string text, string word)
-    {
-        var i = text.IndexOf(word, StringComparison.Ordinal);
-        while (i >= 0)
-        {
-            var leftOk = i == 0 || !char.IsLetter(text[i - 1]);
-            var end = i + word.Length;
-            var rightOk = end >= text.Length || !char.IsLetter(text[end]);
-            if (leftOk && rightOk)
-            {
-                return true;
-            }
-            i = text.IndexOf(word, i + 1, StringComparison.Ordinal);
-        }
-        return false;
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/Chunking/TitleHealthMetricTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/Chunking/TitleHealthMetricTests.cs
@@ -1,0 +1,97 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Services.Chunking;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Services.Chunking;
+
+/// <summary>
+/// Epic #3338 WP3 unit tests for <see cref="TitleHealthMetric"/> — the per-game extraction-quality
+/// signal (regression guard + WP4 go/no-go). Fixtures use the real garbage headings observed on the
+/// Terraforming Mars staging corpus.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public class TitleHealthMetricTests
+{
+    [Theory]
+    // Real section titles → plausible
+    [InlineData("PREPARAZIONE", true)]
+    [InlineData("AZIONI", true)]
+    [InlineData("FINE DEL GIOCO", true)]
+    [InlineData("PANORAMICA DEL GIOCO", true)]
+    [InlineData("Setup", true)]
+    [InlineData("Dato", true)]                 // a real-word fragment: title-LIKE, counts as plausible
+    // Gross extraction garbage → not plausible
+    [InlineData("D", false)]                   // single char
+    [InlineData("S U", false)]                 // spaced single letters, no 3-letter run
+    [InlineData("I L E X Y R F C A A S I", false)] // vertical-text artefact
+    [InlineData("(14%), Oceani", false)]       // symbol/number-heavy (letter fraction < 0.6)
+    [InlineData("© 2016 FryxGames www.fryxgames.se/games/terraforming", false)] // too long + symbol-heavy
+    [InlineData("12 34 56", false)]            // digits only, no word
+    [InlineData("", false)]
+    [InlineData("   ", false)]
+    public void IsPlausibleHeading_ClassifiesRealTitlesVsGarbage(string heading, bool expected)
+    {
+        TitleHealthMetric.IsPlausibleHeading(heading).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Compute_WellExtractedGame_IsGreen()
+    {
+        var headings = new[] { "SETUP", "GAMEPLAY", "SCORING", "END OF GAME", "COMPONENTS" };
+
+        var r = TitleHealthMetric.Compute(headings);
+
+        r.DistinctHeadings.Should().Be(5);
+        r.PlausibleHeadings.Should().Be(5);
+        r.PlausibleFraction.Should().Be(1.0);
+        r.Band.Should().Be("green");
+    }
+
+    [Fact]
+    public void Compute_TmLikeGarbageMix_IsRedOrYellow_BelowThreshold()
+    {
+        // Roughly the TM shape: a few real titles buried under vertical-text / symbol garbage.
+        var headings = new[]
+        {
+            "PREPARAZIONE", "AZIONI", "CARTE",                 // plausible (3)
+            "D", "S U", "I L E X Y R F C A A S I", "(14%), Oceani", "Dato",  // garbage-ish
+        };
+
+        var r = TitleHealthMetric.Compute(headings);
+
+        r.DistinctHeadings.Should().Be(8);
+        r.PlausibleFraction.Should().BeLessThan(TitleHealthMetric.Compute(new[] { "SETUP" }).PlausibleFraction + 0.01);
+        r.Band.Should().NotBe("green"); // extraction quality is degraded → not green
+        r.CanonicalCoverage.Should().BeGreaterThan(0, "PREPARAZIONE/AZIONI are curated lexicon sections");
+    }
+
+    [Fact]
+    public void Compute_DeduplicatesHeadings()
+    {
+        // Child chunks repeat the parent heading; the metric counts DISTINCT headings.
+        var headings = new[] { "PREPARAZIONE", "PREPARAZIONE", "PREPARAZIONE", "AZIONI" };
+
+        TitleHealthMetric.Compute(headings).DistinctHeadings.Should().Be(2);
+    }
+
+    [Fact]
+    public void Compute_NoHeadings_IsRedWithZeroCounts()
+    {
+        var r = TitleHealthMetric.Compute(new string?[] { null, "", "   " });
+
+        r.DistinctHeadings.Should().Be(0);
+        r.PlausibleFraction.Should().Be(0.0);
+        r.Band.Should().Be("red");
+    }
+
+    [Fact]
+    public void Compute_CanonicalCoverage_CountsLexiconSectionsPresent()
+    {
+        // "PANORAMICA DEL GIOCO" contains PANORAMICA; PREPARAZIONE + AZIONI are direct lexicon entries.
+        var r = TitleHealthMetric.Compute(new[] { "PREPARAZIONE", "AZIONI", "PANORAMICA DEL GIOCO", "Random Section" });
+
+        r.CanonicalCoverage.Should().BeGreaterThanOrEqualTo(3);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/Chunking/TitleHealthMetricTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/Chunking/TitleHealthMetricTests.cs
@@ -89,9 +89,31 @@ public class TitleHealthMetricTests
     [Fact]
     public void Compute_CanonicalCoverage_CountsLexiconSectionsPresent()
     {
-        // "PANORAMICA DEL GIOCO" contains PANORAMICA; PREPARAZIONE + AZIONI are direct lexicon entries.
+        // PREPARAZIONE + AZIONI are direct lexicon entries; "PANORAMICA DEL GIOCO" carries PANORAMICA;
+        // "Random Section" is plausible but not canonical → 3 canonical headings.
         var r = TitleHealthMetric.Compute(new[] { "PREPARAZIONE", "AZIONI", "PANORAMICA DEL GIOCO", "Random Section" });
 
-        r.CanonicalCoverage.Should().BeGreaterThanOrEqualTo(3);
+        r.CanonicalCoverage.Should().Be(3);
+    }
+
+    [Fact]
+    public void Compute_CanonicalCoverage_CountsHeadingOnce_ForOverlappingLexiconEntries()
+    {
+        // "SVOLGIMENTO DEL GIOCO" matches both "SVOLGIMENTO" and "SVOLGIMENTO DEL GIOCO" — per-heading
+        // counting credits it once (review: no double-count).
+        var r = TitleHealthMetric.Compute(new[] { "SVOLGIMENTO DEL GIOCO" });
+
+        r.CanonicalCoverage.Should().Be(1);
+    }
+
+    [Fact]
+    public void Compute_CanonicalCoverage_ExcludesGarbageHeadingCarryingLexiconToken()
+    {
+        // A garbage heading that embeds a lexicon word but is NOT plausible (letter fraction < 0.6) must
+        // not credit coverage (review: gate canonical on plausibility so the sub-signals cannot contradict).
+        var r = TitleHealthMetric.Compute(new[] { "3 4 SETUP 9%" });
+
+        TitleHealthMetric.IsPlausibleHeading("3 4 SETUP 9%").Should().BeFalse();
+        r.CanonicalCoverage.Should().Be(0);
     }
 }

--- a/docs/for-developers/operations/2026-07-28-wp3-title-health-go-no-go.md
+++ b/docs/for-developers/operations/2026-07-28-wp3-title-health-go-no-go.md
@@ -17,14 +17,16 @@ Computed over the real staging headings of 6 games. **Only Terraforming Mars was
 | Game | lang | distinct | plausible % | canonical | band |
 |---|---|---|---|---|---|
 | Wingspan | en | 102 | 90 % | 0 | 🟢 green |
-| Catan | en | 104 | 87 % | 1 | 🟢 green |
+| Catan | en | 104 | 87 % | 2 | 🟢 green |
 | Dominion | en | 121 | 85 % | 0 | 🟢 green |
-| Ark Nova | en | 107 | 79 % | 3 | 🟡 yellow |
-| **Terraforming Mars** | it | 68 | **72 %** | **9** | 🟡 **yellow** |
+| Ark Nova | en | 107 | 79 % | 4 | 🟡 yellow |
+| **Terraforming Mars** | it | 68 | **72 %** | **11** | 🟡 **yellow** |
+
+(`canonical` = distinct plausible headings matching a curated lexicon section word.)
 
 ## WP4 go/no-go decision — **DEFERRED / descope-able**
 
-Terraforming Mars — the epic's motivating case — is **yellow (72 %)** after WP1, with the **highest canonical coverage (9)**: the WP1 heading-repair (embedded-title splitter + `Header`→`Title` promotion + synonym-aware boost) recovered the real section headings. The `Setup per N giocatori` query now works end-to-end (WP2: the `PREPARAZIONE` chunk is retrieved rank #1 and the answer is grounded).
+Terraforming Mars — the epic's motivating case — is **yellow (72 %)** after WP1, with the **highest canonical coverage (11)**: the WP1 heading-repair (embedded-title splitter + `Header`→`Title` promotion + synonym-aware boost) recovered the real section headings. The `Setup per N giocatori` query now works end-to-end (WP2: the `PREPARAZIONE` chunk is retrieved rank #1 and the answer is grounded).
 
 The residual 28 % (garbage `Title` elements unstructured emits — `I L E X Y R F`, `D`, `(14%), Oceani`) is **demoted by WP1b (number-noise) and does not block retrieval**. WP4 (hi_res IT extraction) would push TM yellow → green by fixing the extraction at the geometry level, but its cost is real and load-bearing (per epic WP4: HttpClient 35 s timeout + retry storm, yolox weights not baked into the image, hi_res >90 s on CPU) and is **not justified to go yellow → green when the functional goal is already met**.
 

--- a/docs/for-developers/operations/2026-07-28-wp3-title-health-go-no-go.md
+++ b/docs/for-developers/operations/2026-07-28-wp3-title-health-go-no-go.md
@@ -1,0 +1,37 @@
+# WP3 — Title-health metric + WP4 go/no-go read-out
+
+**Epic:** [#3338](https://github.com/meepleAi-app/meepleai-monorepo/issues/3338) (RAG extraction heading-detection). **Date:** 2026-07-28.
+
+## The metric
+
+`TitleHealthMetric.Compute` (`apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/TitleHealthMetric.cs`) scores a game's extraction quality from the **section headings its chunks carry** (`text_chunks.Heading` — what retrieval sees):
+
+- **PlausibleFraction** — fraction of DISTINCT headings that look like real section titles. A heading is *plausible* when it is 2–40 chars, carries a real word (a run of ≥3 consecutive letters — rejects `D`, `S U`, `I L E X Y R F`), and is ≥60 % letters (rejects `(14%), Oceani`, `© 2016 FryxGames www.…`). It measures title-**likeness**, not section-correctness; the target is gross extraction garbage.
+- **CanonicalCoverage** — how many curated `SectionHeadingLexicon` section types are present.
+- **Band** — `green` ≥ 0.80 · `yellow` ≥ 0.50 · `red` otherwise.
+
+## Read-out (staging, 2026-07-28, post-WP1 deploy)
+
+Computed over the real staging headings of 6 games. **Only Terraforming Mars was re-chunked with WP1**; the others reflect the pre-WP1 chunking (baseline).
+
+| Game | lang | distinct | plausible % | canonical | band |
+|---|---|---|---|---|---|
+| Wingspan | en | 102 | 90 % | 0 | 🟢 green |
+| Catan | en | 104 | 87 % | 1 | 🟢 green |
+| Dominion | en | 121 | 85 % | 0 | 🟢 green |
+| Ark Nova | en | 107 | 79 % | 3 | 🟡 yellow |
+| **Terraforming Mars** | it | 68 | **72 %** | **9** | 🟡 **yellow** |
+
+## WP4 go/no-go decision — **DEFERRED / descope-able**
+
+Terraforming Mars — the epic's motivating case — is **yellow (72 %)** after WP1, with the **highest canonical coverage (9)**: the WP1 heading-repair (embedded-title splitter + `Header`→`Title` promotion + synonym-aware boost) recovered the real section headings. The `Setup per N giocatori` query now works end-to-end (WP2: the `PREPARAZIONE` chunk is retrieved rank #1 and the answer is grounded).
+
+The residual 28 % (garbage `Title` elements unstructured emits — `I L E X Y R F`, `D`, `(14%), Oceani`) is **demoted by WP1b (number-noise) and does not block retrieval**. WP4 (hi_res IT extraction) would push TM yellow → green by fixing the extraction at the geometry level, but its cost is real and load-bearing (per epic WP4: HttpClient 35 s timeout + retry storm, yolox weights not baked into the image, hi_res >90 s on CPU) and is **not justified to go yellow → green when the functional goal is already met**.
+
+**Decision:** WP4 is deferred/descope-able. Re-evaluate if a broader IT cohort — once re-chunked with WP1 (the 12 other IT docs + the 65 currently-`Failed` PDFs, both pending a re-index) — shows a **red** cohort whose retrieval actually regresses. Until then WP1 (+ the number-noise demotion) is sufficient.
+
+## Remaining WP3 (follow-up)
+
+- Corpus `title-health` admin endpoint + persistence (so the metric is queryable, not just computed offline).
+- Wire the metric into a CI gate that **fails if a previously-green English game's health drops** after a WP1/WP4 change (the regression guard) — alongside the retrieval regression guard (`rag-smoke-assert.sh`).
+- Capture the `tmars-setup-it` rag-smoke baseline on staging (`--update-baseline`) so the added canonical query asserts instead of SKIPs.

--- a/infra/fixtures/rag-canonical-queries.json
+++ b/infra/fixtures/rag-canonical-queries.json
@@ -59,6 +59,13 @@
       "game": "7 Wonders",
       "language": "it",
       "query": "Come si risolve il conflitto militare alla fine di ogni età in 7 Wonders?"
+    },
+    {
+      "queryId": "tmars-setup-it",
+      "game": "Terraforming Mars",
+      "language": "it",
+      "_comment": "Epic #3338 WP2/WP3 motivating case ('Setup per N giocatori'). Pins that TM's PREPARAZIONE setup section — recovered by the WP1 heading-repair (Header promotion) after the re-chunk — stays retrievable. SKIPs until its baseline is captured via --update-baseline on staging.",
+      "query": "Come funziona la preparazione (setup) di Terraforming Mars per il numero di giocatori?"
     }
   ]
 }

--- a/infra/fixtures/rag-canonical-queries.json
+++ b/infra/fixtures/rag-canonical-queries.json
@@ -64,8 +64,8 @@
       "queryId": "tmars-setup-it",
       "game": "Terraforming Mars",
       "language": "it",
-      "_comment": "Epic #3338 WP2/WP3 motivating case ('Setup per N giocatori'). Pins that TM's PREPARAZIONE setup section — recovered by the WP1 heading-repair (Header promotion) after the re-chunk — stays retrievable. SKIPs until its baseline is captured via --update-baseline on staging.",
-      "query": "Come funziona la preparazione (setup) di Terraforming Mars per il numero di giocatori?"
+      "_comment": "Epic #3338 WP2/WP3 motivating case ('Setup per N giocatori'). Pins that TM's PREPARAZIONE setup section — recovered by the WP1 heading-repair (Header promotion) after the re-chunk — stays retrievable. SKIPs until its baseline is captured via --update-baseline on staging. The query carries TM-specific nouns (Corporation, ossigeno, plancia dei giocatori) so global-ask isolates TM and does not pin a wrong-game baseline (review #3355).",
+      "query": "Come si prepara Terraforming Mars per N giocatori: quante carte Corporation e progetti in mano, la plancia dei giocatori e i parametri iniziali (ossigeno, temperatura, oceani)?"
     }
   ]
 }


### PR DESCRIPTION
Part of #3338 (WP3 — do not auto-close the epic).

## What

**WP3 core — `TitleHealthMetric`**: a pure per-game extraction-quality metric from the section headings a game's chunks carry (`text_chunks.Heading` — what retrieval sees). Reports `{DistinctHeadings, PlausibleHeadings, PlausibleFraction, CanonicalCoverage, Band}` where a heading is *plausible* if it's 2–40 chars, carries a real word (≥3 consecutive letters — rejects `D`/`S U`/`I L E X Y R F`) and is ≥60 % letters (rejects `(14%), Oceani`/URL lines). Band = green ≥0.80 / yellow ≥0.50 / red. 19 unit tests over the real TM garbage headings.

**Deliverable A — TM canonical query**: added `tmars-setup-it` (the epic's "Setup per N giocatori") to the EN+IT rag-smoke retrieval gate. SKIPs until its baseline is captured on staging, so it doesn't red the gate before the ops capture.

**Deliverable #4 — WP4 go/no-go read-out** (doc): ran the metric over the real staging headings.

| Game | band | plaus% | canon |
|---|---|---|---|
| Wingspan/Catan/Dominion (en) | 🟢 green | 85–90% | 0–1 |
| Ark Nova (en) | 🟡 yellow | 79% | 3 |
| **Terraforming Mars (it)** | 🟡 **yellow** | **72%** | **9** |

**Decision: WP4 (hi_res) deferred/descope-able.** TM is yellow after WP1 with the highest canonical coverage (WP1 recovered the sections); the query works (WP2) and the residual garbage is demoted by WP1b — hi_res's real infra cost isn't justified for yellow→green when the functional goal is met. Re-evaluate if a broader re-chunked IT cohort shows a red cohort.

## Remaining WP3 (follow-up, noted in the doc)
Corpus `title-health` endpoint + persistence + a CI regression-guard gate that fails if a green EN game's health drops (acceptance #1/#2). This PR delivers the metric core, the TM assertion (#3), and the go/no-go (#4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)