### PR TITLE
chore(rag): arm golden baseline vs fresh snapshot + tmars-setup-it (#3338)

### DIFF
--- a/infra/fixtures/rag-golden-baseline.json
+++ b/infra/fixtures/rag-golden-baseline.json
@@ -1,78 +1,162 @@
 {
   "schemaVersion": 1,
   "_comment": "Golden baseline for the RAG smoke harness (#2480). Captured once against a fresh, verified snapshot by running `bash infra/scripts/rag-smoke-assert.sh --update-baseline` after `make dev-from-snapshot`. Each entry pins the top-3 retrieved chunks (source + page) for a canonical query; the harness then fails if retrieval drifts. relevanceScore is advisory (compared with tolerance, not exact). Regenerate after an intentional re-index (embedding model change, chunker change, seed-table schema-version bump). See docs/for-developers/operations/rag-smoke-runbook.md.",
-  "capturedAt": "2026-06-29T12:00:21Z",
-  "snapshot": "meepleai_seed_20260629T113602Z_intfloat_multilingual-e5-base_234fc5355",
+  "capturedAt": "2026-07-29T15:09:29Z",
+  "snapshot": "meepleai_seed_20260729T070620Z_intfloat_multilingual-e5-base_9101176e9",
   "embeddingModel": "intfloat/multilingual-e5-base",
   "baseline": {
     "catan-setup": [
       {
-        "source": "27ec1ee5-dbc7-40f4-90d0-83208025ffc1",
-        "page": 13
+        "source": "8d0a2f6f-aa45-4d01-982e-218d47badd79",
+        "page": 1
       },
       {
-        "source": "6d359cba-e8b8-4eaa-b035-4707bcc9df7b",
-        "page": 2
+        "source": "7cb67b4e-9add-4c6d-8d4b-ff338446dc92",
+        "page": 1
       },
       {
-        "source": "b4c23991-9bf7-45f3-8458-5b15de4cadc3",
+        "source": "8e222b6a-8b0d-4137-8f10-dc544e321e74",
         "page": 1
       }
     ],
     "wingspan-round-goals": [
       {
-        "source": "2a9cb705-bb68-4693-a8cb-fc0372f6f163",
-        "page": 11
+        "source": "17093326-1b2f-48a3-b6d4-5daa5ac8dcbb",
+        "page": 1
       },
       {
-        "source": "324a91d6-774a-4365-9cd9-24b6df40bdc3",
-        "page": 22
+        "source": "9ea35ce8-c70a-47b4-92e7-8d5ee21d49c2",
+        "page": 1
       },
       {
-        "source": "95d0f022-a38d-447b-86e6-e8e98666e71d",
+        "source": "f5a914f4-83a0-4c71-8c4a-399e9f595897",
         "page": 1
       }
     ],
     "dominion-buy-phase": [
       {
-        "source": "38fd28c7-dff2-41a0-ba58-733c671013c4",
-        "page": 36
+        "source": "b7766e3e-db14-4e48-86c0-4a519dc64591",
+        "page": 1
       },
       {
-        "source": "85fb2381-251a-4650-865f-0df689441b7e",
-        "page": 6
+        "source": "e6929aa1-02bf-4c23-9ea8-57c24c3dc9c5",
+        "page": 1
       },
       {
-        "source": "f9eb661f-6a17-42c6-90a4-51eece2a8d50",
-        "page": 9
+        "source": "f8733ddb-3fc6-49b8-8988-63ff0f4f34a7",
+        "page": 1
       }
     ],
     "ark-nova-conservation": [
       {
-        "source": "4f654cf3-b930-4521-a7ee-e2bd400d9fb6",
-        "page": 36
+        "source": "45e40e99-1150-46fe-9074-ff5d96682a66",
+        "page": 1
       },
       {
-        "source": "f9b14e7f-66a3-4b66-837e-81839e6f2b2a",
-        "page": 38
+        "source": "2dd89c4d-2a59-4a5e-be5d-dae6818d69aa",
+        "page": 1
       },
       {
-        "source": "faf407fe-1fbf-4081-8b99-26069de89967",
-        "page": 8
+        "source": "f58aec40-eb3d-434b-ab23-7a6c82db1756",
+        "page": 1
       }
     ],
     "seven-wonders-military": [
       {
-        "source": "5b398a03-1540-450d-8791-8ab656719b78",
-        "page": 7
+        "source": "8fbee54d-0849-4199-8ad0-9df3485a7636",
+        "page": 1
       },
       {
-        "source": "eca3c3b1-5842-4eb0-9fb2-93b43a87cdd0",
-        "page": 5
+        "source": "2669c604-df7c-4f7e-88e1-f209f7282029",
+        "page": 1
       },
       {
-        "source": "f9b14e7f-66a3-4b66-837e-81839e6f2b2a",
-        "page": 38
+        "source": "9ea35ce8-c70a-47b4-92e7-8d5ee21d49c2",
+        "page": 1
+      }
+    ],
+    "catan-setup-it": [
+      {
+        "source": "dbc7122d-7a65-401d-83ee-a6b5df594b7b",
+        "page": 1
+      },
+      {
+        "source": "2669c604-df7c-4f7e-88e1-f209f7282029",
+        "page": 1
+      },
+      {
+        "source": "a82e62ac-0cba-48c6-a369-915870e67f4e",
+        "page": 1
+      }
+    ],
+    "wingspan-round-goals-it": [
+      {
+        "source": "26df6ae0-c67e-402a-8ab9-76719c811377",
+        "page": 1
+      },
+      {
+        "source": "76664600-7883-4da8-8737-13c53985561d",
+        "page": 1
+      },
+      {
+        "source": "a7aea6dd-346f-47cc-aa0e-0a2cb38b59b8",
+        "page": 1
+      }
+    ],
+    "dominion-buy-phase-it": [
+      {
+        "source": "0a85b821-94cc-41a3-a8ad-0f299fcb104e",
+        "page": 1
+      },
+      {
+        "source": "ee655f3c-17a4-4dd2-8b00-be603c53a833",
+        "page": 1
+      },
+      {
+        "source": "1e59bf52-80ee-4720-a81a-ae66349da283",
+        "page": 1
+      }
+    ],
+    "ark-nova-conservation-it": [
+      {
+        "source": "dbc7122d-7a65-401d-83ee-a6b5df594b7b",
+        "page": 1
+      },
+      {
+        "source": "d14f2ee6-3fb2-457f-ba3d-92c2f3f4057f",
+        "page": 1
+      },
+      {
+        "source": "eb5759ac-9ca9-416e-9396-26335039e5b4",
+        "page": 1
+      }
+    ],
+    "seven-wonders-military-it": [
+      {
+        "source": "8fbee54d-0849-4199-8ad0-9df3485a7636",
+        "page": 1
+      },
+      {
+        "source": "f6c159a5-8510-4baa-ab2a-b8f39b41e7c4",
+        "page": 1
+      },
+      {
+        "source": "0a85b821-94cc-41a3-a8ad-0f299fcb104e",
+        "page": 1
+      }
+    ],
+    "tmars-setup-it": [
+      {
+        "source": "3eccead9-4483-4c43-a145-60b62140d4fb",
+        "page": 1
+      },
+      {
+        "source": "45e40e99-1150-46fe-9074-ff5d96682a66",
+        "page": 1
+      },
+      {
+        "source": "dc44310e-5ae6-4dca-b776-d053114eb527",
+        "page": 1
       }
     ]
   }


### PR DESCRIPTION
Ri-cattura la golden retrieval baseline contro lo snapshot fresco `meepleai_seed_20260729T070620Z_..._9101176e9` (il nuovo `latest` dopo che il fix #3363 ha risanato la bake pipeline). Ri-baseline obbligatoria dopo un re-bake: il gate asserta le top-3 citazioni contro `latest`. Arma anche `tmars-setup-it` (3 citazioni catturate) che prima SKIPpava.

Catturata via `rag-smoke-dispatch.yml -f update_baseline=true` (run 30462816475).

🤖 Generated with [Claude Code](https://claude.com/claude-code)