### PR TITLE
fix(toolkit): preserve VersionSemver/Description/License on UpdateAsync (#1458)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Infrastructure/Persistence/GameToolkitRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Infrastructure/Persistence/GameToolkitRepository.cs
@@ -134,7 +134,19 @@ internal class GameToolkitRepository : RepositoryBase, IGameToolkitRepository
         ArgumentNullException.ThrowIfNull(toolkit);
         CollectDomainEvents(toolkit);
         var entity = MapToPersistence(toolkit);
-        DbContext.Set<GameToolkitEntity>().Update(entity);
+        var entry = DbContext.Set<GameToolkitEntity>().Update(entity);
+
+        // Issue #1458: the domain aggregate carries no VersionSemver/Description/License,
+        // so MapToPersistence cannot reconstruct them — VersionSemver is synthesized as
+        // "0.{Version}.0" and the other two default to null. Update() marks every column
+        // Modified, which would clobber the published marketplace pointer (e.g. reset
+        // "2.3.1" → "0.1.0") and null the description/license on every non-publish update.
+        // Exclude those three columns so their persisted values survive. PublishToolkitVersion
+        // writes VersionSemver on the tracked entity directly, bypassing this method.
+        entry.Property(e => e.VersionSemver).IsModified = false;
+        entry.Property(e => e.Description).IsModified = false;
+        entry.Property(e => e.License).IsModified = false;
+
         return Task.CompletedTask;
     }
 
@@ -297,18 +309,19 @@ internal class GameToolkitRepository : RepositoryBase, IGameToolkitRepository
 #pragma warning disable CS0618 // Issue #1144 / spec D-5: paired write — legacy int + new semver in same MapToPersistence call.
             Version = toolkit.Version,
 #pragma warning restore CS0618
-#pragma warning disable S1135 // TODO: architectural breadcrumb — active footgun: see comment below.
+#pragma warning disable S1135 // TODO: architectural breadcrumb — mitigated footgun: see comment below.
             // TODO(#1458): VersionSemver already has a real producer.
             // PublishToolkitVersionCommandHandler.cs:137 writes the user-input
             // semver and DELIBERATELY bypasses GameToolkitRepository.UpdateAsync
             // (see handler comment at lines 131-136) precisely because this
             // MapToPersistence synthesis would otherwise overwrite the user
-            // value with "0.{Version}.0". Risk: every OTHER UpdateAsync call
-            // (name rename, config change, future commands) silently overwrites
-            // the column. Fix: surface VersionSemver on the domain aggregate
-            // (separate epic — original paired-write context shipped in #1144
-            // 2026-05-14) so MapToPersistence can read it directly and the
-            // synthesis goes away.
+            // value with "0.{Version}.0". This synthesis is only meaningful for
+            // AddAsync (brand-new toolkit → seed "0.1.0"): UpdateAsync now excludes
+            // VersionSemver (and Description/License) from the Update() so no
+            // non-publish update path clobbers the published marketplace pointer.
+            // Full fix: surface VersionSemver on the domain aggregate (separate
+            // epic — original paired-write context shipped in #1144 2026-05-14)
+            // so MapToPersistence can read it directly and the synthesis goes away.
             VersionSemver = $"0.{toolkit.Version}.0",
 #pragma warning restore S1135
             CreatedByUserId = toolkit.CreatedByUserId,

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Infrastructure/Persistence/GameToolkitRepositoryUpdatePreservationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Infrastructure/Persistence/GameToolkitRepositoryUpdatePreservationTests.cs
@@ -1,0 +1,88 @@
+using Api.BoundedContexts.GameToolkit.Application.Commands;
+using Api.BoundedContexts.GameToolkit.Domain.Enums;
+using Api.BoundedContexts.GameToolkit.Infrastructure.Persistence;
+using Api.Infrastructure.Entities.GameToolkit;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameToolkit.Infrastructure.Persistence;
+
+/// <summary>
+/// Regression tests for <see cref="GameToolkitRepository.UpdateAsync"/> (issue #1458 footgun).
+///
+/// <para>
+/// <c>MapToPersistence</c> synthesizes <c>VersionSemver = "0.{Version}.0"</c> and omits
+/// <c>Description</c>/<c>License</c> entirely (the domain aggregate has no knowledge of these
+/// three entity-level marketplace columns). Because <c>UpdateAsync</c> calls
+/// <c>DbContext.Update(entity)</c>, which marks EVERY scalar column Modified, any non-publish
+/// update path (rename, add/remove tool, override change, …) silently overwrote the published
+/// marketplace pointer: <c>VersionSemver "2.3.1" → "0.1.0"</c> and nulled <c>Description</c>/<c>License</c>.
+/// </para>
+///
+/// InMemory is the correct vehicle: it honors per-property <c>IsModified</c> flags but ignores
+/// the Postgres <c>xmin</c> concurrency token (which would otherwise mask this bug behind a
+/// <c>DbUpdateConcurrencyException</c> on a real database).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameToolkit")]
+[Trait("Issue", "1458")]
+public class GameToolkitRepositoryUpdatePreservationTests
+{
+    private static readonly Guid OwnerId = Guid.Parse("00000000-0000-0000-0000-0000000000a1");
+    private static readonly DateTime Now = new(2026, 7, 28, 12, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task UpdateAsync_RenamingToolkit_PreservesPublishedVersionSemverDescriptionAndLicense()
+    {
+        var collector = TestDbContextFactory.CreateMockEventCollector();
+        var dbName = Guid.NewGuid().ToString();
+        var toolkitId = Guid.NewGuid();
+
+        // ── Arrange: seed a published toolkit with a real semver + marketplace metadata ──
+        using (var seedContext = TestDbContextFactory.CreateInMemoryDbContextWithCollector(collector, dbName))
+        {
+#pragma warning disable CS0618 // legacy int Version setter — required to seed the paired column
+            seedContext.GameToolkits.Add(new GameToolkitEntity
+            {
+                Id = toolkitId,
+                Name = "Original Name",
+                CreatedByUserId = OwnerId,
+                Version = 1,
+                VersionSemver = "2.3.1",
+                Description = "A great community toolkit",
+                License = "CC BY-SA 4.0",
+                IsPublished = true,
+                TemplateStatus = (int)TemplateStatus.Approved,
+                CreatedAt = Now,
+                UpdatedAt = Now,
+            });
+#pragma warning restore CS0618
+            await seedContext.SaveChangesAsync();
+        }
+
+        // ── Act: rename through the real repository + handler (separate context) ──
+        using (var actContext = TestDbContextFactory.CreateInMemoryDbContextWithCollector(collector, dbName))
+        {
+            var repository = new GameToolkitRepository(actContext, collector.Object);
+            var unitOfWork = new EfCoreUnitOfWork(actContext);
+            var handler = new UpdateToolkitCommandHandler(repository, unitOfWork);
+
+            await handler.Handle(new UpdateToolkitCommand(toolkitId, "Renamed Toolkit"), default);
+        }
+
+        // ── Assert: rename applied, but the published marketplace columns are untouched ──
+        using (var assertContext = TestDbContextFactory.CreateInMemoryDbContextWithCollector(collector, dbName))
+        {
+            var reloaded = await assertContext.GameToolkits.FindAsync(toolkitId);
+
+            reloaded.Should().NotBeNull();
+            reloaded!.Name.Should().Be("Renamed Toolkit", "the rename must still persist");
+            reloaded.VersionSemver.Should().Be("2.3.1", "a rename must not regress the published marketplace version pointer");
+            reloaded.Description.Should().Be("A great community toolkit", "a rename must not null the marketplace description");
+            reloaded.License.Should().Be("CC BY-SA 4.0", "a rename must not null the marketplace license");
+        }
+    }
+}


### PR DESCRIPTION
## Problema (#1458 footgun)

`GameToolkitRepository.UpdateAsync` costruisce un'entità detached via `MapToPersistence` e chiama `DbContext.Update(entity)`, che marca **tutte** le colonne come `Modified`. Poiché l'aggregate di dominio `GameToolkit` non espone `VersionSemver`/`Description`/`License`, `MapToPersistence`:

- sintetizza `VersionSemver = "0.{Version}.0"`;
- lascia `Description`/`License` a `null`.

Risultato: **ogni** update non-publish (rename via `UpdateToolkitCommandHandler`, add/remove tool o override via `ToolkitCommandHandlers`, preset, `ApplyAiToolkitSuggestionHandler`) sovrascriveva silenziosamente il puntatore versione del marketplace — il badge current-version regrediva da es. `2.3.1` a `0.1.0` — e nullava descrizione/licenza. Le righe `ToolkitVersion` pubblicate restano intatte; si corrompeva solo il puntatore del parent.

`PublishToolkitVersionCommandHandler` era già l'unico produttore corretto del semver (scrive sull'entità tracked bypassando il repo, con commento esplicito).

## Fix

Dopo `Update(entity)`, escludo le tre colonne dalla modifica:

```csharp
entry.Property(e => e.VersionSemver).IsModified = false;
entry.Property(e => e.Description).IsModified = false;
entry.Property(e => e.License).IsModified = false;
```

Così i valori persistiti sopravvivono a qualsiasi update. La sintesi `"0.{Version}.0"` resta solo per `AddAsync` (seed di un toolkit nuovo). Aggiornato il breadcrumb TODO(#1458) in `MapToPersistence` (footgun ora mitigato, non più "attivo").

## TDD

RED → GREEN: `GameToolkitRepositoryUpdatePreservationTests.UpdateAsync_RenamingToolkit_PreservesPublishedVersionSemverDescriptionAndLicense`

- **RED** (pre-fix): `VersionSemver` ricaricato = `0.1.0` invece di `2.3.1` (il rename applicato correttamente, i tre campi marketplace sovrascritti).
- **GREEN** (post-fix): rename applicato **e** `VersionSemver`/`Description`/`License` preservati.

Unit test InMemory (non Postgres): InMemory rispetta i flag `IsModified` per-proprietà ma ignora il token di concorrenza `xmin`, che su un DB reale mascherebbe il bug dietro una `DbUpdateConcurrencyException`.

## Verifica

- Nuovo test: PASS
- Regressione: **319/319** unit test `BoundedContext=GameToolkit` PASS
- Pre-push backend build: 0 errori

## Scope

Fix mirato al footgun #1458. Il fatto che `MapToPersistence` non round-trippi `xmin` (potenziale `DbUpdateConcurrencyException` su ogni `UpdateAsync` non-publish su Postgres reale) è un bug latente **separato e pre-esistente**, fuori scope qui.