### PR TITLE
chore(release): promote main-dev → main-staging

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/MaterializePdfCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/MaterializePdfCoverCommandHandler.cs
@@ -20,26 +20,37 @@ internal sealed class MaterializePdfCoverCommandHandler : ICommandHandler<Materi
     private readonly IPdfDocumentRepository _repository;
     private readonly IMediator _mediator;
     private readonly IWebpVariantGenerator _webpVariantGenerator;
-    private readonly IPdfCoverUploadPipeline _uploadPipeline;
+    private readonly IPdfCoverUploadPipeline? _uploadPipeline;
     private readonly IUnitOfWork _unitOfWork;
 
     public MaterializePdfCoverCommandHandler(
         IPdfDocumentRepository repository,
         IMediator mediator,
         IWebpVariantGenerator webpVariantGenerator,
-        IPdfCoverUploadPipeline uploadPipeline,
-        IUnitOfWork unitOfWork)
+        IUnitOfWork unitOfWork,
+        // Issue #3363: optional — the R2 upload pipeline is registered only when STORAGE_PROVIDER=s3.
+        // In local-storage mode it is null and Handle() fails fast with a clear domain error instead of
+        // an opaque DI resolution failure.
+        IPdfCoverUploadPipeline? uploadPipeline = null)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
         _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
         _webpVariantGenerator = webpVariantGenerator ?? throw new ArgumentNullException(nameof(webpVariantGenerator));
-        _uploadPipeline = uploadPipeline ?? throw new ArgumentNullException(nameof(uploadPipeline));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _uploadPipeline = uploadPipeline;
     }
 
     public async Task<string> Handle(MaterializePdfCoverCommand command, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(command);
+
+        // Issue #3363: on-demand cover materialization needs the R2 upload pipeline, registered only
+        // when STORAGE_PROVIDER=s3. Fail fast with a clear domain error in local-storage mode.
+        if (_uploadPipeline is null)
+        {
+            throw new CoverMaterializationException(
+                "Materializzazione cover PDF non disponibile: richiede storage S3/R2 (STORAGE_PROVIDER=s3).");
+        }
 
         var pdf = await _repository.GetByIdAsync(command.PdfDocumentId, cancellationToken).ConfigureAwait(false)
             ?? throw new NotFoundException("PdfDocument", command.PdfDocumentId.ToString());
@@ -62,7 +73,8 @@ internal sealed class MaterializePdfCoverCommandHandler : ICommandHandler<Materi
             .GenerateWebpAsync(jpeg, PdfCoverExtractor.ThumbnailWidth, PdfCoverExtractor.ThumbnailHeight, cancellationToken)
             .ConfigureAwait(false);
 
-        var dbKey = await _uploadPipeline.UploadAsync(command.DbKey, webpBytes, cancellationToken).ConfigureAwait(false);
+        // Non-null here: the guard at the top of Handle() throws when _uploadPipeline is null.
+        var dbKey = await _uploadPipeline!.UploadAsync(command.DbKey, webpBytes, cancellationToken).ConfigureAwait(false);
 
         // C1 fix: command.PageNumber is 1-based (render/query contract); PdfDocument.CoverPageIndex
         // is documented and persisted as 0-based (see PdfProcessingPipelineService.cs and

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/BackfillPdfCoversJob.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/BackfillPdfCoversJob.cs
@@ -67,7 +67,14 @@ public sealed class BackfillPdfCoversJob : IJob
         var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
         var extractor = scope.ServiceProvider.GetRequiredService<IPdfCoverExtractor>();
         var blob = scope.ServiceProvider.GetRequiredService<IBlobStorageService>();
-        var coverUploadPipeline = scope.ServiceProvider.GetRequiredService<IPdfCoverUploadPipeline>();
+        var coverUploadPipeline = scope.ServiceProvider.GetService<IPdfCoverUploadPipeline>();
+        if (coverUploadPipeline is null)
+        {
+            // Issue #3363: the R2 cover-upload pipeline is registered only when STORAGE_PROVIDER=s3.
+            // In local-storage mode there is nowhere to upload L4 covers, so the backfill is a no-op.
+            _logger.LogDebug("BackfillPdfCoversJob skipped: cover-upload pipeline unavailable (local storage).");
+            return;
+        }
         var eventCollector = scope.ServiceProvider.GetService<IDomainEventCollector>();
 
         await RunBatchAsync(db, extractor, blob, coverUploadPipeline, eventCollector, ct).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/DependencyInjection/DocumentProcessingServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/DependencyInjection/DocumentProcessingServiceExtensions.cs
@@ -181,7 +181,7 @@ internal static class DocumentProcessingServiceExtensions
         // SharedGameCatalogServiceExtensions.AddSharedGameCatalogContext (same
         // DI container in Program.cs) — not re-registered here to avoid a
         // duplicate registration for the same concrete type.
-        RegisterPdfCoverUploadPipeline(services);
+        RegisterPdfCoverUploadPipeline(services, configuration);
 
         // Shared PDF processing pipeline (used by recovery job and future handler consolidation)
         services.AddScoped<IPdfProcessingPipelineService, PdfProcessingPipelineService>();
@@ -223,8 +223,22 @@ internal static class DocumentProcessingServiceExtensions
     /// two R2 cover pipelines don't drift on endpoint/credentials. Singleton
     /// lifetime matches the long-lived AWS SDK client (thread-safe + connection pool).
     /// </summary>
-    private static void RegisterPdfCoverUploadPipeline(IServiceCollection services)
+    private static void RegisterPdfCoverUploadPipeline(IServiceCollection services, IConfiguration configuration)
     {
+        // Issue #3363: the R2 cover-upload pipeline is a cloud-only, best-effort enrichment. Register it
+        // ONLY when STORAGE_PROVIDER=s3 (mirrors BlobStorageServiceFactory). In local-storage mode the
+        // service stays unregistered, so PdfProcessingPipelineService's optional IPdfCoverUploadPipeline?
+        // resolves to null and cover generation is skipped gracefully (see :562). The previous
+        // unconditional registration threw "S3_ENDPOINT is required" at DI resolution — which happens
+        // when PdfProcessingPipelineService is constructed, BEFORE the best-effort try/catch could skip
+        // the cover — so every PDF upload failed at the Upload step in any local-storage environment
+        // (the CI seed-snapshot bake + `make dev` locally).
+        var storageProvider = configuration["STORAGE_PROVIDER"]?.ToLowerInvariant() ?? "local";
+        if (!string.Equals(storageProvider, "s3", StringComparison.Ordinal))
+        {
+            return;
+        }
+
         services.AddSingleton<IPdfCoverUploadPipeline>(sp =>
         {
             var config = sp.GetRequiredService<IConfiguration>();

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/MaterializePdfCoverCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/MaterializePdfCoverCommandHandlerTests.cs
@@ -36,7 +36,7 @@ public class MaterializePdfCoverCommandHandlerTests
                 .ReturnsAsync((string k, byte[] _, CancellationToken _) => k);
         var uow = new Mock<IUnitOfWork>();
 
-        var handler = new MaterializePdfCoverCommandHandler(repo.Object, mediator.Object, webp.Object, pipeline.Object, uow.Object);
+        var handler = new MaterializePdfCoverCommandHandler(repo.Object, mediator.Object, webp.Object, uow.Object, pipeline.Object);
         // PageNumber is 1-based (user-facing / render contract); CoverPageIndex must be
         // stored 0-based to match PdfDocument.CoverPageIndex's documented convention and
         // the two existing writers (PdfProcessingPipelineService, BackfillPdfCoversJob),
@@ -75,7 +75,7 @@ public class MaterializePdfCoverCommandHandlerTests
                 .ReturnsAsync((string k, byte[] _, CancellationToken _) => k);
         var uow = new Mock<IUnitOfWork>();
 
-        var handler = new MaterializePdfCoverCommandHandler(repo.Object, mediator.Object, webp.Object, pipeline.Object, uow.Object);
+        var handler = new MaterializePdfCoverCommandHandler(repo.Object, mediator.Object, webp.Object, uow.Object, pipeline.Object);
         var cmd = new MaterializePdfCoverCommand(pdfId, PageNumber: 5, DbKey: "covers/g/pdf-cover");
 
         await handler.Handle(cmd, CancellationToken.None);
@@ -99,11 +99,35 @@ public class MaterializePdfCoverCommandHandlerTests
         mediator.Setup(m => m.Send(It.IsAny<GetPdfPageImageQuery>(), It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new HttpRequestException("503"));
         var handler = new MaterializePdfCoverCommandHandler(repo.Object, mediator.Object,
-            Mock.Of<IWebpVariantGenerator>(), Mock.Of<IPdfCoverUploadPipeline>(), Mock.Of<IUnitOfWork>());
+            Mock.Of<IWebpVariantGenerator>(), Mock.Of<IUnitOfWork>(), Mock.Of<IPdfCoverUploadPipeline>());
 
         var act = () => handler.Handle(new MaterializePdfCoverCommand(pdfId, 3, "k"), CancellationToken.None);
 
         await act.Should().ThrowAsync<CoverMaterializationException>();
         pdf.CoverGenerationStatus.Should().Be(PdfCoverGenerationStatus.Pending); // non toccato
+    }
+
+    /// <summary>
+    /// Issue #3363: in local-storage mode the R2 upload pipeline is unregistered, so the optional
+    /// ctor param is null. Handle() must fail fast with a clear domain error (not an opaque DI/NRE),
+    /// and must NOT render the page or touch the PdfDocument.
+    /// </summary>
+    [Fact]
+    public async Task Handle_LocalStorageNoUploadPipeline_ThrowsCoverMaterializationException()
+    {
+        var pdfId = Guid.NewGuid();
+        var repo = new Mock<IPdfDocumentRepository>();
+        var mediator = new Mock<IMediator>();
+
+        var handler = new MaterializePdfCoverCommandHandler(
+            repo.Object, mediator.Object, Mock.Of<IWebpVariantGenerator>(), Mock.Of<IUnitOfWork>(),
+            uploadPipeline: null);
+
+        var act = () => handler.Handle(new MaterializePdfCoverCommand(pdfId, 3, "k"), CancellationToken.None);
+
+        await act.Should().ThrowAsync<CoverMaterializationException>();
+        // Fails before any rendering / repository read.
+        mediator.Verify(m => m.Send(It.IsAny<GetPdfPageImageQuery>(), It.IsAny<CancellationToken>()), Times.Never);
+        repo.Verify(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineServiceCoverTestFactory.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineServiceCoverTestFactory.cs
@@ -22,7 +22,7 @@ internal static class PdfProcessingPipelineServiceCoverTestFactory
         MeepleAiDbContext db,
         IBlobStorageService blob,
         IPdfCoverExtractor coverExtractor,
-        IPdfCoverUploadPipeline coverUploadPipeline,
+        IPdfCoverUploadPipeline? coverUploadPipeline,
         IDomainEventCollector eventCollector)
     {
         return new PdfProcessingPipelineService(

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineServiceCoverTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineServiceCoverTests.cs
@@ -91,4 +91,42 @@ public sealed class PdfProcessingPipelineServiceCoverTests : IDisposable
             .Which.Should().BeOfType<PdfCoverGeneratedEvent>()
             .Which.CoverR2Key.Should().Be(expectedKey);
     }
+
+    /// <summary>
+    /// Issue #3363: in local-storage mode <see cref="IPdfCoverUploadPipeline"/> is unregistered → the
+    /// optional ctor param resolves to null while <see cref="IPdfCoverExtractor"/> stays registered.
+    /// This is the exact production shape the fix protects: the cover step must early-return BEFORE
+    /// touching the extractor (so no wasted render + no NPE on the null pipeline) and leave the PDF's
+    /// cover state untouched, so PDF ingestion completes instead of failing at Upload.
+    /// </summary>
+    [Fact]
+    public async Task ExtractCoverImageAsync_LocalStorageNullUploadPipeline_SkipsWithoutExtracting()
+    {
+        var pdf = new PdfDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            FileName = "rules.pdf",
+            FilePath = "/tmp/rules.pdf",
+            FileSizeBytes = 1,
+            ContentType = "application/pdf",
+            UploadedByUserId = Guid.NewGuid(),
+            UploadedAt = DateTime.UtcNow,
+            ProcessingState = "Extracting",
+            CoverGenerationStatus = "Pending",
+            SharedGameId = Guid.NewGuid(),
+        };
+
+        // Non-null extractor, NULL upload pipeline — the local-storage production combination.
+        var sut = PdfProcessingPipelineServiceCoverTestFactory.Create(
+            _db, _blob.Object, _coverExtractor.Object, coverUploadPipeline: null, _eventCollector.Object);
+
+        var act = () => sut.InvokeExtractCoverImageForTestAsync(pdf, "/tmp/rules.pdf", CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+        _coverExtractor.Verify(e => e.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Never,
+            "with the upload pipeline null the cover step must short-circuit before rendering");
+        pdf.CoverGenerationStatus.Should().Be("Pending", "cover state is left untouched when skipped");
+        pdf.CoverR2Key.Should().BeNull();
+        _collected.Should().BeEmpty();
+    }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/DI/PdfCoverUploadPipelineRegistrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/DI/PdfCoverUploadPipelineRegistrationTests.cs
@@ -1,0 +1,88 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.DependencyInjection;
+using Api.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Infrastructure.DI;
+
+/// <summary>
+/// Issue #3363 regression: the R2 <see cref="IPdfCoverUploadPipeline"/> factory hard-throws
+/// "S3_ENDPOINT is required" at DI resolution. Because <c>PdfProcessingPipelineService</c> resolves
+/// it during every PDF upload, the previous UNCONDITIONAL registration failed every upload in any
+/// local-storage environment (the CI seed-snapshot bake + <c>make dev</c> locally). It must be
+/// registered ONLY when <c>STORAGE_PROVIDER=s3</c> (mirroring <c>BlobStorageServiceFactory</c>); in
+/// local mode it stays unregistered so the optional injection resolves to null and the best-effort
+/// cover step is skipped.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "3363")]
+public sealed class PdfCoverUploadPipelineRegistrationTests
+{
+    private static ServiceProvider BuildProvider(IReadOnlyDictionary<string, string> overrides)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddHttpClient();
+
+        var settings = new Dictionary<string, string>
+        {
+            ["PdfProcessing:Extractor:Unstructured:ApiUrl"] = "http://test:8001",
+            ["PdfProcessing:Extractor:SmolDocling:ApiUrl"] = "http://test:8002",
+            ["PdfProcessing:MaxFileSizeBytes"] = "104857600",
+            ["PdfProcessing:Quality:MinimumThreshold"] = "0.80",
+            ["PdfProcessing:Quality:MinCharsPerPage"] = "500",
+        };
+        foreach (var kv in overrides)
+        {
+            settings[kv.Key] = kv.Value;
+        }
+
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(settings!).Build();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddScoped<ITextChunkingService, TextChunkingService>();
+
+        services.AddDocumentProcessingContext(configuration);
+        return services.BuildServiceProvider();
+    }
+
+    [Theory]
+    [InlineData("local")]
+    [InlineData("")] // unset → the ?? "local" default path
+    public void LocalStorage_DoesNotRegisterCoverUploadPipeline(string storageProvider)
+    {
+        var overrides = new Dictionary<string, string>();
+        if (!string.IsNullOrEmpty(storageProvider))
+        {
+            overrides["STORAGE_PROVIDER"] = storageProvider;
+        }
+
+        using var provider = BuildProvider(overrides);
+
+        provider.GetService<IPdfCoverUploadPipeline>().Should().BeNull(
+            "in local-storage mode the R2 cover pipeline must stay unregistered so PDF ingestion skips " +
+            "the cover instead of throwing 'S3_ENDPOINT is required' at resolution");
+    }
+
+    [Fact]
+    public void S3Storage_RegistersCoverUploadPipeline()
+    {
+        using var provider = BuildProvider(new Dictionary<string, string>
+        {
+            ["STORAGE_PROVIDER"] = "s3",
+            ["S3_ENDPOINT"] = "https://r2.example.com",
+            ["S3_ACCESS_KEY"] = "ak",
+            ["S3_SECRET_KEY"] = "sk",
+            ["S3_BUCKET_NAME"] = "covers",
+        });
+
+        // GetService resolves the singleton factory (constructs the AmazonS3Client — no network I/O),
+        // so this also proves the S3-mode factory does not throw with valid S3_* config.
+        provider.GetService<IPdfCoverUploadPipeline>().Should().NotBeNull(
+            "STORAGE_PROVIDER=s3 with S3_* config must register the R2 cover pipeline");
+    }
+}

--- a/apps/web/src/components/session/SessionCreationWizard.tsx
+++ b/apps/web/src/components/session/SessionCreationWizard.tsx
@@ -195,7 +195,12 @@ function ConfigureScoringStep({
           className="w-24"
           onKeyDown={e => e.key === 'Enter' && addDimension()}
         />
-        <Button variant="outline" size="icon" onClick={addDimension}>
+        <Button
+          variant="outline"
+          size="icon"
+          aria-label="Aggiungi dimensione"
+          onClick={addDimension}
+        >
           <Plus className="h-4 w-4" />
         </Button>
       </div>

--- a/apps/web/src/components/session/SessionHeader.tsx
+++ b/apps/web/src/components/session/SessionHeader.tsx
@@ -71,7 +71,7 @@ export function SessionHeader({ session, onPause, onFinalize, onShare }: Session
                     month: 'short',
                     day: 'numeric',
                     hour: '2-digit',
-                    minute: '2-digit'
+                    minute: '2-digit',
                   })}
                 </time>
                 <span className="flex items-center gap-1">
@@ -111,6 +111,7 @@ export function SessionHeader({ session, onPause, onFinalize, onShare }: Session
                 <Button
                   variant="outline"
                   size="icon"
+                  aria-label="Session actions"
                   className="h-9 w-9 border-amber-900/20 bg-card/80 dark:bg-card hover:bg-card hover:border-amber-600/40 active:scale-95 transition-all"
                 >
                   <MoreVertical className="h-4 w-4 text-muted-foreground" />
@@ -139,7 +140,10 @@ export function SessionHeader({ session, onPause, onFinalize, onShare }: Session
                   </DropdownMenuItem>
                 )}
                 {session.status === 'Active' && onFinalize && (
-                  <DropdownMenuItem onClick={onFinalize} className="gap-2 text-amber-700 dark:text-amber-400">
+                  <DropdownMenuItem
+                    onClick={onFinalize}
+                    className="gap-2 text-amber-700 dark:text-amber-400"
+                  >
                     <Flag className="h-4 w-4" />
                     Finalize Session
                   </DropdownMenuItem>

--- a/apps/web/src/components/session/__tests__/SessionCreationWizard.test.tsx
+++ b/apps/web/src/components/session/__tests__/SessionCreationWizard.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * SessionCreationWizard accessibility tests.
+ * The icon-only "add dimension" button in the scoring step must have an accessible
+ * name (axe button-name / WCAG 4.1.2).
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { SessionCreationWizard } from '../SessionCreationWizard';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), back: vi.fn() }),
+}));
+
+vi.mock('@/lib/api', () => ({ api: { liveSessions: {} } }));
+
+// GamePicker fetches the library catalogue; replace it with a button that selects a game
+// so the wizard can advance from the game step to the scoring step.
+vi.mock('@/components/features/game-picker', () => ({
+  GamePicker: ({
+    onChange,
+  }: {
+    onChange: (game: { id: string; title: string; manual: boolean }) => void;
+  }) => (
+    <button type="button" onClick={() => onChange({ id: 'g1', title: 'Test Game', manual: true })}>
+      mock-select-game
+    </button>
+  ),
+}));
+
+describe('SessionCreationWizard', () => {
+  function advanceToScoringStep() {
+    render(<SessionCreationWizard />);
+    // Step 1 (game) → pick a game so "Avanti" enables → Step 2 (scoring).
+    fireEvent.click(screen.getByText('mock-select-game'));
+    fireEvent.click(screen.getByText('Avanti'));
+  }
+
+  it('exposes an accessible name on the add-dimension icon button', () => {
+    advanceToScoringStep();
+    expect(screen.getByRole('button', { name: /aggiungi dimensione/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/session/__tests__/SessionHeader.test.tsx
+++ b/apps/web/src/components/session/__tests__/SessionHeader.test.tsx
@@ -94,4 +94,10 @@ describe('SessionHeader', () => {
     render(<SessionHeader session={finalizedSession} />);
     expect(screen.getByText('Finalized')).toBeInTheDocument();
   });
+
+  it('should expose an accessible name on the actions menu trigger', () => {
+    // The icon-only DropdownMenuTrigger must have an accessible name (axe button-name / WCAG 4.1.2).
+    render(<SessionHeader session={mockSession} />);
+    expect(screen.getByRole('button', { name: /session actions/i })).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/hooks/__tests__/usePdfStatus.test.ts
+++ b/apps/web/src/hooks/__tests__/usePdfStatus.test.ts
@@ -634,4 +634,90 @@ describe('usePdfStatus', () => {
       expect(result.current.connectionMetrics.fallbackTriggers).toBe(1);
     });
   });
+
+  // ==========================================================================
+  // documentId change without remount — ref hygiene
+  // ==========================================================================
+
+  describe('documentId change (ref hygiene)', () => {
+    it('resets reconnect attempts when documentId changes so the new doc can reconnect', async () => {
+      mockGetProgress.mockResolvedValue({
+        currentStep: 'Uploading',
+        percentComplete: 0,
+        estimatedTimeRemaining: '5m',
+        errorMessage: null,
+      });
+
+      const { result, rerender } = renderHook(
+        ({ id }) => usePdfStatus(id, { enableSSE: true, maxReconnectAttempts: 2 }),
+        { initialProps: { id: 'doc-A' } }
+      );
+
+      // Exhaust doc-A's reconnect budget up to the max (2 errors + their backoffs),
+      // WITHOUT firing the terminal 3rd error that would drop to polling.
+      await act(async () => {
+        getLatestES().simulateError(); // attempt 1
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000);
+      });
+      await act(async () => {
+        getLatestES().simulateError(); // attempt 2 (== max)
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(4000);
+      });
+
+      // Switch documents without unmounting.
+      await act(async () => {
+        rerender({ id: 'doc-B' });
+      });
+
+      // The first transient error on doc-B must retry (reconnecting), NOT drop straight to
+      // polling — which it would if reconnectAttemptsRef still held doc-A's exhausted count.
+      await act(async () => {
+        getLatestES().simulateError();
+      });
+
+      expect(result.current.connectionState).toBe('reconnecting');
+      expect(result.current.isPolling).toBe(false);
+    });
+
+    it('re-emits the same PDF state for a new documentId (previousState is reset)', async () => {
+      const onStateChange = vi.fn();
+
+      const { rerender } = renderHook(
+        ({ id }) => usePdfStatus(id, { enableSSE: true, onStateChange }),
+        { initialProps: { id: 'doc-A' } }
+      );
+
+      await act(async () => {
+        getLatestES().simulateOpen();
+      });
+      await act(async () => {
+        getLatestES().simulateMessage(
+          JSON.stringify({ state: 'extracting', progress: 10, timestamp: '2026-01-01T00:00:00Z' })
+        );
+      });
+      expect(onStateChange).toHaveBeenCalledWith('extracting');
+      onStateChange.mockClear();
+
+      // New document whose first emitted state equals doc-A's last state.
+      await act(async () => {
+        rerender({ id: 'doc-B' });
+      });
+      await act(async () => {
+        getLatestES().simulateOpen();
+      });
+      await act(async () => {
+        getLatestES().simulateMessage(
+          JSON.stringify({ state: 'extracting', progress: 20, timestamp: '2026-01-01T00:01:00Z' })
+        );
+      });
+
+      // Without the reset, previousStateRef would still hold 'extracting' from doc-A and
+      // suppress the callback for doc-B.
+      expect(onStateChange).toHaveBeenCalledWith('extracting');
+    });
+  });
 });

--- a/apps/web/src/hooks/usePdfStatus.ts
+++ b/apps/web/src/hooks/usePdfStatus.ts
@@ -405,6 +405,14 @@ export function usePdfStatus(
 
     if (!documentId) return;
 
+    // Reset per-document connection state when documentId changes without a remount.
+    // Otherwise the new document inherits the previous one's reconnect count (dropping the
+    // first transient error straight to polling) and its last emitted state (suppressing the
+    // new document's first onStateChange). The in-stream reconnect path calls startSSE via
+    // setTimeout without re-running this effect, so backoff counting is preserved.
+    reconnectAttemptsRef.current = 0;
+    previousStateRef.current = null;
+
     // Check network type - auto-fallback to polling for slow-2g
     const usePolling = !enableSSE || shouldUsePollingForNetwork();
 

--- a/apps/web/src/lib/api/schemas/mechanic-analyses.schemas.ts
+++ b/apps/web/src/lib/api/schemas/mechanic-analyses.schemas.ts
@@ -69,6 +69,10 @@ export const MechanicSection = {
   Resources: 3,
   Phases: 4,
   Faq: 5,
+  // v1.1.0 (#2930): Setup / Components / EndgameScoring appended to the C# enum.
+  Setup: 6,
+  Components: 7,
+  EndgameScoring: 8,
 } as const;
 export type MechanicSectionValue = (typeof MechanicSection)[keyof typeof MechanicSection];
 
@@ -147,6 +151,10 @@ const MECHANIC_SECTION_NAME_TO_NUM: Record<string, MechanicSectionValue> = {
   FAQ: MechanicSection.Faq,
   // Some older C# emit aliases used "Questions" — keep tolerant.
   Questions: MechanicSection.Faq,
+  // v1.1.0 (#2930): Setup / Components / EndgameScoring.
+  Setup: MechanicSection.Setup,
+  Components: MechanicSection.Components,
+  EndgameScoring: MechanicSection.EndgameScoring,
 };
 
 export const MechanicSectionSchema = z.preprocess(v => {

--- a/infra/scripts/seed-index-wait.sh
+++ b/infra/scripts/seed-index-wait.sh
@@ -52,11 +52,14 @@ log "termine: $completed/$total OK, $fail_count falliti (${fail_pct}%)"
 
 if [ "$fail_pct" -gt "$FAILURE_THRESHOLD_PCT" ] && [ "$ALLOW_PARTIAL" != "true" ]; then
     log "fail rate ${fail_pct}% > soglia ${FAILURE_THRESHOLD_PCT}%"
+    # NB: pdf_documents.Id/FileName + processing_jobs.Id are PascalCase (EF default, must be quoted);
+    # pdf_document_id/status/error_message/current_step are snake_case. The error text lives on
+    # processing_jobs.error_message — processing_steps has NO error_message column, so the old
+    # 4-column query failed with "column p.id does not exist" and silently swallowed the real cause.
     docker exec meepleai-postgres psql -U "$PG_USER" -d "$PG_DB" -c \
-      "SELECT j.id, p.file_name, s.error_message
+      "SELECT j.\"Id\", p.\"FileName\", j.current_step, j.error_message
        FROM processing_jobs j
-       JOIN pdf_documents p ON p.id = j.pdf_document_id
-       LEFT JOIN processing_steps s ON s.processing_job_id = j.id AND s.status='Failed'
+       JOIN pdf_documents p ON p.\"Id\" = j.pdf_document_id
        WHERE j.status IN ('Failed','DeadLettered')
        LIMIT 50;" >&2 || true
     fail "aborting — usa SEED_INDEX_ALLOW_PARTIAL=true per procedere comunque"


### PR DESCRIPTION
Promote `main-dev` to `main-staging`.

Commits included:
- fix(mechanic-extractor): align MechanicSection enum FE to v1.1.0 (6/7/8) (#3365)
- fix(docprocessing): unblock seed-index bake — gate PDF cover pipeline on STORAGE_PROVIDER (#3364)
- fix(pdf): reset SSE reconnect/state refs on documentId change (#3362)
- fix(a11y): add accessible names to icon-only session buttons (WCAG 4.1.2) (#3361)

🤖 Generated with [Claude Code](https://claude.com/claude-code)