### PR TITLE
feat(catalog): #3373 quick-wins — runner-boundary analyzer (MAI006) + PDF cover-generation metric

### DIFF
--- a/apps/api/src/Api.Analyzers/NoEnrichCatalogCoverCommandBypassAnalyzer.cs
+++ b/apps/api/src/Api.Analyzers/NoEnrichCatalogCoverCommandBypassAnalyzer.cs
@@ -1,0 +1,113 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Api.Analyzers;
+
+/// <summary>
+/// <b>MAI006</b>: flags <c>new EnrichCatalogCoverCommand(...)</c> constructed outside
+/// <c>WikidataCoverEnrichmentRunner</c>.
+///
+/// After #3369 all four Wikidata cover-enrichment triggers (M9 scheduler, M12 admin,
+/// batch, F2 bulk-retry) route through <c>WikidataCoverEnrichmentRunner.EnrichAndRecordAsync</c>,
+/// the single source of truth that persists a <c>WikidataCoverEnrichmentAttempt</c> row,
+/// applies the DEC-3j retry/dead-letter policy and broadcasts SSE. The runner is the ONLY
+/// legitimate place to construct + dispatch the raw <c>EnrichCatalogCoverCommand</c>; any other
+/// construction site re-introduces the batch-bypass class of bug (#3369) — the command runs but
+/// records no attempt, gets no retry classification and emits no SSE.
+///
+/// This rule is deliberately conservative: it targets a single well-known command type and
+/// produces one Warning per occurrence. False-positive risk is low because the type name is
+/// unique to this codebase and the sole allowed site is explicitly allow-listed.
+///
+/// Tracker: umbrella #3373 (decision D2).
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class NoEnrichCatalogCoverCommandBypassAnalyzer : DiagnosticAnalyzer
+{
+    public const string RunnerBypassDiagnosticId = "MAI006";
+
+    private const string Category = "Architecture";
+    private const string HelpLinkUri =
+        "https://github.com/meepleAi-app/meepleai-monorepo/issues/3373";
+
+    /// <summary>
+    /// Fully-qualified name of the M8 command. MAI006 fires when this type is
+    /// constructed via <c>new</c> outside the allow-listed runner.
+    /// </summary>
+    private const string EnrichCatalogCoverCommandFqn =
+        "Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover.EnrichCatalogCoverCommand";
+
+    /// <summary>
+    /// Fully-qualified name of the single legitimate construction site — the SSOT runner.
+    /// Object creations inside this type are allowed.
+    /// </summary>
+    private const string RunnerFqn =
+        "Api.BoundedContexts.SharedGameCatalog.Application.Services.WikidataCoverEnrichmentRunner";
+
+    private static readonly DiagnosticDescriptor Mai006Rule = new(
+        RunnerBypassDiagnosticId,
+        title: "Dispatch EnrichCatalogCoverCommand through WikidataCoverEnrichmentRunner, not directly",
+        messageFormat:
+            "`new EnrichCatalogCoverCommand(...)` outside WikidataCoverEnrichmentRunner bypasses the " +
+            "enrich+record SSOT — the command runs but records no WikidataCoverEnrichmentAttempt, gets " +
+            "no DEC-3j retry/dead-letter classification and emits no SSE (the #3369 batch-bypass bug). " +
+            "Call IWikidataCoverEnrichmentRunner.EnrichAndRecordAsync instead.",
+        Category,
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description:
+            "All four Wikidata cover-enrichment triggers route through WikidataCoverEnrichmentRunner " +
+            "(#3369), which is the single source of truth for attempt-log + retry/dead-letter + SSE. " +
+            "Constructing and dispatching the raw EnrichCatalogCoverCommand anywhere else silently drops " +
+            "that machinery. The only legitimate construction site is the runner itself.",
+        helpLinkUri: HelpLinkUri);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Mai006Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterSyntaxNodeAction(AnalyzeObjectCreation, SyntaxKind.ObjectCreationExpression);
+    }
+
+    private static void AnalyzeObjectCreation(SyntaxNodeAnalysisContext context)
+    {
+        var creation = (ObjectCreationExpressionSyntax)context.Node;
+
+        // Resolve the constructed type via the constructor symbol (more reliable than
+        // GetTypeInfo(creation.Type) for IdentifierNameSyntax cases).
+        var ctorSymbol = context.SemanticModel.GetSymbolInfo(creation, context.CancellationToken).Symbol as IMethodSymbol;
+        var symbol = ctorSymbol?.ContainingType ??
+                     context.SemanticModel.GetTypeInfo(creation.Type, context.CancellationToken).Type;
+        if (symbol is null)
+        {
+            return;
+        }
+
+        if (symbol.OriginalDefinition.ToDisplayString() != EnrichCatalogCoverCommandFqn)
+        {
+            return;
+        }
+
+        // Walk ancestors to find the enclosing type. Construction inside the runner is legitimate.
+        var enclosingType = creation.AncestorsAndSelf().OfType<TypeDeclarationSyntax>().FirstOrDefault();
+        if (enclosingType is not null)
+        {
+            var enclosingSymbol = context.SemanticModel.GetDeclaredSymbol(enclosingType, context.CancellationToken);
+            if (enclosingSymbol is not null &&
+                enclosingSymbol.OriginalDefinition.ToDisplayString() == RunnerFqn)
+            {
+                return; // legitimate construction site (the SSOT runner)
+            }
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(Mai006Rule, creation.GetLocation()));
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/MaterializePdfCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/MaterializePdfCoverCommandHandler.cs
@@ -3,6 +3,7 @@ using Api.BoundedContexts.DocumentProcessing.Application.Services;
 using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 using Api.Middleware.Exceptions;
+using Api.Observability;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
@@ -84,6 +85,7 @@ internal sealed class MaterializePdfCoverCommandHandler : ICommandHandler<Materi
         // BackfillPdfCoversJob.cs, which both store result.SelectedPageIndex, a 0-based value).
         // Only the stored index changes here — the GetPdfPageImageQuery call above stays 1-based.
         pdf.MarkCoverGenerated(dbKey, command.PageNumber - 1);
+        MeepleAiMetrics.RecordPdfCoverGeneration(MeepleAiMetrics.CoverGenerationOutcomeGenerated);
 
         await _repository.UpdateAsync(pdf, cancellationToken).ConfigureAwait(false);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/BackfillPdfCoversJob.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/BackfillPdfCoversJob.cs
@@ -3,6 +3,7 @@ using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.BoundedContexts.DocumentProcessing.Domain.Events;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
+using Api.Observability;
 using Api.Services.Pdf;
 using Api.SharedKernel.Application.Services;
 using Microsoft.EntityFrameworkCore;
@@ -143,6 +144,7 @@ public sealed class BackfillPdfCoversJob : IJob
             {
                 pdf.CoverGenerationStatus = nameof(PdfCoverGenerationStatus.Failed);
                 pdf.CoverGenerationError = "PDF binary not found in blob storage";
+                MeepleAiMetrics.RecordPdfCoverGeneration(MeepleAiMetrics.CoverGenerationOutcomeFailed);
                 _logger.LogWarning(
                     "BackfillPdfCoversJob: PDF {PdfId} binary missing from blob storage; marking Failed",
                     pdf.Id);
@@ -170,6 +172,7 @@ public sealed class BackfillPdfCoversJob : IJob
                         pdf.CoverGenerationStatus = nameof(PdfCoverGenerationStatus.Generated);
                         pdf.CoverPageIndex = result.SelectedPageIndex;
                         pdf.CoverGenerationError = null;
+                        MeepleAiMetrics.RecordPdfCoverGeneration(MeepleAiMetrics.CoverGenerationOutcomeGenerated);
 
                         eventCollector?.Collect(new PdfCoverGeneratedEvent(
                             pdfDocumentId: pdf.Id,
@@ -185,6 +188,7 @@ public sealed class BackfillPdfCoversJob : IJob
                 case PdfCoverExtractionOutcome.Skipped:
                     pdf.CoverGenerationStatus = nameof(PdfCoverGenerationStatus.Skipped);
                     pdf.CoverPageIndex = result.SelectedPageIndex;
+                    MeepleAiMetrics.RecordPdfCoverGeneration(MeepleAiMetrics.CoverGenerationOutcomeSkipped);
                     _logger.LogInformation(
                         "BackfillPdfCoversJob: cover skipped for PDF {PdfId} (heuristic rejected all candidate pages)",
                         pdf.Id);
@@ -192,6 +196,7 @@ public sealed class BackfillPdfCoversJob : IJob
                 case PdfCoverExtractionOutcome.Failed:
                     pdf.CoverGenerationStatus = nameof(PdfCoverGenerationStatus.Failed);
                     pdf.CoverGenerationError = result.ErrorMessage;
+                    MeepleAiMetrics.RecordPdfCoverGeneration(MeepleAiMetrics.CoverGenerationOutcomeFailed);
                     _logger.LogWarning(
                         "BackfillPdfCoversJob: cover extraction failed for PDF {PdfId}: {Error}",
                         pdf.Id, result.ErrorMessage);
@@ -226,6 +231,7 @@ public sealed class BackfillPdfCoversJob : IJob
             pdf.CoverGenerationStatus = nameof(PdfCoverGenerationStatus.Failed);
             var detail = ex.GetType().Name + ": orphan-check-key=" + orphanPhysicalKey;
             pdf.CoverGenerationError = detail.Length > 500 ? detail[..500] : detail;
+            MeepleAiMetrics.RecordPdfCoverGeneration(MeepleAiMetrics.CoverGenerationOutcomeFailed);
             try
             {
                 await db.SaveChangesAsync(ct).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
@@ -593,6 +593,7 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
                         pdfDoc.CoverGenerationStatus = "Generated";
                         pdfDoc.CoverPageIndex = result.SelectedPageIndex;
                         pdfDoc.CoverGenerationError = null;
+                        MeepleAiMetrics.RecordPdfCoverGeneration(MeepleAiMetrics.CoverGenerationOutcomeGenerated);
 
                         // Issue #1852 (Gap A): raise the propagation event so
                         // PdfCoverGeneratedEventHandler can populate SharedGame.PdfCoverR2Key.
@@ -610,6 +611,7 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
                 case PdfCoverExtractionOutcome.Skipped:
                     pdfDoc.CoverGenerationStatus = "Skipped";
                     pdfDoc.CoverPageIndex = result.SelectedPageIndex;
+                    MeepleAiMetrics.RecordPdfCoverGeneration(MeepleAiMetrics.CoverGenerationOutcomeSkipped);
                     _logger.LogInformation(
                         "[PdfPipeline] Cover extraction skipped for PDF {PdfId} (heuristic rejected first 3 pages)",
                         pdfDoc.Id);
@@ -617,6 +619,7 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
                 case PdfCoverExtractionOutcome.Failed:
                     pdfDoc.CoverGenerationStatus = "Failed";
                     pdfDoc.CoverGenerationError = result.ErrorMessage;
+                    MeepleAiMetrics.RecordPdfCoverGeneration(MeepleAiMetrics.CoverGenerationOutcomeFailed);
                     _logger.LogWarning(
                         "[PdfPipeline] Cover extraction failed for PDF {PdfId}: {Error}",
                         pdfDoc.Id, result.ErrorMessage);
@@ -631,6 +634,7 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
         {
             pdfDoc.CoverGenerationStatus = "Failed";
             pdfDoc.CoverGenerationError = ex.Message.Length > 500 ? ex.Message[..500] : ex.Message;
+            MeepleAiMetrics.RecordPdfCoverGeneration(MeepleAiMetrics.CoverGenerationOutcomeFailed);
             _logger.LogWarning(ex,
                 "[PdfPipeline] Cover extraction threw for PDF {PdfId} — continuing pipeline without cover",
                 pdfDoc.Id);

--- a/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.CatalogCovers.cs
+++ b/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.CatalogCovers.cs
@@ -1,4 +1,5 @@
 // Issue #2123 — BGG ToS compliance: catalog cover observability metrics.
+using System.Collections.Generic;
 using System.Diagnostics.Metrics;
 
 namespace Api.Observability;
@@ -54,4 +55,45 @@ internal static partial class MeepleAiMetrics
         name: "meepleai.bgg.url.attempted_render.total",
         unit: "attempts",
         description: "SLO=0: browser attempts to render a BGG-hosted asset (#2123)");
+
+    /// <summary>Wire value for the <c>outcome</c> tag: cover generated successfully.</summary>
+    public const string CoverGenerationOutcomeGenerated = "generated";
+
+    /// <summary>Wire value for the <c>outcome</c> tag: generation skipped (heuristic rejected pages).</summary>
+    public const string CoverGenerationOutcomeSkipped = "skipped";
+
+    /// <summary>Wire value for the <c>outcome</c> tag: generation failed (extraction/upload/save error).</summary>
+    public const string CoverGenerationOutcomeFailed = "failed";
+
+    /// <summary>
+    /// Counter of PDF cover-GENERATION outcomes (as opposed to <see cref="CoverResolution"/>,
+    /// which is read-time). Emitted by the three PDF cover producers —
+    /// <c>PdfProcessingPipelineService</c> (inline ingest), <c>BackfillPdfCoversJob</c> and
+    /// <c>MaterializePdfCoverCommandHandler</c> — so ops can see generation health
+    /// (generated/skipped/failed rate) directly instead of waiting for the lagging
+    /// read-time <c>placeholder&gt;80%</c> signal. Tags: <c>source</c> (currently <c>pdf</c>),
+    /// <c>outcome</c> (<c>generated</c>|<c>skipped</c>|<c>failed</c>). Decision D5-C, umbrella #3373.
+    ///
+    /// Suggested alerting:
+    /// <list type="bullet">
+    ///   <item><c>rate(meepleai_cover_generation_total{outcome="failed"}[15m]) / rate(meepleai_cover_generation_total[15m]) &gt; 0.20</c>
+    ///     sustained → PDF cover generation is degrading (extraction, R2 upload or DB save
+    ///     failing); investigate before the read-time placeholder&gt;80% alert fires.</item>
+    /// </list>
+    /// </summary>
+    public static readonly Counter<long> CoverGeneration = Meter.CreateCounter<long>(
+        name: "meepleai.cover.generation.total",
+        unit: "generations",
+        description: "PDF cover generation outcomes grouped by source + outcome (#3373 D5-C)");
+
+    /// <summary>
+    /// Records one PDF cover-generation outcome. <paramref name="outcome"/> must be one of
+    /// <see cref="CoverGenerationOutcomeGenerated"/> / <see cref="CoverGenerationOutcomeSkipped"/> /
+    /// <see cref="CoverGenerationOutcomeFailed"/>.
+    /// </summary>
+    public static void RecordPdfCoverGeneration(string outcome) =>
+        CoverGeneration.Add(
+            1,
+            new KeyValuePair<string, object?>("source", "pdf"),
+            new KeyValuePair<string, object?>("outcome", outcome));
 }

--- a/apps/api/tests/Api.Analyzers.Tests/NoEnrichCatalogCoverCommandBypassAnalyzerTests.cs
+++ b/apps/api/tests/Api.Analyzers.Tests/NoEnrichCatalogCoverCommandBypassAnalyzerTests.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Xunit;
+
+namespace Api.Analyzers.Tests;
+
+/// <summary>
+/// Snapshot tests for <see cref="NoEnrichCatalogCoverCommandBypassAnalyzer"/> (MAI006).
+///
+/// MAI006 flags <c>new EnrichCatalogCoverCommand(...)</c> constructed outside
+/// <c>WikidataCoverEnrichmentRunner</c>. After #3369 the runner is the single
+/// source of truth for the enrich+record workflow (attempt-log + retry/dead-letter
+/// + SSE); any other construction site dispatches the raw command and bypasses
+/// that machinery. The analyzer matches by fully-qualified type name, so the inline
+/// shims must use the same FQNs as the production types.
+/// </summary>
+public sealed class NoEnrichCatalogCoverCommandBypassAnalyzerTests
+{
+    /// <summary>
+    /// Inline shims matching the production FQNs the analyzer compares against.
+    /// The runner shim itself constructs the command — MAI006 must NOT fire there
+    /// (the single legitimate construction site).
+    /// </summary>
+    private const string SharedShimSource = """
+        namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover
+        {
+            public sealed class EnrichCatalogCoverCommand
+            {
+                public EnrichCatalogCoverCommand(System.Guid gameId, bool forceRefresh = false) { }
+            }
+        }
+        namespace Api.BoundedContexts.SharedGameCatalog.Application.Services
+        {
+            using Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+            public sealed class WikidataCoverEnrichmentRunner
+            {
+                public EnrichCatalogCoverCommand Build()
+                {
+                    // Legitimate construction — MAI006 must NOT fire here.
+                    return new EnrichCatalogCoverCommand(System.Guid.NewGuid(), false);
+                }
+            }
+        }
+        """;
+
+    [Fact]
+    public async Task NewEnrichCatalogCoverCommand_InAdminHandler_ReportsMAI006()
+    {
+        var source = SharedShimSource + """
+
+            namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands
+            {
+                using Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+                public class SomeAdminHandler
+                {
+                    public EnrichCatalogCoverCommand Build()
+                    {
+                        return new EnrichCatalogCoverCommand(System.Guid.NewGuid());
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = await RunAnalyzerAsync(source);
+        var mai006 = OnlyMai006(diagnostics);
+
+        Assert.Single(mai006);
+    }
+
+    [Fact]
+    public async Task NewEnrichCatalogCoverCommand_InsideRunner_DoesNotFlag()
+    {
+        // The runner is the single legitimate construction site. The shared shim
+        // already constructs the command inside WikidataCoverEnrichmentRunner.Build —
+        // running the analyzer over it must NOT produce MAI006.
+        var source = SharedShimSource;
+
+        var diagnostics = await RunAnalyzerAsync(source);
+        AssertNoMai006(diagnostics);
+    }
+
+    [Fact]
+    public async Task NewEnrichCatalogCoverCommand_InBatchHandler_ReportsMAI006()
+    {
+        // Regression guard for the exact #3369 anti-pattern: the batch handler
+        // must NOT reconstruct the raw command — it goes through the runner.
+        var source = SharedShimSource + """
+
+            namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCoverBatch
+            {
+                using Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+                public class EnrichCatalogCoverBatchCommandHandler
+                {
+                    public EnrichCatalogCoverCommand Build(System.Guid id)
+                    {
+                        return new EnrichCatalogCoverCommand(id);
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = await RunAnalyzerAsync(source);
+        Assert.Single(OnlyMai006(diagnostics));
+    }
+
+    [Fact]
+    public async Task UnrelatedTypeCreation_DoesNotFlag()
+    {
+        var source = SharedShimSource + """
+
+            namespace SubjectUnderTest
+            {
+                public sealed class OtherCommand { }
+                public class Builder
+                {
+                    public OtherCommand Build() => new OtherCommand();
+                }
+            }
+            """;
+
+        var diagnostics = await RunAnalyzerAsync(source);
+        AssertNoMai006(diagnostics);
+    }
+
+    // --------------------------------------------------------------------------
+    // Helpers
+    // --------------------------------------------------------------------------
+
+    private static async Task<ImmutableArray<Diagnostic>> RunAnalyzerAsync(string source)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest));
+        var references = new[]
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(System.Runtime.CompilerServices.RuntimeHelpers).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(System.Linq.Enumerable).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Attribute).Assembly.Location),
+        };
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName: "TestAssembly",
+            syntaxTrees: new[] { syntaxTree },
+            references: references,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var compileErrors = compilation.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error).ToImmutableArray();
+        if (!compileErrors.IsEmpty)
+        {
+            throw new InvalidOperationException(
+                "Inline test source did not compile cleanly. Errors:\n  " +
+                string.Join("\n  ", compileErrors.Select(d => d.ToString())));
+        }
+
+        var analyzers = ImmutableArray.Create<DiagnosticAnalyzer>(new NoEnrichCatalogCoverCommandBypassAnalyzer());
+        return await compilation.WithAnalyzers(analyzers).GetAnalyzerDiagnosticsAsync().ConfigureAwait(false);
+    }
+
+    private static ImmutableArray<Diagnostic> OnlyMai006(ImmutableArray<Diagnostic> diagnostics) =>
+        diagnostics.Where(d => d.Id == NoEnrichCatalogCoverCommandBypassAnalyzer.RunnerBypassDiagnosticId).ToImmutableArray();
+
+    private static void AssertNoMai006(ImmutableArray<Diagnostic> diagnostics) =>
+        Assert.Empty(OnlyMai006(diagnostics));
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/MaterializePdfCoverCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/MaterializePdfCoverCommandHandlerTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.Metrics;
 using Api.BoundedContexts.DocumentProcessing.Application.Commands;
 using Api.BoundedContexts.DocumentProcessing.Application.Queries;
 using Api.BoundedContexts.DocumentProcessing.Application.Services;
@@ -51,6 +52,58 @@ public class MaterializePdfCoverCommandHandlerTests
         pdf.CoverGenerationStatus.Should().Be(PdfCoverGenerationStatus.Generated);
         repo.Verify(r => r.UpdateAsync(pdf, It.IsAny<CancellationToken>()), Times.Once);
         uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_EmitsCoverGenerationMetric_WithGeneratedOutcome()
+    {
+        // #3373 D5-C: a successful on-demand materialization must emit
+        // meepleai.cover.generation.total{source=pdf,outcome=generated}.
+        var pdfId = Guid.NewGuid();
+        var pdf = new PdfDocumentBuilder().WithId(pdfId).ThatIsCompleted().Build();
+        var repo = new Mock<IPdfDocumentRepository>();
+        repo.Setup(r => r.GetByIdAsync(pdfId, It.IsAny<CancellationToken>())).ReturnsAsync(pdf);
+        var mediator = new Mock<IMediator>();
+        mediator.Setup(m => m.Send(It.IsAny<GetPdfPageImageQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new byte[] { 0xFF, 0xD8 });
+        var webp = new Mock<IWebpVariantGenerator>();
+        webp.Setup(w => w.GenerateWebpAsync(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new byte[] { 0x52, 0x49, 0x46, 0x46 });
+        var pipeline = new Mock<IPdfCoverUploadPipeline>();
+        pipeline.Setup(p => p.UploadAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((string k, byte[] _, CancellationToken _) => k);
+        var uow = new Mock<IUnitOfWork>();
+        var handler = new MaterializePdfCoverCommandHandler(repo.Object, mediator.Object, webp.Object, uow.Object, pipeline.Object);
+
+        var outcomes = new List<string?>();
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Name == "meepleai.cover.generation.total")
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            },
+        };
+        listener.SetMeasurementEventCallback<long>((_, _, tags, _) =>
+        {
+            foreach (var tag in tags)
+            {
+                if (tag.Key == "outcome")
+                {
+                    outcomes.Add(tag.Value as string);
+                }
+            }
+        });
+        listener.Start();
+
+        await handler.Handle(
+            new MaterializePdfCoverCommand(pdfId, PageNumber: 1, DbKey: "covers/g/pdf-cover"),
+            CancellationToken.None);
+
+        outcomes.Should().Contain("generated",
+            "a successful materialization must emit meepleai.cover.generation.total{outcome=generated}");
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/Observability/CatalogCoverMetricsTests.cs
+++ b/apps/api/tests/Api.Tests/Observability/CatalogCoverMetricsTests.cs
@@ -1,0 +1,81 @@
+using System.Diagnostics.Metrics;
+using Api.Observability;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Observability;
+
+/// <summary>
+/// Unit tests for the PDF cover-GENERATION metric (#3373 D5-C). Distinct from
+/// <see cref="MeepleAiMetrics.CoverResolution"/> (read-time): this counter records
+/// the outcome of each PDF cover generation attempt so ops can see generation
+/// health without waiting for the lagging read-time placeholder&gt;80% signal.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "Observability")]
+public class CatalogCoverMetricsTests
+{
+    private static List<(long Value, string? Source, string? Outcome)> Capture(Action act)
+    {
+        var captured = new List<(long, string?, string?)>();
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Name == "meepleai.cover.generation.total")
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            },
+        };
+        listener.SetMeasurementEventCallback<long>((_, value, tags, _) =>
+        {
+            string? source = null;
+            string? outcome = null;
+            foreach (var tag in tags)
+            {
+                if (tag.Key == "source")
+                {
+                    source = tag.Value as string;
+                }
+                else if (tag.Key == "outcome")
+                {
+                    outcome = tag.Value as string;
+                }
+            }
+            captured.Add((value, source, outcome));
+        });
+        listener.Start();
+
+        act();
+
+        return captured;
+    }
+
+    [Theory]
+    [InlineData("generated")]
+    [InlineData("skipped")]
+    [InlineData("failed")]
+    public void RecordPdfCoverGeneration_EmitsCounterOnceWithSourcePdfAndOutcomeTag(string outcome)
+    {
+        var captured = Capture(() => MeepleAiMetrics.RecordPdfCoverGeneration(outcome));
+
+        // Tolerant: a concurrent test/scheduler may add other measurements on the
+        // shared global counter — we only assert OUR increment made it through.
+        captured.Should().Contain(m => m.Value == 1 && m.Source == "pdf" && m.Outcome == outcome);
+    }
+
+    [Fact]
+    public void CoverGenerationOutcomeConstants_MatchLowercaseWireValues()
+    {
+        MeepleAiMetrics.CoverGenerationOutcomeGenerated.Should().Be("generated");
+        MeepleAiMetrics.CoverGenerationOutcomeSkipped.Should().Be("skipped");
+        MeepleAiMetrics.CoverGenerationOutcomeFailed.Should().Be("failed");
+    }
+
+    [Fact]
+    public void CoverGeneration_Name_FollowsDottedConvention()
+    {
+        MeepleAiMetrics.CoverGeneration.Name.Should().Be("meepleai.cover.generation.total");
+    }
+}


### PR DESCRIPTION
I due quick-win implementabili-subito isolati dal brief decisionale di #3373 (D2, D5-C). Nessuna ratifica richiesta.

## D2 — #3377: analyzer MAI006 (confine runner)
Dopo #3369 tutti e 4 i trigger Wikidata passano da `WikidataCoverEnrichmentRunner` (SSOT). Nuovo analyzer Roslyn **MAI006** (mirror di MAI005 in `NoVectorDocumentBypassAnalyzer`) che segnala `new EnrichCatalogCoverCommand(...)` costruito fuori dal runner — la classe di bug che #3369 ha fixato. Il runner è l'unico sito allow-listato; `dotnet build Api` emette **0 MAI006** oggi.

## D5-C — #3378: metrica generazione cover PDF
La generazione cover PDF non aveva metrica (solo `CoverResolution` a read-time, lagging). Nuovo counter `meepleai.cover.generation.total{source,outcome}` + helper `RecordPdfCoverGeneration(outcome)`, emesso ai **10 siti terminali** di `CoverGenerationStatus` nei 3 produttori (pipeline, backfill, materialize). Emesso DOPO la decisione upload/save (non nell'extractor), così una estrazione Generated il cui upload/save fallisce è contata `failed`.

## Test (TDD, RED→GREEN)
- `NoEnrichCatalogCoverCommandBypassAnalyzerTests`: 4/4 (in-runner ok, batch/admin bypass → MAI006, tipi non correlati ok).
- `CatalogCoverMetricsTests`: 5/5 (MeterListener: tag source/outcome, consts, nome).
- `MaterializePdfCoverCommandHandlerTests`: +1 site-test MeterListener (`outcome=generated`), 6/6.
- `dotnet build Api` verde, 0 MAI006, formattazione LF verificata.

Fixes #3377
Fixes #3378
Refs #3373

🤖 Generated with [Claude Code](https://claude.com/claude-code)
