### PR TITLE
fix(mechanic-extractor): align MechanicSection enum FE to v1.1.0 sections (6/7/8)

### DIFF
--- a/apps/web/src/lib/api/schemas/mechanic-analyses.schemas.ts
+++ b/apps/web/src/lib/api/schemas/mechanic-analyses.schemas.ts
@@ -69,6 +69,10 @@ export const MechanicSection = {
   Resources: 3,
   Phases: 4,
   Faq: 5,
+  // v1.1.0 (#2930): Setup / Components / EndgameScoring appended to the C# enum.
+  Setup: 6,
+  Components: 7,
+  EndgameScoring: 8,
 } as const;
 export type MechanicSectionValue = (typeof MechanicSection)[keyof typeof MechanicSection];
 
@@ -147,6 +151,10 @@ const MECHANIC_SECTION_NAME_TO_NUM: Record<string, MechanicSectionValue> = {
   FAQ: MechanicSection.Faq,
   // Some older C# emit aliases used "Questions" — keep tolerant.
   Questions: MechanicSection.Faq,
+  // v1.1.0 (#2930): Setup / Components / EndgameScoring.
+  Setup: MechanicSection.Setup,
+  Components: MechanicSection.Components,
+  EndgameScoring: MechanicSection.EndgameScoring,
 };
 
 export const MechanicSectionSchema = z.preprocess(v => {


### PR DESCRIPTION
## Problem
The admin **claims viewer** (`/admin/knowledge-base/mechanic-extractor/analyses`) fails with *"Failed to load claims: Schema validation failed"* for any analysis whose claims fall in the sections added by pipeline **v1.1.0** (#2930): Setup, Components, EndgameScoring. The section runs render fine, but the per-claim list is unusable — blocking human review.

## Root cause
In `apps/web/src/lib/api/schemas/mechanic-analyses.schemas.ts` the Zod enum `MechanicSection` (and `MECHANIC_SECTION_NAME_TO_NUM`) only declared sections **0–5**. `MechanicClaimDtoSchema.section` uses `z.nativeEnum(MechanicSection)`, so a single claim with section 6/7/8 makes the whole `z.array(...)` reject → the list fails to load.

The v1.1.0 change updated `MECHANIC_SECTION_LABELS` and `MECHANIC_SECTION_DISPLAY_ORDER` (which is why section runs — typed `z.number().int()` — kept working) but **not** the base enum.

## Fix
Add `Setup: 6`, `Components: 7`, `EndgameScoring: 8` to the enum and their PascalCase names to `MECHANIC_SECTION_NAME_TO_NUM`. 8-line change, no behavior change for 0–5.

## How it was found & verified
Surfaced during a local end-to-end run on **Catan** (59 claims across all 9 sections). After the fix the claims viewer renders every section with guardrail badges and citations; the analysis was reviewed and published to a public card. `tsc --noEmit` passes (pre-commit typecheck).

## Impact
Current production bug: breaks the review UI for every v1.1.0 analysis containing Setup/Components/EndgameScoring claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)