### PR TITLE
fix(shared-game-catalog): type not-found exceptions across Application handlers (#3372)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ActivateGameStateTemplateCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ActivateGameStateTemplateCommandHandler.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Services;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 
@@ -46,7 +47,7 @@ internal sealed class ActivateGameStateTemplateCommandHandler
 
         if (template is null)
         {
-            throw new InvalidOperationException($"Game state template with ID {command.TemplateId} not found");
+            throw new NotFoundException("GameStateTemplate", command.TemplateId.ToString());
         }
 
         // Use domain service to ensure only one active version per game

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddDocumentToSharedGameCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddDocumentToSharedGameCommandHandler.cs
@@ -3,6 +3,7 @@ using Api.BoundedContexts.SharedGameCatalog.Domain.Events;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Services;
 using Api.Infrastructure;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
@@ -53,7 +54,7 @@ internal sealed class AddDocumentToSharedGameCommandHandler : ICommandHandler<Ad
         var game = await _gameRepository.GetByIdAsync(command.SharedGameId, cancellationToken).ConfigureAwait(false);
         if (game is null)
         {
-            throw new InvalidOperationException($"Shared game with ID {command.SharedGameId} not found");
+            throw new NotFoundException("SharedGame", command.SharedGameId.ToString());
         }
 
         // Verify PDF document exists
@@ -63,7 +64,7 @@ internal sealed class AddDocumentToSharedGameCommandHandler : ICommandHandler<Ad
 
         if (!pdfExists)
         {
-            throw new InvalidOperationException($"PDF document with ID {command.PdfDocumentId} not found");
+            throw new NotFoundException("PdfDocument", command.PdfDocumentId.ToString());
         }
 
         // Validate version doesn't already exist

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddGameErrataCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddGameErrataCommandHandler.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 
@@ -36,7 +37,7 @@ internal sealed class AddGameErrataCommandHandler : ICommandHandler<AddGameErrat
         var game = await _repository.GetByIdAsync(command.SharedGameId, cancellationToken).ConfigureAwait(false);
         if (game is null)
         {
-            throw new InvalidOperationException($"Shared game with ID {command.SharedGameId} not found");
+            throw new NotFoundException("SharedGame", command.SharedGameId.ToString());
         }
 
         // Create the erratum

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddGameFaqCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddGameFaqCommandHandler.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 
@@ -36,7 +37,7 @@ internal sealed class AddGameFaqCommandHandler : ICommandHandler<AddGameFaqComma
         var game = await _repository.GetByIdAsync(command.SharedGameId, cancellationToken).ConfigureAwait(false);
         if (game is null)
         {
-            throw new InvalidOperationException($"Shared game with ID {command.SharedGameId} not found");
+            throw new NotFoundException("SharedGame", command.SharedGameId.ToString());
         }
 
         // Create the FAQ

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddManualQuickQuestionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddManualQuickQuestionCommandHandler.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 
@@ -33,7 +34,7 @@ internal sealed class AddManualQuickQuestionCommandHandler : ICommandHandler<Add
         // Fetch aggregate
         var game = await _gameRepository.GetByIdAsync(command.SharedGameId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new InvalidOperationException($"Shared game with ID {command.SharedGameId} not found");
+            ?? throw new NotFoundException("SharedGame", command.SharedGameId.ToString());
 
         // Create domain entity
         var question = QuickQuestion.CreateManual(

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AnalyzeRulebookCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AnalyzeRulebookCommandHandler.cs
@@ -76,7 +76,7 @@ internal sealed class AnalyzeRulebookCommandHandler
 
         if (game is null)
         {
-            throw new InvalidOperationException($"Shared game with ID {command.SharedGameId} not found");
+            throw new NotFoundException("SharedGame", command.SharedGameId.ToString());
         }
 
         // Issue #5443: Gate - only analyzable document categories enter the pipeline

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ApproveDeleteRequestCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ApproveDeleteRequestCommandHandler.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
@@ -37,14 +38,14 @@ internal sealed class ApproveDeleteRequestCommandHandler : ICommandHandler<Appro
             command.RequestId, command.ApprovedBy);
 
         var deleteRequest = await _deleteRequestRepository.GetByIdAsync(command.RequestId, cancellationToken).ConfigureAwait(false)
-            ?? throw new InvalidOperationException($"Delete request with ID {command.RequestId} not found");
+            ?? throw new NotFoundException("DeleteRequest", command.RequestId.ToString());
 
         // Call domain method to approve
         deleteRequest.Approve(command.ApprovedBy, command.Comment);
 
         // Fetch the game and delete it
         var game = await _gameRepository.GetByIdAsync(deleteRequest.SharedGameId, cancellationToken).ConfigureAwait(false)
-            ?? throw new InvalidOperationException($"Shared game with ID {deleteRequest.SharedGameId} not found");
+            ?? throw new NotFoundException("SharedGame", deleteRequest.SharedGameId.ToString());
 
         game.Delete(command.ApprovedBy);
 

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ApproveSharedGamePublicationCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ApproveSharedGamePublicationCommandHandler.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
@@ -34,7 +35,7 @@ internal sealed class ApproveSharedGamePublicationCommandHandler : ICommandHandl
             command.GameId, command.ApprovedBy);
 
         var game = await _repository.GetByIdAsync(command.GameId, cancellationToken).ConfigureAwait(false)
-            ?? throw new InvalidOperationException($"Shared game with ID {command.GameId} not found");
+            ?? throw new NotFoundException("SharedGame", command.GameId.ToString());
 
         // Call domain method (validates status and raises event)
         game.ApprovePublication(command.ApprovedBy);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ArchiveSharedGameCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ArchiveSharedGameCommandHandler.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
@@ -33,7 +34,7 @@ internal sealed class ArchiveSharedGameCommandHandler : ICommandHandler<ArchiveS
             command.GameId, command.ArchivedBy);
 
         var game = await _repository.GetByIdAsync(command.GameId, cancellationToken).ConfigureAwait(false)
-            ?? throw new InvalidOperationException($"Shared game with ID {command.GameId} not found");
+            ?? throw new NotFoundException("SharedGame", command.GameId.ToString());
 
         // Call domain method (validates status and raises event)
         game.Archive(command.ArchivedBy);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/CreateShareRequestCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/CreateShareRequestCommandHandler.cs
@@ -3,6 +3,7 @@ using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
 using Api.BoundedContexts.UserLibrary.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 
@@ -55,7 +56,7 @@ internal sealed class CreateShareRequestCommandHandler : ICommandHandler<CreateS
 
         if (libraryEntry == null)
         {
-            throw new InvalidOperationException($"Game {command.SourceGameId} not found in user's library");
+            throw new NotFoundException("Game", command.SourceGameId.ToString());
         }
 
         // 2. Get the shared game to check its BggId and determine contribution type
@@ -65,7 +66,7 @@ internal sealed class CreateShareRequestCommandHandler : ICommandHandler<CreateS
 
         if (sourceSharedGame == null)
         {
-            throw new InvalidOperationException($"SharedGame {command.SourceGameId} not found");
+            throw new NotFoundException("SharedGame", command.SourceGameId.ToString());
         }
 
         // 3. Determine contribution type by checking if a game with same BggId already exists

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/CreateSharedGameFromPdfCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/CreateSharedGameFromPdfCommandHandler.cs
@@ -7,6 +7,7 @@ using Api.Infrastructure;
 using Api.Infrastructure.Entities.SharedGameCatalog;
 using Api.Models;
 using Api.Services;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
@@ -59,7 +60,7 @@ internal sealed class CreateSharedGameFromPdfCommandHandler : ICommandHandler<Cr
         var pdfDocument = await _pdfRepository.GetByIdAsync(command.PdfDocumentId, cancellationToken).ConfigureAwait(false);
         if (pdfDocument is null)
         {
-            throw new InvalidOperationException($"PDF document with ID {command.PdfDocumentId} not found");
+            throw new NotFoundException("PdfDocument", command.PdfDocumentId.ToString());
         }
 
         // Validate quality threshold (≥0.50 required)

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/DeleteGameErrataCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/DeleteGameErrataCommandHandler.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
@@ -38,7 +39,7 @@ internal sealed class DeleteGameErrataCommandHandler : ICommandHandler<DeleteGam
         var game = await _repository.GetGameByErrataIdAsync(command.ErrataId, cancellationToken).ConfigureAwait(false);
         if (game is null)
         {
-            throw new InvalidOperationException($"Erratum with ID {command.ErrataId} not found");
+            throw new NotFoundException("Erratum", command.ErrataId.ToString());
         }
 
         // Remove the erratum from the game via domain method

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/DeleteGameFaqCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/DeleteGameFaqCommandHandler.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
@@ -31,7 +32,7 @@ internal sealed class DeleteGameFaqCommandHandler : ICommandHandler<DeleteGameFa
         _logger.LogInformation("Deleting FAQ: {FaqId}", command.FaqId);
 
         var game = await _repository.GetGameByFaqIdAsync(command.FaqId, cancellationToken).ConfigureAwait(false)
-            ?? throw new InvalidOperationException($"Game containing FAQ with ID {command.FaqId} not found");
+            ?? throw new NotFoundException("Faq", command.FaqId.ToString());
 
         game.RemoveFaq(command.FaqId);
 

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/DeleteQuickQuestionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/DeleteQuickQuestionCommandHandler.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.Infrastructure;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
@@ -40,12 +41,12 @@ internal sealed class DeleteQuickQuestionCommandHandler : ICommandHandler<Delete
             .AsNoTracking()
             .FirstOrDefaultAsync(q => q.Id == command.QuestionId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new InvalidOperationException($"Quick question with ID {command.QuestionId} not found");
+            ?? throw new NotFoundException("QuickQuestion", command.QuestionId.ToString());
 
         // Fetch aggregate to maintain domain invariants
         var game = await _gameRepository.GetByIdAsync(questionEntity.SharedGameId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new InvalidOperationException($"Shared game with ID {questionEntity.SharedGameId} not found");
+            ?? throw new NotFoundException("SharedGame", questionEntity.SharedGameId.ToString());
 
         // Remove via aggregate method
         game.RemoveQuickQuestion(command.QuestionId);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/DeleteSharedGameCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/DeleteSharedGameCommandHandler.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
@@ -33,7 +34,7 @@ internal sealed class DeleteSharedGameCommandHandler : ICommandHandler<DeleteSha
             command.GameId, command.DeletedBy);
 
         var game = await _repository.GetByIdAsync(command.GameId, cancellationToken).ConfigureAwait(false)
-            ?? throw new InvalidOperationException($"Shared game with ID {command.GameId} not found");
+            ?? throw new NotFoundException("SharedGame", command.GameId.ToString());
 
         // Call domain method (marks as deleted and raises event)
         game.Delete(command.DeletedBy);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/GenerateGameStateTemplateCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/GenerateGameStateTemplateCommandHandler.cs
@@ -5,6 +5,7 @@ using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Services;
 using Api.Infrastructure;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
@@ -63,7 +64,7 @@ internal sealed class GenerateGameStateTemplateCommandHandler
 
         if (game is null)
         {
-            throw new InvalidOperationException($"Shared game with ID {command.SharedGameId} not found");
+            throw new NotFoundException("SharedGame", command.SharedGameId.ToString());
         }
 
         // Get the active rulebook document for the game

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/GenerateQuickQuestionsCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/GenerateQuickQuestionsCommandHandler.cs
@@ -4,6 +4,7 @@ using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.Infrastructure;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
@@ -56,7 +57,7 @@ internal sealed class GenerateQuickQuestionsCommandHandler
 
         if (game is null)
         {
-            throw new InvalidOperationException($"Shared game with ID {command.SharedGameId} not found");
+            throw new NotFoundException("SharedGame", command.SharedGameId.ToString());
         }
 
         // 2. Get the active rulebook document

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ImportGameFromBggCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ImportGameFromBggCommandHandler.cs
@@ -59,7 +59,7 @@ internal sealed class ImportGameFromBggCommandHandler : ICommandHandler<ImportGa
         var bggDetails = await _bggApiService.GetGameDetailsAsync(command.BggId, cancellationToken).ConfigureAwait(false);
         if (bggDetails is null)
         {
-            throw new InvalidOperationException($"Game with BGG ID {command.BggId} not found on BoardGameGeek");
+            throw new NotFoundException("Game", command.BggId.ToString(System.Globalization.CultureInfo.InvariantCulture));
         }
 
         _logger.LogInformation(

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RejectDeleteRequestCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RejectDeleteRequestCommandHandler.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
@@ -34,7 +35,7 @@ internal sealed class RejectDeleteRequestCommandHandler : ICommandHandler<Reject
             command.RequestId, command.RejectedBy);
 
         var deleteRequest = await _deleteRequestRepository.GetByIdAsync(command.RequestId, cancellationToken).ConfigureAwait(false)
-            ?? throw new InvalidOperationException($"Delete request with ID {command.RequestId} not found");
+            ?? throw new NotFoundException("DeleteRequest", command.RequestId.ToString());
 
         // Call domain method to reject
         deleteRequest.Reject(command.RejectedBy, command.Reason);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RejectSharedGamePublicationCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RejectSharedGamePublicationCommandHandler.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
@@ -34,7 +35,7 @@ internal sealed class RejectSharedGamePublicationCommandHandler : ICommandHandle
             command.GameId, command.RejectedBy, command.Reason);
 
         var game = await _repository.GetByIdAsync(command.GameId, cancellationToken).ConfigureAwait(false)
-            ?? throw new InvalidOperationException($"Shared game with ID {command.GameId} not found");
+            ?? throw new NotFoundException("SharedGame", command.GameId.ToString());
 
         // Call domain method (validates status and raises event)
         game.RejectPublication(command.RejectedBy, command.Reason);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RemoveDocumentFromSharedGameCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RemoveDocumentFromSharedGameCommandHandler.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.SharedGameCatalog.Domain.Events;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
@@ -40,7 +41,7 @@ internal sealed class RemoveDocumentFromSharedGameCommandHandler : ICommandHandl
         var document = await _repository.GetByIdAsync(command.DocumentId, cancellationToken).ConfigureAwait(false);
         if (document is null)
         {
-            throw new InvalidOperationException($"Document with ID {command.DocumentId} not found");
+            throw new NotFoundException("Document", command.DocumentId.ToString());
         }
 
         // Verify it belongs to the specified game

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RequestDeleteSharedGameCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RequestDeleteSharedGameCommandHandler.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
@@ -39,7 +40,7 @@ internal sealed class RequestDeleteSharedGameCommandHandler : ICommandHandler<Re
 
         // Verify game exists
         _ = await _gameRepository.GetByIdAsync(command.GameId, cancellationToken).ConfigureAwait(false)
-            ?? throw new InvalidOperationException($"Shared game with ID {command.GameId} not found");
+            ?? throw new NotFoundException("SharedGame", command.GameId.ToString());
 
         // Create delete request
         var deleteRequest = SharedGameDeleteRequest.Create(

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetActiveDocumentVersionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetActiveDocumentVersionCommandHandler.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.SharedGameCatalog.Domain.Events;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Services;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
@@ -45,7 +46,7 @@ internal sealed class SetActiveDocumentVersionCommandHandler : ICommandHandler<S
         var document = await _repository.GetByIdAsync(command.DocumentId, cancellationToken).ConfigureAwait(false);
         if (document is null)
         {
-            throw new InvalidOperationException($"Document with ID {command.DocumentId} not found");
+            throw new NotFoundException("Document", command.DocumentId.ToString());
         }
 
         // Verify it belongs to the specified game

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SubmitSharedGameForApprovalCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SubmitSharedGameForApprovalCommandHandler.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
@@ -34,7 +35,7 @@ internal sealed class SubmitSharedGameForApprovalCommandHandler : ICommandHandle
             command.GameId, command.SubmittedBy);
 
         var game = await _repository.GetByIdAsync(command.GameId, cancellationToken).ConfigureAwait(false)
-            ?? throw new InvalidOperationException($"Shared game with ID {command.GameId} not found");
+            ?? throw new NotFoundException("SharedGame", command.GameId.ToString());
 
         // Call domain method (validates status and raises event)
         game.SubmitForApproval(command.SubmittedBy);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateGameErrataCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateGameErrataCommandHandler.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
@@ -38,14 +39,14 @@ internal sealed class UpdateGameErrataCommandHandler : ICommandHandler<UpdateGam
         var game = await _repository.GetGameByErrataIdAsync(command.ErrataId, cancellationToken).ConfigureAwait(false);
         if (game is null)
         {
-            throw new InvalidOperationException($"Erratum with ID {command.ErrataId} not found");
+            throw new NotFoundException("Erratum", command.ErrataId.ToString());
         }
 
         // Find the erratum in the game's collection
         var errata = game.Erratas.FirstOrDefault(e => e.Id == command.ErrataId);
         if (errata is null)
         {
-            throw new InvalidOperationException($"Erratum with ID {command.ErrataId} not found in game");
+            throw new NotFoundException("Erratum", command.ErrataId.ToString());
         }
 
         // Update the erratum properties via domain method

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateGameFaqCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateGameFaqCommandHandler.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
@@ -33,7 +34,7 @@ internal sealed class UpdateGameFaqCommandHandler : ICommandHandler<UpdateGameFa
             command.FaqId, command.Question, command.Order);
 
         var game = await _repository.GetGameByFaqIdAsync(command.FaqId, cancellationToken).ConfigureAwait(false)
-            ?? throw new InvalidOperationException($"Game containing FAQ with ID {command.FaqId} not found");
+            ?? throw new NotFoundException("Faq", command.FaqId.ToString());
 
         game.UpdateFaq(command.FaqId, command.Question, command.Answer, command.Order);
 

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateGameStateTemplateCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateGameStateTemplateCommandHandler.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 
@@ -42,7 +43,7 @@ internal sealed class UpdateGameStateTemplateCommandHandler
 
         if (template is null)
         {
-            throw new InvalidOperationException($"Game state template with ID {command.TemplateId} not found");
+            throw new NotFoundException("GameStateTemplate", command.TemplateId.ToString());
         }
 
         // Update name if provided

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateQuickQuestionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateQuickQuestionCommandHandler.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.Infrastructure;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
@@ -43,16 +44,16 @@ internal sealed class UpdateQuickQuestionCommandHandler
             .AsNoTracking()
             .FirstOrDefaultAsync(q => q.Id == command.QuestionId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new InvalidOperationException($"Quick question with ID {command.QuestionId} not found");
+            ?? throw new NotFoundException("QuickQuestion", command.QuestionId.ToString());
 
         // Fetch aggregate (SharedGame owns QuickQuestion)
         var game = await _gameRepository.GetByIdAsync(questionEntity.SharedGameId, cancellationToken)
             .ConfigureAwait(false)
-            ?? throw new InvalidOperationException($"Shared game with ID {questionEntity.SharedGameId} not found");
+            ?? throw new NotFoundException("SharedGame", questionEntity.SharedGameId.ToString());
 
         // Find domain entity within aggregate
         var question = game.QuickQuestions.FirstOrDefault(q => q.Id == command.QuestionId)
-            ?? throw new InvalidOperationException($"Quick question {command.QuestionId} not found in aggregate");
+            ?? throw new NotFoundException("QuickQuestion", command.QuestionId.ToString());
 
         // Update via domain methods (preserves encapsulation)
         question.UpdateText(command.Text);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateShareRequestDocumentsCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateShareRequestDocumentsCommandHandler.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 
@@ -45,7 +46,7 @@ internal sealed class UpdateShareRequestDocumentsCommandHandler : ICommandHandle
 
         if (shareRequest == null)
         {
-            throw new InvalidOperationException($"Share request {command.ShareRequestId} not found");
+            throw new NotFoundException("ShareRequest", command.ShareRequestId.ToString());
         }
 
         // 2. Verify user owns the request
@@ -86,7 +87,7 @@ internal sealed class UpdateShareRequestDocumentsCommandHandler : ICommandHandle
                 var document = documents.FirstOrDefault(d => d.Id == docId);
                 if (document == null)
                 {
-                    throw new InvalidOperationException($"Document {docId} not found");
+                    throw new NotFoundException("Document", docId.ToString());
                 }
 
                 if (document.UploadedByUserId != command.UserId)

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpvoteFaqCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpvoteFaqCommandHandler.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 
@@ -31,7 +32,7 @@ internal sealed class UpvoteFaqCommandHandler : ICommandHandler<UpvoteFaqCommand
         _logger.LogInformation("Upvoting FAQ: {FaqId}", command.FaqId);
 
         var game = await _repository.GetGameByFaqIdAsync(command.FaqId, cancellationToken).ConfigureAwait(false)
-            ?? throw new InvalidOperationException($"FAQ with ID {command.FaqId} not found");
+            ?? throw new NotFoundException("Faq", command.FaqId.ToString());
 
         var newUpvoteCount = game.UpvoteFaq(command.FaqId);
 

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/WithdrawShareRequestCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/WithdrawShareRequestCommandHandler.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 
@@ -41,7 +42,7 @@ internal sealed class WithdrawShareRequestCommandHandler : ICommandHandler<Withd
 
         if (shareRequest == null)
         {
-            throw new InvalidOperationException($"Share request {command.ShareRequestId} not found");
+            throw new NotFoundException("ShareRequest", command.ShareRequestId.ToString());
         }
 
         // 2. Verify user owns the request

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/AddDocumentToSharedGameCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/AddDocumentToSharedGameCommandHandlerTests.cs
@@ -6,6 +6,7 @@ using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Services;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Services;
 using Api.SharedKernel.Domain.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
@@ -144,7 +145,7 @@ public class AddDocumentToSharedGameCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithNonExistentGame_ThrowsException()
+    public async Task Handle_WithNonExistentGame_ThrowsNotFoundException()
     {
         // Arrange
         var command = new AddDocumentToSharedGameCommand(
@@ -162,7 +163,7 @@ public class AddDocumentToSharedGameCommandHandlerTests
 
         // Act & Assert
         var act = () => _handler.Handle(command, TestContext.Current.CancellationToken);
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        await act.Should().ThrowAsync<NotFoundException>();
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/AddGameErrataCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/AddGameErrataCommandHandlerTests.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.Constants;
 using FluentAssertions;
@@ -72,7 +73,7 @@ public class AddGameErrataCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithNonExistentGame_ThrowsInvalidOperationException()
+    public async Task Handle_WithNonExistentGame_ThrowsNotFoundException()
     {
         // Arrange
         var gameId = Guid.NewGuid();
@@ -89,7 +90,7 @@ public class AddGameErrataCommandHandlerTests
         // Act & Assert
         var act = () =>
             _handler.Handle(command, TestContext.Current.CancellationToken);
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        await act.Should().ThrowAsync<NotFoundException>();
 
         _repositoryMock.Verify(r => r.Update(It.IsAny<SharedGame>()), Times.Never);
         _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/AddGameFaqCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/AddGameFaqCommandHandlerTests.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.Constants;
 using FluentAssertions;
@@ -71,7 +72,7 @@ public class AddGameFaqCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithNonExistentGame_ThrowsInvalidOperationException()
+    public async Task Handle_WithNonExistentGame_ThrowsNotFoundException()
     {
         // Arrange
         var gameId = Guid.NewGuid();
@@ -88,7 +89,7 @@ public class AddGameFaqCommandHandlerTests
         // Act & Assert
         var act = () =>
             _handler.Handle(command, TestContext.Current.CancellationToken);
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        await act.Should().ThrowAsync<NotFoundException>();
 
         _repositoryMock.Verify(r => r.Update(It.IsAny<SharedGame>()), Times.Never);
         _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/AnalyzeRulebookCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/AnalyzeRulebookCommandHandlerTests.cs
@@ -133,7 +133,7 @@ public class AnalyzeRulebookCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithNonExistentGame_ThrowsInvalidOperationException()
+    public async Task Handle_WithNonExistentGame_ThrowsNotFoundException()
     {
         // Arrange
         var gameId = Guid.NewGuid();
@@ -148,7 +148,7 @@ public class AnalyzeRulebookCommandHandlerTests
         // Act & Assert
         var act = () =>
             _handler.Handle(command, TestContext.Current.CancellationToken);
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        await act.Should().ThrowAsync<NotFoundException>();
 
         _analysisRepositoryMock.Verify(
             r => r.AddAsync(It.IsAny<RulebookAnalysis>(), It.IsAny<CancellationToken>()),

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/ApproveDeleteRequestCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/ApproveDeleteRequestCommandHandlerTests.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.Constants;
 using FluentAssertions;
@@ -87,7 +88,7 @@ public class ApproveDeleteRequestCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithNonExistentRequest_ThrowsInvalidOperationException()
+    public async Task Handle_WithNonExistentRequest_ThrowsNotFoundException()
     {
         // Arrange
         var requestId = Guid.NewGuid();
@@ -103,7 +104,7 @@ public class ApproveDeleteRequestCommandHandlerTests
         // Act & Assert
         var act = () =>
             _handler.Handle(command, TestContext.Current.CancellationToken);
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        await act.Should().ThrowAsync<NotFoundException>();
 
         _deleteRequestRepositoryMock.Verify(r => r.Update(It.IsAny<SharedGameDeleteRequest>()), Times.Never);
         _gameRepositoryMock.Verify(r => r.Update(It.IsAny<SharedGame>()), Times.Never);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/ApproveSharedGamePublicationCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/ApproveSharedGamePublicationCommandHandlerTests.cs
@@ -4,6 +4,7 @@ using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Events;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.Constants;
 using Microsoft.Extensions.Logging;
@@ -96,7 +97,7 @@ public class ApproveSharedGamePublicationCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithNonExistentGame_ThrowsInvalidOperationException()
+    public async Task Handle_WithNonExistentGame_ThrowsNotFoundException()
     {
         // Arrange
         var command = new ApproveSharedGamePublicationCommand(Guid.NewGuid(), Guid.NewGuid());
@@ -107,7 +108,7 @@ public class ApproveSharedGamePublicationCommandHandlerTests
 
         // Act & Assert
         var act = () => _handler.Handle(command, TestContext.Current.CancellationToken);
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        await act.Should().ThrowAsync<NotFoundException>();
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/ArchiveSharedGameCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/ArchiveSharedGameCommandHandlerTests.cs
@@ -4,6 +4,7 @@ using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Events;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.Constants;
 using Microsoft.Extensions.Logging;
@@ -94,7 +95,7 @@ public class ArchiveSharedGameCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithNonExistentGame_ThrowsInvalidOperationException()
+    public async Task Handle_WithNonExistentGame_ThrowsNotFoundException()
     {
         // Arrange
         var command = new ArchiveSharedGameCommand(Guid.NewGuid(), Guid.NewGuid());
@@ -105,7 +106,7 @@ public class ArchiveSharedGameCommandHandlerTests
 
         // Act & Assert
         var act = () => _handler.Handle(command, TestContext.Current.CancellationToken);
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        await act.Should().ThrowAsync<NotFoundException>();
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/CreateShareRequestCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/CreateShareRequestCommandHandlerTests.cs
@@ -8,6 +8,7 @@ using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
 using Api.BoundedContexts.UserLibrary.Domain.Entities;
 using Api.BoundedContexts.UserLibrary.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.Constants;
 using Microsoft.Extensions.Logging;
@@ -169,7 +170,7 @@ public class CreateShareRequestCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithNullLibraryEntry_ThrowsInvalidOperationException()
+    public async Task Handle_WithNullLibraryEntry_ThrowsNotFoundException()
     {
         // Arrange
         var command = new CreateShareRequestCommand(
@@ -182,7 +183,7 @@ public class CreateShareRequestCommandHandlerTests
 
         // Act & Assert
         var act = () => _handler.Handle(command, TestContext.Current.CancellationToken);
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        await act.Should().ThrowAsync<NotFoundException>();
 
         _shareRequestRepositoryMock.Verify(
             r => r.AddAsync(It.IsAny<ShareRequest>(), It.IsAny<CancellationToken>()),
@@ -190,7 +191,7 @@ public class CreateShareRequestCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithNullSharedGame_ThrowsInvalidOperationException()
+    public async Task Handle_WithNullSharedGame_ThrowsNotFoundException()
     {
         // Arrange
         var command = new CreateShareRequestCommand(
@@ -209,7 +210,7 @@ public class CreateShareRequestCommandHandlerTests
 
         // Act & Assert
         var act = () => _handler.Handle(command, TestContext.Current.CancellationToken);
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        await act.Should().ThrowAsync<NotFoundException>();
 
         _shareRequestRepositoryMock.Verify(
             r => r.AddAsync(It.IsAny<ShareRequest>(), It.IsAny<CancellationToken>()),

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/CreateSharedGameFromPdfCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/CreateSharedGameFromPdfCommandHandlerTests.cs
@@ -9,6 +9,7 @@ using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Middleware.Exceptions;
 using Api.Models;
 using Api.Services;
 using Api.SharedKernel.Application.Services;
@@ -381,7 +382,7 @@ public sealed class CreateSharedGameFromPdfCommandHandlerTests : IDisposable
     #region Error Scenarios
 
     [Fact]
-    public async Task Handle_WithPdfNotFound_ThrowsInvalidOperationException()
+    public async Task Handle_WithPdfNotFound_ThrowsNotFoundException()
     {
         // Arrange
         var pdfId = Guid.NewGuid();
@@ -393,7 +394,7 @@ public sealed class CreateSharedGameFromPdfCommandHandlerTests : IDisposable
 
         // Act & Assert
         var act = () => _handler.Handle(command, CancellationToken.None);
-        await act.Should().ThrowAsync<InvalidOperationException>()
+        await act.Should().ThrowAsync<NotFoundException>()
             .WithMessage($"*{pdfId}*");
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/DeleteGameErrataCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/DeleteGameErrataCommandHandlerTests.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.Constants;
 using FluentAssertions;
@@ -71,7 +72,7 @@ public class DeleteGameErrataCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithNonExistentErrata_ThrowsInvalidOperationException()
+    public async Task Handle_WithNonExistentErrata_ThrowsNotFoundException()
     {
         // Arrange
         var errataId = Guid.NewGuid();
@@ -84,7 +85,7 @@ public class DeleteGameErrataCommandHandlerTests
         // Act & Assert
         var act = () =>
             _handler.Handle(command, TestContext.Current.CancellationToken);
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        await act.Should().ThrowAsync<NotFoundException>();
 
         _repositoryMock.Verify(r => r.Update(It.IsAny<SharedGame>()), Times.Never);
         _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/DeleteGameFaqCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/DeleteGameFaqCommandHandlerTests.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.Constants;
 using FluentAssertions;
@@ -71,7 +72,7 @@ public class DeleteGameFaqCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithNonExistentFaq_ThrowsInvalidOperationException()
+    public async Task Handle_WithNonExistentFaq_ThrowsNotFoundException()
     {
         // Arrange
         var faqId = Guid.NewGuid();
@@ -84,7 +85,7 @@ public class DeleteGameFaqCommandHandlerTests
         // Act & Assert
         var act = () =>
             _handler.Handle(command, TestContext.Current.CancellationToken);
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        await act.Should().ThrowAsync<NotFoundException>();
 
         _repositoryMock.Verify(r => r.Update(It.IsAny<SharedGame>()), Times.Never);
         _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/DeleteSharedGameCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/DeleteSharedGameCommandHandlerTests.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.Constants;
 using FluentAssertions;
@@ -71,7 +72,7 @@ public class DeleteSharedGameCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithNonExistentGame_ThrowsInvalidOperationException()
+    public async Task Handle_WithNonExistentGame_ThrowsNotFoundException()
     {
         // Arrange
         var gameId = Guid.NewGuid();
@@ -86,7 +87,7 @@ public class DeleteSharedGameCommandHandlerTests
         // Act & Assert
         var act = () =>
             _handler.Handle(command, TestContext.Current.CancellationToken);
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        await act.Should().ThrowAsync<NotFoundException>();
 
         _repositoryMock.Verify(r => r.Update(It.IsAny<SharedGame>()), Times.Never);
         _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/RejectDeleteRequestCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/RejectDeleteRequestCommandHandlerTests.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.Constants;
 using FluentAssertions;
@@ -61,7 +62,7 @@ public class RejectDeleteRequestCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithNonExistentRequest_ThrowsInvalidOperationException()
+    public async Task Handle_WithNonExistentRequest_ThrowsNotFoundException()
     {
         // Arrange
         var requestId = Guid.NewGuid();
@@ -77,7 +78,7 @@ public class RejectDeleteRequestCommandHandlerTests
         // Act & Assert
         var act = () =>
             _handler.Handle(command, TestContext.Current.CancellationToken);
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        await act.Should().ThrowAsync<NotFoundException>();
 
         _deleteRequestRepositoryMock.Verify(r => r.Update(It.IsAny<SharedGameDeleteRequest>()), Times.Never);
         _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/RejectSharedGamePublicationCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/RejectSharedGamePublicationCommandHandlerTests.cs
@@ -4,6 +4,7 @@ using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Events;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.Constants;
 using Microsoft.Extensions.Logging;
@@ -98,7 +99,7 @@ public class RejectSharedGamePublicationCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithNonExistentGame_ThrowsInvalidOperationException()
+    public async Task Handle_WithNonExistentGame_ThrowsNotFoundException()
     {
         // Arrange
         var command = new RejectSharedGamePublicationCommand(Guid.NewGuid(), Guid.NewGuid(), "Reason");
@@ -109,7 +110,7 @@ public class RejectSharedGamePublicationCommandHandlerTests
 
         // Act & Assert
         var act = () => _handler.Handle(command, TestContext.Current.CancellationToken);
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        await act.Should().ThrowAsync<NotFoundException>();
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/RequestDeleteSharedGameCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/RequestDeleteSharedGameCommandHandlerTests.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.Constants;
 using FluentAssertions;
@@ -83,7 +84,7 @@ public class RequestDeleteSharedGameCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithNonExistentGame_ThrowsInvalidOperationException()
+    public async Task Handle_WithNonExistentGame_ThrowsNotFoundException()
     {
         // Arrange
         var gameId = Guid.NewGuid();
@@ -99,7 +100,7 @@ public class RequestDeleteSharedGameCommandHandlerTests
         // Act & Assert
         var act = () =>
             _handler.Handle(command, TestContext.Current.CancellationToken);
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        await act.Should().ThrowAsync<NotFoundException>();
 
         _deleteRequestRepositoryMock.Verify(
             r => r.AddAsync(It.IsAny<SharedGameDeleteRequest>(), It.IsAny<CancellationToken>()),

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/SetActiveDocumentVersionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/SetActiveDocumentVersionCommandHandlerTests.cs
@@ -3,6 +3,7 @@ using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Events;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Services;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.Constants;
 using MediatR;
@@ -94,7 +95,7 @@ public class SetActiveDocumentVersionCommandHandlerTests
 
         // Act & Assert
         var act = () => _handler.Handle(command, TestContext.Current.CancellationToken);
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        await act.Should().ThrowAsync<NotFoundException>();
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/SubmitSharedGameForApprovalCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/SubmitSharedGameForApprovalCommandHandlerTests.cs
@@ -4,6 +4,7 @@ using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Events;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.Constants;
 using Microsoft.Extensions.Logging;
@@ -93,7 +94,7 @@ public class SubmitSharedGameForApprovalCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithNonExistentGame_ThrowsInvalidOperationException()
+    public async Task Handle_WithNonExistentGame_ThrowsNotFoundException()
     {
         // Arrange
         var command = new SubmitSharedGameForApprovalCommand(Guid.NewGuid(), Guid.NewGuid());
@@ -104,7 +105,7 @@ public class SubmitSharedGameForApprovalCommandHandlerTests
 
         // Act & Assert
         var act = () => _handler.Handle(command, TestContext.Current.CancellationToken);
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        await act.Should().ThrowAsync<NotFoundException>();
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/UpdateGameErrataCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/UpdateGameErrataCommandHandlerTests.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.Constants;
 using FluentAssertions;
@@ -76,7 +77,7 @@ public class UpdateGameErrataCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithNonExistentErrata_ThrowsInvalidOperationException()
+    public async Task Handle_WithNonExistentErrata_ThrowsNotFoundException()
     {
         // Arrange
         var errataId = Guid.NewGuid();
@@ -93,7 +94,7 @@ public class UpdateGameErrataCommandHandlerTests
         // Act & Assert
         var act = () =>
             _handler.Handle(command, TestContext.Current.CancellationToken);
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        await act.Should().ThrowAsync<NotFoundException>();
 
         _repositoryMock.Verify(r => r.Update(It.IsAny<SharedGame>()), Times.Never);
         _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/UpdateGameFaqCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/UpdateGameFaqCommandHandlerTests.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.Constants;
 using FluentAssertions;
@@ -75,7 +76,7 @@ public class UpdateGameFaqCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithNonExistentFaq_ThrowsInvalidOperationException()
+    public async Task Handle_WithNonExistentFaq_ThrowsNotFoundException()
     {
         // Arrange
         var faqId = Guid.NewGuid();
@@ -92,7 +93,7 @@ public class UpdateGameFaqCommandHandlerTests
         // Act & Assert
         var act = () =>
             _handler.Handle(command, TestContext.Current.CancellationToken);
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        await act.Should().ThrowAsync<NotFoundException>();
 
         _repositoryMock.Verify(r => r.Update(It.IsAny<SharedGame>()), Times.Never);
         _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/UpdateShareRequestDocumentsCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/UpdateShareRequestDocumentsCommandHandlerTests.cs
@@ -5,6 +5,7 @@ using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.Constants;
 using Microsoft.Extensions.Logging;
@@ -93,7 +94,7 @@ public class UpdateShareRequestDocumentsCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithNonExistentRequest_ThrowsInvalidOperationException()
+    public async Task Handle_WithNonExistentRequest_ThrowsNotFoundException()
     {
         // Arrange
         var command = new UpdateShareRequestDocumentsCommand(
@@ -107,7 +108,7 @@ public class UpdateShareRequestDocumentsCommandHandlerTests
 
         // Act & Assert
         var act = () => _handler.Handle(command, TestContext.Current.CancellationToken);
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        await act.Should().ThrowAsync<NotFoundException>();
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/UpvoteFaqCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/UpvoteFaqCommandHandlerTests.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.Constants;
 using FluentAssertions;
@@ -112,7 +113,7 @@ public class UpvoteFaqCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithNonExistentFaq_ThrowsInvalidOperationException()
+    public async Task Handle_WithNonExistentFaq_ThrowsNotFoundException()
     {
         // Arrange
         var faqId = Guid.NewGuid();
@@ -125,7 +126,7 @@ public class UpvoteFaqCommandHandlerTests
         // Act & Assert
         var act = () =>
             _handler.Handle(command, TestContext.Current.CancellationToken);
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        await act.Should().ThrowAsync<NotFoundException>();
 
         _repositoryMock.Verify(r => r.Update(It.IsAny<SharedGame>()), Times.Never);
         _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/WithdrawShareRequestCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/WithdrawShareRequestCommandHandlerTests.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.Constants;
 using Microsoft.Extensions.Logging;
@@ -73,7 +74,7 @@ public class WithdrawShareRequestCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithNonExistentRequest_ThrowsInvalidOperationException()
+    public async Task Handle_WithNonExistentRequest_ThrowsNotFoundException()
     {
         // Arrange
         var requestId = Guid.NewGuid();
@@ -85,7 +86,7 @@ public class WithdrawShareRequestCommandHandlerTests
 
         // Act & Assert
         var act = () => _handler.Handle(command, TestContext.Current.CancellationToken);
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        await act.Should().ThrowAsync<NotFoundException>();
     }
 
     [Fact]


### PR DESCRIPTION
## Sommario

Sweep sistematico dell'anti-pattern #2568 nel layer **Application** del bounded context `SharedGameCatalog`: i command handler lanciavano `InvalidOperationException` nudo per condizioni **not-found** (carica-per-id → `null` → throw). Questi raggiungevano HTTP 404 **solo per coincidenza** — il middleware fa string-match su `ex.Message.Contains("not found")` (`ApiExceptionHandlerMiddleware.cs:452`); qualsiasi variazione del messaggio sarebbe caduta nel default → **500**.

Closes #3372.

## Cosa cambia

Convertiti **~43 siti not-found in 31 handler** a `NotFoundException(resourceType, id)` (mappata a 404 da un case dedicato del middleware), aggiungendo `using Api.Middleware.Exceptions;` dove mancava. Stesso pattern già presente in `ApproveDocumentForRagProcessingCommandHandler` (#2845).

Include il sito originariamente segnalato (`CreateSharedGameFromPdfCommandHandler`) e tutti i suoi fratelli nel BC.

## Deliberatamente NON toccati (con motivazione)

- **Ownership/permessi**: `"User does not own..."`, `"does not belong to user..."` → non è not-found.
- **Errori tecnici/invarianti**: `"Failed to track SharedGameEntity"`, `"Unknown approval action"`, storage error → 500 corretto.
- **Invarianti di stato del dominio** in `SharedGame.cs` (es. "Cannot submit in {status}", "already archived"): sono eccezioni di **dominio** sollevate dagli aggregate, non dai handler; concern separato (i handler le traducono dove serve). Fuori scope.

Ogni skip è documentato nel report del workflow di conversione.

## Metodo

Verifica esaustiva e conversione orchestrata: un agente dedicato per ciascun handler (file distinti) ha classificato ogni `throw` e convertito solo i not-found + aggiornato il test corrispondente, saltando i genuine-invalid. Classificazione a valle verificata con build + suite di test.

## TDD & Verifica

- **RED→GREEN** verificato sui siti rappresentativi (5 classi di test handler: le asserzioni not-found aggiornate da `InvalidOperationException` a `NotFoundException`, viste fallire prima del fix).
- ~19 ulteriori file di test aggiornati per gli handler dello sweep.
- ✅ **Build pulito** + **1428 test unit del BC SharedGameCatalog Application passati, 0 falliti**.
- Grep di verifica: zero `throw new InvalidOperationException("...not found")` rimasti nel codice `.cs` di `Application/Commands` (solo in un file README di esempi).
- Nessun integration test dipende dal vecchio status/body (l'unico assert rilevante usa un set permissivo `BeOneOf(...NotFound, InternalServerError)`).

## Note

- Comportamento HTTP osservabile **invariato** (404 sia prima — via string-match — sia dopo — tipizzato); il valore è robustezza + rimozione della dipendenza fragile dal testo del messaggio.
- Il ramo string-match nel middleware (`:452`) resta per altri BC non ancora ripuliti; non toccato qui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
