### PR TITLE
release: promote main-dev → main-staging (WP3 title-health gate #3358 + 5)

### DIFF
--- a/.github/workflows/rag-smoke-dispatch.yml
+++ b/.github/workflows/rag-smoke-dispatch.yml
@@ -1,25 +1,31 @@
-name: RAG Smoke (canonical queries vs golden baseline)
+name: RAG Smoke (retrieval + extraction-quality regression guards)
 
-# Tier 3 D8 of #2126 / #2480 — retrieval-quality smoke.
+# Tier 3 D8 of #2126 / #2480 — retrieval-quality smoke + Epic #3338 WP3 extraction-quality guard.
 #
-# Consumes a published seed snapshot (`make dev-from-snapshot`), runs the canonical
-# RAG queries in infra/fixtures/rag-canonical-queries.json, and asserts the top-3
-# retrieved chunks match infra/fixtures/rag-golden-baseline.json. Catches silent
-# retrieval regressions (embedding model / chunker / index drift) that the bake
-# smoke does not cover.
+# Consumes a published seed snapshot (`make dev-from-snapshot`) ONCE and runs two guards
+# against the booted API:
+#   1. RETRIEVAL (#2480): the canonical RAG queries in infra/fixtures/rag-canonical-queries.json
+#      → asserts the top-3 retrieved chunks match infra/fixtures/rag-golden-baseline.json.
+#      Catches silent retrieval regressions (embedding model / chunker / index drift).
+#   2. EXTRACTION QUALITY (#3338 WP3): GET /api/v1/admin/kb/title-health (TitleHealthMetric over
+#      each game's distinct text_chunks.Heading) → asserts no game's band DOWNGRADED / plausible
+#      fraction dropped vs infra/fixtures/title-health-baseline.json. Catches a chunking change
+#      that buries section headings (the TM "PREPARAZIONE" case) — regressing what retrieval sees.
+# Both share the single ~20-min snapshot boot; the title-health guard is dormant (SKIP) until its
+# baseline is captured via update_baseline (its `games` map ships empty).
 #
-# Runs weekly (schedule) in ASSERT mode against the committed golden baseline, and
-# can be dispatched manually to re-capture the baseline (update_baseline=true) after a
-# re-bake. R2 snapshot distribution works (#2516): the dedicated meepleai-seed-snapshots
-# bucket + SEED_BLOB_* repo secrets are configured, and dev-from-snapshot fetches the
-# published snapshot via the read creds synthesized in "Configure snapshot bucket read
-# credentials" below. The golden baseline was first committed for snapshot
-# meepleai_seed_20260628T211806Z_intfloat_multilingual-e5-base_7cee37d47 (#2480).
+# Runs weekly (schedule) in ASSERT mode against the committed baselines, and can be dispatched
+# manually to re-capture BOTH baselines (update_baseline=true) after a re-bake. R2 snapshot
+# distribution works (#2516): the dedicated meepleai-seed-snapshots bucket + SEED_BLOB_* repo
+# secrets are configured, and dev-from-snapshot fetches the published snapshot via the read creds
+# synthesized in "Configure snapshot bucket read credentials" below. The golden baseline was first
+# committed for snapshot meepleai_seed_20260628T211806Z_intfloat_multilingual-e5-base_7cee37d47 (#2480).
 #
-# Re-baseline procedure (after a re-bake that changes the EF head / embedding model):
+# Re-baseline procedure (after a re-bake that changes the EF head / embedding model / chunker):
 #   1. re-bake + publish (seed-snapshot-bake-full.yml -f publish=true)
 #   2. dispatch this workflow with update_baseline=true
-#   3. download the rag-golden-baseline-<run_id> artifact, commit infra/fixtures/rag-golden-baseline.json
+#   3. download the rag-golden-baseline-<run_id> + title-health-baseline-<run_id> artifacts,
+#      commit infra/fixtures/rag-golden-baseline.json + infra/fixtures/title-health-baseline.json
 #
 # On a schedule trigger github.event.inputs.update_baseline is empty → assert mode.
 
@@ -126,6 +132,7 @@ jobs:
           echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
 
       - name: Boot from published snapshot
+        id: boot
         working-directory: infra
         env:
           # Canonical out-dir (repo root, gitignored) so fetch/verify/restore use
@@ -179,6 +186,25 @@ jobs:
             bash scripts/rag-smoke-assert.sh
           fi
 
+      - name: Run title-health regression guard
+        id: titlehealth
+        # Run whenever the API booted (steps.boot success), even if the retrieval smoke DRIFTED —
+        # the two guards are independent, and update_baseline must capture both in one dispatch. Gating
+        # on boot (not always()) keeps a snapshot/infra boot failure from firing a false regression issue.
+        if: ${{ always() && steps.boot.outcome == 'success' }}
+        working-directory: infra
+        env:
+          API_BASE_URL: http://localhost:8080
+          SMOKE_EMAIL: bake-admin@meepleai.test
+          SMOKE_PASSWORD: BakeSeed1!Admin
+        run: |
+          if [ "${{ github.event.inputs.update_baseline }}" = "true" ]; then
+            bash scripts/title-health-assert.sh --update-baseline
+            echo "::notice:: title-health baseline updated — download the artifact and commit infra/fixtures/title-health-baseline.json"
+          else
+            bash scripts/title-health-assert.sh
+          fi
+
       - name: Diagnose smoke failure
         # always() is required: without it GitHub implicitly ANDs the condition
         # with success(), so the step is skipped after the smoke step fails (#2480).
@@ -226,10 +252,22 @@ jobs:
           path: infra/fixtures/rag-golden-baseline.json
           retention-days: 14
 
+      - name: Upload updated title-health baseline (when --update-baseline)
+        if: ${{ github.event.inputs.update_baseline == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: title-health-baseline-${{ github.run_id }}
+          path: infra/fixtures/title-health-baseline.json
+          retention-days: 14
+
       - name: Open issue on retrieval drift
         # Only on actual retrieval drift (the smoke step failed), NOT on an infra
         # failure like the broken R2 snapshot fetch in "Boot from published snapshot".
-        if: ${{ steps.ragsmoke.outcome == 'failure' && github.event.inputs.update_baseline != 'true' }}
+        # always() is required: without a status function GitHub ANDs an implicit success()
+        # into the condition, so after ragsmoke fails the job is failed → success() is false
+        # → this step is skipped and the issue is never opened. The outcome check still scopes
+        # it to a real drift (skipped/successful ragsmoke → not 'failure').
+        if: ${{ always() && steps.ragsmoke.outcome == 'failure' && github.event.inputs.update_baseline != 'true' }}
         uses: actions/github-script@v7
         with:
           script: |
@@ -243,5 +281,28 @@ jobs:
                 title: `[RAG SMOKE] retrieval drift — ${new Date().toISOString().slice(0,10)}`,
                 labels: ['bug', 'rag-smoke-failure'],
                 body: `Canonical RAG queries drifted from the golden baseline. See run ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}.\n\nIf the drift is intentional (re-index), regenerate via \`--update-baseline\` per docs/for-developers/operations/rag-smoke-runbook.md.`
+              });
+            }
+
+      - name: Open issue on title-health regression
+        # Only on an actual extraction-quality regression (the guard step failed), NOT on an
+        # infra failure in "Boot from published snapshot". Epic #3338 WP3.
+        # always() is required: without a status function the implicit success() would skip this
+        # after titlehealth fails (same gotcha as the retrieval-drift step above). The outcome
+        # check scopes it to a real regression; the guard step is skipped on boot failure.
+        if: ${{ always() && steps.titlehealth.outcome == 'failure' && github.event.inputs.update_baseline != 'true' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner, repo: context.repo.repo,
+              labels: 'title-health-regression', state: 'open'
+            });
+            if (existing.data.length === 0) {
+              await github.rest.issues.create({
+                owner: context.repo.owner, repo: context.repo.repo,
+                title: `[TITLE-HEALTH] extraction-quality regression — ${new Date().toISOString().slice(0,10)}`,
+                labels: ['bug', 'title-health-regression'],
+                body: `A game's title-health band downgraded or its plausible-heading fraction dropped vs infra/fixtures/title-health-baseline.json (a chunking change buried section headings). See run ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}.\n\nIf the change is intentional (re-chunk / re-index), regenerate via \`--update-baseline\` per docs/for-developers/operations/2026-07-28-wp3-title-health-go-no-go.md.`
               });
             }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/CastVoteOnDisputeCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/CastVoteOnDisputeCommandHandler.cs
@@ -44,7 +44,7 @@ internal sealed class CastVoteOnDisputeCommandHandler
 
         if (!isEnabled)
         {
-            throw new InvalidOperationException("Feature Arbitro.DemocraticOverride is disabled");
+            throw new ConflictException("Feature Arbitro.DemocraticOverride is disabled");
         }
 
         // 2. Get dispute

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/OpenStructuredDisputeCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/OpenStructuredDisputeCommandHandler.cs
@@ -50,7 +50,7 @@ internal sealed class OpenStructuredDisputeCommandHandler
 
         if (!isEnabled)
         {
-            throw new InvalidOperationException("Feature Arbitro.StructuredDisputes is disabled");
+            throw new ConflictException("Feature Arbitro.StructuredDisputes is disabled");
         }
 
         // 2. Get session

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/GenerateSetupChecklistCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/GenerateSetupChecklistCommandHandler.cs
@@ -52,7 +52,7 @@ internal class GenerateSetupChecklistCommandHandler
 
         if (!isEnabled)
         {
-            throw new InvalidOperationException("Feature SetupWizard.Enabled is disabled");
+            throw new ConflictException("Feature SetupWizard.Enabled is disabled");
         }
 
         // 2. Get session

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/RuleCommentCommandValidators.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/RuleCommentCommandValidators.cs
@@ -72,6 +72,10 @@ internal sealed class CreateRuleCommentCommandValidator : AbstractValidator<Crea
 
         RuleFor(x => x.UserId)
             .NotEmpty().WithMessage("User ID is required");
+
+        RuleFor(x => x.LineNumber)
+            .Must(lineNumber => lineNumber is null or >= 1)
+            .WithMessage("Line number must be positive");
     }
 }
 

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Infrastructure/Persistence/GameToolkitRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Infrastructure/Persistence/GameToolkitRepository.cs
@@ -134,7 +134,19 @@ internal class GameToolkitRepository : RepositoryBase, IGameToolkitRepository
         ArgumentNullException.ThrowIfNull(toolkit);
         CollectDomainEvents(toolkit);
         var entity = MapToPersistence(toolkit);
-        DbContext.Set<GameToolkitEntity>().Update(entity);
+        var entry = DbContext.Set<GameToolkitEntity>().Update(entity);
+
+        // Issue #1458: the domain aggregate carries no VersionSemver/Description/License,
+        // so MapToPersistence cannot reconstruct them — VersionSemver is synthesized as
+        // "0.{Version}.0" and the other two default to null. Update() marks every column
+        // Modified, which would clobber the published marketplace pointer (e.g. reset
+        // "2.3.1" → "0.1.0") and null the description/license on every non-publish update.
+        // Exclude those three columns so their persisted values survive. PublishToolkitVersion
+        // writes VersionSemver on the tracked entity directly, bypassing this method.
+        entry.Property(e => e.VersionSemver).IsModified = false;
+        entry.Property(e => e.Description).IsModified = false;
+        entry.Property(e => e.License).IsModified = false;
+
         return Task.CompletedTask;
     }
 
@@ -297,18 +309,19 @@ internal class GameToolkitRepository : RepositoryBase, IGameToolkitRepository
 #pragma warning disable CS0618 // Issue #1144 / spec D-5: paired write — legacy int + new semver in same MapToPersistence call.
             Version = toolkit.Version,
 #pragma warning restore CS0618
-#pragma warning disable S1135 // TODO: architectural breadcrumb — active footgun: see comment below.
+#pragma warning disable S1135 // TODO: architectural breadcrumb — mitigated footgun: see comment below.
             // TODO(#1458): VersionSemver already has a real producer.
             // PublishToolkitVersionCommandHandler.cs:137 writes the user-input
             // semver and DELIBERATELY bypasses GameToolkitRepository.UpdateAsync
             // (see handler comment at lines 131-136) precisely because this
             // MapToPersistence synthesis would otherwise overwrite the user
-            // value with "0.{Version}.0". Risk: every OTHER UpdateAsync call
-            // (name rename, config change, future commands) silently overwrites
-            // the column. Fix: surface VersionSemver on the domain aggregate
-            // (separate epic — original paired-write context shipped in #1144
-            // 2026-05-14) so MapToPersistence can read it directly and the
-            // synthesis goes away.
+            // value with "0.{Version}.0". This synthesis is only meaningful for
+            // AddAsync (brand-new toolkit → seed "0.1.0"): UpdateAsync now excludes
+            // VersionSemver (and Description/License) from the Update() so no
+            // non-publish update path clobbers the published marketplace pointer.
+            // Full fix: surface VersionSemver on the domain aggregate (separate
+            // epic — original paired-write context shipped in #1144 2026-05-14)
+            // so MapToPersistence can read it directly and the synthesis goes away.
             VersionSemver = $"0.{toolkit.Version}.0",
 #pragma warning restore S1135
             CreatedByUserId = toolkit.CreatedByUserId,

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/AbTest/CreateAbTestCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/AbTest/CreateAbTestCommandHandler.cs
@@ -3,6 +3,7 @@ using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services;
+using Api.Middleware.Exceptions;
 using Api.Services;
 using Api.SharedKernel.Application.Interfaces;
 using Microsoft.Extensions.Logging;
@@ -45,10 +46,10 @@ internal sealed class CreateAbTestCommandHandler : ICommandHandler<CreateAbTestC
 
         // Check budget and rate limit
         if (!await _budgetService.HasBudgetRemainingAsync(cancellationToken).ConfigureAwait(false))
-            throw new InvalidOperationException("Daily A/B test budget exhausted");
+            throw new ConflictException("ab_test_budget_exhausted", "Daily A/B test budget exhausted");
 
         if (!await _budgetService.HasRateLimitRemainingAsync(command.CreatedBy, isAdmin: true, cancellationToken).ConfigureAwait(false))
-            throw new InvalidOperationException("Daily A/B test rate limit reached");
+            throw new TooManyRequestsException("ab_test_rate_limit_reached", "Daily A/B test rate limit reached");
 
         // Create session and add variants
         var session = AbTestSession.Create(command.CreatedBy, command.Query, command.KnowledgeBaseId);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/AddChatSessionMessageCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/AddChatSessionMessageCommand.cs
@@ -8,6 +8,7 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Commands;
 /// </summary>
 internal record AddChatSessionMessageCommand(
     Guid SessionId,
+    Guid UserId,
     string Role,
     string Content,
     Dictionary<string, object>? Metadata = null

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/AddChatSessionMessageCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/AddChatSessionMessageCommandHandler.cs
@@ -47,6 +47,13 @@ internal sealed class AddChatSessionMessageCommandHandler : IRequestHandler<AddC
             throw new NotFoundException("ChatSession", request.SessionId.ToString());
         }
 
+        // Ownership check (IDOR): a non-owner gets the same 404 as a non-existent
+        // session, so injecting messages into another user's chat is impossible.
+        if (session.UserId != request.UserId)
+        {
+            throw new NotFoundException("ChatSession", request.SessionId.ToString());
+        }
+
         var sequenceNumber = session.MessageCount;
         var message = new SessionChatMessage(
             content: request.Content,

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/DeleteChatSessionCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/DeleteChatSessionCommand.cs
@@ -7,5 +7,6 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Commands;
 /// Issue #3483: Chat Session Persistence Service.
 /// </summary>
 internal record DeleteChatSessionCommand(
-    Guid SessionId
+    Guid SessionId,
+    Guid UserId
 ) : IRequest;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/DeleteChatSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/DeleteChatSessionCommandHandler.cs
@@ -46,6 +46,13 @@ internal sealed class DeleteChatSessionCommandHandler : IRequestHandler<DeleteCh
             throw new NotFoundException("ChatSession", request.SessionId.ToString());
         }
 
+        // Ownership check (IDOR): a non-owner gets the same 404 as a non-existent
+        // session, so deletion of another user's chat is impossible and undetectable.
+        if (session.UserId != request.UserId)
+        {
+            throw new NotFoundException("ChatSession", request.SessionId.ToString());
+        }
+
         await _sessionRepository.DeleteAsync(session, cancellationToken).ConfigureAwait(false);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/RenameChatSessionCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/RenameChatSessionCommand.cs
@@ -9,5 +9,6 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Commands;
 /// </summary>
 internal record RenameChatSessionCommand(
     Guid SessionId,
+    Guid UserId,
     string Title
 ) : ICommand<ChatSessionDto>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/RenameChatSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/RenameChatSessionCommandHandler.cs
@@ -34,6 +34,11 @@ internal sealed class RenameChatSessionCommandHandler : ICommandHandler<RenameCh
         if (session == null)
             throw new NotFoundException("ChatSession", command.SessionId.ToString());
 
+        // Ownership check (IDOR): a non-owner gets the same 404 as a non-existent
+        // session, so renaming another user's chat is impossible and undetectable.
+        if (session.UserId != command.UserId)
+            throw new NotFoundException("ChatSession", command.SessionId.ToString());
+
         // Update title (domain validates max 200 chars, non-empty, trim)
         session.SetTitle(command.Title);
 

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetChatSessionQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetChatSessionQuery.cs
@@ -9,6 +9,7 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Queries;
 /// </summary>
 internal record GetChatSessionQuery(
     Guid SessionId,
+    Guid UserId,
     int MessageSkip = 0,
     int MessageTake = 50
 ) : IRequest<ChatSessionDto?>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetChatSessionQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetChatSessionQueryHandler.cs
@@ -48,6 +48,13 @@ internal sealed class GetChatSessionQueryHandler : IRequestHandler<GetChatSessio
             return null;
         }
 
+        // Ownership check (IDOR): a non-owner sees the same null → 404 as a
+        // non-existent session, so the endpoint discloses nothing about it.
+        if (session.UserId != request.UserId)
+        {
+            return null;
+        }
+
         var messageDtos = session.Messages
             .Select(m => new ChatSessionMessageDto(
                 Id: m.Id,

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetCorpusTitleHealth/GameTitleHealthDto.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetCorpusTitleHealth/GameTitleHealthDto.cs
@@ -1,0 +1,25 @@
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetCorpusTitleHealth;
+
+/// <summary>
+/// Epic #3338 WP3: the per-game extraction-quality read-out exposed by
+/// <c>GET /api/v1/admin/kb/title-health</c> — one row per shared game that has chunked headings.
+/// Computed by <see cref="Api.BoundedContexts.KnowledgeBase.Application.Services.Chunking.TitleHealthMetric"/>
+/// over the game's distinct <c>text_chunks.Heading</c> values (what retrieval sees).
+/// </summary>
+/// <param name="GameId">The <c>shared_games.id</c> the chunks are scoped to.</param>
+/// <param name="GameTitle">The shared game's title (for the read-out / baseline label).</param>
+/// <param name="Language">The effective language (<c>LanguageOverride ?? Language</c>) labelling the most distinct headings for this game (retrieval-surface-weighted majority, not the per-PDF count).</param>
+/// <param name="DistinctHeadings">Distinct non-blank headings across the game's chunks.</param>
+/// <param name="PlausibleHeadings">How many of those look like real section titles.</param>
+/// <param name="PlausibleFraction">PlausibleHeadings / DistinctHeadings, rounded to 4 dp for a stable baseline (0 when there are none).</param>
+/// <param name="CanonicalCoverage">Distinct plausible headings matching a curated lexicon section word.</param>
+/// <param name="Band">green ≥ 0.80 · yellow ≥ 0.50 · red otherwise — the WP4 go/no-go band.</param>
+public sealed record GameTitleHealthDto(
+    Guid GameId,
+    string GameTitle,
+    string? Language,
+    int DistinctHeadings,
+    int PlausibleHeadings,
+    double PlausibleFraction,
+    int CanonicalCoverage,
+    string Band);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetCorpusTitleHealth/GetCorpusTitleHealthQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetCorpusTitleHealth/GetCorpusTitleHealthQuery.cs
@@ -1,0 +1,11 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetCorpusTitleHealth;
+
+/// <summary>
+/// Epic #3338 WP3 regression guard: compute the per-game title-health metric across the whole
+/// chunked corpus (every shared game with at least one non-blank <c>text_chunks.Heading</c>).
+/// Backs the admin read-out endpoint and the CI gate that fails if a previously-green game's
+/// extraction health drops after a WP1/WP4 chunking change. Read-only, admin-scoped.
+/// </summary>
+internal sealed record GetCorpusTitleHealthQuery() : IQuery<IReadOnlyList<GameTitleHealthDto>>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetCorpusTitleHealth/GetCorpusTitleHealthQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetCorpusTitleHealth/GetCorpusTitleHealthQueryHandler.cs
@@ -1,0 +1,96 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Services.Chunking;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetCorpusTitleHealth;
+
+/// <summary>
+/// Handles <see cref="GetCorpusTitleHealthQuery"/>.
+///
+/// <para>Pulls the DISTINCT <c>(game, effective-language, heading)</c> triples the corpus carries
+/// — joining <c>text_chunks</c> → <c>shared_games</c> (title) → <c>pdf_documents</c> (language) — then
+/// groups by game and runs the pure <see cref="TitleHealthMetric"/> over each game's headings. The
+/// DISTINCT is pushed to the DB so child chunks repeating their parent heading do not inflate the
+/// transfer; <see cref="TitleHealthMetric.Compute"/> dedups again defensively.</para>
+///
+/// <para>Only games with at least one non-blank heading appear — a game with zero chunked headings has
+/// no extraction-quality signal to report. Ordered by title (ordinal) for a deterministic baseline.</para>
+/// </summary>
+internal sealed class GetCorpusTitleHealthQueryHandler
+    : IQueryHandler<GetCorpusTitleHealthQuery, IReadOnlyList<GameTitleHealthDto>>
+{
+    private const int FractionPrecision = 4;
+
+    private readonly MeepleAiDbContext _db;
+
+    public GetCorpusTitleHealthQueryHandler(MeepleAiDbContext db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public async Task<IReadOnlyList<GameTitleHealthDto>> Handle(
+        GetCorpusTitleHealthQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // Correlated Where instead of an explicit join keeps the nullable GameId (Guid?) lift clean;
+        // both projections are inner (a chunk with an orphaned GameId / PdfDocumentId is dropped).
+        var rows = await (
+            from tc in _db.TextChunks.AsNoTracking()
+            // Exclude blank headings at the DB (btrim(heading) <> '') so a game whose chunks carry only
+            // null/empty/whitespace headings forms no group and is absent — it has no extraction signal.
+            // A real (even garbage) heading like "D" is NOT blank and correctly yields a red-band game.
+            where tc.GameId != null && tc.Heading != null && tc.Heading.Trim() != ""
+            from sg in _db.SharedGames.AsNoTracking().Where(g => g.Id == tc.GameId)
+            from pd in _db.PdfDocuments.AsNoTracking().Where(p => p.Id == tc.PdfDocumentId)
+            select new HeadingRow
+            {
+                GameId = sg.Id,
+                Title = sg.Title,
+                Language = pd.LanguageOverride ?? pd.Language,
+                Heading = tc.Heading!,
+            })
+            .Distinct()
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return rows
+            .GroupBy(r => new { r.GameId, r.Title })
+            .Select(g =>
+            {
+                var health = TitleHealthMetric.Compute(g.Select(x => x.Heading));
+
+                // The effective language labelling the MOST distinct headings for this game (rows are
+                // already Distinct on (game,lang,heading), so this weights the retrieval surface, not the
+                // PDF count); ordinal tiebreak keeps a tie stable.
+                var language = g
+                    .GroupBy(x => x.Language, StringComparer.Ordinal)
+                    .OrderByDescending(lg => lg.Count())
+                    .ThenBy(lg => lg.Key, StringComparer.Ordinal)
+                    .First().Key;
+
+                return new GameTitleHealthDto(
+                    g.Key.GameId,
+                    g.Key.Title,
+                    language,
+                    health.DistinctHeadings,
+                    health.PlausibleHeadings,
+                    Math.Round(health.PlausibleFraction, FractionPrecision, MidpointRounding.AwayFromZero),
+                    health.CanonicalCoverage,
+                    health.Band);
+            })
+            .OrderBy(d => d.GameTitle, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    /// <summary>DB projection row — a named type (not anonymous) so EF's DISTINCT is stable and the group key is explicit.</summary>
+    private sealed record HeadingRow
+    {
+        public Guid GameId { get; init; }
+        public string Title { get; init; } = string.Empty;
+        public string? Language { get; init; }
+        public string Heading { get; init; } = string.Empty;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/EmbeddedTitleSplitter.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/EmbeddedTitleSplitter.cs
@@ -150,7 +150,12 @@ internal static class EmbeddedTitleSplitter
         return hasLetter;
     }
 
-    private static bool ContainsLexiconTitle(string text)
+    /// <summary>
+    /// True when <paramref name="text"/> contains a curated <see cref="SectionHeadingLexicon"/> section
+    /// title as an exact UPPERCASE whole word. Shared with <see cref="TitleHealthMetric"/> (WP3 canonical
+    /// coverage) so the "is this a known section type" predicate has a single definition.
+    /// </summary>
+    internal static bool ContainsLexiconTitle(string text)
     {
         foreach (var title in SectionHeadingLexicon.Titles)
         {

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/TitleHealthMetric.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/TitleHealthMetric.cs
@@ -1,0 +1,114 @@
+using Api.Constants;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Services.Chunking;
+
+/// <summary>
+/// Epic #3338 WP3: a per-game extraction-quality signal computed from the section HEADINGS a game's
+/// chunks carry (<c>text_chunks.Heading</c>) — what retrieval actually sees. It measures how many
+/// distinct headings are plausible section titles (vs. the garbage unstructured's 'fast' strategy
+/// emits on complex layouts — spaced single letters "I L E X Y R F", single chars "D", symbol/number
+/// noise "(14%), Oceani") and how many curated canonical section types are present. Its purpose is the
+/// WP3 regression guard (a well-extracted game's health must not drop after a WP1/WP4 change) and the
+/// WP4 go/no-go read-out (a residual IT cohort below the band threshold triggers hi_res extraction).
+/// <para>Pure and allocation-light — no I/O; the caller supplies the game's chunk headings.</para>
+/// </summary>
+internal static class TitleHealthMetric
+{
+    /// <summary>
+    /// A section title is short (real ones observed: "PLANCE DEI GIOCATORI"=20, "SVOLGIMENTO DELLA
+    /// PARTITA"=25). Longer strings are running headers, copyright/URL lines
+    /// ("© 2016 FryxGames www.fryxgames.se/…") or prose bleed.
+    /// </summary>
+    private const int MaxPlausibleHeadingLength = 40;
+
+    /// <summary>Minimum fraction of non-space characters that must be letters for a heading to be plausible.</summary>
+    private const double MinLetterFraction = 0.6;
+
+    private const double GreenThreshold = 0.80;
+    private const double YellowThreshold = 0.50;
+
+    /// <param name="DistinctHeadings">Distinct non-blank headings across the game's chunks.</param>
+    /// <param name="PlausibleHeadings">How many of those look like real section titles.</param>
+    /// <param name="PlausibleFraction">PlausibleHeadings / DistinctHeadings (0 when there are none).</param>
+    /// <param name="CanonicalCoverage">Distinct PLAUSIBLE headings that match a curated <see cref="SectionHeadingLexicon"/> section word (counted per-heading, so a heading is credited once regardless of how many overlapping lexicon entries it matches).</param>
+    /// <param name="Band">green ≥ 0.80 · yellow ≥ 0.50 · red otherwise — the WP4 go/no-go band.</param>
+    public readonly record struct TitleHealthResult(
+        int DistinctHeadings,
+        int PlausibleHeadings,
+        double PlausibleFraction,
+        int CanonicalCoverage,
+        string Band);
+
+    public static TitleHealthResult Compute(IEnumerable<string?> chunkHeadings)
+    {
+        ArgumentNullException.ThrowIfNull(chunkHeadings);
+
+        var distinct = chunkHeadings
+            .Where(h => !string.IsNullOrWhiteSpace(h))
+            .Select(h => h!.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        var plausible = distinct.Count(IsPlausibleHeading);
+        var fraction = distinct.Count == 0 ? 0.0 : (double)plausible / distinct.Count;
+        // Per-heading (not per-lexicon-entry) and gated on plausibility: a heading is a "canonical
+        // section" once when it is a plausible title carrying a lexicon word — so an overlapping entry
+        // ("SVOLGIMENTO" ⊂ "SVOLGIMENTO DEL GIOCO") is not double-counted, and a garbage heading that
+        // merely embeds a lexicon token ("3 4 SETUP 9%") does not credit coverage.
+        var canonical = distinct.Count(h =>
+            IsPlausibleHeading(h) && EmbeddedTitleSplitter.ContainsLexiconTitle(h.ToUpperInvariant()));
+        var band = fraction >= GreenThreshold ? "green"
+            : fraction >= YellowThreshold ? "yellow"
+            : "red";
+
+        return new TitleHealthResult(distinct.Count, plausible, fraction, canonical, band);
+    }
+
+    /// <summary>
+    /// True when a heading looks like a real section title: 2–40 chars, carrying a real word (a run of
+    /// ≥ <see cref="ChunkingConstants.MinSubstantiveLetterRun"/> consecutive letters, so "D", "S U",
+    /// "I L E X Y R F" are rejected) and dominantly letters (≥ 60 % of non-space chars, so "(14%), Oceani"
+    /// and "© 2016 FryxGames" are rejected). Measures title-LIKENESS, not section-correctness — a real
+    /// word fragment like "Dato" counts as plausible; the target is gross extraction garbage.
+    /// </summary>
+    internal static bool IsPlausibleHeading(string? heading)
+    {
+        if (string.IsNullOrWhiteSpace(heading))
+        {
+            return false;
+        }
+
+        var t = heading.Trim();
+        if (t.Length < 2 || t.Length > MaxPlausibleHeadingLength)
+        {
+            return false;
+        }
+
+        var run = 0;
+        var letters = 0;
+        var nonSpace = 0;
+        var hasWord = false;
+        foreach (var ch in t)
+        {
+            if (!char.IsWhiteSpace(ch))
+            {
+                nonSpace++;
+            }
+
+            if (char.IsLetter(ch))
+            {
+                letters++;
+                if (++run >= ChunkingConstants.MinSubstantiveLetterRun)
+                {
+                    hasWord = true;
+                }
+            }
+            else
+            {
+                run = 0;
+            }
+        }
+
+        return hasWord && nonSpace > 0 && (double)letters / nonSpace >= MinLetterFraction;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Validators/AddMessageCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Validators/AddMessageCommandValidator.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.KnowledgeBase.Application.Commands;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
 using FluentValidation;
 
 namespace Api.BoundedContexts.KnowledgeBase.Application.Validators;
@@ -24,6 +25,9 @@ internal sealed class AddMessageCommandValidator : AbstractValidator<AddMessageC
             .NotEmpty()
             .WithMessage("Role is required")
             .MaximumLength(50)
-            .WithMessage("Role cannot exceed 50 characters");
+            .WithMessage("Role cannot exceed 50 characters")
+            .Must(role => string.Equals(role, ChatMessage.UserRole, StringComparison.Ordinal)
+                       || string.Equals(role, ChatMessage.AssistantRole, StringComparison.Ordinal))
+            .WithMessage("Role must be 'user' or 'assistant'");
     }
 }

--- a/apps/api/src/Api/Middleware/Exceptions/TooManyRequestsException.cs
+++ b/apps/api/src/Api/Middleware/Exceptions/TooManyRequestsException.cs
@@ -1,0 +1,36 @@
+namespace Api.Middleware.Exceptions;
+
+using System.Diagnostics.CodeAnalysis;
+
+/// <summary>
+/// Exception thrown when a caller exceeds a rate limit or quota.
+/// Maps to HTTP 429 Too Many Requests via the generic <see cref="HttpException"/> arm
+/// of the exception-handling middleware.
+/// </summary>
+public class TooManyRequestsException : HttpException
+{
+    [SetsRequiredMembers]
+    public TooManyRequestsException(string message)
+        : base(StatusCodes.Status429TooManyRequests, "too_many_requests", message)
+    {
+    }
+
+    /// <summary>
+    /// Creates a 429 with an explicit machine-readable <paramref name="errorCode"/>.
+    /// </summary>
+    [SetsRequiredMembers]
+    public TooManyRequestsException(string errorCode, string message)
+        : base(StatusCodes.Status429TooManyRequests, errorCode, message)
+    {
+    }
+
+    [SetsRequiredMembers]
+    public TooManyRequestsException(string message, Exception innerException)
+        : base(StatusCodes.Status429TooManyRequests, "too_many_requests", message, innerException)
+    {
+    }
+
+    public TooManyRequestsException()
+    {
+    }
+}

--- a/apps/api/src/Api/Routing/AdminAbTestEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminAbTestEndpoints.cs
@@ -53,7 +53,9 @@ internal static class AdminAbTestEndpoints
         .Produces<AbTestSessionDto>(StatusCodes.Status201Created)
         .ProducesProblem(StatusCodes.Status400BadRequest)
         .ProducesProblem(StatusCodes.Status401Unauthorized)
-        .ProducesProblem(StatusCodes.Status403Forbidden);
+        .ProducesProblem(StatusCodes.Status403Forbidden)
+        .ProducesProblem(StatusCodes.Status409Conflict)
+        .ProducesProblem(StatusCodes.Status429TooManyRequests);
 
         // GET /api/v1/admin/ab-tests
         // List A/B test sessions (paginated)

--- a/apps/api/src/Api/Routing/AdminKnowledgeBaseEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminKnowledgeBaseEndpoints.cs
@@ -3,6 +3,7 @@ using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.EstimateAgentCost;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.ExportDocumentChunks;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetCorpusTitleHealth;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetDocumentEmbeddingsMeta;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetGamesWithoutKb;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbNavCounts;
@@ -189,6 +190,18 @@ internal static class AdminKnowledgeBaseEndpoints
         .WithSummary("List shared games with no active Knowledge Base (admin RAG onboarding)")
         .WithDescription("Returns SharedGames where HasKnowledgeBase = false. Supports pagination and search on Title.")
         .Produces<GamesWithoutKbPagedResponse>();
+
+        // GET /api/v1/admin/kb/title-health — Epic #3338 WP3: per-game extraction-quality read-out +
+        // CI regression guard (fails if a previously-green game's title-health drops after a chunking change).
+        kbGroup.MapGet("/title-health", async (IMediator mediator, CancellationToken ct) =>
+        {
+            var result = await mediator.Send(new GetCorpusTitleHealthQuery(), ct).ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .WithName("GetCorpusTitleHealth")
+        .WithSummary("Per-game title-health (extraction quality) across the chunked corpus")
+        .WithDescription("Computes TitleHealthMetric over each shared game's distinct text_chunks.Heading values. Backs the WP3 regression guard + WP4 go/no-go read-out.")
+        .Produces<IReadOnlyList<GameTitleHealthDto>>(StatusCodes.Status200OK);
 
         // GET /api/v1/admin/shared-games (extended for admin - #4654, #4785)
         var gamesGroup = group.MapGroup("/admin/shared-games")

--- a/apps/api/src/Api/Routing/ChatSessionEndpoints.cs
+++ b/apps/api/src/Api/Routing/ChatSessionEndpoints.cs
@@ -140,10 +140,12 @@ internal static class ChatSessionEndpoints
         [FromRoute] Guid sessionId,
         [FromBody] AddChatSessionMessageRequest request,
         [FromServices] IMediator mediator,
+        HttpContext httpContext,
         CancellationToken cancellationToken)
     {
         var command = new AddChatSessionMessageCommand(
             SessionId: sessionId,
+            UserId: httpContext.User.GetUserId(),
             Role: request.Role,
             Content: request.Content,
             Metadata: request.Metadata
@@ -156,6 +158,7 @@ internal static class ChatSessionEndpoints
 
     private static async Task<IResult> HandleGetSession(
         [FromRoute] Guid sessionId,
+        HttpContext httpContext,
         [FromQuery] int skip = 0,
         [FromQuery] int take = 50,
         [FromServices] IMediator mediator = null!,
@@ -163,6 +166,7 @@ internal static class ChatSessionEndpoints
     {
         var query = new GetChatSessionQuery(
             SessionId: sessionId,
+            UserId: httpContext.User.GetUserId(),
             MessageSkip: skip,
             MessageTake: take
         );
@@ -263,9 +267,10 @@ internal static class ChatSessionEndpoints
     private static async Task<IResult> HandleDeleteSession(
         [FromRoute] Guid sessionId,
         [FromServices] IMediator mediator,
+        HttpContext httpContext,
         CancellationToken cancellationToken)
     {
-        var command = new DeleteChatSessionCommand(SessionId: sessionId);
+        var command = new DeleteChatSessionCommand(SessionId: sessionId, UserId: httpContext.User.GetUserId());
 
         await mediator.Send(command, cancellationToken).ConfigureAwait(false);
 
@@ -278,6 +283,7 @@ internal static class ChatSessionEndpoints
         [FromServices] IMediator mediator,
         [FromServices] IChatSessionRepository sessionRepository,
         [FromServices] IChatThreadRepository threadRepository,
+        HttpContext httpContext,
         CancellationToken cancellationToken)
     {
         // Naming disambiguation: detect if caller passed a ChatThread UUID to a ChatSession endpoint
@@ -297,7 +303,7 @@ internal static class ChatSessionEndpoints
             return Results.NotFound();
         }
 
-        var command = new RenameChatSessionCommand(SessionId: sessionId, Title: body.Title);
+        var command = new RenameChatSessionCommand(SessionId: sessionId, UserId: httpContext.User.GetUserId(), Title: body.Title);
 
         try
         {

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GameNight/CastVoteOnDisputeCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GameNight/CastVoteOnDisputeCommandHandlerTests.cs
@@ -106,7 +106,7 @@ disputeId,
     }
 
     [Fact]
-    public async Task CastVote_FeatureDisabled_ThrowsInvalidOperationException()
+    public async Task CastVote_FeatureDisabled_ThrowsConflict()
     {
         // Arrange
         SetupFeatureFlagEnabled(false);
@@ -120,7 +120,7 @@ Guid.NewGuid(),
         // Act & Assert
         var act =
             () => _handler.Handle(command, CancellationToken.None);
-        var ex = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
+        var ex = (await act.Should().ThrowAsync<ConflictException>()).Which;
 
         ex.Message.Should().Contain("disabled");
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GameNight/OpenStructuredDisputeCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GameNight/OpenStructuredDisputeCommandHandlerTests.cs
@@ -139,7 +139,7 @@ public class OpenStructuredDisputeCommandHandlerTests
     }
 
     [Fact]
-    public async Task OpenStructuredDispute_FeatureDisabled_ThrowsInvalidOperationException()
+    public async Task OpenStructuredDispute_FeatureDisabled_ThrowsConflict()
     {
         // Arrange
         SetupFeatureFlagEnabled(false);
@@ -152,7 +152,7 @@ public class OpenStructuredDisputeCommandHandlerTests
         // Act & Assert
         var act =
             () => _openHandler.Handle(command, CancellationToken.None);
-        var ex = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
+        var ex = (await act.Should().ThrowAsync<ConflictException>()).Which;
 
         ex.Message.Should().Contain("disabled");
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/GenerateSetupChecklistCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/GenerateSetupChecklistCommandHandlerTests.cs
@@ -126,7 +126,7 @@ public class GenerateSetupChecklistCommandHandlerTests
     // === Feature flag disabled ===
 
     [Fact]
-    public async Task Handle_FeatureDisabled_ThrowsInvalidOperationException()
+    public async Task Handle_FeatureDisabled_ThrowsConflict()
     {
         // Arrange
         SetupFeatureFlagEnabled(false);
@@ -135,7 +135,7 @@ public class GenerateSetupChecklistCommandHandlerTests
         // Act & Assert
         var act =
             () => _handler.Handle(command, CancellationToken.None);
-        var ex = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
+        var ex = (await act.Should().ThrowAsync<ConflictException>()).Which;
 
         ex.Message.Should().Be("Feature SetupWizard.Enabled is disabled");
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Validators/CreateRuleCommentCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Validators/CreateRuleCommentCommandValidatorTests.cs
@@ -1,0 +1,49 @@
+using Api.BoundedContexts.GameManagement.Application.Commands;
+using Api.BoundedContexts.GameManagement.Application.Validators;
+using Api.Tests.Constants;
+using FluentValidation.TestHelper;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.Validators;
+
+/// <summary>
+/// Tests for <see cref="CreateRuleCommentCommandValidator"/> line-number handling.
+/// A non-positive line number previously reached the handler, which threw
+/// <see cref="InvalidOperationException"/> (→ HTTP 500). The validator must reject it → 422.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public sealed class CreateRuleCommentCommandValidatorTests
+{
+    private readonly CreateRuleCommentCommandValidator _validator = new();
+
+    private static CreateRuleCommentCommand CommandWithLineNumber(int? lineNumber) =>
+        new(
+            GameId: "game-1",
+            Version: "1.0.0",
+            LineNumber: lineNumber,
+            CommentText: "A rule comment",
+            UserId: Guid.NewGuid());
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(1)]
+    [InlineData(42)]
+    public void Validate_WithNullOrPositiveLineNumber_HasNoLineNumberError(int? lineNumber)
+    {
+        var result = _validator.TestValidate(CommandWithLineNumber(lineNumber));
+
+        result.ShouldNotHaveValidationErrorFor(x => x.LineNumber);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-100)]
+    public void Validate_WithNonPositiveLineNumber_HasLineNumberError(int? lineNumber)
+    {
+        var result = _validator.TestValidate(CommandWithLineNumber(lineNumber));
+
+        result.ShouldHaveValidationErrorFor(x => x.LineNumber);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Infrastructure/Persistence/GameToolkitRepositoryUpdatePreservationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Infrastructure/Persistence/GameToolkitRepositoryUpdatePreservationTests.cs
@@ -1,0 +1,88 @@
+using Api.BoundedContexts.GameToolkit.Application.Commands;
+using Api.BoundedContexts.GameToolkit.Domain.Enums;
+using Api.BoundedContexts.GameToolkit.Infrastructure.Persistence;
+using Api.Infrastructure.Entities.GameToolkit;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameToolkit.Infrastructure.Persistence;
+
+/// <summary>
+/// Regression tests for <see cref="GameToolkitRepository.UpdateAsync"/> (issue #1458 footgun).
+///
+/// <para>
+/// <c>MapToPersistence</c> synthesizes <c>VersionSemver = "0.{Version}.0"</c> and omits
+/// <c>Description</c>/<c>License</c> entirely (the domain aggregate has no knowledge of these
+/// three entity-level marketplace columns). Because <c>UpdateAsync</c> calls
+/// <c>DbContext.Update(entity)</c>, which marks EVERY scalar column Modified, any non-publish
+/// update path (rename, add/remove tool, override change, …) silently overwrote the published
+/// marketplace pointer: <c>VersionSemver "2.3.1" → "0.1.0"</c> and nulled <c>Description</c>/<c>License</c>.
+/// </para>
+///
+/// InMemory is the correct vehicle: it honors per-property <c>IsModified</c> flags but ignores
+/// the Postgres <c>xmin</c> concurrency token (which would otherwise mask this bug behind a
+/// <c>DbUpdateConcurrencyException</c> on a real database).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameToolkit")]
+[Trait("Issue", "1458")]
+public class GameToolkitRepositoryUpdatePreservationTests
+{
+    private static readonly Guid OwnerId = Guid.Parse("00000000-0000-0000-0000-0000000000a1");
+    private static readonly DateTime Now = new(2026, 7, 28, 12, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task UpdateAsync_RenamingToolkit_PreservesPublishedVersionSemverDescriptionAndLicense()
+    {
+        var collector = TestDbContextFactory.CreateMockEventCollector();
+        var dbName = Guid.NewGuid().ToString();
+        var toolkitId = Guid.NewGuid();
+
+        // ── Arrange: seed a published toolkit with a real semver + marketplace metadata ──
+        using (var seedContext = TestDbContextFactory.CreateInMemoryDbContextWithCollector(collector, dbName))
+        {
+#pragma warning disable CS0618 // legacy int Version setter — required to seed the paired column
+            seedContext.GameToolkits.Add(new GameToolkitEntity
+            {
+                Id = toolkitId,
+                Name = "Original Name",
+                CreatedByUserId = OwnerId,
+                Version = 1,
+                VersionSemver = "2.3.1",
+                Description = "A great community toolkit",
+                License = "CC BY-SA 4.0",
+                IsPublished = true,
+                TemplateStatus = (int)TemplateStatus.Approved,
+                CreatedAt = Now,
+                UpdatedAt = Now,
+            });
+#pragma warning restore CS0618
+            await seedContext.SaveChangesAsync();
+        }
+
+        // ── Act: rename through the real repository + handler (separate context) ──
+        using (var actContext = TestDbContextFactory.CreateInMemoryDbContextWithCollector(collector, dbName))
+        {
+            var repository = new GameToolkitRepository(actContext, collector.Object);
+            var unitOfWork = new EfCoreUnitOfWork(actContext);
+            var handler = new UpdateToolkitCommandHandler(repository, unitOfWork);
+
+            await handler.Handle(new UpdateToolkitCommand(toolkitId, "Renamed Toolkit"), default);
+        }
+
+        // ── Assert: rename applied, but the published marketplace columns are untouched ──
+        using (var assertContext = TestDbContextFactory.CreateInMemoryDbContextWithCollector(collector, dbName))
+        {
+            var reloaded = await assertContext.GameToolkits.FindAsync(toolkitId);
+
+            reloaded.Should().NotBeNull();
+            reloaded!.Name.Should().Be("Renamed Toolkit", "the rename must still persist");
+            reloaded.VersionSemver.Should().Be("2.3.1", "a rename must not regress the published marketplace version pointer");
+            reloaded.Description.Should().Be("A great community toolkit", "a rename must not null the marketplace description");
+            reloaded.License.Should().Be("CC BY-SA 4.0", "a rename must not null the marketplace license");
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AbTest/CreateAbTestCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AbTest/CreateAbTestCommandHandlerTests.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.KnowledgeBase.Application.Commands.AbTest;
 using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services;
+using Api.Middleware.Exceptions;
 using Api.Services;
 using Api.Tests.Constants;
 using Microsoft.Extensions.Logging;
@@ -94,7 +95,7 @@ public sealed class CreateAbTestCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WhenBudgetExhausted_ThrowsInvalidOperation()
+    public async Task Handle_WhenBudgetExhausted_ThrowsConflict()
     {
         _budgetServiceMock.Setup(b => b.HasBudgetRemainingAsync(It.IsAny<CancellationToken>())).ReturnsAsync(false);
 
@@ -103,11 +104,12 @@ public sealed class CreateAbTestCommandHandlerTests
 
         Func<Task> act = () =>
             sut.Handle(command, CancellationToken.None);
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        // Budget exhausted is a conflict with server state (409), not an unhandled 500.
+        await act.Should().ThrowAsync<ConflictException>();
     }
 
     [Fact]
-    public async Task Handle_WhenRateLimitReached_ThrowsInvalidOperation()
+    public async Task Handle_WhenRateLimitReached_ThrowsTooManyRequests()
     {
         _budgetServiceMock.Setup(b => b.HasRateLimitRemainingAsync(UserId, It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
 
@@ -116,7 +118,8 @@ public sealed class CreateAbTestCommandHandlerTests
 
         Func<Task> act = () =>
             sut.Handle(command, CancellationToken.None);
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        // Rate limit reached maps to 429, not an unhandled 500.
+        await act.Should().ThrowAsync<TooManyRequestsException>();
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/ChatSession/AddChatSessionMessageCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/ChatSession/AddChatSessionMessageCommandHandlerTests.cs
@@ -19,6 +19,7 @@ namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Handlers.ChatSessi
 [Trait("Category", TestCategories.Unit)]
 public class AddChatSessionMessageCommandHandlerTests
 {
+    private static readonly Guid TestUserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
     private readonly Mock<IChatSessionRepository> _mockRepository;
     private readonly Mock<IUnitOfWork> _mockUnitOfWork;
     private readonly Mock<ILogger<AddChatSessionMessageCommandHandler>> _mockLogger;
@@ -48,6 +49,7 @@ public class AddChatSessionMessageCommandHandlerTests
 
         var command = new AddChatSessionMessageCommand(
             SessionId: sessionId,
+            UserId: TestUserId,
             Role: SessionChatMessage.UserRole,
             Content: "Hello, I need help with the rules");
 
@@ -78,6 +80,7 @@ public class AddChatSessionMessageCommandHandlerTests
 
         var command = new AddChatSessionMessageCommand(
             SessionId: sessionId,
+            UserId: TestUserId,
             Role: SessionChatMessage.AssistantRole,
             Content: "I can help you with that!");
 
@@ -103,6 +106,7 @@ public class AddChatSessionMessageCommandHandlerTests
 
         var command = new AddChatSessionMessageCommand(
             SessionId: sessionId,
+            UserId: TestUserId,
             Role: SessionChatMessage.SystemRole,
             Content: "You are a helpful assistant");
 
@@ -133,6 +137,7 @@ public class AddChatSessionMessageCommandHandlerTests
 
         var command = new AddChatSessionMessageCommand(
             SessionId: sessionId,
+            UserId: TestUserId,
             Role: SessionChatMessage.UserRole,
             Content: "Test message",
             Metadata: metadata);
@@ -155,6 +160,7 @@ public class AddChatSessionMessageCommandHandlerTests
 
         var command = new AddChatSessionMessageCommand(
             SessionId: sessionId,
+            UserId: TestUserId,
             Role: SessionChatMessage.UserRole,
             Content: "Test message");
 
@@ -178,12 +184,12 @@ public class AddChatSessionMessageCommandHandlerTests
 
         // Add first message
         await _handler.Handle(
-            new AddChatSessionMessageCommand(sessionId, SessionChatMessage.UserRole, "Message 1"),
+            new AddChatSessionMessageCommand(sessionId, TestUserId, SessionChatMessage.UserRole, "Message 1"),
             TestContext.Current.CancellationToken);
 
         // Add second message
         await _handler.Handle(
-            new AddChatSessionMessageCommand(sessionId, SessionChatMessage.AssistantRole, "Message 2"),
+            new AddChatSessionMessageCommand(sessionId, TestUserId, SessionChatMessage.AssistantRole, "Message 2"),
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -213,6 +219,7 @@ public class AddChatSessionMessageCommandHandlerTests
 
         var command = new AddChatSessionMessageCommand(
             SessionId: sessionId,
+            UserId: TestUserId,
             Role: SessionChatMessage.UserRole,
             Content: "Test");
 
@@ -270,11 +277,40 @@ public class AddChatSessionMessageCommandHandlerTests
         act.Should().Throw<ArgumentNullException>();
     }
 
+    [Fact]
+    public async Task Handle_WhenCallerIsNotOwner_ThrowsNotFoundAndDoesNotPersist()
+    {
+        // Arrange — session owned by someone else; a non-owner must get 404, no write.
+        var sessionId = Guid.NewGuid();
+        var attackerId = Guid.NewGuid();
+        var session = CreateTestSession(sessionId); // owned by TestUserId
+
+        _mockRepository
+            .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var command = new AddChatSessionMessageCommand(
+            SessionId: sessionId,
+            UserId: attackerId,
+            Role: SessionChatMessage.UserRole,
+            Content: "injected");
+
+        // Act & Assert
+        Func<Task> act = () => _handler.Handle(command, TestContext.Current.CancellationToken);
+        await act.Should().ThrowAsync<NotFoundException>();
+
+        session.MessageCount.Should().Be(0);
+        _mockRepository.Verify(
+            r => r.UpdateAsync(It.IsAny<Api.BoundedContexts.KnowledgeBase.Domain.Entities.ChatSession>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _mockUnitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
     private static Api.BoundedContexts.KnowledgeBase.Domain.Entities.ChatSession CreateTestSession(Guid sessionId)
     {
         return new Api.BoundedContexts.KnowledgeBase.Domain.Entities.ChatSession(
             id: sessionId,
-            userId: Guid.NewGuid(),
+            userId: TestUserId,
             gameId: Guid.NewGuid(),
             title: "Test Session");
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/ChatSession/DeleteChatSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/ChatSession/DeleteChatSessionCommandHandlerTests.cs
@@ -39,13 +39,14 @@ public class DeleteChatSessionCommandHandlerTests
     {
         // Arrange
         var sessionId = Guid.NewGuid();
-        var session = CreateTestSession(sessionId);
+        var userId = Guid.NewGuid();
+        var session = CreateTestSession(sessionId, userId);
 
         _mockRepository
             .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(session);
 
-        var command = new DeleteChatSessionCommand(SessionId: sessionId);
+        var command = new DeleteChatSessionCommand(SessionId: sessionId, UserId: userId);
 
         // Act
         await _handler.Handle(command, TestContext.Current.CancellationToken);
@@ -69,7 +70,7 @@ public class DeleteChatSessionCommandHandlerTests
             .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((Api.BoundedContexts.KnowledgeBase.Domain.Entities.ChatSession?)null);
 
-        var command = new DeleteChatSessionCommand(SessionId: sessionId);
+        var command = new DeleteChatSessionCommand(SessionId: sessionId, UserId: Guid.NewGuid());
 
         // Act & Assert
         Func<Task> act = () =>
@@ -83,7 +84,8 @@ public class DeleteChatSessionCommandHandlerTests
     {
         // Arrange
         var sessionId = Guid.NewGuid();
-        var session = CreateTestSession(sessionId);
+        var userId = Guid.NewGuid();
+        var session = CreateTestSession(sessionId, userId);
         var callOrder = new List<string>();
 
         _mockRepository
@@ -96,7 +98,7 @@ public class DeleteChatSessionCommandHandlerTests
             .Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
             .Callback(() => callOrder.Add("UnitOfWork.SaveChangesAsync"));
 
-        var command = new DeleteChatSessionCommand(SessionId: sessionId);
+        var command = new DeleteChatSessionCommand(SessionId: sessionId, UserId: userId);
 
         // Act
         await _handler.Handle(command, TestContext.Current.CancellationToken);
@@ -152,11 +154,36 @@ public class DeleteChatSessionCommandHandlerTests
         act.Should().Throw<ArgumentNullException>();
     }
 
-    private static Api.BoundedContexts.KnowledgeBase.Domain.Entities.ChatSession CreateTestSession(Guid sessionId)
+    [Fact]
+    public async Task Handle_WhenCallerIsNotOwner_ThrowsNotFoundAndDoesNotDelete()
+    {
+        // Arrange — session owned by someone else; a non-owner must get 404, no delete.
+        var sessionId = Guid.NewGuid();
+        var ownerId = Guid.NewGuid();
+        var attackerId = Guid.NewGuid();
+        var session = CreateTestSession(sessionId, ownerId);
+
+        _mockRepository
+            .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var command = new DeleteChatSessionCommand(SessionId: sessionId, UserId: attackerId);
+
+        // Act & Assert
+        Func<Task> act = () => _handler.Handle(command, TestContext.Current.CancellationToken);
+        await act.Should().ThrowAsync<NotFoundException>();
+
+        _mockRepository.Verify(
+            r => r.DeleteAsync(It.IsAny<Api.BoundedContexts.KnowledgeBase.Domain.Entities.ChatSession>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _mockUnitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private static Api.BoundedContexts.KnowledgeBase.Domain.Entities.ChatSession CreateTestSession(Guid sessionId, Guid? userId = null)
     {
         return new Api.BoundedContexts.KnowledgeBase.Domain.Entities.ChatSession(
             id: sessionId,
-            userId: Guid.NewGuid(),
+            userId: userId ?? Guid.NewGuid(),
             gameId: Guid.NewGuid(),
             title: "Test Session");
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/ChatSession/GetChatSessionQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/ChatSession/GetChatSessionQueryHandlerTests.cs
@@ -42,7 +42,7 @@ public class GetChatSessionQueryHandlerTests
             .Setup(r => r.GetByIdWithPaginatedMessagesAsync(sessionId, 0, 50, It.IsAny<CancellationToken>()))
             .ReturnsAsync(session);
 
-        var query = new GetChatSessionQuery(SessionId: sessionId);
+        var query = new GetChatSessionQuery(SessionId: sessionId, UserId: userId);
 
         // Act
         var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
@@ -64,7 +64,7 @@ public class GetChatSessionQueryHandlerTests
             .Setup(r => r.GetByIdWithPaginatedMessagesAsync(sessionId, 0, 50, It.IsAny<CancellationToken>()))
             .ReturnsAsync((Api.BoundedContexts.KnowledgeBase.Domain.Entities.ChatSession?)null);
 
-        var query = new GetChatSessionQuery(SessionId: sessionId);
+        var query = new GetChatSessionQuery(SessionId: sessionId, UserId: Guid.NewGuid());
 
         // Act
         var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
@@ -78,7 +78,8 @@ public class GetChatSessionQueryHandlerTests
     {
         // Arrange
         var sessionId = Guid.NewGuid();
-        var session = CreateTestSession(sessionId, Guid.NewGuid(), Guid.NewGuid());
+        var userId = Guid.NewGuid();
+        var session = CreateTestSession(sessionId, userId, Guid.NewGuid());
         session.AddUserMessage("Hello");
         session.AddAssistantMessage("Hi there!");
 
@@ -86,7 +87,7 @@ public class GetChatSessionQueryHandlerTests
             .Setup(r => r.GetByIdWithPaginatedMessagesAsync(sessionId, 0, 50, It.IsAny<CancellationToken>()))
             .ReturnsAsync(session);
 
-        var query = new GetChatSessionQuery(SessionId: sessionId);
+        var query = new GetChatSessionQuery(SessionId: sessionId, UserId: userId);
 
         // Act
         var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
@@ -106,7 +107,8 @@ public class GetChatSessionQueryHandlerTests
     {
         // Arrange
         var sessionId = Guid.NewGuid();
-        var session = CreateTestSession(sessionId, Guid.NewGuid(), Guid.NewGuid());
+        var userId = Guid.NewGuid();
+        var session = CreateTestSession(sessionId, userId, Guid.NewGuid());
 
         _mockRepository
             .Setup(r => r.GetByIdWithPaginatedMessagesAsync(sessionId, 10, 25, It.IsAny<CancellationToken>()))
@@ -114,6 +116,7 @@ public class GetChatSessionQueryHandlerTests
 
         var query = new GetChatSessionQuery(
             SessionId: sessionId,
+            UserId: userId,
             MessageSkip: 10,
             MessageTake: 25);
 
@@ -151,7 +154,7 @@ public class GetChatSessionQueryHandlerTests
             .Setup(r => r.GetByIdWithPaginatedMessagesAsync(sessionId, 0, 50, It.IsAny<CancellationToken>()))
             .ReturnsAsync(session);
 
-        var query = new GetChatSessionQuery(SessionId: sessionId);
+        var query = new GetChatSessionQuery(SessionId: sessionId, UserId: userId);
 
         // Act
         var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
@@ -197,6 +200,28 @@ public class GetChatSessionQueryHandlerTests
                 _mockRepository.Object,
                 null!);
         act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task Handle_WhenCallerIsNotOwner_ReturnsNull()
+    {
+        // Arrange — session owned by someone else; a non-owner must see the same null → 404.
+        var sessionId = Guid.NewGuid();
+        var ownerId = Guid.NewGuid();
+        var attackerId = Guid.NewGuid();
+        var session = CreateTestSession(sessionId, ownerId, Guid.NewGuid());
+
+        _mockRepository
+            .Setup(r => r.GetByIdWithPaginatedMessagesAsync(sessionId, 0, 50, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var query = new GetChatSessionQuery(SessionId: sessionId, UserId: attackerId);
+
+        // Act
+        var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Should().BeNull("a non-owner must not read another user's chat session");
     }
 
     private static Api.BoundedContexts.KnowledgeBase.Domain.Entities.ChatSession CreateTestSession(

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetCorpusTitleHealth/Integration/GetCorpusTitleHealthQueryHandlerIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetCorpusTitleHealth/Integration/GetCorpusTitleHealthQueryHandlerIntegrationTests.cs
@@ -1,0 +1,209 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetCorpusTitleHealth;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Queries.GetCorpusTitleHealth.Integration;
+
+/// <summary>
+/// Integration tests for <see cref="GetCorpusTitleHealthQueryHandler"/> against a real PostgreSQL
+/// database via Testcontainers (Epic #3338 WP3). The handler's value is its EF Core query — a
+/// nullable-<c>GameId</c>-lifted join <c>text_chunks → shared_games → pdf_documents</c>, a
+/// <c>LanguageOverride ?? Language</c> coalesce, and a server-side <c>Distinct()</c> over a named
+/// projection — so these tests assert that translation end-to-end (a unit test with mocks would not
+/// catch an untranslatable LINQ shape). The band/plausibility maths itself is covered by
+/// <c>TitleHealthMetricTests</c>.
+/// </summary>
+[Collection("Integration-GroupA")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Issue", "3338")]
+public sealed class GetCorpusTitleHealthQueryHandlerIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly Guid _uploaderId = Guid.NewGuid();
+    private string _dbName = null!;
+    private MeepleAiDbContext _dbContext = null!;
+
+    private static CancellationToken Token => TestContext.Current.CancellationToken;
+
+    public GetCorpusTitleHealthQueryHandlerIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _dbName = $"test_corpus_title_health_{Guid.NewGuid():N}";
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_dbName);
+
+        var mockMediator = TestDbContextFactory.CreateMockMediator();
+        var mockEventCollector = TestDbContextFactory.CreateMockEventCollector();
+
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseNpgsql(connectionString, o => o.UseVector())
+            .EnableSensitiveDataLogging()
+            .EnableDetailedErrors()
+            .Options;
+
+        _dbContext = new MeepleAiDbContext(options, mockMediator.Object, mockEventCollector.Object);
+        await _dbContext.Database.MigrateAsync(Token);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _fixture.DropIsolatedDatabaseAsync(_dbName);
+        if (_dbContext is not null)
+            await _dbContext.DisposeAsync();
+    }
+
+    [Fact(Timeout = 60_000)]
+    public async Task Handle_RealPostgres_GroupsPerGame_ComputesBandLanguageAndCoverage()
+    {
+        // Arrange ----------------------------------------------------------------
+        // pdf_documents.UploadedByUserId is a Restrict FK to users → seed the uploader once.
+        _dbContext.Users.Add(new UserEntity
+        {
+            Id = _uploaderId,
+            Email = $"title-health-{_uploaderId:N}@test.local",
+            DisplayName = "Title Health Test User",
+            PasswordHash = "hashed",
+            Role = "Admin",
+            Tier = "free",
+            CreatedAt = DateTime.UtcNow,
+            IsTwoFactorEnabled = false,
+        });
+
+        // "Alpha Green" (en): 5 clean section titles, each repeated by a child chunk → distinct=5,
+        // fraction=1.0 → green; SETUP is a lexicon section → canonical ≥ 1.
+        var greenId = Guid.NewGuid();
+        var greenPdf = Guid.NewGuid();
+        SeedGame(greenId, "Alpha Green");
+        SeedPdf(greenPdf, language: "en");
+        AddChunks(greenPdf, greenId, new[] { "SETUP", "GAMEPLAY", "SCORING", "END OF GAME", "COMPONENTS" });
+        AddChunks(greenPdf, greenId, new[] { "SETUP", "GAMEPLAY" }); // duplicate headings from child chunks
+
+        // "Zeta Garbage" (effective it via LanguageOverride over Language=en): 4 garbage headings + 1
+        // real "PREPARAZIONE" → distinct=5, plausible=1, fraction=0.2 → red; PREPARAZIONE is a lexicon
+        // section → canonical=1.
+        var redId = Guid.NewGuid();
+        var redPdf = Guid.NewGuid();
+        SeedGame(redId, "Zeta Garbage");
+        SeedPdf(redPdf, language: "en", languageOverride: "it");
+        AddChunks(redPdf, redId, new[] { "PREPARAZIONE", "D", "S U", "I L E X Y R F", "(14%), Oceani" });
+
+        // "Multi Lang": headings from TWO pdfs of different languages. en pdf has 2 distinct headings,
+        // it pdf has 1 → dominant language = en. distinct=3 (SETUP, GAMEPLAY, D), plausible=2 →
+        // fraction=0.6667 → yellow.
+        var multiId = Guid.NewGuid();
+        var multiEnPdf = Guid.NewGuid();
+        var multiItPdf = Guid.NewGuid();
+        SeedGame(multiId, "Multi Lang");
+        SeedPdf(multiEnPdf, language: "en");
+        SeedPdf(multiItPdf, language: "it");
+        AddChunks(multiEnPdf, multiId, new[] { "SETUP", "GAMEPLAY" });
+        AddChunks(multiItPdf, multiId, new[] { "D" });
+
+        // "No Headings": every chunk has a null/blank heading → the game has no extraction signal and
+        // MUST NOT appear in the read-out.
+        var noneId = Guid.NewGuid();
+        var nonePdf = Guid.NewGuid();
+        SeedGame(noneId, "No Headings");
+        SeedPdf(nonePdf, language: "en");
+        AddChunks(nonePdf, noneId, new string?[] { null, "", "   " });
+
+        await _dbContext.SaveChangesAsync(Token);
+
+        var sut = new GetCorpusTitleHealthQueryHandler(_dbContext);
+
+        // Act --------------------------------------------------------------------
+        var result = await sut.Handle(new GetCorpusTitleHealthQuery(), Token);
+
+        // Assert -----------------------------------------------------------------
+        result.Should().HaveCount(3, "the null-heading-only game contributes no signal and is excluded");
+        result.Select(r => r.GameTitle).Should().ContainInOrder("Alpha Green", "Multi Lang", "Zeta Garbage");
+        result.Select(r => r.GameTitle).Should().NotContain("No Headings");
+
+        var green = result.Single(r => r.GameTitle == "Alpha Green");
+        green.Band.Should().Be("green");
+        green.DistinctHeadings.Should().Be(5, "duplicate child-chunk headings are deduplicated");
+        green.PlausibleHeadings.Should().Be(5);
+        green.PlausibleFraction.Should().Be(1.0);
+        green.Language.Should().Be("en");
+        green.CanonicalCoverage.Should().BeGreaterThanOrEqualTo(1, "SETUP is a curated lexicon section");
+
+        var red = result.Single(r => r.GameTitle == "Zeta Garbage");
+        red.Band.Should().Be("red");
+        red.DistinctHeadings.Should().Be(5);
+        red.PlausibleHeadings.Should().Be(1, "only PREPARAZIONE survives the plausibility filter");
+        red.PlausibleFraction.Should().Be(0.2);
+        red.CanonicalCoverage.Should().Be(1);
+        red.Language.Should().Be("it", "LanguageOverride ?? Language must resolve to the override");
+
+        var multi = result.Single(r => r.GameTitle == "Multi Lang");
+        multi.Band.Should().Be("yellow");
+        multi.DistinctHeadings.Should().Be(3);
+        multi.PlausibleHeadings.Should().Be(2);
+        multi.PlausibleFraction.Should().Be(0.6667, "2/3 rounded to 4 dp");
+        multi.Language.Should().Be("en", "the language carrying more distinct headings wins the tiebreak");
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task Handle_RealPostgres_EmptyCorpus_ReturnsEmpty()
+    {
+        var sut = new GetCorpusTitleHealthQueryHandler(_dbContext);
+
+        var result = await sut.Handle(new GetCorpusTitleHealthQuery(), Token);
+
+        result.Should().BeEmpty("no chunks → no games to report");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    private void SeedGame(Guid id, string title) => _dbContext.SharedGames.Add(new SharedGameEntity
+    {
+        Id = id,
+        Title = title,
+        CreatedBy = Guid.NewGuid(),
+        CreatedAt = DateTime.UtcNow,
+    });
+
+    private void SeedPdf(Guid id, string language, string? languageOverride = null) =>
+        _dbContext.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = id,
+            FileName = $"rulebook-{id:N}.pdf",
+            FilePath = $"/test/{id:N}.pdf",
+            FileSizeBytes = 1024L,
+            UploadedByUserId = _uploaderId,
+            UploadedAt = DateTime.UtcNow,
+            ProcessingState = "Ready",
+            Language = language,
+            LanguageOverride = languageOverride,
+        });
+
+    private void AddChunks(Guid pdfId, Guid gameId, IReadOnlyList<string?> headings)
+    {
+        for (var i = 0; i < headings.Count; i++)
+        {
+            _dbContext.TextChunks.Add(new TextChunkEntity
+            {
+                Id = Guid.NewGuid(),
+                PdfDocumentId = pdfId,
+                GameId = gameId,
+                Heading = headings[i],
+                Content = $"body-{pdfId:N}-{i}",
+                ChunkIndex = i,
+                CharacterCount = 100,
+            });
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/Chunking/TitleHealthMetricTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/Chunking/TitleHealthMetricTests.cs
@@ -1,0 +1,119 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Services.Chunking;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Services.Chunking;
+
+/// <summary>
+/// Epic #3338 WP3 unit tests for <see cref="TitleHealthMetric"/> — the per-game extraction-quality
+/// signal (regression guard + WP4 go/no-go). Fixtures use the real garbage headings observed on the
+/// Terraforming Mars staging corpus.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public class TitleHealthMetricTests
+{
+    [Theory]
+    // Real section titles → plausible
+    [InlineData("PREPARAZIONE", true)]
+    [InlineData("AZIONI", true)]
+    [InlineData("FINE DEL GIOCO", true)]
+    [InlineData("PANORAMICA DEL GIOCO", true)]
+    [InlineData("Setup", true)]
+    [InlineData("Dato", true)]                 // a real-word fragment: title-LIKE, counts as plausible
+    // Gross extraction garbage → not plausible
+    [InlineData("D", false)]                   // single char
+    [InlineData("S U", false)]                 // spaced single letters, no 3-letter run
+    [InlineData("I L E X Y R F C A A S I", false)] // vertical-text artefact
+    [InlineData("(14%), Oceani", false)]       // symbol/number-heavy (letter fraction < 0.6)
+    [InlineData("© 2016 FryxGames www.fryxgames.se/games/terraforming", false)] // too long + symbol-heavy
+    [InlineData("12 34 56", false)]            // digits only, no word
+    [InlineData("", false)]
+    [InlineData("   ", false)]
+    public void IsPlausibleHeading_ClassifiesRealTitlesVsGarbage(string heading, bool expected)
+    {
+        TitleHealthMetric.IsPlausibleHeading(heading).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Compute_WellExtractedGame_IsGreen()
+    {
+        var headings = new[] { "SETUP", "GAMEPLAY", "SCORING", "END OF GAME", "COMPONENTS" };
+
+        var r = TitleHealthMetric.Compute(headings);
+
+        r.DistinctHeadings.Should().Be(5);
+        r.PlausibleHeadings.Should().Be(5);
+        r.PlausibleFraction.Should().Be(1.0);
+        r.Band.Should().Be("green");
+    }
+
+    [Fact]
+    public void Compute_TmLikeGarbageMix_IsRedOrYellow_BelowThreshold()
+    {
+        // Roughly the TM shape: a few real titles buried under vertical-text / symbol garbage.
+        var headings = new[]
+        {
+            "PREPARAZIONE", "AZIONI", "CARTE",                 // plausible (3)
+            "D", "S U", "I L E X Y R F C A A S I", "(14%), Oceani", "Dato",  // garbage-ish
+        };
+
+        var r = TitleHealthMetric.Compute(headings);
+
+        r.DistinctHeadings.Should().Be(8);
+        r.PlausibleFraction.Should().BeLessThan(TitleHealthMetric.Compute(new[] { "SETUP" }).PlausibleFraction + 0.01);
+        r.Band.Should().NotBe("green"); // extraction quality is degraded → not green
+        r.CanonicalCoverage.Should().BeGreaterThan(0, "PREPARAZIONE/AZIONI are curated lexicon sections");
+    }
+
+    [Fact]
+    public void Compute_DeduplicatesHeadings()
+    {
+        // Child chunks repeat the parent heading; the metric counts DISTINCT headings.
+        var headings = new[] { "PREPARAZIONE", "PREPARAZIONE", "PREPARAZIONE", "AZIONI" };
+
+        TitleHealthMetric.Compute(headings).DistinctHeadings.Should().Be(2);
+    }
+
+    [Fact]
+    public void Compute_NoHeadings_IsRedWithZeroCounts()
+    {
+        var r = TitleHealthMetric.Compute(new string?[] { null, "", "   " });
+
+        r.DistinctHeadings.Should().Be(0);
+        r.PlausibleFraction.Should().Be(0.0);
+        r.Band.Should().Be("red");
+    }
+
+    [Fact]
+    public void Compute_CanonicalCoverage_CountsLexiconSectionsPresent()
+    {
+        // PREPARAZIONE + AZIONI are direct lexicon entries; "PANORAMICA DEL GIOCO" carries PANORAMICA;
+        // "Random Section" is plausible but not canonical → 3 canonical headings.
+        var r = TitleHealthMetric.Compute(new[] { "PREPARAZIONE", "AZIONI", "PANORAMICA DEL GIOCO", "Random Section" });
+
+        r.CanonicalCoverage.Should().Be(3);
+    }
+
+    [Fact]
+    public void Compute_CanonicalCoverage_CountsHeadingOnce_ForOverlappingLexiconEntries()
+    {
+        // "SVOLGIMENTO DEL GIOCO" matches both "SVOLGIMENTO" and "SVOLGIMENTO DEL GIOCO" — per-heading
+        // counting credits it once (review: no double-count).
+        var r = TitleHealthMetric.Compute(new[] { "SVOLGIMENTO DEL GIOCO" });
+
+        r.CanonicalCoverage.Should().Be(1);
+    }
+
+    [Fact]
+    public void Compute_CanonicalCoverage_ExcludesGarbageHeadingCarryingLexiconToken()
+    {
+        // A garbage heading that embeds a lexicon word but is NOT plausible (letter fraction < 0.6) must
+        // not credit coverage (review: gate canonical on plausibility so the sub-signals cannot contradict).
+        var r = TitleHealthMetric.Compute(new[] { "3 4 SETUP 9%" });
+
+        TitleHealthMetric.IsPlausibleHeading("3 4 SETUP 9%").Should().BeFalse();
+        r.CanonicalCoverage.Should().Be(0);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Validators/AddMessageCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Validators/AddMessageCommandValidatorTests.cs
@@ -1,0 +1,46 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Commands;
+using Api.BoundedContexts.KnowledgeBase.Application.Validators;
+using Api.Tests.Constants;
+using FluentValidation.TestHelper;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Validators;
+
+/// <summary>
+/// Tests for <see cref="AddMessageCommandValidator"/>.
+/// The handler only accepts <c>user</c>/<c>assistant</c> roles and previously threw
+/// <see cref="InvalidOperationException"/> (→ HTTP 500) on anything else. The validator
+/// must reject an unknown role up front so the request maps to 422.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public sealed class AddMessageCommandValidatorTests
+{
+    private readonly AddMessageCommandValidator _validator = new();
+
+    [Theory]
+    [InlineData("user")]
+    [InlineData("assistant")]
+    public void Validate_WithKnownRole_HasNoRoleError(string role)
+    {
+        var command = new AddMessageCommand(Guid.NewGuid(), "hello", role);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.Role);
+    }
+
+    [Theory]
+    [InlineData("system")]
+    [InlineData("admin")]
+    [InlineData("unknown_role")]
+    [InlineData("USER")]
+    public void Validate_WithUnknownRole_HasRoleError(string role)
+    {
+        var command = new AddMessageCommand(Guid.NewGuid(), "hello", role);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.Role);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Validators/ChatSession/AddChatSessionMessageCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Validators/ChatSession/AddChatSessionMessageCommandValidatorTests.cs
@@ -30,6 +30,7 @@ public class AddChatSessionMessageCommandValidatorTests
         // Arrange
         var command = new AddChatSessionMessageCommand(
             SessionId: Guid.NewGuid(),
+            UserId: Guid.NewGuid(),
             Role: role,
             Content: "Valid message content");
 
@@ -46,6 +47,7 @@ public class AddChatSessionMessageCommandValidatorTests
         // Arrange
         var command = new AddChatSessionMessageCommand(
             SessionId: Guid.Empty,
+            UserId: Guid.NewGuid(),
             Role: "user",
             Content: "Valid content");
 
@@ -65,6 +67,7 @@ public class AddChatSessionMessageCommandValidatorTests
         // Arrange
         var command = new AddChatSessionMessageCommand(
             SessionId: Guid.NewGuid(),
+            UserId: Guid.NewGuid(),
             Role: role,
             Content: "Valid content");
 
@@ -87,6 +90,7 @@ public class AddChatSessionMessageCommandValidatorTests
         // Arrange
         var command = new AddChatSessionMessageCommand(
             SessionId: Guid.NewGuid(),
+            UserId: Guid.NewGuid(),
             Role: role,
             Content: "Valid content");
 
@@ -106,6 +110,7 @@ public class AddChatSessionMessageCommandValidatorTests
         // Arrange
         var command = new AddChatSessionMessageCommand(
             SessionId: Guid.NewGuid(),
+            UserId: Guid.NewGuid(),
             Role: "user",
             Content: content);
 
@@ -123,6 +128,7 @@ public class AddChatSessionMessageCommandValidatorTests
         // Arrange
         var command = new AddChatSessionMessageCommand(
             SessionId: Guid.NewGuid(),
+            UserId: Guid.NewGuid(),
             Role: "user",
             Content: new string('a', 50000));
 
@@ -139,6 +145,7 @@ public class AddChatSessionMessageCommandValidatorTests
         // Arrange
         var command = new AddChatSessionMessageCommand(
             SessionId: Guid.NewGuid(),
+            UserId: Guid.NewGuid(),
             Role: "user",
             Content: new string('a', 50001));
 
@@ -156,6 +163,7 @@ public class AddChatSessionMessageCommandValidatorTests
         // Arrange
         var command = new AddChatSessionMessageCommand(
             SessionId: Guid.Empty,
+            UserId: Guid.NewGuid(),
             Role: "invalid",
             Content: "");
 
@@ -181,6 +189,7 @@ public class AddChatSessionMessageCommandValidatorTests
         // Arrange
         var command = new AddChatSessionMessageCommand(
             SessionId: Guid.NewGuid(),
+            UserId: Guid.NewGuid(),
             Role: "user",
             Content: new string('a', length));
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Validators/ChatSession/DeleteChatSessionCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Validators/ChatSession/DeleteChatSessionCommandValidatorTests.cs
@@ -25,7 +25,8 @@ public class DeleteChatSessionCommandValidatorTests
     {
         // Arrange
         var command = new DeleteChatSessionCommand(
-            SessionId: Guid.NewGuid());
+            SessionId: Guid.NewGuid(),
+            UserId: Guid.NewGuid());
 
         // Act
         var result = _validator.TestValidate(command);
@@ -39,7 +40,8 @@ public class DeleteChatSessionCommandValidatorTests
     {
         // Arrange
         var command = new DeleteChatSessionCommand(
-            SessionId: Guid.Empty);
+            SessionId: Guid.Empty,
+            UserId: Guid.NewGuid());
 
         // Act
         var result = _validator.TestValidate(command);
@@ -54,7 +56,7 @@ public class DeleteChatSessionCommandValidatorTests
     public void Validate_WithVariousValidGuids_ShouldNotHaveValidationErrors(Guid sessionId)
     {
         // Arrange
-        var command = new DeleteChatSessionCommand(SessionId: sessionId);
+        var command = new DeleteChatSessionCommand(SessionId: sessionId, UserId: Guid.NewGuid());
 
         // Act
         var result = _validator.TestValidate(command);

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Endpoints/ChatSessionByIdEndpointsIdorIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Endpoints/ChatSessionByIdEndpointsIdorIntegrationTests.cs
@@ -1,0 +1,191 @@
+using System.Net;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.KnowledgeBase;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Endpoints;
+
+/// <summary>
+/// HTTP-layer IDOR tests for the by-<c>sessionId</c> chat-session endpoints.
+/// <para>
+/// GET/DELETE <c>/chat/sessions/{sessionId}</c>, POST <c>/rename</c> and POST <c>/messages</c>
+/// are keyed purely by the route <c>sessionId</c>. They must derive the caller identity from
+/// the authenticated principal and refuse to read, delete, rename, or append to a chat session
+/// owned by another user. A non-owner must receive the same 404 as for a non-existent session
+/// (no existence disclosure), mirroring the collection-endpoint hardening (IDOR #3120).
+/// </para>
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public sealed class ChatSessionByIdEndpointsIdorIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _ownerClient = null!;
+    private HttpClient _otherClient = null!;
+    private Guid _ownerId;
+    private string _ownerToken = null!;
+    private string _otherToken = null!;
+    private Guid _sessionId;
+
+    public ChatSessionByIdEndpointsIdorIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"chatsession_byid_idor_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        await db.Database.MigrateAsync();
+
+        (_ownerId, _ownerToken) = await TestSessionHelper.CreateUserSessionAsync(db);
+        (_, _otherToken) = await TestSessionHelper.CreateUserSessionAsync(db);
+
+        // ChatSessions.GameId FKs the SharedGame catalog.
+        var sharedGameId = await TestSessionHelper.SeedSharedGameAsync(db, "IDOR Chat Game");
+        var chatSession = new ChatSessionEntity
+        {
+            Id = Guid.NewGuid(),
+            UserId = _ownerId,
+            GameId = sharedGameId,
+            Title = "Owner private chat",
+            CreatedAt = DateTime.UtcNow,
+            LastMessageAt = DateTime.UtcNow,
+        };
+        db.ChatSessions.Add(chatSession);
+        await db.SaveChangesAsync();
+        _sessionId = chatSession.Id;
+
+        _ownerClient = _factory.CreateClient();
+        _otherClient = _factory.CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _ownerClient?.Dispose();
+        _otherClient?.Dispose();
+        _factory?.Dispose();
+        await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    private string SessionUrl => $"/api/v1/chat/sessions/{_sessionId}";
+
+    // ── GET ───────────────────────────────────────────────────────────────────
+
+    [Fact(Timeout = 90_000)]
+    public async Task GetSession_AsOwner_ReturnsSession()
+    {
+        var response = await _ownerClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(HttpMethod.Get, SessionUrl, _ownerToken));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact(Timeout = 90_000)]
+    public async Task GetSession_AsOtherUser_Returns404()
+    {
+        var response = await _otherClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(HttpMethod.Get, SessionUrl, _otherToken));
+
+        response.StatusCode.Should().Be(
+            HttpStatusCode.NotFound,
+            "a non-owner must not be able to read another user's chat session (nor its UserId)");
+    }
+
+    // ── DELETE ──────────────────────────────────────────────────────────────────
+
+    [Fact(Timeout = 90_000)]
+    public async Task DeleteSession_AsOwner_Succeeds()
+    {
+        var response = await _ownerClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(HttpMethod.Delete, SessionUrl, _ownerToken));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact(Timeout = 90_000)]
+    public async Task DeleteSession_AsOtherUser_Returns404()
+    {
+        var response = await _otherClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(HttpMethod.Delete, SessionUrl, _otherToken));
+
+        response.StatusCode.Should().Be(
+            HttpStatusCode.NotFound,
+            "a non-owner must not be able to delete another user's chat session");
+
+        // The session must still exist after the blocked delete.
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        (await db.ChatSessions.AnyAsync(s => s.Id == _sessionId)).Should().BeTrue();
+    }
+
+    // ── RENAME ──────────────────────────────────────────────────────────────────
+
+    [Fact(Timeout = 90_000)]
+    public async Task RenameSession_AsOwner_Succeeds()
+    {
+        var response = await _ownerClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(
+                HttpMethod.Post, $"{SessionUrl}/rename", _ownerToken, new { Title = "Owner rename" }));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact(Timeout = 90_000)]
+    public async Task RenameSession_AsOtherUser_Returns404()
+    {
+        var response = await _otherClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(
+                HttpMethod.Post, $"{SessionUrl}/rename", _otherToken, new { Title = "Hacked title" }));
+
+        response.StatusCode.Should().Be(
+            HttpStatusCode.NotFound,
+            "a non-owner must not be able to rename another user's chat session");
+
+        // The title must be untouched after the blocked rename.
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var session = await db.ChatSessions.AsNoTracking().FirstAsync(s => s.Id == _sessionId);
+        session.Title.Should().Be("Owner private chat");
+    }
+
+    // ── ADD MESSAGE ─────────────────────────────────────────────────────────────
+
+    [Fact(Timeout = 90_000)]
+    public async Task AddMessage_AsOwner_Succeeds()
+    {
+        var response = await _ownerClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(
+                HttpMethod.Post, $"{SessionUrl}/messages", _ownerToken,
+                new { Role = "user", Content = "hello" }));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact(Timeout = 90_000)]
+    public async Task AddMessage_AsOtherUser_Returns404()
+    {
+        var response = await _otherClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(
+                HttpMethod.Post, $"{SessionUrl}/messages", _otherToken,
+                new { Role = "user", Content = "injected" }));
+
+        response.StatusCode.Should().Be(
+            HttpStatusCode.NotFound,
+            "a non-owner must not be able to inject messages into another user's chat session");
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/Smoke/RenameChatSessionIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Smoke/RenameChatSessionIntegrationTests.cs
@@ -153,7 +153,7 @@ public sealed class RenameChatSessionIntegrationTests : IAsyncLifetime
     {
         // Arrange
         var mediator = _serviceProvider!.GetRequiredService<IMediator>();
-        var command = new RenameChatSessionCommand(SessionId: TestSessionId, Title: "Renamed Title SG4");
+        var command = new RenameChatSessionCommand(SessionId: TestSessionId, UserId: TestUserId, Title: "Renamed Title SG4");
 
         // Act
         var dto = await mediator.Send(command, TestCancellationToken);
@@ -170,6 +170,28 @@ public sealed class RenameChatSessionIntegrationTests : IAsyncLifetime
 
         persisted.Should().NotBeNull();
         persisted!.Title.Should().Be("Renamed Title SG4");
+    }
+
+    /// <summary>
+    /// IDOR: a non-owner renaming another user's session gets the same 404 as an unknown id,
+    /// and the title is left untouched.
+    /// </summary>
+    [Fact]
+    public async Task RenameChatSession_ByNonOwner_ThrowsNotFoundAndLeavesTitleUntouched()
+    {
+        // Arrange — session is owned by TestUserId; a different caller must be rejected.
+        var mediator = _serviceProvider!.GetRequiredService<IMediator>();
+        var attackerId = Guid.NewGuid();
+        var command = new RenameChatSessionCommand(SessionId: TestSessionId, UserId: attackerId, Title: "Hacked title");
+
+        // Act & Assert
+        await Assert.ThrowsAsync<NotFoundException>(
+            () => mediator.Send(command, TestCancellationToken));
+
+        var persisted = await _dbContext!.ChatSessions
+            .AsNoTracking()
+            .FirstAsync(s => s.Id == TestSessionId, TestCancellationToken);
+        persisted.Title.Should().Be("Original Title");
     }
 
     /// <summary>
@@ -213,7 +235,7 @@ public sealed class RenameChatSessionIntegrationTests : IAsyncLifetime
     {
         // Arrange
         var mediator = _serviceProvider!.GetRequiredService<IMediator>();
-        var command = new RenameChatSessionCommand(SessionId: TestUnknownId, Title: "Irrelevant Title");
+        var command = new RenameChatSessionCommand(SessionId: TestUnknownId, UserId: TestUserId, Title: "Irrelevant Title");
 
         // Act & Assert — handler throws NotFoundException (maps to 404 at endpoint level)
         await Assert.ThrowsAsync<NotFoundException>(

--- a/apps/web/src/lib/domain-hooks/__tests__/useSessionSync.test.ts
+++ b/apps/web/src/lib/domain-hooks/__tests__/useSessionSync.test.ts
@@ -7,10 +7,45 @@
  * These unit tests verify hook initialization and basic structure.
  */
 
-import { renderHook } from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { useSessionSync } from '../useSessionSync';
+
+/**
+ * EventSource mock that records every constructed instance so a test can assert
+ * how many times `new EventSource(...)` ran. Mirrors the pattern used in
+ * useTurnOrder.test.ts (Vitest v4: assign the class directly, no `vi.fn` wrap).
+ */
+interface TrackedEventSourceInstance {
+  url: string;
+  withCredentials: boolean;
+  onopen: (() => void) | null;
+  onerror: (() => void) | null;
+  close: ReturnType<typeof vi.fn>;
+  addEventListener: ReturnType<typeof vi.fn>;
+  removeEventListener: ReturnType<typeof vi.fn>;
+  readyState: number;
+}
+
+let trackedEventSourceInstances: TrackedEventSourceInstance[] = [];
+
+class TrackedEventSource {
+  url: string;
+  withCredentials: boolean;
+  onopen: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  close = vi.fn();
+  addEventListener = vi.fn();
+  removeEventListener = vi.fn();
+  readyState = 0; // CONNECTING
+
+  constructor(url: string, options?: { withCredentials?: boolean }) {
+    this.url = url;
+    this.withCredentials = options?.withCredentials ?? false;
+    trackedEventSourceInstances.push(this as TrackedEventSourceInstance);
+  }
+}
 
 describe('useSessionSync', () => {
   const mockSessionId = 'session-123';
@@ -122,5 +157,41 @@ describe('useSessionSync', () => {
     unmount();
 
     expect(mockClose).toHaveBeenCalled();
+  });
+
+  it('creates the EventSource only once when re-rendered with unstable inline callbacks (#P3 churn)', () => {
+    // Mirrors the real consumer (toolkit/[sessionId]/_content.tsx): fresh inline
+    // callback identities on every render. With the churn bug, each re-render
+    // recreates `connect`, so the mount effect tears down and re-opens the SSE
+    // stream — dropping in-flight pause/resume/finalize/score events and
+    // flickering `isConnected`.
+    trackedEventSourceInstances = [];
+    global.EventSource = TrackedEventSource as unknown as typeof EventSource;
+
+    const { rerender } = renderHook(() =>
+      useSessionSync({
+        sessionId: mockSessionId,
+        onScoreUpdate: () => {},
+        onPaused: () => {},
+        onResumed: () => {},
+        onFinalized: () => {},
+        onError: () => {},
+      })
+    );
+
+    expect(trackedEventSourceInstances).toHaveLength(1);
+
+    // onopen flips isConnected → an internal re-render in which the consumer's
+    // inline callbacks are re-created with new identities.
+    act(() => {
+      trackedEventSourceInstances[0]?.onopen?.();
+    });
+
+    // Explicit parent re-render with brand-new inline callback identities.
+    rerender();
+
+    // Exactly one EventSource must ever be constructed for a stable
+    // (sessionId, apiBaseUrl) pair.
+    expect(trackedEventSourceInstances).toHaveLength(1);
   });
 });

--- a/apps/web/src/lib/domain-hooks/useSessionSync.ts
+++ b/apps/web/src/lib/domain-hooks/useSessionSync.ts
@@ -124,51 +124,70 @@ export function useSessionSync(options: UseSessionSyncOptions): SessionSyncState
   const maxReconnectAttempts = 5;
   const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
+  // Keep the latest callbacks in refs so the SSE connection is NOT torn down and
+  // re-established when a consumer passes fresh inline callbacks on every render
+  // (e.g. toolkit/[sessionId]/_content.tsx). Without this, `handleEvent` → `connect`
+  // → the mount effect all get new identities each render, closing and re-opening
+  // the EventSource in a self-sustaining loop that drops in-flight events and
+  // flickers `isConnected`. Mirrors the ref pattern in useTurnOrder.
+  const onScoreUpdateRef = useRef(onScoreUpdate);
+  const onPausedRef = useRef(onPaused);
+  const onResumedRef = useRef(onResumed);
+  const onFinalizedRef = useRef(onFinalized);
+  const onErrorRef = useRef(onError);
+  const onTurnAdvancedRef = useRef(onTurnAdvanced);
+
+  useEffect(() => {
+    onScoreUpdateRef.current = onScoreUpdate;
+    onPausedRef.current = onPaused;
+    onResumedRef.current = onResumed;
+    onFinalizedRef.current = onFinalized;
+    onErrorRef.current = onError;
+    onTurnAdvancedRef.current = onTurnAdvanced;
+  });
+
   /**
    * Handle SSE event
    */
-  const handleEvent = useCallback(
-    (event: MessageEvent<string>) => {
-      try {
-        const parsedEvent: SessionEvent = JSON.parse(event.data);
+  const handleEvent = useCallback((event: MessageEvent<string>) => {
+    try {
+      const parsedEvent: SessionEvent = JSON.parse(event.data);
 
-        switch (parsedEvent.type) {
-          case SessionEventType.ScoreUpdatedEvent: {
-            const data = parsedEvent.data as ScoreUpdatedEventData;
-            const scoreEntry = {
-              ...data.scoreEntry,
-              timestamp: new Date(data.scoreEntry.timestamp),
-            };
+      switch (parsedEvent.type) {
+        case SessionEventType.ScoreUpdatedEvent: {
+          const data = parsedEvent.data as ScoreUpdatedEventData;
+          const scoreEntry = {
+            ...data.scoreEntry,
+            timestamp: new Date(data.scoreEntry.timestamp),
+          };
 
-            setScores(prev => [...prev, scoreEntry]);
-            onScoreUpdate?.(scoreEntry);
-            break;
-          }
-
-          case SessionEventType.SessionPausedEvent: {
-            onPaused?.();
-            break;
-          }
-
-          case SessionEventType.SessionResumedEvent: {
-            onResumed?.();
-            break;
-          }
-
-          case SessionEventType.SessionFinalizedEvent: {
-            onFinalized?.();
-            break;
-          }
+          setScores(prev => [...prev, scoreEntry]);
+          onScoreUpdateRef.current?.(scoreEntry);
+          break;
         }
-      } catch (err) {
-        logger.error(
-          `[useSessionSync] Event parsing error: ${event.data}`,
-          err instanceof Error ? err : undefined
-        );
+
+        case SessionEventType.SessionPausedEvent: {
+          onPausedRef.current?.();
+          break;
+        }
+
+        case SessionEventType.SessionResumedEvent: {
+          onResumedRef.current?.();
+          break;
+        }
+
+        case SessionEventType.SessionFinalizedEvent: {
+          onFinalizedRef.current?.();
+          break;
+        }
       }
-    },
-    [onScoreUpdate, onPaused, onResumed, onFinalized]
-  );
+    } catch (err) {
+      logger.error(
+        `[useSessionSync] Event parsing error: ${event.data}`,
+        err instanceof Error ? err : undefined
+      );
+    }
+  }, []);
 
   /**
    * Connect to SSE stream
@@ -195,7 +214,7 @@ export function useSessionSync(options: UseSessionSyncOptions): SessionSyncState
 
         const errorObj = new Error('SSE connection failed');
         setError(errorObj);
-        onError?.(errorObj);
+        onErrorRef.current?.(errorObj);
 
         // Auto-reconnect with exponential backoff
         if (reconnectAttemptsRef.current < maxReconnectAttempts) {
@@ -221,26 +240,25 @@ export function useSessionSync(options: UseSessionSyncOptions): SessionSyncState
         eventSource.addEventListener(eventType, handleEvent);
       });
 
-      // Listen to turn-order toolkit events (Issue #4975)
-      if (onTurnAdvanced) {
-        eventSource.addEventListener('session:toolkit', (event: MessageEvent<string>) => {
-          try {
-            const payload = JSON.parse(event.data) as TurnAdvancedPayload;
-            onTurnAdvanced(payload);
-          } catch (err) {
-            logger.error('[useSessionSync] session:toolkit parse error:', err);
-          }
-        });
-      }
+      // Listen to turn-order toolkit events (Issue #4975). Always registered; the
+      // callback is invoked through a ref so `connect` stays stable across renders.
+      eventSource.addEventListener('session:toolkit', (event: MessageEvent<string>) => {
+        try {
+          const payload = JSON.parse(event.data) as TurnAdvancedPayload;
+          onTurnAdvancedRef.current?.(payload);
+        } catch (err) {
+          logger.error('[useSessionSync] session:toolkit parse error:', err);
+        }
+      });
 
       eventSourceRef.current = eventSource;
     } catch (err) {
       const errorObj = err instanceof Error ? err : new Error('Failed to create EventSource');
       setError(errorObj);
       setIsConnected(false);
-      onError?.(errorObj);
+      onErrorRef.current?.(errorObj);
     }
-  }, [sessionId, apiBaseUrl, handleEvent, onError, onTurnAdvanced]);
+  }, [sessionId, apiBaseUrl, handleEvent]);
 
   /**
    * Disconnect SSE stream

--- a/docs/for-claude/architecture/adr/adr-078-auto-issue-noise-thresholds.md
+++ b/docs/for-claude/architecture/adr/adr-078-auto-issue-noise-thresholds.md
@@ -18,7 +18,7 @@ MeepleAI's CI/CD infrastructure includes several automated workflows that create
 
 3. **`ci-minutes-digest.yml`**: Presumably creates or updates a digest issue with CI minute consumption.
 
-4. **`runner-health-check.yml`** and **`monitor-runner-queue.yml`**: Runner health monitoring — likely emit issues or Slack alerts on runner anomalies.
+4. ~~**`runner-health-check.yml`** and **`monitor-runner-queue.yml`**~~ — **removed 2026-07-28 (#3331 / #3348)**: the self-hosted runner was retired (Option E; all workflows now run on GitHub-hosted), so these runner-health monitors were deleted. Kept here for historical context of the convention.
 
 5. **`validate-secrets.yml`**: Validates secrets configuration — could emit issues on secret drift.
 
@@ -29,7 +29,7 @@ MeepleAI's CI/CD infrastructure includes several automated workflows that create
 - The `dev-auto-revert.yml` uses a failure-mode classification with threshold logic ("would-revert only after 30min continuous red") before taking action — a noise-reduction strategy.
 - The `spec-debt-false-positive-allowlist.json` is an explicit allowlist pattern for suppressing known-false-positive auto-issues.
 
-**Problem space**: as the number of automated monitors grows (security scans, dependency drift, spec debt, seed snapshot freshness, runner health), each generating potential issues, the GitHub issue tracker can be polluted with:
+**Problem space**: as the number of automated monitors grows (security scans, dependency drift, spec debt, seed snapshot freshness), each generating potential issues, the GitHub issue tracker can be polluted with:
 - **Noise issues** (same condition detected on consecutive scans, creating N identical issues).
 - **Burst issues** (a single root cause — e.g. a network blip — causing 10 simultaneous "health check failed" issues across 10 monitors).
 - **Stale issues** (a condition that auto-resolved but the issue remains open, accumulating false backlog).

--- a/docs/for-developers/operations/2026-07-28-wp3-title-health-go-no-go.md
+++ b/docs/for-developers/operations/2026-07-28-wp3-title-health-go-no-go.md
@@ -1,0 +1,39 @@
+# WP3 — Title-health metric + WP4 go/no-go read-out
+
+**Epic:** [#3338](https://github.com/meepleAi-app/meepleai-monorepo/issues/3338) (RAG extraction heading-detection). **Date:** 2026-07-28.
+
+## The metric
+
+`TitleHealthMetric.Compute` (`apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/TitleHealthMetric.cs`) scores a game's extraction quality from the **section headings its chunks carry** (`text_chunks.Heading` — what retrieval sees):
+
+- **PlausibleFraction** — fraction of DISTINCT headings that look like real section titles. A heading is *plausible* when it is 2–40 chars, carries a real word (a run of ≥3 consecutive letters — rejects `D`, `S U`, `I L E X Y R F`), and is ≥60 % letters (rejects `(14%), Oceani`, `© 2016 FryxGames www.…`). It measures title-**likeness**, not section-correctness; the target is gross extraction garbage.
+- **CanonicalCoverage** — how many curated `SectionHeadingLexicon` section types are present.
+- **Band** — `green` ≥ 0.80 · `yellow` ≥ 0.50 · `red` otherwise.
+
+## Read-out (staging, 2026-07-28, post-WP1 deploy)
+
+Computed over the real staging headings of 6 games. **Only Terraforming Mars was re-chunked with WP1**; the others reflect the pre-WP1 chunking (baseline).
+
+| Game | lang | distinct | plausible % | canonical | band |
+|---|---|---|---|---|---|
+| Wingspan | en | 102 | 90 % | 0 | 🟢 green |
+| Catan | en | 104 | 87 % | 2 | 🟢 green |
+| Dominion | en | 121 | 85 % | 0 | 🟢 green |
+| Ark Nova | en | 107 | 79 % | 4 | 🟡 yellow |
+| **Terraforming Mars** | it | 68 | **72 %** | **11** | 🟡 **yellow** |
+
+(`canonical` = distinct plausible headings matching a curated lexicon section word.)
+
+## WP4 go/no-go decision — **DEFERRED / descope-able**
+
+Terraforming Mars — the epic's motivating case — is **yellow (72 %)** after WP1, with the **highest canonical coverage (11)**: the WP1 heading-repair (embedded-title splitter + `Header`→`Title` promotion + synonym-aware boost) recovered the real section headings. The `Setup per N giocatori` query now works end-to-end (WP2: the `PREPARAZIONE` chunk is retrieved rank #1 and the answer is grounded).
+
+The residual 28 % (garbage `Title` elements unstructured emits — `I L E X Y R F`, `D`, `(14%), Oceani`) is **demoted by WP1b (number-noise) and does not block retrieval**. WP4 (hi_res IT extraction) would push TM yellow → green by fixing the extraction at the geometry level, but its cost is real and load-bearing (per epic WP4: HttpClient 35 s timeout + retry storm, yolox weights not baked into the image, hi_res >90 s on CPU) and is **not justified to go yellow → green when the functional goal is already met**.
+
+**Decision:** WP4 is deferred/descope-able. Re-evaluate if a broader IT cohort — once re-chunked with WP1 (the 12 other IT docs + the 65 currently-`Failed` PDFs, both pending a re-index) — shows a **red** cohort whose retrieval actually regresses. Until then WP1 (+ the number-noise demotion) is sufficient.
+
+## Remaining WP3 (follow-up)
+
+- Corpus `title-health` admin endpoint + persistence (so the metric is queryable, not just computed offline).
+- Wire the metric into a CI gate that **fails if a previously-green English game's health drops** after a WP1/WP4 change (the regression guard) — alongside the retrieval regression guard (`rag-smoke-assert.sh`).
+- Capture the `tmars-setup-it` rag-smoke baseline on staging (`--update-baseline`) so the added canonical query asserts instead of SKIPs.

--- a/docs/for-developers/operations/2026-07-28-wp3-title-health-go-no-go.md
+++ b/docs/for-developers/operations/2026-07-28-wp3-title-health-go-no-go.md
@@ -32,8 +32,15 @@ The residual 28 % (garbage `Title` elements unstructured emits — `I L E X Y R 
 
 **Decision:** WP4 is deferred/descope-able. Re-evaluate if a broader IT cohort — once re-chunked with WP1 (the 12 other IT docs + the 65 currently-`Failed` PDFs, both pending a re-index) — shows a **red** cohort whose retrieval actually regresses. Until then WP1 (+ the number-noise demotion) is sufficient.
 
-## Remaining WP3 (follow-up)
+## Remaining WP3 (follow-up) — SHIPPED
 
-- Corpus `title-health` admin endpoint + persistence (so the metric is queryable, not just computed offline).
-- Wire the metric into a CI gate that **fails if a previously-green English game's health drops** after a WP1/WP4 change (the regression guard) — alongside the retrieval regression guard (`rag-smoke-assert.sh`).
-- Capture the `tmars-setup-it` rag-smoke baseline on staging (`--update-baseline`) so the added canonical query asserts instead of SKIPs.
+- **Corpus `title-health` admin endpoint** — `GET /api/v1/admin/kb/title-health` (`AdminKnowledgeBaseEndpoints`, admin-scoped). Computes `TitleHealthMetric` per shared game over its distinct `text_chunks.Heading` values, returning `GameTitleHealthDto[]` (band, plausibleFraction, canonicalCoverage, distinctHeadings, dominant language). Query/handler: `KnowledgeBase/Application/Queries/GetCorpusTitleHealth`. Handler EF translation (nullable-`GameId` join → `shared_games`/`pdf_documents`, `LanguageOverride ?? Language`, server-side `Distinct`) is covered by a Testcontainers integration test.
+- **CI regression guard** — `infra/scripts/title-health-assert.sh` + committed baseline `infra/fixtures/title-health-baseline.json`, wired into `.github/workflows/rag-smoke-dispatch.yml` (shares the one snapshot boot with the retrieval smoke). Assert mode FAILs on a **band downgrade** (green→yellow/red, yellow→red), a **plausible-fraction drop** beyond `fractionRegressionTolerance` (0.05), or a **baselined game vanishing** from the corpus. A new (unbaselined) game is a NOTICE, never a FAIL. It opens a deduped `title-health-regression` issue on failure (ADR-078 one-per-open-label).
+
+### Capture step (required to arm the gate)
+
+The baseline ships with an EMPTY `games` map, so the gate is **dormant (SKIP)** until captured — mirroring the rag-smoke unbaselined-query SKIP (no green theatre; the SKIP is a visible NOTICE). Arm it by capturing against the **published seed snapshot** (the corpus the CI gate asserts against — NOT staging): dispatch `rag-smoke-dispatch.yml` with `update_baseline=true`, then download the `title-health-baseline-<run_id>` artifact and commit `infra/fixtures/title-health-baseline.json`. Re-capture after any re-bake/re-chunk that intentionally changes headings (same procedure as the golden retrieval baseline).
+
+### Still open (unchanged)
+
+- Capture the `tmars-setup-it` rag-smoke baseline (`--update-baseline`) so the added canonical query asserts instead of SKIPs.

--- a/docs/for-developers/operations/operations-manual.md
+++ b/docs/for-developers/operations/operations-manual.md
@@ -2786,6 +2786,16 @@ Either failure blocks merge. Bypassing requires an explicit lift comment from
 
 ## 21. Self-Hosted Runner Recovery
 
+> **⚠️ OBSOLETE (2026-07-28, #3331)** — the self-hosted runner was **retired** (Option E):
+> the `RUNNER` repo variable was removed, all workflows now run on GitHub-hosted, and the
+> runner was deregistered + decommissioned on the VPS. The scripts referenced below
+> (`apply-memory-overrides.sh`, `10-memory-limits.conf`, `maintenance.sh`, `monitor.sh`)
+> and the babysitting workflows (`runner-health-check`, `runner-maintenance`,
+> `monitor-runner-queue`) were deleted in #3348. This section is kept as historical
+> reference and as the operational guide **if** a dedicated runner is ever re-introduced
+> (Option D fallback, provisioned from `infra/runner/cloud-init.yml` + `setup-*.sh`). See
+> the [migration plan](../../superpowers/plans/2026-07-28-issue-3331-eliminate-self-hosted-runner.md).
+
 ### Background
 
 A GitHub Actions self-hosted runner (`meepleai-staging`, ARM64, Hetzner CX31)

--- a/infra/fixtures/rag-canonical-queries.json
+++ b/infra/fixtures/rag-canonical-queries.json
@@ -59,6 +59,13 @@
       "game": "7 Wonders",
       "language": "it",
       "query": "Come si risolve il conflitto militare alla fine di ogni età in 7 Wonders?"
+    },
+    {
+      "queryId": "tmars-setup-it",
+      "game": "Terraforming Mars",
+      "language": "it",
+      "_comment": "Epic #3338 WP2/WP3 motivating case ('Setup per N giocatori'). Pins that TM's PREPARAZIONE setup section — recovered by the WP1 heading-repair (Header promotion) after the re-chunk — stays retrievable. SKIPs until its baseline is captured via --update-baseline on staging. The query carries TM-specific nouns (Corporation, ossigeno, plancia dei giocatori) so global-ask isolates TM and does not pin a wrong-game baseline (review #3355).",
+      "query": "Come si prepara Terraforming Mars per N giocatori: quante carte Corporation e progetti in mano, la plancia dei giocatori e i parametri iniziali (ossigeno, temperatura, oceani)?"
     }
   ]
 }

--- a/infra/fixtures/title-health-baseline.json
+++ b/infra/fixtures/title-health-baseline.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": 1,
+  "_comment": "Epic #3338 WP3 extraction-quality regression guard. Per-game title-health captured from GET /api/v1/admin/kb/title-health (TitleHealthMetric over each shared game's distinct text_chunks.Heading). The harness (infra/scripts/title-health-assert.sh) fails a run if a baselined game's band DOWNGRADES (green→yellow/red, yellow→red) or its plausibleFraction drops by more than `fractionRegressionTolerance`, or if a baselined game vanishes from the corpus. New (unbaselined) games are a NOTICE, never a FAIL. `games` starts EMPTY: the endpoint ships in the WP3 PR, so the baseline is captured on staging AFTER deploy via `bash scripts/title-health-assert.sh --update-baseline` (see docs/for-developers/operations/2026-07-28-wp3-title-health-go-no-go.md). Until then the gate reports SKIP (dormant), mirroring the rag-smoke unbaselined-query SKIP.",
+  "fractionRegressionTolerance": 0.05,
+  "capturedAt": null,
+  "games": {}
+}

--- a/infra/scripts/title-health-assert.sh
+++ b/infra/scripts/title-health-assert.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# infra/scripts/title-health-assert.sh
+# RAG extraction-quality regression guard (Epic #3338 WP3).
+#
+# Fetches the per-game title-health metric from GET /api/v1/admin/kb/title-health
+# (TitleHealthMetric over each shared game's distinct text_chunks.Heading values) and
+# asserts no game REGRESSED versus the committed baseline in
+# fixtures/title-health-baseline.json (keyed by the unique gameId, not the non-unique title):
+#   - a band DOWNGRADE (green→yellow/red, yellow→red) FAILs — the acceptance guard
+#     ("a previously-green English game's health must not drop after a chunking change");
+#   - a plausible-fraction drop beyond `fractionRegressionTolerance` FAILs even within
+#     the same band (catches within-band erosion before it tips a band);
+#   - a baselined game ABSENT from the current corpus FAILs (its chunks/headings vanished);
+#   - a game present now but NOT in the baseline is a NOTICE (newly-indexed), never a FAIL.
+#
+# The endpoint is admin-only, so SMOKE_EMAIL/SMOKE_PASSWORD (admin creds) are REQUIRED.
+#
+# Usage:
+#   API_BASE_URL=http://localhost:8080 SMOKE_EMAIL=admin@… SMOKE_PASSWORD=… \
+#     bash scripts/title-health-assert.sh                    # assert against baseline
+#   … bash scripts/title-health-assert.sh --update-baseline  # capture baseline from current corpus
+#
+# Exit: 0 = no regression (or baseline updated / baseline empty); 1 = a game regressed / fetch failed.
+set -uo pipefail
+
+BASE_URL="${API_BASE_URL:-http://localhost:8080}"
+EMAIL="${SMOKE_EMAIL:-${TEST_EMAIL:-}}"
+PASSWORD="${SMOKE_PASSWORD:-${TEST_PASSWORD:-}}"
+UPDATE_BASELINE=false
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"   # infra/
+BASELINE="$DIR/fixtures/title-health-baseline.json"
+ENDPOINT="/api/v1/admin/kb/title-health"
+
+for arg in "$@"; do
+  case "$arg" in
+    --update-baseline) UPDATE_BASELINE=true ;;
+    --base-url=*) BASE_URL="${arg#*=}" ;;
+    *) echo "::error:: unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+log()  { echo "[title-health] $*" >&2; }
+fail() { echo "::error:: $*" >&2; exit 1; }
+
+command -v jq   >/dev/null || fail "jq is required"
+command -v curl >/dev/null || fail "curl is required"
+[ -f "$BASELINE" ] || fail "missing $BASELINE"
+
+TOLERANCE=$(jq -r '.fractionRegressionTolerance // 0.05' "$BASELINE")
+TOLERANCE=${TOLERANCE%$'\r'}   # native Windows jq.exe emits CRLF; strip the CR so --arg/comparisons are clean
+
+COOKIE=$(mktemp); trap 'rm -f "$COOKIE" "${CURRENT:-}"' EXIT
+
+# --- login (admin required: the endpoint is behind RequireAdminSessionFilter) ---
+[ -n "$EMAIL" ] && [ -n "$PASSWORD" ] || fail "SMOKE_EMAIL/SMOKE_PASSWORD (admin creds) are required for the admin endpoint"
+code=$(curl -s -o /dev/null -w '%{http_code}' -c "$COOKIE" -X POST "$BASE_URL/api/v1/auth/login" \
+  -H 'Content-Type: application/json' \
+  -d "$(jq -n --arg e "$EMAIL" --arg p "$PASSWORD" '{email:$e, password:$p}')") || true
+[ "$code" = "200" ] || fail "login failed (HTTP ${code:-000})"
+log "login OK ($EMAIL)"
+
+# --- fetch current corpus title-health (array of GameTitleHealthDto) ---
+CURRENT=$(mktemp)
+code=$(curl -s -o "$CURRENT" -w '%{http_code}' -b "$COOKIE" "$BASE_URL$ENDPOINT") || true
+[ "$code" = "200" ] || fail "GET $ENDPOINT failed (HTTP ${code:-000}) — admin session/deploy issue"
+jq -e 'type == "array"' "$CURRENT" >/dev/null 2>&1 || fail "unexpected response (not a JSON array): $(head -c 200 "$CURRENT")"
+COUNT=$(jq 'length' "$CURRENT"); COUNT=${COUNT%$'\r'}
+log "fetched $COUNT game(s) from the corpus"
+
+# --- capture mode ---
+# Keyed by gameId (stable, unique) — gameTitle is NOT unique in the community catalog, so keying
+# on it would let two same-titled games clobber/mask each other. gameTitle is stored as a value for
+# readable failure messages.
+if [ "$UPDATE_BASELINE" = true ]; then
+  [ "$COUNT" -gt 0 ] || fail "corpus returned 0 games — baseline NOT written (index cold / wrong env?)"
+  ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  games=$(jq 'map({key: .gameId, value: {gameTitle, language, band, plausibleFraction, canonicalCoverage, distinctHeadings}}) | from_entries' "$CURRENT")
+  jq --argjson g "$games" --arg ts "$ts" '.games=$g | .capturedAt=$ts' "$BASELINE" > "$BASELINE.2" && mv "$BASELINE.2" "$BASELINE"
+  log "baseline updated → $BASELINE ($COUNT games, capturedAt=$ts)"
+  exit 0
+fi
+
+# --- assert mode ---
+BASELINE_N=$(jq '.games | length' "$BASELINE"); BASELINE_N=${BASELINE_N%$'\r'}
+if [ "$BASELINE_N" -eq 0 ]; then
+  # An empty baseline is a wired-but-dormant gate (the endpoint ships in this PR; the baseline is
+  # captured on staging post-deploy via --update-baseline). Report a visible NOTICE, never green theatre.
+  echo "::notice:: SKIP — title-health baseline is empty (pending --update-baseline capture on staging post-deploy)"
+  log "result: baseline empty → gate dormant (no regression possible)"
+  exit 0
+fi
+
+# A non-empty baseline but an empty corpus is an INFRA/config fault (cold index, wrong DB), not N
+# simultaneous regressions — fail loudly instead of reporting every baselined game as "vanished"
+# (which would otherwise open a false regression issue).
+[ "$COUNT" -gt 0 ] || fail "corpus returned 0 games but baseline has $BASELINE_N — cold index / wrong env, NOT a regression"
+
+# band ordinal: red < yellow < green. A current ordinal below the baseline ordinal is a downgrade.
+ORD='{"red":0,"yellow":1,"green":2}'
+
+PASS=0; FAIL=0; NEW=0
+# Iterate baselined game IDs (unique keys). gameTitle comes from the baseline value for display.
+while IFS= read -r id; do
+  id=${id%$'\r'}
+  base=$(jq -c --arg i "$id" '.games[$i]' "$BASELINE")
+  name=$(jq -r --arg i "$id" '.games[$i].gameTitle // $i' "$BASELINE"); name=${name%$'\r'}
+  cur=$(jq -c --arg i "$id" '.[] | select(.gameId==$i)' "$CURRENT" | head -1)
+
+  if [ -z "$cur" ] || [ "$cur" = "null" ]; then
+    echo "FAIL  $name — baselined game absent from the current corpus (chunks/headings vanished)"
+    FAIL=$((FAIL+1)); continue
+  fi
+
+  verdict=$(jq -n --argjson base "$base" --argjson cur "$cur" --argjson ord "$ORD" --argjson tol "$TOLERANCE" '
+    ($ord[$base.band]) as $bo | ($ord[$cur.band]) as $co
+    | ($base.plausibleFraction - $cur.plausibleFraction) as $drop
+    | if $co < $bo then "BAND \($base.band)→\($cur.band)"
+      elif $drop > $tol then "FRACTION \($base.plausibleFraction)→\($cur.plausibleFraction) (−\($drop|.*10000|round/10000) > \($tol))"
+      else "OK" end')
+  verdict=${verdict//\"/}
+
+  if [ "$verdict" = "OK" ]; then
+    echo "PASS  $name — $(jq -r '.band' <<<"$cur") $(jq -r '.plausibleFraction' <<<"$cur")"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL  $name — regressed: $verdict"
+    FAIL=$((FAIL+1))
+  fi
+done < <(jq -r '.games | keys[]' "$BASELINE")
+
+# New (unbaselined) games: informational only. Matched by gameId (the baseline key).
+while IFS= read -r name; do
+  name=${name%$'\r'}
+  echo "::notice:: NEW $name — not in baseline (newly-indexed; capture with --update-baseline to guard it)"
+  NEW=$((NEW+1))
+done < <(jq -r --slurpfile b "$BASELINE" '.[] | select((.gameId) as $i | ($b[0].games | has($i)) | not) | .gameTitle' "$CURRENT")
+
+log "result: $PASS passed, $FAIL regressed, $NEW new (unguarded)"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Promozione release `main-dev → main-staging` (auto-trigger `deploy-staging.yml`).

## Commit inclusi (6)
- **#3358** feat(rag): corpus title-health endpoint + CI regression guard (#3338 WP3)
- **#3355** feat(rag): WP3 Title-health metric + TM canonical query + WP4 go/no-go (#3338)
- #3357 fix(chat): enforce ownership on by-id chat-session endpoints (IDOR)
- #3356 fix(toolkit): preserve VersionSemver/Description/License on UpdateAsync
- #3354 docs: mark retired self-hosted-runner sections obsolete
- #3353 fix(session-sync): stabilize SSE connection vs inline-callback churn

Motivazione: portare in staging l'endpoint admin `/api/v1/admin/kb/title-health` (epic #3338 WP3) + i fix accumulati su main-dev dall'ultima release (#3352).