### PR TITLE
fix(catalog): Wikidata retry jitter (#3371) + materialized PDF cover preview size (#3370)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/MaterializePdfCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/MaterializePdfCoverCommandHandler.cs
@@ -69,8 +69,11 @@ internal sealed class MaterializePdfCoverCommandHandler : ICommandHandler<Materi
             throw new CoverMaterializationException("Rendering pagina PDF non disponibile.", ex);
         }
 
+        // The upload pipeline stores this under the {DbKey}-preview.webp physical key that
+        // CoverUrlResolver serves as the L4 preview (600x900). Encode at preview dimensions
+        // so a manually-materialized cover is not a 200x300 thumbnail stretched as a preview.
         var webpBytes = await _webpVariantGenerator
-            .GenerateWebpAsync(jpeg, PdfCoverExtractor.ThumbnailWidth, PdfCoverExtractor.ThumbnailHeight, cancellationToken)
+            .GenerateWebpAsync(jpeg, PdfCoverExtractor.PreviewWidth, PdfCoverExtractor.PreviewHeight, cancellationToken)
             .ConfigureAwait(false);
 
         // Non-null here: the guard at the top of Handle() throws when _uploadPipeline is null.

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRetryPolicy.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRetryPolicy.cs
@@ -78,6 +78,17 @@ internal sealed class WikidataCoverEnrichmentRetryPolicy : IWikidataCoverEnrichm
         TimeSpan.FromMinutes(15),
     };
 
+    /// <summary>
+    /// Upper bound (seconds) of the additive anti-thundering-herd jitter layered on
+    /// top of every scheduled retry. A batch of games that fail simultaneously (a
+    /// transient R2 outage, a tripped breaker) would otherwise be rescheduled to the
+    /// identical instant and stampede Wikimedia in lockstep on the next scheduler
+    /// tick. Additive-only (never negative) so the DEC-3j backoff floor is preserved
+    /// and — for circuit-open — the retry still lands past the 5min BreakDuration.
+    /// Mirrors the 0-30s jitter on <c>NotificationQueueItem</c>.
+    /// </summary>
+    internal const int MaxJitterSeconds = 30;
+
     public WikidataCoverEnrichmentRetryDecision Classify(
         EnrichCatalogCoverResult result,
         int currentRetryCount,
@@ -115,7 +126,7 @@ internal sealed class WikidataCoverEnrichmentRetryPolicy : IWikidataCoverEnrichm
 
             // currentRetryCount = 0 → schedule the first retry (BackoffSchedule[0] = 1m)
             var backoff = BackoffSchedule[Math.Min(currentRetryCount, BackoffSchedule.Length - 1)];
-            return new WikidataCoverEnrichmentRetryDecision.ScheduleRetry(nowUtc.Add(backoff));
+            return ScheduleWithJitter(nowUtc, backoff);
         }
 
         // Issue #1823 Wave 3 M13 / M10 follow-up: Polly circuit OPEN. The
@@ -126,11 +137,22 @@ internal sealed class WikidataCoverEnrichmentRetryPolicy : IWikidataCoverEnrichm
         // not a per-game failure.
         if (string.Equals(failed.Reason, EnrichCatalogCoverCommandHandler.FailReasonCircuitOpen, StringComparison.Ordinal))
         {
-            return new WikidataCoverEnrichmentRetryDecision.ScheduleRetry(nowUtc.Add(CircuitOpenBackoff));
+            return ScheduleWithJitter(nowUtc, CircuitOpenBackoff);
         }
 
         // Unknown failure reason — fail-fast to surface it on the admin dead-letter page
         // for triage rather than silently retrying.
         return new WikidataCoverEnrichmentRetryDecision.DeadLetter();
+    }
+
+    /// <summary>
+    /// Wraps a base backoff in a <see cref="WikidataCoverEnrichmentRetryDecision.ScheduleRetry"/>
+    /// with additive [0, <see cref="MaxJitterSeconds"/>]s jitter so simultaneously-failed
+    /// games do not all reschedule to the identical <c>NextRetryAt</c>.
+    /// </summary>
+    private static WikidataCoverEnrichmentRetryDecision.ScheduleRetry ScheduleWithJitter(DateTime nowUtc, TimeSpan baseDelay)
+    {
+        var jitter = TimeSpan.FromSeconds(Random.Shared.Next(0, MaxJitterSeconds + 1));
+        return new WikidataCoverEnrichmentRetryDecision.ScheduleRetry(nowUtc.Add(baseDelay + jitter));
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/MaterializePdfCoverCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/MaterializePdfCoverCommandHandlerTests.cs
@@ -29,7 +29,7 @@ public class MaterializePdfCoverCommandHandlerTests
         mediator.Setup(m => m.Send(It.IsAny<GetPdfPageImageQuery>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new byte[] { 0xFF, 0xD8 }); // JPEG magic
         var webp = new Mock<IWebpVariantGenerator>();
-        webp.Setup(w => w.GenerateWebpAsync(It.IsAny<byte[]>(), 200, 300, It.IsAny<CancellationToken>()))
+        webp.Setup(w => w.GenerateWebpAsync(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new byte[] { 0x52, 0x49, 0x46, 0x46 }); // RIFF
         var pipeline = new Mock<IPdfCoverUploadPipeline>();
         pipeline.Setup(p => p.UploadAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
@@ -51,6 +51,40 @@ public class MaterializePdfCoverCommandHandlerTests
         pdf.CoverGenerationStatus.Should().Be(PdfCoverGenerationStatus.Generated);
         repo.Verify(r => r.UpdateAsync(pdf, It.IsAny<CancellationToken>()), Times.Once);
         uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_EncodesWebpAtPreviewDimensionsNotThumbnail()
+    {
+        // The materialized cover is uploaded under the same key the resolver serves as
+        // the -preview.webp variant (600x900). Encoding at thumbnail dimensions (200x300)
+        // would serve a low-res image stretched as a preview.
+        var pdfId = Guid.NewGuid();
+        var pdf = new PdfDocumentBuilder().WithId(pdfId).ThatIsCompleted().Build();
+        var repo = new Mock<IPdfDocumentRepository>();
+        repo.Setup(r => r.GetByIdAsync(pdfId, It.IsAny<CancellationToken>())).ReturnsAsync(pdf);
+        var mediator = new Mock<IMediator>();
+        mediator.Setup(m => m.Send(It.IsAny<GetPdfPageImageQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new byte[] { 0xFF, 0xD8 });
+        var webp = new Mock<IWebpVariantGenerator>();
+        webp.Setup(w => w.GenerateWebpAsync(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new byte[] { 0x52, 0x49, 0x46, 0x46 });
+        var pipeline = new Mock<IPdfCoverUploadPipeline>();
+        pipeline.Setup(p => p.UploadAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((string k, byte[] _, CancellationToken _) => k);
+        var uow = new Mock<IUnitOfWork>();
+
+        var handler = new MaterializePdfCoverCommandHandler(repo.Object, mediator.Object, webp.Object, uow.Object, pipeline.Object);
+
+        await handler.Handle(new MaterializePdfCoverCommand(pdfId, PageNumber: 1, DbKey: "covers/g/pdf-cover"), CancellationToken.None);
+
+        webp.Verify(w => w.GenerateWebpAsync(
+                It.IsAny<byte[]>(),
+                PdfCoverExtractor.PreviewWidth,
+                PdfCoverExtractor.PreviewHeight,
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "the cover is served as the 600x900 -preview.webp variant, so it must be encoded at preview dimensions, not thumbnail (200x300)");
     }
 
     /// <summary>

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRetryPolicyTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRetryPolicyTests.cs
@@ -71,9 +71,51 @@ public class WikidataCoverEnrichmentRetryPolicyTests
         var decision = _sut.Classify(result, currentRetryCount, FixedNow);
 
         decision.Should().BeOfType<WikidataCoverEnrichmentRetryDecision.ScheduleRetry>();
-        ((WikidataCoverEnrichmentRetryDecision.ScheduleRetry)decision).NextRetryAt
-            .Should().Be(FixedNow.AddMinutes(expectedBackoffMinutes),
-                $"DEC-3j exponential backoff: retry #{currentRetryCount + 1} fires at +{expectedBackoffMinutes}m");
+        var nextRetryAt = ((WikidataCoverEnrichmentRetryDecision.ScheduleRetry)decision).NextRetryAt;
+        nextRetryAt.Should().BeOnOrAfter(FixedNow.AddMinutes(expectedBackoffMinutes),
+            $"DEC-3j exponential backoff floor: retry #{currentRetryCount + 1} fires no earlier than +{expectedBackoffMinutes}m");
+        nextRetryAt.Should().BeOnOrBefore(
+            FixedNow.AddMinutes(expectedBackoffMinutes).AddSeconds(WikidataCoverEnrichmentRetryPolicy.MaxJitterSeconds),
+            "additive anti-herd jitter is bounded at MaxJitterSeconds above the base backoff");
+    }
+
+    [Fact]
+    public void Classify_FailedR2Upload_AppliesJitterSpreadingRetriesInsteadOfSchedulingThemAtTheSameInstant()
+    {
+        // A batch of games that all hit the same transient r2-upload-error must NOT
+        // be rescheduled to the identical NextRetryAt, or they stampede Wikimedia in
+        // lockstep on the next scheduler tick. Additive jitter spreads them.
+        var result = new EnrichCatalogCoverResult.Failed(
+            EnrichCatalogCoverCommandHandler.FailReasonR2Upload,
+            "503 service unavailable");
+
+        var scheduledTimes = new HashSet<DateTime>();
+        for (var i = 0; i < 200; i++)
+        {
+            var decision = _sut.Classify(result, currentRetryCount: 0, FixedNow);
+            scheduledTimes.Add(((WikidataCoverEnrichmentRetryDecision.ScheduleRetry)decision).NextRetryAt);
+        }
+
+        scheduledTimes.Count.Should().BeGreaterThan(1,
+            "additive jitter must spread simultaneously-failed retries across a band, not schedule them all at one instant");
+    }
+
+    [Fact]
+    public void Classify_FailedR2Upload_JitterStaysWithinAdditiveBandAboveTheBaseBackoff()
+    {
+        var result = new EnrichCatalogCoverResult.Failed(
+            EnrichCatalogCoverCommandHandler.FailReasonR2Upload,
+            "503 service unavailable");
+        var floor = FixedNow.AddMinutes(1);
+        var ceiling = floor.AddSeconds(WikidataCoverEnrichmentRetryPolicy.MaxJitterSeconds);
+
+        for (var i = 0; i < 200; i++)
+        {
+            var decision = _sut.Classify(result, currentRetryCount: 0, FixedNow);
+            var nextRetryAt = ((WikidataCoverEnrichmentRetryDecision.ScheduleRetry)decision).NextRetryAt;
+            nextRetryAt.Should().BeOnOrAfter(floor, "jitter is additive — it never fires before the base backoff")
+                .And.BeOnOrBefore(ceiling, "jitter never exceeds MaxJitterSeconds above the base backoff");
+        }
     }
 
     [Fact]
@@ -120,8 +162,11 @@ public class WikidataCoverEnrichmentRetryPolicyTests
 
         decision.Should().BeOfType<WikidataCoverEnrichmentRetryDecision.ScheduleRetry>(
             "circuit-open is an upstream-infra signal — schedule a single retry past the 5min DEC-3f BreakDuration");
-        ((WikidataCoverEnrichmentRetryDecision.ScheduleRetry)decision).NextRetryAt
-            .Should().Be(FixedNow.Add(WikidataCoverEnrichmentRetryPolicy.CircuitOpenBackoff));
+        var nextRetryAt = ((WikidataCoverEnrichmentRetryDecision.ScheduleRetry)decision).NextRetryAt;
+        nextRetryAt.Should().BeOnOrAfter(FixedNow.Add(WikidataCoverEnrichmentRetryPolicy.CircuitOpenBackoff),
+            "the retry must still land past the 5min BreakDuration even with jitter");
+        nextRetryAt.Should().BeOnOrBefore(
+            FixedNow.Add(WikidataCoverEnrichmentRetryPolicy.CircuitOpenBackoff).AddSeconds(WikidataCoverEnrichmentRetryPolicy.MaxJitterSeconds));
     }
 
     [Theory]

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRunnerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRunnerTests.cs
@@ -108,7 +108,9 @@ public class WikidataCoverEnrichmentRunnerTests
 
         recorded!.Outcome.Should().Be(WikidataCoverEnrichmentOutcome.Failed);
         recorded.RetryCount.Should().Be(1);
-        recorded.NextRetryAt.Should().Be(FixedNow.AddMinutes(1));
+        // Real policy layers additive [0,30]s anti-herd jitter (#3371) on the 1m base backoff.
+        recorded.NextRetryAt.Should().BeOnOrAfter(FixedNow.AddMinutes(1))
+            .And.BeOnOrBefore(FixedNow.AddMinutes(1).AddSeconds(WikidataCoverEnrichmentRetryPolicy.MaxJitterSeconds));
     }
 
     [Fact]


### PR DESCRIPTION
Due fix tattici della procedura cover, emersi da uno spec-panel (critique + socratic) del 2026-07-29. Tracker delle decisioni strutturali correlate: #3373.

## #3371 — jitter sul retry backoff Wikidata

`WikidataCoverEnrichmentRetryPolicy` schedulava ogni retry a un offset esatto (1m/5m/15m per `r2-upload-error`, 6m per `circuit-open`). Un batch di giochi che falliva insieme (outage R2 transitorio, breaker aperto) veniva rischedulato allo **stesso istante** → stampede verso Wikimedia in lockstep al tick successivo.

- Jitter additivo `[0,30]s` su entrambi i path `ScheduleRetry`, via helper condiviso.
- **Additivo** (mai negativo): preserva il floor del backoff e mantiene il retry circuit-open oltre i 5min di `BreakDuration`.
- Rispecchia il jitter 0-30s già usato da `NotificationQueueItem`.

## #3370 — cover PDF materializzata a dimensione preview

`MaterializePdfCoverCommandHandler` encodava il WebP a `ThumbnailWidth/Height` (200×300) ma lo carica sotto la chiave `{DbKey}-preview.webp` che `CoverUrlResolver` serve come preview L4 (600×900) — la stessa chiave riempita a 600×900 dalla ingest pipeline e da `BackfillPdfCoversJob`. Una cover materializzata on-demand era quindi un thumbnail 200×300 stirato come preview.

- Encode a `PreviewWidth/Height` (600×900).

## Test

- TDD (RED→GREEN) per entrambi.
- `WikidataCoverEnrichmentRetryPolicyTests`: 20/20 (dispersione + banda + i test esatti convertiti a band-assertion).
- `WikidataCoverEnrichmentRunnerTests`: 14/14 (usa la policy **reale** — la band-assertion del runner è stata allineata al jitter).
- `MaterializePdfCoverCommandHandlerTests`: 5/5 (nuovo test dimensioni preview).
- Blast-radius del jitter verificato su tutto il test-suite (nessun'altra asserzione esatta `NextRetryAt`).

Fixes #3371
Fixes #3370
Refs #3373

🤖 Generated with [Claude Code](https://claude.com/claude-code)
