### PR TITLE
feat(rag): corpus title-health endpoint + CI regression guard (#3338 WP3)

### DIFF
--- a/.github/workflows/rag-smoke-dispatch.yml
+++ b/.github/workflows/rag-smoke-dispatch.yml
@@ -263,7 +263,11 @@ jobs:
       - name: Open issue on retrieval drift
         # Only on actual retrieval drift (the smoke step failed), NOT on an infra
         # failure like the broken R2 snapshot fetch in "Boot from published snapshot".
-        if: ${{ steps.ragsmoke.outcome == 'failure' && github.event.inputs.update_baseline != 'true' }}
+        # always() is required: without a status function GitHub ANDs an implicit success()
+        # into the condition, so after ragsmoke fails the job is failed → success() is false
+        # → this step is skipped and the issue is never opened. The outcome check still scopes
+        # it to a real drift (skipped/successful ragsmoke → not 'failure').
+        if: ${{ always() && steps.ragsmoke.outcome == 'failure' && github.event.inputs.update_baseline != 'true' }}
         uses: actions/github-script@v7
         with:
           script: |
@@ -283,7 +287,10 @@ jobs:
       - name: Open issue on title-health regression
         # Only on an actual extraction-quality regression (the guard step failed), NOT on an
         # infra failure in "Boot from published snapshot". Epic #3338 WP3.
-        if: ${{ steps.titlehealth.outcome == 'failure' && github.event.inputs.update_baseline != 'true' }}
+        # always() is required: without a status function the implicit success() would skip this
+        # after titlehealth fails (same gotcha as the retrieval-drift step above). The outcome
+        # check scopes it to a real regression; the guard step is skipped on boot failure.
+        if: ${{ always() && steps.titlehealth.outcome == 'failure' && github.event.inputs.update_baseline != 'true' }}
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/rag-smoke-dispatch.yml
+++ b/.github/workflows/rag-smoke-dispatch.yml
@@ -1,25 +1,31 @@
-name: RAG Smoke (canonical queries vs golden baseline)
+name: RAG Smoke (retrieval + extraction-quality regression guards)
 
-# Tier 3 D8 of #2126 / #2480 — retrieval-quality smoke.
+# Tier 3 D8 of #2126 / #2480 — retrieval-quality smoke + Epic #3338 WP3 extraction-quality guard.
 #
-# Consumes a published seed snapshot (`make dev-from-snapshot`), runs the canonical
-# RAG queries in infra/fixtures/rag-canonical-queries.json, and asserts the top-3
-# retrieved chunks match infra/fixtures/rag-golden-baseline.json. Catches silent
-# retrieval regressions (embedding model / chunker / index drift) that the bake
-# smoke does not cover.
+# Consumes a published seed snapshot (`make dev-from-snapshot`) ONCE and runs two guards
+# against the booted API:
+#   1. RETRIEVAL (#2480): the canonical RAG queries in infra/fixtures/rag-canonical-queries.json
+#      → asserts the top-3 retrieved chunks match infra/fixtures/rag-golden-baseline.json.
+#      Catches silent retrieval regressions (embedding model / chunker / index drift).
+#   2. EXTRACTION QUALITY (#3338 WP3): GET /api/v1/admin/kb/title-health (TitleHealthMetric over
+#      each game's distinct text_chunks.Heading) → asserts no game's band DOWNGRADED / plausible
+#      fraction dropped vs infra/fixtures/title-health-baseline.json. Catches a chunking change
+#      that buries section headings (the TM "PREPARAZIONE" case) — regressing what retrieval sees.
+# Both share the single ~20-min snapshot boot; the title-health guard is dormant (SKIP) until its
+# baseline is captured via update_baseline (its `games` map ships empty).
 #
-# Runs weekly (schedule) in ASSERT mode against the committed golden baseline, and
-# can be dispatched manually to re-capture the baseline (update_baseline=true) after a
-# re-bake. R2 snapshot distribution works (#2516): the dedicated meepleai-seed-snapshots
-# bucket + SEED_BLOB_* repo secrets are configured, and dev-from-snapshot fetches the
-# published snapshot via the read creds synthesized in "Configure snapshot bucket read
-# credentials" below. The golden baseline was first committed for snapshot
-# meepleai_seed_20260628T211806Z_intfloat_multilingual-e5-base_7cee37d47 (#2480).
+# Runs weekly (schedule) in ASSERT mode against the committed baselines, and can be dispatched
+# manually to re-capture BOTH baselines (update_baseline=true) after a re-bake. R2 snapshot
+# distribution works (#2516): the dedicated meepleai-seed-snapshots bucket + SEED_BLOB_* repo
+# secrets are configured, and dev-from-snapshot fetches the published snapshot via the read creds
+# synthesized in "Configure snapshot bucket read credentials" below. The golden baseline was first
+# committed for snapshot meepleai_seed_20260628T211806Z_intfloat_multilingual-e5-base_7cee37d47 (#2480).
 #
-# Re-baseline procedure (after a re-bake that changes the EF head / embedding model):
+# Re-baseline procedure (after a re-bake that changes the EF head / embedding model / chunker):
 #   1. re-bake + publish (seed-snapshot-bake-full.yml -f publish=true)
 #   2. dispatch this workflow with update_baseline=true
-#   3. download the rag-golden-baseline-<run_id> artifact, commit infra/fixtures/rag-golden-baseline.json
+#   3. download the rag-golden-baseline-<run_id> + title-health-baseline-<run_id> artifacts,
+#      commit infra/fixtures/rag-golden-baseline.json + infra/fixtures/title-health-baseline.json
 #
 # On a schedule trigger github.event.inputs.update_baseline is empty → assert mode.
 
@@ -126,6 +132,7 @@ jobs:
           echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
 
       - name: Boot from published snapshot
+        id: boot
         working-directory: infra
         env:
           # Canonical out-dir (repo root, gitignored) so fetch/verify/restore use
@@ -179,6 +186,25 @@ jobs:
             bash scripts/rag-smoke-assert.sh
           fi
 
+      - name: Run title-health regression guard
+        id: titlehealth
+        # Run whenever the API booted (steps.boot success), even if the retrieval smoke DRIFTED —
+        # the two guards are independent, and update_baseline must capture both in one dispatch. Gating
+        # on boot (not always()) keeps a snapshot/infra boot failure from firing a false regression issue.
+        if: ${{ always() && steps.boot.outcome == 'success' }}
+        working-directory: infra
+        env:
+          API_BASE_URL: http://localhost:8080
+          SMOKE_EMAIL: bake-admin@meepleai.test
+          SMOKE_PASSWORD: BakeSeed1!Admin
+        run: |
+          if [ "${{ github.event.inputs.update_baseline }}" = "true" ]; then
+            bash scripts/title-health-assert.sh --update-baseline
+            echo "::notice:: title-health baseline updated — download the artifact and commit infra/fixtures/title-health-baseline.json"
+          else
+            bash scripts/title-health-assert.sh
+          fi
+
       - name: Diagnose smoke failure
         # always() is required: without it GitHub implicitly ANDs the condition
         # with success(), so the step is skipped after the smoke step fails (#2480).
@@ -226,6 +252,14 @@ jobs:
           path: infra/fixtures/rag-golden-baseline.json
           retention-days: 14
 
+      - name: Upload updated title-health baseline (when --update-baseline)
+        if: ${{ github.event.inputs.update_baseline == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: title-health-baseline-${{ github.run_id }}
+          path: infra/fixtures/title-health-baseline.json
+          retention-days: 14
+
       - name: Open issue on retrieval drift
         # Only on actual retrieval drift (the smoke step failed), NOT on an infra
         # failure like the broken R2 snapshot fetch in "Boot from published snapshot".
@@ -243,5 +277,25 @@ jobs:
                 title: `[RAG SMOKE] retrieval drift — ${new Date().toISOString().slice(0,10)}`,
                 labels: ['bug', 'rag-smoke-failure'],
                 body: `Canonical RAG queries drifted from the golden baseline. See run ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}.\n\nIf the drift is intentional (re-index), regenerate via \`--update-baseline\` per docs/for-developers/operations/rag-smoke-runbook.md.`
+              });
+            }
+
+      - name: Open issue on title-health regression
+        # Only on an actual extraction-quality regression (the guard step failed), NOT on an
+        # infra failure in "Boot from published snapshot". Epic #3338 WP3.
+        if: ${{ steps.titlehealth.outcome == 'failure' && github.event.inputs.update_baseline != 'true' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner, repo: context.repo.repo,
+              labels: 'title-health-regression', state: 'open'
+            });
+            if (existing.data.length === 0) {
+              await github.rest.issues.create({
+                owner: context.repo.owner, repo: context.repo.repo,
+                title: `[TITLE-HEALTH] extraction-quality regression — ${new Date().toISOString().slice(0,10)}`,
+                labels: ['bug', 'title-health-regression'],
+                body: `A game's title-health band downgraded or its plausible-heading fraction dropped vs infra/fixtures/title-health-baseline.json (a chunking change buried section headings). See run ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}.\n\nIf the change is intentional (re-chunk / re-index), regenerate via \`--update-baseline\` per docs/for-developers/operations/2026-07-28-wp3-title-health-go-no-go.md.`
               });
             }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetCorpusTitleHealth/GameTitleHealthDto.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetCorpusTitleHealth/GameTitleHealthDto.cs
@@ -1,0 +1,25 @@
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetCorpusTitleHealth;
+
+/// <summary>
+/// Epic #3338 WP3: the per-game extraction-quality read-out exposed by
+/// <c>GET /api/v1/admin/kb/title-health</c> — one row per shared game that has chunked headings.
+/// Computed by <see cref="Api.BoundedContexts.KnowledgeBase.Application.Services.Chunking.TitleHealthMetric"/>
+/// over the game's distinct <c>text_chunks.Heading</c> values (what retrieval sees).
+/// </summary>
+/// <param name="GameId">The <c>shared_games.id</c> the chunks are scoped to.</param>
+/// <param name="GameTitle">The shared game's title (for the read-out / baseline label).</param>
+/// <param name="Language">The dominant effective language (<c>LanguageOverride ?? Language</c>) across the game's PDFs.</param>
+/// <param name="DistinctHeadings">Distinct non-blank headings across the game's chunks.</param>
+/// <param name="PlausibleHeadings">How many of those look like real section titles.</param>
+/// <param name="PlausibleFraction">PlausibleHeadings / DistinctHeadings, rounded to 4 dp for a stable baseline (0 when there are none).</param>
+/// <param name="CanonicalCoverage">Distinct plausible headings matching a curated lexicon section word.</param>
+/// <param name="Band">green ≥ 0.80 · yellow ≥ 0.50 · red otherwise — the WP4 go/no-go band.</param>
+public sealed record GameTitleHealthDto(
+    Guid GameId,
+    string GameTitle,
+    string? Language,
+    int DistinctHeadings,
+    int PlausibleHeadings,
+    double PlausibleFraction,
+    int CanonicalCoverage,
+    string Band);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetCorpusTitleHealth/GameTitleHealthDto.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetCorpusTitleHealth/GameTitleHealthDto.cs
@@ -8,7 +8,7 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetCorpusTitleHe
 /// </summary>
 /// <param name="GameId">The <c>shared_games.id</c> the chunks are scoped to.</param>
 /// <param name="GameTitle">The shared game's title (for the read-out / baseline label).</param>
-/// <param name="Language">The dominant effective language (<c>LanguageOverride ?? Language</c>) across the game's PDFs.</param>
+/// <param name="Language">The effective language (<c>LanguageOverride ?? Language</c>) labelling the most distinct headings for this game (retrieval-surface-weighted majority, not the per-PDF count).</param>
 /// <param name="DistinctHeadings">Distinct non-blank headings across the game's chunks.</param>
 /// <param name="PlausibleHeadings">How many of those look like real section titles.</param>
 /// <param name="PlausibleFraction">PlausibleHeadings / DistinctHeadings, rounded to 4 dp for a stable baseline (0 when there are none).</param>

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetCorpusTitleHealth/GetCorpusTitleHealthQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetCorpusTitleHealth/GetCorpusTitleHealthQuery.cs
@@ -1,0 +1,11 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetCorpusTitleHealth;
+
+/// <summary>
+/// Epic #3338 WP3 regression guard: compute the per-game title-health metric across the whole
+/// chunked corpus (every shared game with at least one non-blank <c>text_chunks.Heading</c>).
+/// Backs the admin read-out endpoint and the CI gate that fails if a previously-green game's
+/// extraction health drops after a WP1/WP4 chunking change. Read-only, admin-scoped.
+/// </summary>
+internal sealed record GetCorpusTitleHealthQuery() : IQuery<IReadOnlyList<GameTitleHealthDto>>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetCorpusTitleHealth/GetCorpusTitleHealthQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetCorpusTitleHealth/GetCorpusTitleHealthQueryHandler.cs
@@ -62,7 +62,9 @@ internal sealed class GetCorpusTitleHealthQueryHandler
             {
                 var health = TitleHealthMetric.Compute(g.Select(x => x.Heading));
 
-                // Dominant effective language across the game's docs; ordinal tiebreak keeps it stable.
+                // The effective language labelling the MOST distinct headings for this game (rows are
+                // already Distinct on (game,lang,heading), so this weights the retrieval surface, not the
+                // PDF count); ordinal tiebreak keeps a tie stable.
                 var language = g
                     .GroupBy(x => x.Language, StringComparer.Ordinal)
                     .OrderByDescending(lg => lg.Count())

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetCorpusTitleHealth/GetCorpusTitleHealthQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetCorpusTitleHealth/GetCorpusTitleHealthQueryHandler.cs
@@ -1,0 +1,94 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Services.Chunking;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetCorpusTitleHealth;
+
+/// <summary>
+/// Handles <see cref="GetCorpusTitleHealthQuery"/>.
+///
+/// <para>Pulls the DISTINCT <c>(game, effective-language, heading)</c> triples the corpus carries
+/// — joining <c>text_chunks</c> → <c>shared_games</c> (title) → <c>pdf_documents</c> (language) — then
+/// groups by game and runs the pure <see cref="TitleHealthMetric"/> over each game's headings. The
+/// DISTINCT is pushed to the DB so child chunks repeating their parent heading do not inflate the
+/// transfer; <see cref="TitleHealthMetric.Compute"/> dedups again defensively.</para>
+///
+/// <para>Only games with at least one non-blank heading appear — a game with zero chunked headings has
+/// no extraction-quality signal to report. Ordered by title (ordinal) for a deterministic baseline.</para>
+/// </summary>
+internal sealed class GetCorpusTitleHealthQueryHandler
+    : IQueryHandler<GetCorpusTitleHealthQuery, IReadOnlyList<GameTitleHealthDto>>
+{
+    private const int FractionPrecision = 4;
+
+    private readonly MeepleAiDbContext _db;
+
+    public GetCorpusTitleHealthQueryHandler(MeepleAiDbContext db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public async Task<IReadOnlyList<GameTitleHealthDto>> Handle(
+        GetCorpusTitleHealthQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // Correlated Where instead of an explicit join keeps the nullable GameId (Guid?) lift clean;
+        // both projections are inner (a chunk with an orphaned GameId / PdfDocumentId is dropped).
+        var rows = await (
+            from tc in _db.TextChunks.AsNoTracking()
+            // Exclude blank headings at the DB (btrim(heading) <> '') so a game whose chunks carry only
+            // null/empty/whitespace headings forms no group and is absent — it has no extraction signal.
+            // A real (even garbage) heading like "D" is NOT blank and correctly yields a red-band game.
+            where tc.GameId != null && tc.Heading != null && tc.Heading.Trim() != ""
+            from sg in _db.SharedGames.AsNoTracking().Where(g => g.Id == tc.GameId)
+            from pd in _db.PdfDocuments.AsNoTracking().Where(p => p.Id == tc.PdfDocumentId)
+            select new HeadingRow
+            {
+                GameId = sg.Id,
+                Title = sg.Title,
+                Language = pd.LanguageOverride ?? pd.Language,
+                Heading = tc.Heading!,
+            })
+            .Distinct()
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return rows
+            .GroupBy(r => new { r.GameId, r.Title })
+            .Select(g =>
+            {
+                var health = TitleHealthMetric.Compute(g.Select(x => x.Heading));
+
+                // Dominant effective language across the game's docs; ordinal tiebreak keeps it stable.
+                var language = g
+                    .GroupBy(x => x.Language, StringComparer.Ordinal)
+                    .OrderByDescending(lg => lg.Count())
+                    .ThenBy(lg => lg.Key, StringComparer.Ordinal)
+                    .First().Key;
+
+                return new GameTitleHealthDto(
+                    g.Key.GameId,
+                    g.Key.Title,
+                    language,
+                    health.DistinctHeadings,
+                    health.PlausibleHeadings,
+                    Math.Round(health.PlausibleFraction, FractionPrecision, MidpointRounding.AwayFromZero),
+                    health.CanonicalCoverage,
+                    health.Band);
+            })
+            .OrderBy(d => d.GameTitle, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    /// <summary>DB projection row — a named type (not anonymous) so EF's DISTINCT is stable and the group key is explicit.</summary>
+    private sealed record HeadingRow
+    {
+        public Guid GameId { get; init; }
+        public string Title { get; init; } = string.Empty;
+        public string? Language { get; init; }
+        public string Heading { get; init; } = string.Empty;
+    }
+}

--- a/apps/api/src/Api/Routing/AdminKnowledgeBaseEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminKnowledgeBaseEndpoints.cs
@@ -3,6 +3,7 @@ using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.EstimateAgentCost;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.ExportDocumentChunks;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetCorpusTitleHealth;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetDocumentEmbeddingsMeta;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetGamesWithoutKb;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbNavCounts;
@@ -189,6 +190,18 @@ internal static class AdminKnowledgeBaseEndpoints
         .WithSummary("List shared games with no active Knowledge Base (admin RAG onboarding)")
         .WithDescription("Returns SharedGames where HasKnowledgeBase = false. Supports pagination and search on Title.")
         .Produces<GamesWithoutKbPagedResponse>();
+
+        // GET /api/v1/admin/kb/title-health — Epic #3338 WP3: per-game extraction-quality read-out +
+        // CI regression guard (fails if a previously-green game's title-health drops after a chunking change).
+        kbGroup.MapGet("/title-health", async (IMediator mediator, CancellationToken ct) =>
+        {
+            var result = await mediator.Send(new GetCorpusTitleHealthQuery(), ct).ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .WithName("GetCorpusTitleHealth")
+        .WithSummary("Per-game title-health (extraction quality) across the chunked corpus")
+        .WithDescription("Computes TitleHealthMetric over each shared game's distinct text_chunks.Heading values. Backs the WP3 regression guard + WP4 go/no-go read-out.")
+        .Produces<IReadOnlyList<GameTitleHealthDto>>(StatusCodes.Status200OK);
 
         // GET /api/v1/admin/shared-games (extended for admin - #4654, #4785)
         var gamesGroup = group.MapGroup("/admin/shared-games")

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetCorpusTitleHealth/Integration/GetCorpusTitleHealthQueryHandlerIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetCorpusTitleHealth/Integration/GetCorpusTitleHealthQueryHandlerIntegrationTests.cs
@@ -1,0 +1,209 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetCorpusTitleHealth;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Queries.GetCorpusTitleHealth.Integration;
+
+/// <summary>
+/// Integration tests for <see cref="GetCorpusTitleHealthQueryHandler"/> against a real PostgreSQL
+/// database via Testcontainers (Epic #3338 WP3). The handler's value is its EF Core query — a
+/// nullable-<c>GameId</c>-lifted join <c>text_chunks → shared_games → pdf_documents</c>, a
+/// <c>LanguageOverride ?? Language</c> coalesce, and a server-side <c>Distinct()</c> over a named
+/// projection — so these tests assert that translation end-to-end (a unit test with mocks would not
+/// catch an untranslatable LINQ shape). The band/plausibility maths itself is covered by
+/// <c>TitleHealthMetricTests</c>.
+/// </summary>
+[Collection("Integration-GroupA")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Issue", "3338")]
+public sealed class GetCorpusTitleHealthQueryHandlerIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly Guid _uploaderId = Guid.NewGuid();
+    private string _dbName = null!;
+    private MeepleAiDbContext _dbContext = null!;
+
+    private static CancellationToken Token => TestContext.Current.CancellationToken;
+
+    public GetCorpusTitleHealthQueryHandlerIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _dbName = $"test_corpus_title_health_{Guid.NewGuid():N}";
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_dbName);
+
+        var mockMediator = TestDbContextFactory.CreateMockMediator();
+        var mockEventCollector = TestDbContextFactory.CreateMockEventCollector();
+
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseNpgsql(connectionString, o => o.UseVector())
+            .EnableSensitiveDataLogging()
+            .EnableDetailedErrors()
+            .Options;
+
+        _dbContext = new MeepleAiDbContext(options, mockMediator.Object, mockEventCollector.Object);
+        await _dbContext.Database.MigrateAsync(Token);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _fixture.DropIsolatedDatabaseAsync(_dbName);
+        if (_dbContext is not null)
+            await _dbContext.DisposeAsync();
+    }
+
+    [Fact(Timeout = 60_000)]
+    public async Task Handle_RealPostgres_GroupsPerGame_ComputesBandLanguageAndCoverage()
+    {
+        // Arrange ----------------------------------------------------------------
+        // pdf_documents.UploadedByUserId is a Restrict FK to users → seed the uploader once.
+        _dbContext.Users.Add(new UserEntity
+        {
+            Id = _uploaderId,
+            Email = $"title-health-{_uploaderId:N}@test.local",
+            DisplayName = "Title Health Test User",
+            PasswordHash = "hashed",
+            Role = "Admin",
+            Tier = "free",
+            CreatedAt = DateTime.UtcNow,
+            IsTwoFactorEnabled = false,
+        });
+
+        // "Alpha Green" (en): 5 clean section titles, each repeated by a child chunk → distinct=5,
+        // fraction=1.0 → green; SETUP is a lexicon section → canonical ≥ 1.
+        var greenId = Guid.NewGuid();
+        var greenPdf = Guid.NewGuid();
+        SeedGame(greenId, "Alpha Green");
+        SeedPdf(greenPdf, language: "en");
+        AddChunks(greenPdf, greenId, new[] { "SETUP", "GAMEPLAY", "SCORING", "END OF GAME", "COMPONENTS" });
+        AddChunks(greenPdf, greenId, new[] { "SETUP", "GAMEPLAY" }); // duplicate headings from child chunks
+
+        // "Zeta Garbage" (effective it via LanguageOverride over Language=en): 4 garbage headings + 1
+        // real "PREPARAZIONE" → distinct=5, plausible=1, fraction=0.2 → red; PREPARAZIONE is a lexicon
+        // section → canonical=1.
+        var redId = Guid.NewGuid();
+        var redPdf = Guid.NewGuid();
+        SeedGame(redId, "Zeta Garbage");
+        SeedPdf(redPdf, language: "en", languageOverride: "it");
+        AddChunks(redPdf, redId, new[] { "PREPARAZIONE", "D", "S U", "I L E X Y R F", "(14%), Oceani" });
+
+        // "Multi Lang": headings from TWO pdfs of different languages. en pdf has 2 distinct headings,
+        // it pdf has 1 → dominant language = en. distinct=3 (SETUP, GAMEPLAY, D), plausible=2 →
+        // fraction=0.6667 → yellow.
+        var multiId = Guid.NewGuid();
+        var multiEnPdf = Guid.NewGuid();
+        var multiItPdf = Guid.NewGuid();
+        SeedGame(multiId, "Multi Lang");
+        SeedPdf(multiEnPdf, language: "en");
+        SeedPdf(multiItPdf, language: "it");
+        AddChunks(multiEnPdf, multiId, new[] { "SETUP", "GAMEPLAY" });
+        AddChunks(multiItPdf, multiId, new[] { "D" });
+
+        // "No Headings": every chunk has a null/blank heading → the game has no extraction signal and
+        // MUST NOT appear in the read-out.
+        var noneId = Guid.NewGuid();
+        var nonePdf = Guid.NewGuid();
+        SeedGame(noneId, "No Headings");
+        SeedPdf(nonePdf, language: "en");
+        AddChunks(nonePdf, noneId, new string?[] { null, "", "   " });
+
+        await _dbContext.SaveChangesAsync(Token);
+
+        var sut = new GetCorpusTitleHealthQueryHandler(_dbContext);
+
+        // Act --------------------------------------------------------------------
+        var result = await sut.Handle(new GetCorpusTitleHealthQuery(), Token);
+
+        // Assert -----------------------------------------------------------------
+        result.Should().HaveCount(3, "the null-heading-only game contributes no signal and is excluded");
+        result.Select(r => r.GameTitle).Should().ContainInOrder("Alpha Green", "Multi Lang", "Zeta Garbage");
+        result.Select(r => r.GameTitle).Should().NotContain("No Headings");
+
+        var green = result.Single(r => r.GameTitle == "Alpha Green");
+        green.Band.Should().Be("green");
+        green.DistinctHeadings.Should().Be(5, "duplicate child-chunk headings are deduplicated");
+        green.PlausibleHeadings.Should().Be(5);
+        green.PlausibleFraction.Should().Be(1.0);
+        green.Language.Should().Be("en");
+        green.CanonicalCoverage.Should().BeGreaterThanOrEqualTo(1, "SETUP is a curated lexicon section");
+
+        var red = result.Single(r => r.GameTitle == "Zeta Garbage");
+        red.Band.Should().Be("red");
+        red.DistinctHeadings.Should().Be(5);
+        red.PlausibleHeadings.Should().Be(1, "only PREPARAZIONE survives the plausibility filter");
+        red.PlausibleFraction.Should().Be(0.2);
+        red.CanonicalCoverage.Should().Be(1);
+        red.Language.Should().Be("it", "LanguageOverride ?? Language must resolve to the override");
+
+        var multi = result.Single(r => r.GameTitle == "Multi Lang");
+        multi.Band.Should().Be("yellow");
+        multi.DistinctHeadings.Should().Be(3);
+        multi.PlausibleHeadings.Should().Be(2);
+        multi.PlausibleFraction.Should().Be(0.6667, "2/3 rounded to 4 dp");
+        multi.Language.Should().Be("en", "the language carrying more distinct headings wins the tiebreak");
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task Handle_RealPostgres_EmptyCorpus_ReturnsEmpty()
+    {
+        var sut = new GetCorpusTitleHealthQueryHandler(_dbContext);
+
+        var result = await sut.Handle(new GetCorpusTitleHealthQuery(), Token);
+
+        result.Should().BeEmpty("no chunks → no games to report");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    private void SeedGame(Guid id, string title) => _dbContext.SharedGames.Add(new SharedGameEntity
+    {
+        Id = id,
+        Title = title,
+        CreatedBy = Guid.NewGuid(),
+        CreatedAt = DateTime.UtcNow,
+    });
+
+    private void SeedPdf(Guid id, string language, string? languageOverride = null) =>
+        _dbContext.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = id,
+            FileName = $"rulebook-{id:N}.pdf",
+            FilePath = $"/test/{id:N}.pdf",
+            FileSizeBytes = 1024L,
+            UploadedByUserId = _uploaderId,
+            UploadedAt = DateTime.UtcNow,
+            ProcessingState = "Ready",
+            Language = language,
+            LanguageOverride = languageOverride,
+        });
+
+    private void AddChunks(Guid pdfId, Guid gameId, IReadOnlyList<string?> headings)
+    {
+        for (var i = 0; i < headings.Count; i++)
+        {
+            _dbContext.TextChunks.Add(new TextChunkEntity
+            {
+                Id = Guid.NewGuid(),
+                PdfDocumentId = pdfId,
+                GameId = gameId,
+                Heading = headings[i],
+                Content = $"body-{pdfId:N}-{i}",
+                ChunkIndex = i,
+                CharacterCount = 100,
+            });
+        }
+    }
+}

--- a/docs/for-developers/operations/2026-07-28-wp3-title-health-go-no-go.md
+++ b/docs/for-developers/operations/2026-07-28-wp3-title-health-go-no-go.md
@@ -32,8 +32,15 @@ The residual 28 % (garbage `Title` elements unstructured emits — `I L E X Y R 
 
 **Decision:** WP4 is deferred/descope-able. Re-evaluate if a broader IT cohort — once re-chunked with WP1 (the 12 other IT docs + the 65 currently-`Failed` PDFs, both pending a re-index) — shows a **red** cohort whose retrieval actually regresses. Until then WP1 (+ the number-noise demotion) is sufficient.
 
-## Remaining WP3 (follow-up)
+## Remaining WP3 (follow-up) — SHIPPED
 
-- Corpus `title-health` admin endpoint + persistence (so the metric is queryable, not just computed offline).
-- Wire the metric into a CI gate that **fails if a previously-green English game's health drops** after a WP1/WP4 change (the regression guard) — alongside the retrieval regression guard (`rag-smoke-assert.sh`).
-- Capture the `tmars-setup-it` rag-smoke baseline on staging (`--update-baseline`) so the added canonical query asserts instead of SKIPs.
+- **Corpus `title-health` admin endpoint** — `GET /api/v1/admin/kb/title-health` (`AdminKnowledgeBaseEndpoints`, admin-scoped). Computes `TitleHealthMetric` per shared game over its distinct `text_chunks.Heading` values, returning `GameTitleHealthDto[]` (band, plausibleFraction, canonicalCoverage, distinctHeadings, dominant language). Query/handler: `KnowledgeBase/Application/Queries/GetCorpusTitleHealth`. Handler EF translation (nullable-`GameId` join → `shared_games`/`pdf_documents`, `LanguageOverride ?? Language`, server-side `Distinct`) is covered by a Testcontainers integration test.
+- **CI regression guard** — `infra/scripts/title-health-assert.sh` + committed baseline `infra/fixtures/title-health-baseline.json`, wired into `.github/workflows/rag-smoke-dispatch.yml` (shares the one snapshot boot with the retrieval smoke). Assert mode FAILs on a **band downgrade** (green→yellow/red, yellow→red), a **plausible-fraction drop** beyond `fractionRegressionTolerance` (0.05), or a **baselined game vanishing** from the corpus. A new (unbaselined) game is a NOTICE, never a FAIL. It opens a deduped `title-health-regression` issue on failure (ADR-078 one-per-open-label).
+
+### Capture step (required to arm the gate)
+
+The baseline ships with an EMPTY `games` map, so the gate is **dormant (SKIP)** until captured — mirroring the rag-smoke unbaselined-query SKIP (no green theatre; the SKIP is a visible NOTICE). Arm it by capturing against the **published seed snapshot** (the corpus the CI gate asserts against — NOT staging): dispatch `rag-smoke-dispatch.yml` with `update_baseline=true`, then download the `title-health-baseline-<run_id>` artifact and commit `infra/fixtures/title-health-baseline.json`. Re-capture after any re-bake/re-chunk that intentionally changes headings (same procedure as the golden retrieval baseline).
+
+### Still open (unchanged)
+
+- Capture the `tmars-setup-it` rag-smoke baseline (`--update-baseline`) so the added canonical query asserts instead of SKIPs.

--- a/infra/fixtures/title-health-baseline.json
+++ b/infra/fixtures/title-health-baseline.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": 1,
+  "_comment": "Epic #3338 WP3 extraction-quality regression guard. Per-game title-health captured from GET /api/v1/admin/kb/title-health (TitleHealthMetric over each shared game's distinct text_chunks.Heading). The harness (infra/scripts/title-health-assert.sh) fails a run if a baselined game's band DOWNGRADES (green→yellow/red, yellow→red) or its plausibleFraction drops by more than `fractionRegressionTolerance`, or if a baselined game vanishes from the corpus. New (unbaselined) games are a NOTICE, never a FAIL. `games` starts EMPTY: the endpoint ships in the WP3 PR, so the baseline is captured on staging AFTER deploy via `bash scripts/title-health-assert.sh --update-baseline` (see docs/for-developers/operations/2026-07-28-wp3-title-health-go-no-go.md). Until then the gate reports SKIP (dormant), mirroring the rag-smoke unbaselined-query SKIP.",
+  "fractionRegressionTolerance": 0.05,
+  "capturedAt": null,
+  "games": {}
+}

--- a/infra/scripts/title-health-assert.sh
+++ b/infra/scripts/title-health-assert.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# infra/scripts/title-health-assert.sh
+# RAG extraction-quality regression guard (Epic #3338 WP3).
+#
+# Fetches the per-game title-health metric from GET /api/v1/admin/kb/title-health
+# (TitleHealthMetric over each shared game's distinct text_chunks.Heading values) and
+# asserts no game REGRESSED versus the committed baseline in
+# fixtures/title-health-baseline.json:
+#   - a band DOWNGRADE (green→yellow/red, yellow→red) FAILs — the acceptance guard
+#     ("a previously-green English game's health must not drop after a chunking change");
+#   - a plausible-fraction drop beyond `fractionRegressionTolerance` FAILs even within
+#     the same band (catches within-band erosion before it tips a band);
+#   - a baselined game ABSENT from the current corpus FAILs (its chunks/headings vanished);
+#   - a game present now but NOT in the baseline is a NOTICE (newly-indexed), never a FAIL.
+#
+# The endpoint is admin-only, so SMOKE_EMAIL/SMOKE_PASSWORD (admin creds) are REQUIRED.
+#
+# Usage:
+#   API_BASE_URL=http://localhost:8080 SMOKE_EMAIL=admin@… SMOKE_PASSWORD=… \
+#     bash scripts/title-health-assert.sh                    # assert against baseline
+#   … bash scripts/title-health-assert.sh --update-baseline  # capture baseline from current corpus
+#
+# Exit: 0 = no regression (or baseline updated / baseline empty); 1 = a game regressed / fetch failed.
+set -uo pipefail
+
+BASE_URL="${API_BASE_URL:-http://localhost:8080}"
+EMAIL="${SMOKE_EMAIL:-${TEST_EMAIL:-}}"
+PASSWORD="${SMOKE_PASSWORD:-${TEST_PASSWORD:-}}"
+UPDATE_BASELINE=false
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"   # infra/
+BASELINE="$DIR/fixtures/title-health-baseline.json"
+ENDPOINT="/api/v1/admin/kb/title-health"
+
+for arg in "$@"; do
+  case "$arg" in
+    --update-baseline) UPDATE_BASELINE=true ;;
+    --base-url=*) BASE_URL="${arg#*=}" ;;
+    *) echo "::error:: unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+log()  { echo "[title-health] $*" >&2; }
+fail() { echo "::error:: $*" >&2; exit 1; }
+
+command -v jq   >/dev/null || fail "jq is required"
+command -v curl >/dev/null || fail "curl is required"
+[ -f "$BASELINE" ] || fail "missing $BASELINE"
+
+TOLERANCE=$(jq -r '.fractionRegressionTolerance // 0.05' "$BASELINE")
+TOLERANCE=${TOLERANCE%$'\r'}   # native Windows jq.exe emits CRLF; strip the CR so --arg/comparisons are clean
+
+COOKIE=$(mktemp); trap 'rm -f "$COOKIE" "${CURRENT:-}"' EXIT
+
+# --- login (admin required: the endpoint is behind RequireAdminSessionFilter) ---
+[ -n "$EMAIL" ] && [ -n "$PASSWORD" ] || fail "SMOKE_EMAIL/SMOKE_PASSWORD (admin creds) are required for the admin endpoint"
+code=$(curl -s -o /dev/null -w '%{http_code}' -c "$COOKIE" -X POST "$BASE_URL/api/v1/auth/login" \
+  -H 'Content-Type: application/json' \
+  -d "$(jq -n --arg e "$EMAIL" --arg p "$PASSWORD" '{email:$e, password:$p}')") || true
+[ "$code" = "200" ] || fail "login failed (HTTP ${code:-000})"
+log "login OK ($EMAIL)"
+
+# --- fetch current corpus title-health (array of GameTitleHealthDto) ---
+CURRENT=$(mktemp)
+code=$(curl -s -o "$CURRENT" -w '%{http_code}' -b "$COOKIE" "$BASE_URL$ENDPOINT") || true
+[ "$code" = "200" ] || fail "GET $ENDPOINT failed (HTTP ${code:-000}) — admin session/deploy issue"
+jq -e 'type == "array"' "$CURRENT" >/dev/null 2>&1 || fail "unexpected response (not a JSON array): $(head -c 200 "$CURRENT")"
+COUNT=$(jq 'length' "$CURRENT")
+log "fetched $COUNT game(s) from the corpus"
+
+# --- capture mode ---
+if [ "$UPDATE_BASELINE" = true ]; then
+  [ "$COUNT" -gt 0 ] || fail "corpus returned 0 games — baseline NOT written (index cold / wrong env?)"
+  ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  games=$(jq 'map({key: .gameTitle, value: {gameId, language, band, plausibleFraction, canonicalCoverage, distinctHeadings}}) | from_entries' "$CURRENT")
+  jq --argjson g "$games" --arg ts "$ts" '.games=$g | .capturedAt=$ts' "$BASELINE" > "$BASELINE.2" && mv "$BASELINE.2" "$BASELINE"
+  log "baseline updated → $BASELINE ($COUNT games, capturedAt=$ts)"
+  exit 0
+fi
+
+# --- assert mode ---
+BASELINE_N=$(jq '.games | length' "$BASELINE")
+if [ "$BASELINE_N" -eq 0 ]; then
+  # An empty baseline is a wired-but-dormant gate (the endpoint ships in this PR; the baseline is
+  # captured on staging post-deploy via --update-baseline). Report a visible NOTICE, never green theatre.
+  echo "::notice:: SKIP — title-health baseline is empty (pending --update-baseline capture on staging post-deploy)"
+  log "result: baseline empty → gate dormant (no regression possible)"
+  exit 0
+fi
+
+# band ordinal: red < yellow < green. A current ordinal below the baseline ordinal is a downgrade.
+ORD='{"red":0,"yellow":1,"green":2}'
+
+PASS=0; FAIL=0; NEW=0
+while IFS= read -r title; do
+  title=${title%$'\r'}
+  base=$(jq -c --arg t "$title" '.games[$t]' "$BASELINE")
+  cur=$(jq -c --arg t "$title" '.[] | select(.gameTitle==$t)' "$CURRENT" | head -1)
+
+  if [ -z "$cur" ] || [ "$cur" = "null" ]; then
+    echo "FAIL  $title — baselined game absent from the current corpus (chunks/headings vanished)"
+    FAIL=$((FAIL+1)); continue
+  fi
+
+  verdict=$(jq -n --argjson base "$base" --argjson cur "$cur" --argjson ord "$ORD" --argjson tol "$TOLERANCE" '
+    ($ord[$base.band]) as $bo | ($ord[$cur.band]) as $co
+    | ($base.plausibleFraction - $cur.plausibleFraction) as $drop
+    | if $co < $bo then "BAND \($base.band)→\($cur.band)"
+      elif $drop > $tol then "FRACTION \($base.plausibleFraction)→\($cur.plausibleFraction) (−\($drop|.*10000|round/10000) > \($tol))"
+      else "OK" end')
+  verdict=${verdict//\"/}
+
+  if [ "$verdict" = "OK" ]; then
+    echo "PASS  $title — $(jq -r '.band' <<<"$cur") $(jq -r '.plausibleFraction' <<<"$cur")"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL  $title — regressed: $verdict"
+    FAIL=$((FAIL+1))
+  fi
+done < <(jq -r '.games | keys[]' "$BASELINE")
+
+# New (unbaselined) games: informational only.
+while IFS= read -r title; do
+  title=${title%$'\r'}
+  echo "::notice:: NEW $title — not in baseline (newly-indexed; capture with --update-baseline to guard it)"
+  NEW=$((NEW+1))
+done < <(jq -r --slurpfile b "$BASELINE" '.[] | select((.gameTitle) as $t | ($b[0].games | has($t)) | not) | .gameTitle' "$CURRENT")
+
+log "result: $PASS passed, $FAIL regressed, $NEW new (unguarded)"
+[ "$FAIL" -eq 0 ]

--- a/infra/scripts/title-health-assert.sh
+++ b/infra/scripts/title-health-assert.sh
@@ -5,7 +5,7 @@
 # Fetches the per-game title-health metric from GET /api/v1/admin/kb/title-health
 # (TitleHealthMetric over each shared game's distinct text_chunks.Heading values) and
 # asserts no game REGRESSED versus the committed baseline in
-# fixtures/title-health-baseline.json:
+# fixtures/title-health-baseline.json (keyed by the unique gameId, not the non-unique title):
 #   - a band DOWNGRADE (green→yellow/red, yellow→red) FAILs — the acceptance guard
 #     ("a previously-green English game's health must not drop after a chunking change");
 #   - a plausible-fraction drop beyond `fractionRegressionTolerance` FAILs even within
@@ -65,21 +65,24 @@ CURRENT=$(mktemp)
 code=$(curl -s -o "$CURRENT" -w '%{http_code}' -b "$COOKIE" "$BASE_URL$ENDPOINT") || true
 [ "$code" = "200" ] || fail "GET $ENDPOINT failed (HTTP ${code:-000}) — admin session/deploy issue"
 jq -e 'type == "array"' "$CURRENT" >/dev/null 2>&1 || fail "unexpected response (not a JSON array): $(head -c 200 "$CURRENT")"
-COUNT=$(jq 'length' "$CURRENT")
+COUNT=$(jq 'length' "$CURRENT"); COUNT=${COUNT%$'\r'}
 log "fetched $COUNT game(s) from the corpus"
 
 # --- capture mode ---
+# Keyed by gameId (stable, unique) — gameTitle is NOT unique in the community catalog, so keying
+# on it would let two same-titled games clobber/mask each other. gameTitle is stored as a value for
+# readable failure messages.
 if [ "$UPDATE_BASELINE" = true ]; then
   [ "$COUNT" -gt 0 ] || fail "corpus returned 0 games — baseline NOT written (index cold / wrong env?)"
   ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-  games=$(jq 'map({key: .gameTitle, value: {gameId, language, band, plausibleFraction, canonicalCoverage, distinctHeadings}}) | from_entries' "$CURRENT")
+  games=$(jq 'map({key: .gameId, value: {gameTitle, language, band, plausibleFraction, canonicalCoverage, distinctHeadings}}) | from_entries' "$CURRENT")
   jq --argjson g "$games" --arg ts "$ts" '.games=$g | .capturedAt=$ts' "$BASELINE" > "$BASELINE.2" && mv "$BASELINE.2" "$BASELINE"
   log "baseline updated → $BASELINE ($COUNT games, capturedAt=$ts)"
   exit 0
 fi
 
 # --- assert mode ---
-BASELINE_N=$(jq '.games | length' "$BASELINE")
+BASELINE_N=$(jq '.games | length' "$BASELINE"); BASELINE_N=${BASELINE_N%$'\r'}
 if [ "$BASELINE_N" -eq 0 ]; then
   # An empty baseline is a wired-but-dormant gate (the endpoint ships in this PR; the baseline is
   # captured on staging post-deploy via --update-baseline). Report a visible NOTICE, never green theatre.
@@ -88,17 +91,24 @@ if [ "$BASELINE_N" -eq 0 ]; then
   exit 0
 fi
 
+# A non-empty baseline but an empty corpus is an INFRA/config fault (cold index, wrong DB), not N
+# simultaneous regressions — fail loudly instead of reporting every baselined game as "vanished"
+# (which would otherwise open a false regression issue).
+[ "$COUNT" -gt 0 ] || fail "corpus returned 0 games but baseline has $BASELINE_N — cold index / wrong env, NOT a regression"
+
 # band ordinal: red < yellow < green. A current ordinal below the baseline ordinal is a downgrade.
 ORD='{"red":0,"yellow":1,"green":2}'
 
 PASS=0; FAIL=0; NEW=0
-while IFS= read -r title; do
-  title=${title%$'\r'}
-  base=$(jq -c --arg t "$title" '.games[$t]' "$BASELINE")
-  cur=$(jq -c --arg t "$title" '.[] | select(.gameTitle==$t)' "$CURRENT" | head -1)
+# Iterate baselined game IDs (unique keys). gameTitle comes from the baseline value for display.
+while IFS= read -r id; do
+  id=${id%$'\r'}
+  base=$(jq -c --arg i "$id" '.games[$i]' "$BASELINE")
+  name=$(jq -r --arg i "$id" '.games[$i].gameTitle // $i' "$BASELINE"); name=${name%$'\r'}
+  cur=$(jq -c --arg i "$id" '.[] | select(.gameId==$i)' "$CURRENT" | head -1)
 
   if [ -z "$cur" ] || [ "$cur" = "null" ]; then
-    echo "FAIL  $title — baselined game absent from the current corpus (chunks/headings vanished)"
+    echo "FAIL  $name — baselined game absent from the current corpus (chunks/headings vanished)"
     FAIL=$((FAIL+1)); continue
   fi
 
@@ -111,20 +121,20 @@ while IFS= read -r title; do
   verdict=${verdict//\"/}
 
   if [ "$verdict" = "OK" ]; then
-    echo "PASS  $title — $(jq -r '.band' <<<"$cur") $(jq -r '.plausibleFraction' <<<"$cur")"
+    echo "PASS  $name — $(jq -r '.band' <<<"$cur") $(jq -r '.plausibleFraction' <<<"$cur")"
     PASS=$((PASS+1))
   else
-    echo "FAIL  $title — regressed: $verdict"
+    echo "FAIL  $name — regressed: $verdict"
     FAIL=$((FAIL+1))
   fi
 done < <(jq -r '.games | keys[]' "$BASELINE")
 
-# New (unbaselined) games: informational only.
-while IFS= read -r title; do
-  title=${title%$'\r'}
-  echo "::notice:: NEW $title — not in baseline (newly-indexed; capture with --update-baseline to guard it)"
+# New (unbaselined) games: informational only. Matched by gameId (the baseline key).
+while IFS= read -r name; do
+  name=${name%$'\r'}
+  echo "::notice:: NEW $name — not in baseline (newly-indexed; capture with --update-baseline to guard it)"
   NEW=$((NEW+1))
-done < <(jq -r --slurpfile b "$BASELINE" '.[] | select((.gameTitle) as $t | ($b[0].games | has($t)) | not) | .gameTitle' "$CURRENT")
+done < <(jq -r --slurpfile b "$BASELINE" '.[] | select((.gameId) as $i | ($b[0].games | has($i)) | not) | .gameTitle' "$CURRENT")
 
 log "result: $PASS passed, $FAIL regressed, $NEW new (unguarded)"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Sommario

Epic **#3338 WP3** — chiude le acceptance #1/#2 (guard di regressione qualità-estrazione). Una modifica al chunking che seppellisce gli heading di sezione (il caso TM "PREPARAZIONE") non deve più regredire silenziosamente ciò che il retrieval vede.

## Cosa cambia

- **`GET /api/v1/admin/kb/title-health`** (admin) — calcola `TitleHealthMetric` per shared game sui suoi `text_chunks.Heading` distinti, restituendo `GameTitleHealthDto[]` (band, plausibleFraction, canonicalCoverage, distinctHeadings, lingua dominante). Query/Handler/DTO in `KnowledgeBase/Application/Queries/GetCorpusTitleHealth` (CQRS, handler MediatR auto-scan).
- **CI regression guard** — `infra/scripts/title-health-assert.sh` + baseline `infra/fixtures/title-health-baseline.json`, wired in `rag-smoke-dispatch.yml` (condivide l'unico boot da snapshot ~20min con lo smoke di retrieval). Assert mode FAILa su **band downgrade** / **fraction drop** oltre tolleranza (0.05) / **gioco baselined sparito**; giochi nuovi = NOTICE. Apre una issue `title-health-regression` dedupata (ADR-078), gated sul successo del boot.
- Baseline ships **vuota** → gate **dormiente (SKIP)** finché catturata contro lo snapshot via dispatch `update_baseline=true` (nessun green theatre; mirrora lo SKIP rag-smoke non-baselined).

## Test

- **Integration (Testcontainers Postgres)** — `GetCorpusTitleHealthQueryHandlerIntegrationTests` esercita la traduzione EF reale: join nullable-`GameId` → `shared_games`/`pdf_documents`, coalesce `LanguageOverride ?? Language`, `Distinct` server-side, group per-gioco, banda/lingua dominante, esclusione heading blank (`btrim`). 2 test verdi.
- Metriche band/fraction/canonical già coperte da `TitleHealthMetricTests` (#3355).
- Logica bash dell'assert (band-ordinal, fraction-drop, gioco-assente, gioco-nuovo, due-giochi-stesso-titolo) validata offline.

## Code review

Review multi-agente (correttezza + convenzioni). 5 finding risolti nel 2° commit: HIGH implicit-`success()` che skippava l'apertura issue (fixato anche sullo step rag-smoke pre-esistente); MEDIUM baseline keyed su `gameId` unico invece del titolo non-unico; + 3 LOW (CR-strip, guard corpus-vuoto, commento lingua).

## Follow-up (documentati nel go/no-go doc)

- Cattura baseline title-health contro lo snapshot (`update_baseline`) per armare il gate.
- Cattura baseline `tmars-setup-it` rag-smoke.
- Rifattorizzare lo scaffolding bash condiviso tra i due assert script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)