### PR TITLE
fix(api): map exception cluster to 4xx instead of 500 (#2568)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/CastVoteOnDisputeCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/CastVoteOnDisputeCommandHandler.cs
@@ -44,7 +44,7 @@ internal sealed class CastVoteOnDisputeCommandHandler
 
         if (!isEnabled)
         {
-            throw new InvalidOperationException("Feature Arbitro.DemocraticOverride is disabled");
+            throw new ConflictException("Feature Arbitro.DemocraticOverride is disabled");
         }
 
         // 2. Get dispute

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/OpenStructuredDisputeCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/OpenStructuredDisputeCommandHandler.cs
@@ -50,7 +50,7 @@ internal sealed class OpenStructuredDisputeCommandHandler
 
         if (!isEnabled)
         {
-            throw new InvalidOperationException("Feature Arbitro.StructuredDisputes is disabled");
+            throw new ConflictException("Feature Arbitro.StructuredDisputes is disabled");
         }
 
         // 2. Get session

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/GenerateSetupChecklistCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/GenerateSetupChecklistCommandHandler.cs
@@ -52,7 +52,7 @@ internal class GenerateSetupChecklistCommandHandler
 
         if (!isEnabled)
         {
-            throw new InvalidOperationException("Feature SetupWizard.Enabled is disabled");
+            throw new ConflictException("Feature SetupWizard.Enabled is disabled");
         }
 
         // 2. Get session

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/RuleCommentCommandValidators.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/RuleCommentCommandValidators.cs
@@ -72,6 +72,10 @@ internal sealed class CreateRuleCommentCommandValidator : AbstractValidator<Crea
 
         RuleFor(x => x.UserId)
             .NotEmpty().WithMessage("User ID is required");
+
+        RuleFor(x => x.LineNumber)
+            .Must(lineNumber => lineNumber is null or >= 1)
+            .WithMessage("Line number must be positive");
     }
 }
 

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/AbTest/CreateAbTestCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/AbTest/CreateAbTestCommandHandler.cs
@@ -3,6 +3,7 @@ using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services;
+using Api.Middleware.Exceptions;
 using Api.Services;
 using Api.SharedKernel.Application.Interfaces;
 using Microsoft.Extensions.Logging;
@@ -45,10 +46,10 @@ internal sealed class CreateAbTestCommandHandler : ICommandHandler<CreateAbTestC
 
         // Check budget and rate limit
         if (!await _budgetService.HasBudgetRemainingAsync(cancellationToken).ConfigureAwait(false))
-            throw new InvalidOperationException("Daily A/B test budget exhausted");
+            throw new ConflictException("ab_test_budget_exhausted", "Daily A/B test budget exhausted");
 
         if (!await _budgetService.HasRateLimitRemainingAsync(command.CreatedBy, isAdmin: true, cancellationToken).ConfigureAwait(false))
-            throw new InvalidOperationException("Daily A/B test rate limit reached");
+            throw new TooManyRequestsException("ab_test_rate_limit_reached", "Daily A/B test rate limit reached");
 
         // Create session and add variants
         var session = AbTestSession.Create(command.CreatedBy, command.Query, command.KnowledgeBaseId);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Validators/AddMessageCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Validators/AddMessageCommandValidator.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.KnowledgeBase.Application.Commands;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
 using FluentValidation;
 
 namespace Api.BoundedContexts.KnowledgeBase.Application.Validators;
@@ -24,6 +25,9 @@ internal sealed class AddMessageCommandValidator : AbstractValidator<AddMessageC
             .NotEmpty()
             .WithMessage("Role is required")
             .MaximumLength(50)
-            .WithMessage("Role cannot exceed 50 characters");
+            .WithMessage("Role cannot exceed 50 characters")
+            .Must(role => string.Equals(role, ChatMessage.UserRole, StringComparison.Ordinal)
+                       || string.Equals(role, ChatMessage.AssistantRole, StringComparison.Ordinal))
+            .WithMessage("Role must be 'user' or 'assistant'");
     }
 }

--- a/apps/api/src/Api/Middleware/Exceptions/TooManyRequestsException.cs
+++ b/apps/api/src/Api/Middleware/Exceptions/TooManyRequestsException.cs
@@ -1,0 +1,36 @@
+namespace Api.Middleware.Exceptions;
+
+using System.Diagnostics.CodeAnalysis;
+
+/// <summary>
+/// Exception thrown when a caller exceeds a rate limit or quota.
+/// Maps to HTTP 429 Too Many Requests via the generic <see cref="HttpException"/> arm
+/// of the exception-handling middleware.
+/// </summary>
+public class TooManyRequestsException : HttpException
+{
+    [SetsRequiredMembers]
+    public TooManyRequestsException(string message)
+        : base(StatusCodes.Status429TooManyRequests, "too_many_requests", message)
+    {
+    }
+
+    /// <summary>
+    /// Creates a 429 with an explicit machine-readable <paramref name="errorCode"/>.
+    /// </summary>
+    [SetsRequiredMembers]
+    public TooManyRequestsException(string errorCode, string message)
+        : base(StatusCodes.Status429TooManyRequests, errorCode, message)
+    {
+    }
+
+    [SetsRequiredMembers]
+    public TooManyRequestsException(string message, Exception innerException)
+        : base(StatusCodes.Status429TooManyRequests, "too_many_requests", message, innerException)
+    {
+    }
+
+    public TooManyRequestsException()
+    {
+    }
+}

--- a/apps/api/src/Api/Routing/AdminAbTestEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminAbTestEndpoints.cs
@@ -53,7 +53,9 @@ internal static class AdminAbTestEndpoints
         .Produces<AbTestSessionDto>(StatusCodes.Status201Created)
         .ProducesProblem(StatusCodes.Status400BadRequest)
         .ProducesProblem(StatusCodes.Status401Unauthorized)
-        .ProducesProblem(StatusCodes.Status403Forbidden);
+        .ProducesProblem(StatusCodes.Status403Forbidden)
+        .ProducesProblem(StatusCodes.Status409Conflict)
+        .ProducesProblem(StatusCodes.Status429TooManyRequests);
 
         // GET /api/v1/admin/ab-tests
         // List A/B test sessions (paginated)

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GameNight/CastVoteOnDisputeCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GameNight/CastVoteOnDisputeCommandHandlerTests.cs
@@ -106,7 +106,7 @@ disputeId,
     }
 
     [Fact]
-    public async Task CastVote_FeatureDisabled_ThrowsInvalidOperationException()
+    public async Task CastVote_FeatureDisabled_ThrowsConflict()
     {
         // Arrange
         SetupFeatureFlagEnabled(false);
@@ -120,7 +120,7 @@ Guid.NewGuid(),
         // Act & Assert
         var act =
             () => _handler.Handle(command, CancellationToken.None);
-        var ex = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
+        var ex = (await act.Should().ThrowAsync<ConflictException>()).Which;
 
         ex.Message.Should().Contain("disabled");
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GameNight/OpenStructuredDisputeCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GameNight/OpenStructuredDisputeCommandHandlerTests.cs
@@ -139,7 +139,7 @@ public class OpenStructuredDisputeCommandHandlerTests
     }
 
     [Fact]
-    public async Task OpenStructuredDispute_FeatureDisabled_ThrowsInvalidOperationException()
+    public async Task OpenStructuredDispute_FeatureDisabled_ThrowsConflict()
     {
         // Arrange
         SetupFeatureFlagEnabled(false);
@@ -152,7 +152,7 @@ public class OpenStructuredDisputeCommandHandlerTests
         // Act & Assert
         var act =
             () => _openHandler.Handle(command, CancellationToken.None);
-        var ex = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
+        var ex = (await act.Should().ThrowAsync<ConflictException>()).Which;
 
         ex.Message.Should().Contain("disabled");
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/GenerateSetupChecklistCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/GenerateSetupChecklistCommandHandlerTests.cs
@@ -126,7 +126,7 @@ public class GenerateSetupChecklistCommandHandlerTests
     // === Feature flag disabled ===
 
     [Fact]
-    public async Task Handle_FeatureDisabled_ThrowsInvalidOperationException()
+    public async Task Handle_FeatureDisabled_ThrowsConflict()
     {
         // Arrange
         SetupFeatureFlagEnabled(false);
@@ -135,7 +135,7 @@ public class GenerateSetupChecklistCommandHandlerTests
         // Act & Assert
         var act =
             () => _handler.Handle(command, CancellationToken.None);
-        var ex = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
+        var ex = (await act.Should().ThrowAsync<ConflictException>()).Which;
 
         ex.Message.Should().Be("Feature SetupWizard.Enabled is disabled");
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Validators/CreateRuleCommentCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Validators/CreateRuleCommentCommandValidatorTests.cs
@@ -1,0 +1,49 @@
+using Api.BoundedContexts.GameManagement.Application.Commands;
+using Api.BoundedContexts.GameManagement.Application.Validators;
+using Api.Tests.Constants;
+using FluentValidation.TestHelper;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.Validators;
+
+/// <summary>
+/// Tests for <see cref="CreateRuleCommentCommandValidator"/> line-number handling.
+/// A non-positive line number previously reached the handler, which threw
+/// <see cref="InvalidOperationException"/> (→ HTTP 500). The validator must reject it → 422.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public sealed class CreateRuleCommentCommandValidatorTests
+{
+    private readonly CreateRuleCommentCommandValidator _validator = new();
+
+    private static CreateRuleCommentCommand CommandWithLineNumber(int? lineNumber) =>
+        new(
+            GameId: "game-1",
+            Version: "1.0.0",
+            LineNumber: lineNumber,
+            CommentText: "A rule comment",
+            UserId: Guid.NewGuid());
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(1)]
+    [InlineData(42)]
+    public void Validate_WithNullOrPositiveLineNumber_HasNoLineNumberError(int? lineNumber)
+    {
+        var result = _validator.TestValidate(CommandWithLineNumber(lineNumber));
+
+        result.ShouldNotHaveValidationErrorFor(x => x.LineNumber);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-100)]
+    public void Validate_WithNonPositiveLineNumber_HasLineNumberError(int? lineNumber)
+    {
+        var result = _validator.TestValidate(CommandWithLineNumber(lineNumber));
+
+        result.ShouldHaveValidationErrorFor(x => x.LineNumber);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AbTest/CreateAbTestCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AbTest/CreateAbTestCommandHandlerTests.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.KnowledgeBase.Application.Commands.AbTest;
 using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services;
+using Api.Middleware.Exceptions;
 using Api.Services;
 using Api.Tests.Constants;
 using Microsoft.Extensions.Logging;
@@ -94,7 +95,7 @@ public sealed class CreateAbTestCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WhenBudgetExhausted_ThrowsInvalidOperation()
+    public async Task Handle_WhenBudgetExhausted_ThrowsConflict()
     {
         _budgetServiceMock.Setup(b => b.HasBudgetRemainingAsync(It.IsAny<CancellationToken>())).ReturnsAsync(false);
 
@@ -103,11 +104,12 @@ public sealed class CreateAbTestCommandHandlerTests
 
         Func<Task> act = () =>
             sut.Handle(command, CancellationToken.None);
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        // Budget exhausted is a conflict with server state (409), not an unhandled 500.
+        await act.Should().ThrowAsync<ConflictException>();
     }
 
     [Fact]
-    public async Task Handle_WhenRateLimitReached_ThrowsInvalidOperation()
+    public async Task Handle_WhenRateLimitReached_ThrowsTooManyRequests()
     {
         _budgetServiceMock.Setup(b => b.HasRateLimitRemainingAsync(UserId, It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
 
@@ -116,7 +118,8 @@ public sealed class CreateAbTestCommandHandlerTests
 
         Func<Task> act = () =>
             sut.Handle(command, CancellationToken.None);
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        // Rate limit reached maps to 429, not an unhandled 500.
+        await act.Should().ThrowAsync<TooManyRequestsException>();
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Validators/AddMessageCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Validators/AddMessageCommandValidatorTests.cs
@@ -1,0 +1,46 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Commands;
+using Api.BoundedContexts.KnowledgeBase.Application.Validators;
+using Api.Tests.Constants;
+using FluentValidation.TestHelper;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Validators;
+
+/// <summary>
+/// Tests for <see cref="AddMessageCommandValidator"/>.
+/// The handler only accepts <c>user</c>/<c>assistant</c> roles and previously threw
+/// <see cref="InvalidOperationException"/> (→ HTTP 500) on anything else. The validator
+/// must reject an unknown role up front so the request maps to 422.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public sealed class AddMessageCommandValidatorTests
+{
+    private readonly AddMessageCommandValidator _validator = new();
+
+    [Theory]
+    [InlineData("user")]
+    [InlineData("assistant")]
+    public void Validate_WithKnownRole_HasNoRoleError(string role)
+    {
+        var command = new AddMessageCommand(Guid.NewGuid(), "hello", role);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.Role);
+    }
+
+    [Theory]
+    [InlineData("system")]
+    [InlineData("admin")]
+    [InlineData("unknown_role")]
+    [InlineData("USER")]
+    public void Validate_WithUnknownRole_HasRoleError(string role)
+    {
+        var command = new AddMessageCommand(Guid.NewGuid(), "hello", role);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.Role);
+    }
+}


### PR DESCRIPTION
## Problema

Sei handler lanciavano `InvalidOperationException` (senza "not found" nel messaggio) per errori che sono lato-client o di stato. Il middleware mappa quelle eccezioni a **HTTP 500** (regola #2568: mai `InvalidOperationException` → 500 per errori 4xx).

## Fix (cluster exception-mapping 500 → 4xx)

| Punto | Prima | Dopo |
|---|---|---|
| `CreateAbTestCommandHandler` budget esaurito | IOE → 500 | `ConflictException` → **409** (`ab_test_budget_exhausted`) |
| `CreateAbTestCommandHandler` rate-limit | IOE → 500 | nuova `TooManyRequestsException` → **429** (`ab_test_rate_limit_reached`) |
| `AddMessageCommandHandler` ruolo sconosciuto | IOE → 500 | `AddMessageCommandValidator` vincola Role a user/assistant → **422** |
| `CreateRuleCommentCommandHandler` LineNumber ≤ 0 | IOE → 500 | validator regola `LineNumber is null or >= 1` → **422** |
| `GenerateSetupChecklistCommandHandler` feature disabled | IOE → 500 | `ConflictException` → **409** |
| `CastVoteOnDisputeCommandHandler` feature disabled | IOE → 500 | `ConflictException` → **409** |
| `OpenStructuredDisputeCommandHandler` feature disabled | IOE → 500 | `ConflictException` → **409** |

Dettagli:
- **`TooManyRequestsException : HttpException(429)`** (nuovo, in `Middleware/Exceptions/`): il middleware ha già un arm generico per `HttpException`, quindi nessuna modifica al mapper. `AdminAbTestEndpoints` ora dichiara `.ProducesProblem(409/429)`.
- I validator sfruttano `ValidationBehavior` → `FluentValidation.ValidationException` → **422**.
- Le 3 feature-flag → 409 sono coerenti con la convenzione "precondition conflict" già presente in quegli handler.

## TDD

12 asserzioni (2 A/B flippate + 3 feature-flag flippate + 4 role + 3 line-number nuove) sono andate **RED** (ancora 500/IOE) → **GREEN** dopo il fix.

## Verifica locale

- Test del cluster: **40/40** PASS
- Regressione `Category=Unit & (KnowledgeBase | GameManagement)`: **4135** PASS (1 skip pre-esistente)
- Pre-push backend build: 0 errori