### PR TITLE
fix(a11y): add accessible names to icon-only session buttons (WCAG 4.1.2)

### DIFF
--- a/apps/web/src/components/session/SessionCreationWizard.tsx
+++ b/apps/web/src/components/session/SessionCreationWizard.tsx
@@ -195,7 +195,12 @@ function ConfigureScoringStep({
           className="w-24"
           onKeyDown={e => e.key === 'Enter' && addDimension()}
         />
-        <Button variant="outline" size="icon" onClick={addDimension}>
+        <Button
+          variant="outline"
+          size="icon"
+          aria-label="Aggiungi dimensione"
+          onClick={addDimension}
+        >
           <Plus className="h-4 w-4" />
         </Button>
       </div>

--- a/apps/web/src/components/session/SessionHeader.tsx
+++ b/apps/web/src/components/session/SessionHeader.tsx
@@ -71,7 +71,7 @@ export function SessionHeader({ session, onPause, onFinalize, onShare }: Session
                     month: 'short',
                     day: 'numeric',
                     hour: '2-digit',
-                    minute: '2-digit'
+                    minute: '2-digit',
                   })}
                 </time>
                 <span className="flex items-center gap-1">
@@ -111,6 +111,7 @@ export function SessionHeader({ session, onPause, onFinalize, onShare }: Session
                 <Button
                   variant="outline"
                   size="icon"
+                  aria-label="Session actions"
                   className="h-9 w-9 border-amber-900/20 bg-card/80 dark:bg-card hover:bg-card hover:border-amber-600/40 active:scale-95 transition-all"
                 >
                   <MoreVertical className="h-4 w-4 text-muted-foreground" />
@@ -139,7 +140,10 @@ export function SessionHeader({ session, onPause, onFinalize, onShare }: Session
                   </DropdownMenuItem>
                 )}
                 {session.status === 'Active' && onFinalize && (
-                  <DropdownMenuItem onClick={onFinalize} className="gap-2 text-amber-700 dark:text-amber-400">
+                  <DropdownMenuItem
+                    onClick={onFinalize}
+                    className="gap-2 text-amber-700 dark:text-amber-400"
+                  >
                     <Flag className="h-4 w-4" />
                     Finalize Session
                   </DropdownMenuItem>

--- a/apps/web/src/components/session/__tests__/SessionCreationWizard.test.tsx
+++ b/apps/web/src/components/session/__tests__/SessionCreationWizard.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * SessionCreationWizard accessibility tests.
+ * The icon-only "add dimension" button in the scoring step must have an accessible
+ * name (axe button-name / WCAG 4.1.2).
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { SessionCreationWizard } from '../SessionCreationWizard';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), back: vi.fn() }),
+}));
+
+vi.mock('@/lib/api', () => ({ api: { liveSessions: {} } }));
+
+// GamePicker fetches the library catalogue; replace it with a button that selects a game
+// so the wizard can advance from the game step to the scoring step.
+vi.mock('@/components/features/game-picker', () => ({
+  GamePicker: ({
+    onChange,
+  }: {
+    onChange: (game: { id: string; title: string; manual: boolean }) => void;
+  }) => (
+    <button type="button" onClick={() => onChange({ id: 'g1', title: 'Test Game', manual: true })}>
+      mock-select-game
+    </button>
+  ),
+}));
+
+describe('SessionCreationWizard', () => {
+  function advanceToScoringStep() {
+    render(<SessionCreationWizard />);
+    // Step 1 (game) → pick a game so "Avanti" enables → Step 2 (scoring).
+    fireEvent.click(screen.getByText('mock-select-game'));
+    fireEvent.click(screen.getByText('Avanti'));
+  }
+
+  it('exposes an accessible name on the add-dimension icon button', () => {
+    advanceToScoringStep();
+    expect(screen.getByRole('button', { name: /aggiungi dimensione/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/session/__tests__/SessionHeader.test.tsx
+++ b/apps/web/src/components/session/__tests__/SessionHeader.test.tsx
@@ -94,4 +94,10 @@ describe('SessionHeader', () => {
     render(<SessionHeader session={finalizedSession} />);
     expect(screen.getByText('Finalized')).toBeInTheDocument();
   });
+
+  it('should expose an accessible name on the actions menu trigger', () => {
+    // The icon-only DropdownMenuTrigger must have an accessible name (axe button-name / WCAG 4.1.2).
+    render(<SessionHeader session={mockSession} />);
+    expect(screen.getByRole('button', { name: /session actions/i })).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Problema (WCAG 4.1.2 / axe button-name)

Due button icon-only privi di accessible name, su route fuori dal set testato da axe (il gate axe CI è bloccante ma non copre queste route):

1. **`SessionHeader`** — il trigger del menu azioni (Pause/Resume/Share/Finalize): `DropdownMenuTrigger` → `Button size="icon"` con solo `<MoreVertical/>`. Usato su `/toolkit/[sessionId]` e `library/[gameId]/toolkit/[sessionId]`.
2. **`SessionCreationWizard`** (step scoring) — il button "aggiungi dimensione": `Button size="icon"` con solo `<Plus/>`. Su `/sessions/new`.

## Fix

- `SessionHeader`: `aria-label="Session actions"` (inglese, coerente con le stringhe hardcoded del file e con l'`aria-label` del sibling copy-code button).
- `SessionCreationWizard`: `aria-label="Aggiungi dimensione"` (italiano, coerente con la copy inline). Il button "Aggiungi" giocatore ha già testo visibile → **non toccato**.

## TDD

- **RED**: `getByRole('button', { name })` fallisce (nessun accessible name).
- **GREEN**: passa dopo l'aria-label.
- Nuovo `SessionCreationWizard.test.tsx` guida il wizard fino allo step scoring via `GamePicker` mockato.

## Verifica locale

- Test: **12/12** PASS (SessionHeader + SessionCreationWizard)
- `pnpm typecheck`: pulito · `eslint` sui 2 sorgenti: 0 errori