### PR TITLE
fix(ci): staging title-health fetch via docker exec (#3338)

### DIFF
--- a/.github/workflows/title-health-staging.yml
+++ b/.github/workflows/title-health-staging.yml
@@ -73,15 +73,20 @@ jobs:
             "${STAGING_USER}@${STAGING_HOST}" 'bash -s' > raw.out <<'REMOTE'
           set -euo pipefail
           set -a; . /opt/meepleai/repo/infra/secrets/admin.secret; set +a
-          C=$(mktemp)
-          body=$(jq -n --arg e "$ADMIN_EMAIL" --arg p "$ADMIN_PASSWORD" '{email:$e, password:$p}')
-          lc=$(curl -sS -o /dev/null -w '%{http_code}' -c "$C" -X POST http://localhost:8080/api/v1/auth/login \
-            -H 'Content-Type: application/json' -d "$body")
-          [ "$lc" = "200" ] || { echo "staging admin login failed (HTTP $lc)" >&2; exit 1; }
-          echo "===TH_JSON_BEGIN==="
-          curl -sS -b "$C" http://localhost:8080/api/v1/admin/kb/title-health
-          printf '\n===TH_JSON_END===\n'
-          rm -f "$C"
+          # The API runs in a container fronted by Traefik — localhost:8080 does NOT resolve on the
+          # host (no port map), only INSIDE the api container. Run login + GET via `docker exec`
+          # (curl is present in the image). Build the login body on the host and pass it in via -e.
+          BODY=$(printf '{"email":"%s","password":"%s"}' "$ADMIN_EMAIL" "$ADMIN_PASSWORD")
+          docker exec -e BODY="$BODY" meepleai-api sh -c '
+            C=/tmp/th_cookie.$$
+            lc=$(curl -sS -o /dev/null -w "%{http_code}" -c "$C" -X POST http://localhost:8080/api/v1/auth/login \
+              -H "Content-Type: application/json" -d "$BODY")
+            [ "$lc" = "200" ] || { echo "staging admin login failed (HTTP $lc)" >&2; rm -f "$C"; exit 1; }
+            echo "===TH_JSON_BEGIN==="
+            curl -sS -b "$C" http://localhost:8080/api/v1/admin/kb/title-health
+            printf "\n===TH_JSON_END===\n"
+            rm -f "$C"
+          '
           REMOTE
           rm -f "$KEY"
           # Extract only the JSON between the sentinels (drops any MOTD/banner the channel prepended).


### PR DESCRIPTION
Il primo dispatch live di `title-health-staging.yml` è fallito al fetch: `curl: (7) Failed to connect to localhost port 8080`. L'SSH connette, ma sul server staging l'API gira in un **container** (fronted da Traefik) → `localhost:8080` non risolve sull'host, solo dentro il container.

Fix: login + GET via `docker exec meepleai-api sh -c '...'` (curl è nell'immagine; lo staging user può usare docker, come `check-role-case.yml`). Il body di login è costruito sull'host e passato nel container via `-e`; il JSON resta wrappato nelle sentinelle anti-MOTD ed estratto sul runner. `bash -n` OK sul run block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)