### PR TITLE
fix(chat): enforce ownership on by-id chat-session endpoints (IDOR)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/AddChatSessionMessageCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/AddChatSessionMessageCommand.cs
@@ -8,6 +8,7 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Commands;
 /// </summary>
 internal record AddChatSessionMessageCommand(
     Guid SessionId,
+    Guid UserId,
     string Role,
     string Content,
     Dictionary<string, object>? Metadata = null

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/AddChatSessionMessageCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/AddChatSessionMessageCommandHandler.cs
@@ -47,6 +47,13 @@ internal sealed class AddChatSessionMessageCommandHandler : IRequestHandler<AddC
             throw new NotFoundException("ChatSession", request.SessionId.ToString());
         }
 
+        // Ownership check (IDOR): a non-owner gets the same 404 as a non-existent
+        // session, so injecting messages into another user's chat is impossible.
+        if (session.UserId != request.UserId)
+        {
+            throw new NotFoundException("ChatSession", request.SessionId.ToString());
+        }
+
         var sequenceNumber = session.MessageCount;
         var message = new SessionChatMessage(
             content: request.Content,

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/DeleteChatSessionCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/DeleteChatSessionCommand.cs
@@ -7,5 +7,6 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Commands;
 /// Issue #3483: Chat Session Persistence Service.
 /// </summary>
 internal record DeleteChatSessionCommand(
-    Guid SessionId
+    Guid SessionId,
+    Guid UserId
 ) : IRequest;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/DeleteChatSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/DeleteChatSessionCommandHandler.cs
@@ -46,6 +46,13 @@ internal sealed class DeleteChatSessionCommandHandler : IRequestHandler<DeleteCh
             throw new NotFoundException("ChatSession", request.SessionId.ToString());
         }
 
+        // Ownership check (IDOR): a non-owner gets the same 404 as a non-existent
+        // session, so deletion of another user's chat is impossible and undetectable.
+        if (session.UserId != request.UserId)
+        {
+            throw new NotFoundException("ChatSession", request.SessionId.ToString());
+        }
+
         await _sessionRepository.DeleteAsync(session, cancellationToken).ConfigureAwait(false);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/RenameChatSessionCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/RenameChatSessionCommand.cs
@@ -9,5 +9,6 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Commands;
 /// </summary>
 internal record RenameChatSessionCommand(
     Guid SessionId,
+    Guid UserId,
     string Title
 ) : ICommand<ChatSessionDto>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/RenameChatSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/RenameChatSessionCommandHandler.cs
@@ -34,6 +34,11 @@ internal sealed class RenameChatSessionCommandHandler : ICommandHandler<RenameCh
         if (session == null)
             throw new NotFoundException("ChatSession", command.SessionId.ToString());
 
+        // Ownership check (IDOR): a non-owner gets the same 404 as a non-existent
+        // session, so renaming another user's chat is impossible and undetectable.
+        if (session.UserId != command.UserId)
+            throw new NotFoundException("ChatSession", command.SessionId.ToString());
+
         // Update title (domain validates max 200 chars, non-empty, trim)
         session.SetTitle(command.Title);
 

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetChatSessionQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetChatSessionQuery.cs
@@ -9,6 +9,7 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Queries;
 /// </summary>
 internal record GetChatSessionQuery(
     Guid SessionId,
+    Guid UserId,
     int MessageSkip = 0,
     int MessageTake = 50
 ) : IRequest<ChatSessionDto?>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetChatSessionQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetChatSessionQueryHandler.cs
@@ -48,6 +48,13 @@ internal sealed class GetChatSessionQueryHandler : IRequestHandler<GetChatSessio
             return null;
         }
 
+        // Ownership check (IDOR): a non-owner sees the same null → 404 as a
+        // non-existent session, so the endpoint discloses nothing about it.
+        if (session.UserId != request.UserId)
+        {
+            return null;
+        }
+
         var messageDtos = session.Messages
             .Select(m => new ChatSessionMessageDto(
                 Id: m.Id,

--- a/apps/api/src/Api/Routing/ChatSessionEndpoints.cs
+++ b/apps/api/src/Api/Routing/ChatSessionEndpoints.cs
@@ -140,10 +140,12 @@ internal static class ChatSessionEndpoints
         [FromRoute] Guid sessionId,
         [FromBody] AddChatSessionMessageRequest request,
         [FromServices] IMediator mediator,
+        HttpContext httpContext,
         CancellationToken cancellationToken)
     {
         var command = new AddChatSessionMessageCommand(
             SessionId: sessionId,
+            UserId: httpContext.User.GetUserId(),
             Role: request.Role,
             Content: request.Content,
             Metadata: request.Metadata
@@ -156,6 +158,7 @@ internal static class ChatSessionEndpoints
 
     private static async Task<IResult> HandleGetSession(
         [FromRoute] Guid sessionId,
+        HttpContext httpContext,
         [FromQuery] int skip = 0,
         [FromQuery] int take = 50,
         [FromServices] IMediator mediator = null!,
@@ -163,6 +166,7 @@ internal static class ChatSessionEndpoints
     {
         var query = new GetChatSessionQuery(
             SessionId: sessionId,
+            UserId: httpContext.User.GetUserId(),
             MessageSkip: skip,
             MessageTake: take
         );
@@ -263,9 +267,10 @@ internal static class ChatSessionEndpoints
     private static async Task<IResult> HandleDeleteSession(
         [FromRoute] Guid sessionId,
         [FromServices] IMediator mediator,
+        HttpContext httpContext,
         CancellationToken cancellationToken)
     {
-        var command = new DeleteChatSessionCommand(SessionId: sessionId);
+        var command = new DeleteChatSessionCommand(SessionId: sessionId, UserId: httpContext.User.GetUserId());
 
         await mediator.Send(command, cancellationToken).ConfigureAwait(false);
 
@@ -278,6 +283,7 @@ internal static class ChatSessionEndpoints
         [FromServices] IMediator mediator,
         [FromServices] IChatSessionRepository sessionRepository,
         [FromServices] IChatThreadRepository threadRepository,
+        HttpContext httpContext,
         CancellationToken cancellationToken)
     {
         // Naming disambiguation: detect if caller passed a ChatThread UUID to a ChatSession endpoint
@@ -297,7 +303,7 @@ internal static class ChatSessionEndpoints
             return Results.NotFound();
         }
 
-        var command = new RenameChatSessionCommand(SessionId: sessionId, Title: body.Title);
+        var command = new RenameChatSessionCommand(SessionId: sessionId, UserId: httpContext.User.GetUserId(), Title: body.Title);
 
         try
         {

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/ChatSession/AddChatSessionMessageCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/ChatSession/AddChatSessionMessageCommandHandlerTests.cs
@@ -19,6 +19,7 @@ namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Handlers.ChatSessi
 [Trait("Category", TestCategories.Unit)]
 public class AddChatSessionMessageCommandHandlerTests
 {
+    private static readonly Guid TestUserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
     private readonly Mock<IChatSessionRepository> _mockRepository;
     private readonly Mock<IUnitOfWork> _mockUnitOfWork;
     private readonly Mock<ILogger<AddChatSessionMessageCommandHandler>> _mockLogger;
@@ -48,6 +49,7 @@ public class AddChatSessionMessageCommandHandlerTests
 
         var command = new AddChatSessionMessageCommand(
             SessionId: sessionId,
+            UserId: TestUserId,
             Role: SessionChatMessage.UserRole,
             Content: "Hello, I need help with the rules");
 
@@ -78,6 +80,7 @@ public class AddChatSessionMessageCommandHandlerTests
 
         var command = new AddChatSessionMessageCommand(
             SessionId: sessionId,
+            UserId: TestUserId,
             Role: SessionChatMessage.AssistantRole,
             Content: "I can help you with that!");
 
@@ -103,6 +106,7 @@ public class AddChatSessionMessageCommandHandlerTests
 
         var command = new AddChatSessionMessageCommand(
             SessionId: sessionId,
+            UserId: TestUserId,
             Role: SessionChatMessage.SystemRole,
             Content: "You are a helpful assistant");
 
@@ -133,6 +137,7 @@ public class AddChatSessionMessageCommandHandlerTests
 
         var command = new AddChatSessionMessageCommand(
             SessionId: sessionId,
+            UserId: TestUserId,
             Role: SessionChatMessage.UserRole,
             Content: "Test message",
             Metadata: metadata);
@@ -155,6 +160,7 @@ public class AddChatSessionMessageCommandHandlerTests
 
         var command = new AddChatSessionMessageCommand(
             SessionId: sessionId,
+            UserId: TestUserId,
             Role: SessionChatMessage.UserRole,
             Content: "Test message");
 
@@ -178,12 +184,12 @@ public class AddChatSessionMessageCommandHandlerTests
 
         // Add first message
         await _handler.Handle(
-            new AddChatSessionMessageCommand(sessionId, SessionChatMessage.UserRole, "Message 1"),
+            new AddChatSessionMessageCommand(sessionId, TestUserId, SessionChatMessage.UserRole, "Message 1"),
             TestContext.Current.CancellationToken);
 
         // Add second message
         await _handler.Handle(
-            new AddChatSessionMessageCommand(sessionId, SessionChatMessage.AssistantRole, "Message 2"),
+            new AddChatSessionMessageCommand(sessionId, TestUserId, SessionChatMessage.AssistantRole, "Message 2"),
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -213,6 +219,7 @@ public class AddChatSessionMessageCommandHandlerTests
 
         var command = new AddChatSessionMessageCommand(
             SessionId: sessionId,
+            UserId: TestUserId,
             Role: SessionChatMessage.UserRole,
             Content: "Test");
 
@@ -270,11 +277,40 @@ public class AddChatSessionMessageCommandHandlerTests
         act.Should().Throw<ArgumentNullException>();
     }
 
+    [Fact]
+    public async Task Handle_WhenCallerIsNotOwner_ThrowsNotFoundAndDoesNotPersist()
+    {
+        // Arrange — session owned by someone else; a non-owner must get 404, no write.
+        var sessionId = Guid.NewGuid();
+        var attackerId = Guid.NewGuid();
+        var session = CreateTestSession(sessionId); // owned by TestUserId
+
+        _mockRepository
+            .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var command = new AddChatSessionMessageCommand(
+            SessionId: sessionId,
+            UserId: attackerId,
+            Role: SessionChatMessage.UserRole,
+            Content: "injected");
+
+        // Act & Assert
+        Func<Task> act = () => _handler.Handle(command, TestContext.Current.CancellationToken);
+        await act.Should().ThrowAsync<NotFoundException>();
+
+        session.MessageCount.Should().Be(0);
+        _mockRepository.Verify(
+            r => r.UpdateAsync(It.IsAny<Api.BoundedContexts.KnowledgeBase.Domain.Entities.ChatSession>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _mockUnitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
     private static Api.BoundedContexts.KnowledgeBase.Domain.Entities.ChatSession CreateTestSession(Guid sessionId)
     {
         return new Api.BoundedContexts.KnowledgeBase.Domain.Entities.ChatSession(
             id: sessionId,
-            userId: Guid.NewGuid(),
+            userId: TestUserId,
             gameId: Guid.NewGuid(),
             title: "Test Session");
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/ChatSession/DeleteChatSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/ChatSession/DeleteChatSessionCommandHandlerTests.cs
@@ -39,13 +39,14 @@ public class DeleteChatSessionCommandHandlerTests
     {
         // Arrange
         var sessionId = Guid.NewGuid();
-        var session = CreateTestSession(sessionId);
+        var userId = Guid.NewGuid();
+        var session = CreateTestSession(sessionId, userId);
 
         _mockRepository
             .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(session);
 
-        var command = new DeleteChatSessionCommand(SessionId: sessionId);
+        var command = new DeleteChatSessionCommand(SessionId: sessionId, UserId: userId);
 
         // Act
         await _handler.Handle(command, TestContext.Current.CancellationToken);
@@ -69,7 +70,7 @@ public class DeleteChatSessionCommandHandlerTests
             .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((Api.BoundedContexts.KnowledgeBase.Domain.Entities.ChatSession?)null);
 
-        var command = new DeleteChatSessionCommand(SessionId: sessionId);
+        var command = new DeleteChatSessionCommand(SessionId: sessionId, UserId: Guid.NewGuid());
 
         // Act & Assert
         Func<Task> act = () =>
@@ -83,7 +84,8 @@ public class DeleteChatSessionCommandHandlerTests
     {
         // Arrange
         var sessionId = Guid.NewGuid();
-        var session = CreateTestSession(sessionId);
+        var userId = Guid.NewGuid();
+        var session = CreateTestSession(sessionId, userId);
         var callOrder = new List<string>();
 
         _mockRepository
@@ -96,7 +98,7 @@ public class DeleteChatSessionCommandHandlerTests
             .Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
             .Callback(() => callOrder.Add("UnitOfWork.SaveChangesAsync"));
 
-        var command = new DeleteChatSessionCommand(SessionId: sessionId);
+        var command = new DeleteChatSessionCommand(SessionId: sessionId, UserId: userId);
 
         // Act
         await _handler.Handle(command, TestContext.Current.CancellationToken);
@@ -152,11 +154,36 @@ public class DeleteChatSessionCommandHandlerTests
         act.Should().Throw<ArgumentNullException>();
     }
 
-    private static Api.BoundedContexts.KnowledgeBase.Domain.Entities.ChatSession CreateTestSession(Guid sessionId)
+    [Fact]
+    public async Task Handle_WhenCallerIsNotOwner_ThrowsNotFoundAndDoesNotDelete()
+    {
+        // Arrange — session owned by someone else; a non-owner must get 404, no delete.
+        var sessionId = Guid.NewGuid();
+        var ownerId = Guid.NewGuid();
+        var attackerId = Guid.NewGuid();
+        var session = CreateTestSession(sessionId, ownerId);
+
+        _mockRepository
+            .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var command = new DeleteChatSessionCommand(SessionId: sessionId, UserId: attackerId);
+
+        // Act & Assert
+        Func<Task> act = () => _handler.Handle(command, TestContext.Current.CancellationToken);
+        await act.Should().ThrowAsync<NotFoundException>();
+
+        _mockRepository.Verify(
+            r => r.DeleteAsync(It.IsAny<Api.BoundedContexts.KnowledgeBase.Domain.Entities.ChatSession>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _mockUnitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private static Api.BoundedContexts.KnowledgeBase.Domain.Entities.ChatSession CreateTestSession(Guid sessionId, Guid? userId = null)
     {
         return new Api.BoundedContexts.KnowledgeBase.Domain.Entities.ChatSession(
             id: sessionId,
-            userId: Guid.NewGuid(),
+            userId: userId ?? Guid.NewGuid(),
             gameId: Guid.NewGuid(),
             title: "Test Session");
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/ChatSession/GetChatSessionQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/ChatSession/GetChatSessionQueryHandlerTests.cs
@@ -42,7 +42,7 @@ public class GetChatSessionQueryHandlerTests
             .Setup(r => r.GetByIdWithPaginatedMessagesAsync(sessionId, 0, 50, It.IsAny<CancellationToken>()))
             .ReturnsAsync(session);
 
-        var query = new GetChatSessionQuery(SessionId: sessionId);
+        var query = new GetChatSessionQuery(SessionId: sessionId, UserId: userId);
 
         // Act
         var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
@@ -64,7 +64,7 @@ public class GetChatSessionQueryHandlerTests
             .Setup(r => r.GetByIdWithPaginatedMessagesAsync(sessionId, 0, 50, It.IsAny<CancellationToken>()))
             .ReturnsAsync((Api.BoundedContexts.KnowledgeBase.Domain.Entities.ChatSession?)null);
 
-        var query = new GetChatSessionQuery(SessionId: sessionId);
+        var query = new GetChatSessionQuery(SessionId: sessionId, UserId: Guid.NewGuid());
 
         // Act
         var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
@@ -78,7 +78,8 @@ public class GetChatSessionQueryHandlerTests
     {
         // Arrange
         var sessionId = Guid.NewGuid();
-        var session = CreateTestSession(sessionId, Guid.NewGuid(), Guid.NewGuid());
+        var userId = Guid.NewGuid();
+        var session = CreateTestSession(sessionId, userId, Guid.NewGuid());
         session.AddUserMessage("Hello");
         session.AddAssistantMessage("Hi there!");
 
@@ -86,7 +87,7 @@ public class GetChatSessionQueryHandlerTests
             .Setup(r => r.GetByIdWithPaginatedMessagesAsync(sessionId, 0, 50, It.IsAny<CancellationToken>()))
             .ReturnsAsync(session);
 
-        var query = new GetChatSessionQuery(SessionId: sessionId);
+        var query = new GetChatSessionQuery(SessionId: sessionId, UserId: userId);
 
         // Act
         var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
@@ -106,7 +107,8 @@ public class GetChatSessionQueryHandlerTests
     {
         // Arrange
         var sessionId = Guid.NewGuid();
-        var session = CreateTestSession(sessionId, Guid.NewGuid(), Guid.NewGuid());
+        var userId = Guid.NewGuid();
+        var session = CreateTestSession(sessionId, userId, Guid.NewGuid());
 
         _mockRepository
             .Setup(r => r.GetByIdWithPaginatedMessagesAsync(sessionId, 10, 25, It.IsAny<CancellationToken>()))
@@ -114,6 +116,7 @@ public class GetChatSessionQueryHandlerTests
 
         var query = new GetChatSessionQuery(
             SessionId: sessionId,
+            UserId: userId,
             MessageSkip: 10,
             MessageTake: 25);
 
@@ -151,7 +154,7 @@ public class GetChatSessionQueryHandlerTests
             .Setup(r => r.GetByIdWithPaginatedMessagesAsync(sessionId, 0, 50, It.IsAny<CancellationToken>()))
             .ReturnsAsync(session);
 
-        var query = new GetChatSessionQuery(SessionId: sessionId);
+        var query = new GetChatSessionQuery(SessionId: sessionId, UserId: userId);
 
         // Act
         var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
@@ -197,6 +200,28 @@ public class GetChatSessionQueryHandlerTests
                 _mockRepository.Object,
                 null!);
         act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task Handle_WhenCallerIsNotOwner_ReturnsNull()
+    {
+        // Arrange — session owned by someone else; a non-owner must see the same null → 404.
+        var sessionId = Guid.NewGuid();
+        var ownerId = Guid.NewGuid();
+        var attackerId = Guid.NewGuid();
+        var session = CreateTestSession(sessionId, ownerId, Guid.NewGuid());
+
+        _mockRepository
+            .Setup(r => r.GetByIdWithPaginatedMessagesAsync(sessionId, 0, 50, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var query = new GetChatSessionQuery(SessionId: sessionId, UserId: attackerId);
+
+        // Act
+        var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Should().BeNull("a non-owner must not read another user's chat session");
     }
 
     private static Api.BoundedContexts.KnowledgeBase.Domain.Entities.ChatSession CreateTestSession(

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Validators/ChatSession/AddChatSessionMessageCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Validators/ChatSession/AddChatSessionMessageCommandValidatorTests.cs
@@ -30,6 +30,7 @@ public class AddChatSessionMessageCommandValidatorTests
         // Arrange
         var command = new AddChatSessionMessageCommand(
             SessionId: Guid.NewGuid(),
+            UserId: Guid.NewGuid(),
             Role: role,
             Content: "Valid message content");
 
@@ -46,6 +47,7 @@ public class AddChatSessionMessageCommandValidatorTests
         // Arrange
         var command = new AddChatSessionMessageCommand(
             SessionId: Guid.Empty,
+            UserId: Guid.NewGuid(),
             Role: "user",
             Content: "Valid content");
 
@@ -65,6 +67,7 @@ public class AddChatSessionMessageCommandValidatorTests
         // Arrange
         var command = new AddChatSessionMessageCommand(
             SessionId: Guid.NewGuid(),
+            UserId: Guid.NewGuid(),
             Role: role,
             Content: "Valid content");
 
@@ -87,6 +90,7 @@ public class AddChatSessionMessageCommandValidatorTests
         // Arrange
         var command = new AddChatSessionMessageCommand(
             SessionId: Guid.NewGuid(),
+            UserId: Guid.NewGuid(),
             Role: role,
             Content: "Valid content");
 
@@ -106,6 +110,7 @@ public class AddChatSessionMessageCommandValidatorTests
         // Arrange
         var command = new AddChatSessionMessageCommand(
             SessionId: Guid.NewGuid(),
+            UserId: Guid.NewGuid(),
             Role: "user",
             Content: content);
 
@@ -123,6 +128,7 @@ public class AddChatSessionMessageCommandValidatorTests
         // Arrange
         var command = new AddChatSessionMessageCommand(
             SessionId: Guid.NewGuid(),
+            UserId: Guid.NewGuid(),
             Role: "user",
             Content: new string('a', 50000));
 
@@ -139,6 +145,7 @@ public class AddChatSessionMessageCommandValidatorTests
         // Arrange
         var command = new AddChatSessionMessageCommand(
             SessionId: Guid.NewGuid(),
+            UserId: Guid.NewGuid(),
             Role: "user",
             Content: new string('a', 50001));
 
@@ -156,6 +163,7 @@ public class AddChatSessionMessageCommandValidatorTests
         // Arrange
         var command = new AddChatSessionMessageCommand(
             SessionId: Guid.Empty,
+            UserId: Guid.NewGuid(),
             Role: "invalid",
             Content: "");
 
@@ -181,6 +189,7 @@ public class AddChatSessionMessageCommandValidatorTests
         // Arrange
         var command = new AddChatSessionMessageCommand(
             SessionId: Guid.NewGuid(),
+            UserId: Guid.NewGuid(),
             Role: "user",
             Content: new string('a', length));
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Validators/ChatSession/DeleteChatSessionCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Validators/ChatSession/DeleteChatSessionCommandValidatorTests.cs
@@ -25,7 +25,8 @@ public class DeleteChatSessionCommandValidatorTests
     {
         // Arrange
         var command = new DeleteChatSessionCommand(
-            SessionId: Guid.NewGuid());
+            SessionId: Guid.NewGuid(),
+            UserId: Guid.NewGuid());
 
         // Act
         var result = _validator.TestValidate(command);
@@ -39,7 +40,8 @@ public class DeleteChatSessionCommandValidatorTests
     {
         // Arrange
         var command = new DeleteChatSessionCommand(
-            SessionId: Guid.Empty);
+            SessionId: Guid.Empty,
+            UserId: Guid.NewGuid());
 
         // Act
         var result = _validator.TestValidate(command);
@@ -54,7 +56,7 @@ public class DeleteChatSessionCommandValidatorTests
     public void Validate_WithVariousValidGuids_ShouldNotHaveValidationErrors(Guid sessionId)
     {
         // Arrange
-        var command = new DeleteChatSessionCommand(SessionId: sessionId);
+        var command = new DeleteChatSessionCommand(SessionId: sessionId, UserId: Guid.NewGuid());
 
         // Act
         var result = _validator.TestValidate(command);

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Endpoints/ChatSessionByIdEndpointsIdorIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Endpoints/ChatSessionByIdEndpointsIdorIntegrationTests.cs
@@ -1,0 +1,191 @@
+using System.Net;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.KnowledgeBase;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Endpoints;
+
+/// <summary>
+/// HTTP-layer IDOR tests for the by-<c>sessionId</c> chat-session endpoints.
+/// <para>
+/// GET/DELETE <c>/chat/sessions/{sessionId}</c>, POST <c>/rename</c> and POST <c>/messages</c>
+/// are keyed purely by the route <c>sessionId</c>. They must derive the caller identity from
+/// the authenticated principal and refuse to read, delete, rename, or append to a chat session
+/// owned by another user. A non-owner must receive the same 404 as for a non-existent session
+/// (no existence disclosure), mirroring the collection-endpoint hardening (IDOR #3120).
+/// </para>
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public sealed class ChatSessionByIdEndpointsIdorIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _ownerClient = null!;
+    private HttpClient _otherClient = null!;
+    private Guid _ownerId;
+    private string _ownerToken = null!;
+    private string _otherToken = null!;
+    private Guid _sessionId;
+
+    public ChatSessionByIdEndpointsIdorIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"chatsession_byid_idor_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        await db.Database.MigrateAsync();
+
+        (_ownerId, _ownerToken) = await TestSessionHelper.CreateUserSessionAsync(db);
+        (_, _otherToken) = await TestSessionHelper.CreateUserSessionAsync(db);
+
+        // ChatSessions.GameId FKs the SharedGame catalog.
+        var sharedGameId = await TestSessionHelper.SeedSharedGameAsync(db, "IDOR Chat Game");
+        var chatSession = new ChatSessionEntity
+        {
+            Id = Guid.NewGuid(),
+            UserId = _ownerId,
+            GameId = sharedGameId,
+            Title = "Owner private chat",
+            CreatedAt = DateTime.UtcNow,
+            LastMessageAt = DateTime.UtcNow,
+        };
+        db.ChatSessions.Add(chatSession);
+        await db.SaveChangesAsync();
+        _sessionId = chatSession.Id;
+
+        _ownerClient = _factory.CreateClient();
+        _otherClient = _factory.CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _ownerClient?.Dispose();
+        _otherClient?.Dispose();
+        _factory?.Dispose();
+        await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    private string SessionUrl => $"/api/v1/chat/sessions/{_sessionId}";
+
+    // ── GET ───────────────────────────────────────────────────────────────────
+
+    [Fact(Timeout = 90_000)]
+    public async Task GetSession_AsOwner_ReturnsSession()
+    {
+        var response = await _ownerClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(HttpMethod.Get, SessionUrl, _ownerToken));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact(Timeout = 90_000)]
+    public async Task GetSession_AsOtherUser_Returns404()
+    {
+        var response = await _otherClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(HttpMethod.Get, SessionUrl, _otherToken));
+
+        response.StatusCode.Should().Be(
+            HttpStatusCode.NotFound,
+            "a non-owner must not be able to read another user's chat session (nor its UserId)");
+    }
+
+    // ── DELETE ──────────────────────────────────────────────────────────────────
+
+    [Fact(Timeout = 90_000)]
+    public async Task DeleteSession_AsOwner_Succeeds()
+    {
+        var response = await _ownerClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(HttpMethod.Delete, SessionUrl, _ownerToken));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact(Timeout = 90_000)]
+    public async Task DeleteSession_AsOtherUser_Returns404()
+    {
+        var response = await _otherClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(HttpMethod.Delete, SessionUrl, _otherToken));
+
+        response.StatusCode.Should().Be(
+            HttpStatusCode.NotFound,
+            "a non-owner must not be able to delete another user's chat session");
+
+        // The session must still exist after the blocked delete.
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        (await db.ChatSessions.AnyAsync(s => s.Id == _sessionId)).Should().BeTrue();
+    }
+
+    // ── RENAME ──────────────────────────────────────────────────────────────────
+
+    [Fact(Timeout = 90_000)]
+    public async Task RenameSession_AsOwner_Succeeds()
+    {
+        var response = await _ownerClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(
+                HttpMethod.Post, $"{SessionUrl}/rename", _ownerToken, new { Title = "Owner rename" }));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact(Timeout = 90_000)]
+    public async Task RenameSession_AsOtherUser_Returns404()
+    {
+        var response = await _otherClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(
+                HttpMethod.Post, $"{SessionUrl}/rename", _otherToken, new { Title = "Hacked title" }));
+
+        response.StatusCode.Should().Be(
+            HttpStatusCode.NotFound,
+            "a non-owner must not be able to rename another user's chat session");
+
+        // The title must be untouched after the blocked rename.
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var session = await db.ChatSessions.AsNoTracking().FirstAsync(s => s.Id == _sessionId);
+        session.Title.Should().Be("Owner private chat");
+    }
+
+    // ── ADD MESSAGE ─────────────────────────────────────────────────────────────
+
+    [Fact(Timeout = 90_000)]
+    public async Task AddMessage_AsOwner_Succeeds()
+    {
+        var response = await _ownerClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(
+                HttpMethod.Post, $"{SessionUrl}/messages", _ownerToken,
+                new { Role = "user", Content = "hello" }));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact(Timeout = 90_000)]
+    public async Task AddMessage_AsOtherUser_Returns404()
+    {
+        var response = await _otherClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(
+                HttpMethod.Post, $"{SessionUrl}/messages", _otherToken,
+                new { Role = "user", Content = "injected" }));
+
+        response.StatusCode.Should().Be(
+            HttpStatusCode.NotFound,
+            "a non-owner must not be able to inject messages into another user's chat session");
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/Smoke/RenameChatSessionIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Smoke/RenameChatSessionIntegrationTests.cs
@@ -153,7 +153,7 @@ public sealed class RenameChatSessionIntegrationTests : IAsyncLifetime
     {
         // Arrange
         var mediator = _serviceProvider!.GetRequiredService<IMediator>();
-        var command = new RenameChatSessionCommand(SessionId: TestSessionId, Title: "Renamed Title SG4");
+        var command = new RenameChatSessionCommand(SessionId: TestSessionId, UserId: TestUserId, Title: "Renamed Title SG4");
 
         // Act
         var dto = await mediator.Send(command, TestCancellationToken);
@@ -170,6 +170,28 @@ public sealed class RenameChatSessionIntegrationTests : IAsyncLifetime
 
         persisted.Should().NotBeNull();
         persisted!.Title.Should().Be("Renamed Title SG4");
+    }
+
+    /// <summary>
+    /// IDOR: a non-owner renaming another user's session gets the same 404 as an unknown id,
+    /// and the title is left untouched.
+    /// </summary>
+    [Fact]
+    public async Task RenameChatSession_ByNonOwner_ThrowsNotFoundAndLeavesTitleUntouched()
+    {
+        // Arrange — session is owned by TestUserId; a different caller must be rejected.
+        var mediator = _serviceProvider!.GetRequiredService<IMediator>();
+        var attackerId = Guid.NewGuid();
+        var command = new RenameChatSessionCommand(SessionId: TestSessionId, UserId: attackerId, Title: "Hacked title");
+
+        // Act & Assert
+        await Assert.ThrowsAsync<NotFoundException>(
+            () => mediator.Send(command, TestCancellationToken));
+
+        var persisted = await _dbContext!.ChatSessions
+            .AsNoTracking()
+            .FirstAsync(s => s.Id == TestSessionId, TestCancellationToken);
+        persisted.Title.Should().Be("Original Title");
     }
 
     /// <summary>
@@ -213,7 +235,7 @@ public sealed class RenameChatSessionIntegrationTests : IAsyncLifetime
     {
         // Arrange
         var mediator = _serviceProvider!.GetRequiredService<IMediator>();
-        var command = new RenameChatSessionCommand(SessionId: TestUnknownId, Title: "Irrelevant Title");
+        var command = new RenameChatSessionCommand(SessionId: TestUnknownId, UserId: TestUserId, Title: "Irrelevant Title");
 
         // Act & Assert — handler throws NotFoundException (maps to 404 at endpoint level)
         await Assert.ThrowsAsync<NotFoundException>(


### PR DESCRIPTION
## Problema (IDOR)

Gli endpoint chat-session keyed per `sessionId` non verificavano l'ownership:

- `GET /chat/sessions/{sessionId}`
- `DELETE /chat/sessions/{sessionId}`
- `POST /chat/sessions/{sessionId}/rename`
- `POST /chat/sessions/{sessionId}/messages`

Con un `sessionId` trapelato, qualsiasi utente autenticato poteva leggere la chat di un'altra vittima (incluso il suo `UserId`, esposto nel DTO), cancellarla, rinominarla o iniettarci messaggi. Gli handler caricavano per `SessionId` senza confronto owner e i command/query non portavano il caller id.

Gli endpoint **collection** dello stesso file erano già induriti (IDOR #3120): questa PR chiude il gap sui 4 endpoint by-id con lo stesso pattern.

## Fix

1. `Guid UserId` aggiunto a `GetChatSessionQuery`, `DeleteChatSessionCommand`, `RenameChatSessionCommand`, `AddChatSessionMessageCommand`.
2. I 4 endpoint iniettano `HttpContext` e passano `httpContext.User.GetUserId()`.
3. Ogni handler, dopo il load, confronta `session.UserId != request.UserId` e tratta il mismatch come **not-found** (Get → `null` → 404; i command → `NotFoundException` → 404).

**Fail-closed**: un caller id vuoto/assente non matcha alcun owner reale → 404 (nessun bypass). Il non-owner riceve lo stesso 404 di una sessione inesistente → nessuna existence-disclosure. Nessuna violazione CQRS (nessun accesso repository aggiunto negli endpoint oltre alla disambiguation già presente in rename).

## TDD

- **RED**: `ChatSessionByIdEndpointsIdorIntegrationTests` (Testcontainers) — i 4 accessi cross-user restituivano **200/204**; i 4 owner-success passavano.
- **GREEN**: cross-user ora **404** (verificato anche che il DELETE non elimina e il RENAME non modifica il titolo); owner-success invariati.
- Aggiunti ownership unit test agli handler (Get/Delete/AddMessage) + un test rename cross-user a livello mediator in `RenameChatSessionIntegrationTests`.

## Verifica locale

- `ChatSessionByIdEndpointsIdorIntegrationTests` + `RenameChatSessionIntegrationTests`: **12/12** PASS
- ChatSession unit (handler + validator): **116/116** PASS
- Regressione `BoundedContext=KnowledgeBase&Category=Unit`: **2460** PASS (1 skip pre-esistente)
- Pre-push backend build: 0 errori