### PR TITLE
fix(pdf): reset SSE reconnect/state refs on documentId change

### DIFF
--- a/apps/web/src/hooks/__tests__/usePdfStatus.test.ts
+++ b/apps/web/src/hooks/__tests__/usePdfStatus.test.ts
@@ -634,4 +634,90 @@ describe('usePdfStatus', () => {
       expect(result.current.connectionMetrics.fallbackTriggers).toBe(1);
     });
   });
+
+  // ==========================================================================
+  // documentId change without remount — ref hygiene
+  // ==========================================================================
+
+  describe('documentId change (ref hygiene)', () => {
+    it('resets reconnect attempts when documentId changes so the new doc can reconnect', async () => {
+      mockGetProgress.mockResolvedValue({
+        currentStep: 'Uploading',
+        percentComplete: 0,
+        estimatedTimeRemaining: '5m',
+        errorMessage: null,
+      });
+
+      const { result, rerender } = renderHook(
+        ({ id }) => usePdfStatus(id, { enableSSE: true, maxReconnectAttempts: 2 }),
+        { initialProps: { id: 'doc-A' } }
+      );
+
+      // Exhaust doc-A's reconnect budget up to the max (2 errors + their backoffs),
+      // WITHOUT firing the terminal 3rd error that would drop to polling.
+      await act(async () => {
+        getLatestES().simulateError(); // attempt 1
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000);
+      });
+      await act(async () => {
+        getLatestES().simulateError(); // attempt 2 (== max)
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(4000);
+      });
+
+      // Switch documents without unmounting.
+      await act(async () => {
+        rerender({ id: 'doc-B' });
+      });
+
+      // The first transient error on doc-B must retry (reconnecting), NOT drop straight to
+      // polling — which it would if reconnectAttemptsRef still held doc-A's exhausted count.
+      await act(async () => {
+        getLatestES().simulateError();
+      });
+
+      expect(result.current.connectionState).toBe('reconnecting');
+      expect(result.current.isPolling).toBe(false);
+    });
+
+    it('re-emits the same PDF state for a new documentId (previousState is reset)', async () => {
+      const onStateChange = vi.fn();
+
+      const { rerender } = renderHook(
+        ({ id }) => usePdfStatus(id, { enableSSE: true, onStateChange }),
+        { initialProps: { id: 'doc-A' } }
+      );
+
+      await act(async () => {
+        getLatestES().simulateOpen();
+      });
+      await act(async () => {
+        getLatestES().simulateMessage(
+          JSON.stringify({ state: 'extracting', progress: 10, timestamp: '2026-01-01T00:00:00Z' })
+        );
+      });
+      expect(onStateChange).toHaveBeenCalledWith('extracting');
+      onStateChange.mockClear();
+
+      // New document whose first emitted state equals doc-A's last state.
+      await act(async () => {
+        rerender({ id: 'doc-B' });
+      });
+      await act(async () => {
+        getLatestES().simulateOpen();
+      });
+      await act(async () => {
+        getLatestES().simulateMessage(
+          JSON.stringify({ state: 'extracting', progress: 20, timestamp: '2026-01-01T00:01:00Z' })
+        );
+      });
+
+      // Without the reset, previousStateRef would still hold 'extracting' from doc-A and
+      // suppress the callback for doc-B.
+      expect(onStateChange).toHaveBeenCalledWith('extracting');
+    });
+  });
 });

--- a/apps/web/src/hooks/usePdfStatus.ts
+++ b/apps/web/src/hooks/usePdfStatus.ts
@@ -405,6 +405,14 @@ export function usePdfStatus(
 
     if (!documentId) return;
 
+    // Reset per-document connection state when documentId changes without a remount.
+    // Otherwise the new document inherits the previous one's reconnect count (dropping the
+    // first transient error straight to polling) and its last emitted state (suppressing the
+    // new document's first onStateChange). The in-stream reconnect path calls startSSE via
+    // setTimeout without re-running this effect, so backoff counting is preserved.
+    reconnectAttemptsRef.current = 0;
+    previousStateRef.current = null;
+
     // Check network type - auto-fallback to polling for slow-2g
     const usePolling = !enableSSE || shouldUsePollingForNetwork();
 


### PR DESCRIPTION
## Problema (igiene dei ref)

`usePdfStatus` re-esegue l'effetto di init quando `documentId` cambia **senza remount** (deps includono `documentId`), ma NON resettava `reconnectAttemptsRef` né `previousStateRef`. Conseguenze sul nuovo documento:

- se il documento precedente aveva esaurito i 5 reconnect, il **primo errore transiente** sul nuovo doc cadeva subito in polling invece di ritentare;
- se lo stato iniziale del nuovo doc coincideva con l'ultimo del precedente, `onStateChange` veniva **soppresso**.

> Nota: il meccanismo "cursor-bleed cross-stream" è **refutato** (lo status stream non emette frame `id:`) — questo è puramente igiene dei ref, non una vulnerabilità.

## Fix

Nell'effetto di init, dopo `if (!documentId) return;` e prima del branch SSE/polling:

```ts
reconnectAttemptsRef.current = 0;
previousStateRef.current = null;
```

Il path di reconnect in-stream chiama `startSSE` via `setTimeout` **senza** ri-eseguire l'effetto, quindi il conteggio backoff e il resume dello stream sono preservati (il reset non deve stare in `startSSE`, altrimenti azzererebbe il conteggio a ogni reconnect).

## TDD

Due test `renderHook` con `rerender` che cambia `documentId`:
- **reconnect carryover**: esaurisce i reconnect del doc A, cambia a doc B → il primo errore su B deve ritentare (`reconnecting`), non cadere in polling. RED (`polling`) → GREEN.
- **state suppression**: doc A emette `extracting`, doc B riemette `extracting` → `onStateChange` deve rifirare. RED (0 chiamate) → GREEN.

## Verifica locale

- Suite completa `usePdfStatus`: **26/26** PASS (24 esistenti + 2 nuovi)
- `pnpm typecheck`: pulito · `eslint` sull'hook: 0 errori