### PR TITLE
feat(catalog): ADR-087 cover decisions + D4 single-pod tripwire (#3373)

### DIFF
--- a/docs/for-claude/architecture/adr/adr-087-cover-procedure-design-decisions.md
+++ b/docs/for-claude/architecture/adr/adr-087-cover-procedure-design-decisions.md
@@ -1,0 +1,61 @@
+# ADR-087 — Cover procedure design decisions (D1–D5)
+
+**Status**: Accepted
+**Date**: 2026-07-29
+**Tracker**: [#3373](https://github.com/meepleAi-app/meepleai-monorepo/issues/3373)
+**Supersedes/relates**: [ADR (wikidata-enrichment)](./adr-2026-06-09-wikidata-enrichment-architecture.md) (DEC-3e amended by D4), [ADR-060](./adr-060-live-session-persistence.md) (xmin precedent, referenced by D3)
+
+## Context
+
+A multi-agent spec-panel (critique + Socratic, 2026-07-29) reviewed the game-cover procedure — four cover sources (user-custom, PDF-derived, BGG re-upload, Wikidata/Commons) resolved at read time by `CoverUrlResolver` with precedence `user → PDF(L4) → BGG(L2.5) → Wikidata(L2) → placeholder`, backed by deterministic per-source R2 keys.
+
+The review surfaced three tactical bugs — all shipped (#3369 batch→runner, #3370 preview size, #3371 retry jitter) — plus **five structural design decisions** that must be settled before any broader cover refactor, because the refactor would cement whatever answer is left implicit. This ADR records the ratified outcome of those five decisions. Two (D2, D5-C) were ratified as implementable-now and shipped in #3379; three (D1, D3, D4) and one sub-decision (D5-A) were ratified in the Socratic session on 2026-07-29.
+
+Fresh evidence that informed the ratifications:
+- The PDF **cover-generation metric** (`meepleai.cover.generation.total{source,outcome}`, D5-C, #3379) now measures the PDF failure rate → D1's retry budget is tunable on data.
+- **Staging is a single Compose instance** (`container_name: meepleai-api`, no Kubernetes/HPA) → D4 is a real-deployment fact, not a hypothetical.
+- The **Wikidata at-least-once pipeline is proven end-to-end** on staging (Chess → Q718 → CC0 image → R2 upload → resolver presigned URL) → the retry/dead-letter model that D1 extends to PDF is validated.
+
+## Decisions
+
+### D1 — Unified delivery contract *(ratified)*
+
+One declared delivery semantics applies to **both** the PDF and Wikidata cover paths:
+- **Transient** infra failure (`r2-upload-error`, DB save failure) → **bounded retry**.
+- **Permanent** outcome (heuristic-reject/`Skipped`, corrupted image) → **terminal**.
+
+PDF gains bounded retry by reusing `BackfillPdfCoversJob` + an attempt counter (terminal after ~3, tunable against the D5-C metric). No separate dead-letter apparatus is duplicated. Rationale: today the same `r2-upload-error` is terminal on the PDF path but retried on Wikidata — an accidental asymmetry, not a chosen contract. Implementation: [#3382](https://github.com/meepleAi-app/meepleai-monorepo/issues/3382).
+
+### D2 — Runner as mandatory SSOT boundary *(ratified — SHIPPED)*
+
+Every Wikidata enrichment entry point MUST route through `WikidataCoverEnrichmentRunner` (attempt-log + retry/dead-letter + SSE). Enforced at compile time by Roslyn analyzer **MAI006** (`NoEnrichCatalogCoverCommandBypassAnalyzer`), which flags `new EnrichCatalogCoverCommand` outside the runner. Shipped: #3377 / PR #3379.
+
+### D3 — Cross-store consistency: reconcile + benign last-writer-wins *(ratified)*
+
+- **Orphan reconcile**: the orphan-recovery job is extended to `Failed`-without-`CoverR2Key` rows by scanning for the deterministic physical key (`covers/pdf/{id}/cover-preview.webp`) — the same determinism that gives idempotency gives recovery.
+- **Concurrency**: the Wikidata cover write is wrapped in `try/catch(DbUpdateConcurrencyException)` with reload+retry; **last-writer-wins is declared benign-by-design** because two concurrent enrichments of the same QID produce identical columns (same license, same deterministic key). `xmin` (per ADR-060) is deliberately NOT added here — the write is commutative, not merely un-collided. Implementation: [#3382](https://github.com/meepleAi-app/meepleai-monorepo/issues/3382).
+
+### D4 — Deployment contract: single-pod, presidiato *(ratified)*
+
+The enrichment tier is single-instance **by contract**. The in-process `InMemoryWikimediaRateLimiter` (5 RPS) and the dead-letter gauge are correct only at one instance; a second instance would double the Wikimedia request rate (ToS violation) and skew the metric, **silently**.
+- **Now**: a Prometheus tripwire `count(up{job="meepleai-api"}) > 1` (alert `MultipleApiInstances`) makes a scale-out **loud**; a comment in the compose files; this DEC-3e amendment. Implemented in the same PR as this ADR.
+- **Deferred (fast-follow)**: a Redis fail-closed lease on the batch (hard prevention) and a DB-`COUNT`-backed dead-letter gauge — both only matter at >1 instance, which the tripwire now guards. A distributed Redis rate-limiter stays in reserve for an actual HPA roadmap. Deferred tasks: [#3383](https://github.com/meepleAi-app/meepleai-monorepo/issues/3383).
+
+Rationale: staging is Compose single-instance with no HPA roadmap, so a distributed rate-limiter is YAGNI; but leaving the constraint incidental (pinned only by `container_name`) is unacceptable because it touches legal correctness (Wikimedia ToS) and would fail silently.
+
+### D5 — Executable writer↔resolver contract + generation telemetry
+
+- **D5-C — telemetry *(ratified — SHIPPED)***: `meepleai.cover.generation.total{source,outcome}` emitted at every terminal generation site across the three PDF producers. Shipped: #3378 / PR #3379.
+- **D5-A — CoverKind key-builder *(ratified)***: the suffix convention (`.webp` / none / `-preview.webp`) is centralized into a `CoverKind` enum → shared key-builder used by both the writers and the resolver, so write-key and read-key coincide by construction and the double-suffix `.webp.webp`→404 becomes impossible; plus a Docker-free contract-test that runs locally (today `CoverR2ConventionIntegrationTests` skips on the MinIO limit). Eliminates the root cause of the `ValidateIdentifier` bug that recurred three times. Implementation: [#3384](https://github.com/meepleAi-app/meepleai-monorepo/issues/3384).
+
+## Consequences
+
+- **Positive**: a single delivery contract (D1) removes the "PDF failures need manual reset" surprise; the reconcile + benign-LWW (D3) closes the orphan/race without the cost of `xmin`+outbox; the single-pod tripwire (D4) converts a silent legal risk into a loud alert at near-zero cost; the `CoverKind` builder (D5-A) makes the suffix bug structurally impossible.
+- **Costs / risks**: D1+D3 are a single ~M PDF work-stream (shared jobs — must not compete on records); D4's hard-prevention (lease) and correct multi-pod gauge are deferred and only become necessary if the org adopts HPA; D5-A is an ~M refactor whose value is realized when the cover-stack is next touched.
+- **Sequence**: D5-C ✅ (baseline) → **D1+D3 as one PDF work-stream** → **D4 tripwire+docs** (parallel, independent) → **D5-A** refactor. Nothing else in a broader cover refactor should start before the D5-C baseline (already in `main-dev`) exists, since it is the only way to prove no regression.
+
+## Links
+
+- Umbrella tracker + Socratic ratification: [#3373](https://github.com/meepleAi-app/meepleai-monorepo/issues/3373)
+- Shipped: #3369, #3370, #3371 (tactical); #3377 (D2), #3378 (D5-C) via PR #3379
+- To implement: #3382 (D1+D3), #3383 (D4 deferred), #3384 (D5-A)

--- a/docs/for-claude/architecture/adr/adr-2026-06-09-wikidata-enrichment-architecture.md
+++ b/docs/for-claude/architecture/adr/adr-2026-06-09-wikidata-enrichment-architecture.md
@@ -71,6 +71,8 @@ Regex (case-insensitive): `^(public domain|PD|CC0|CC[ -]BY([ -][0-9.]+)?|CC[ -]B
 
 **Rationale**: Spike measured 30k catalog × 2 API calls × 200ms = 3.3 hours per full pass. Well within 24h CRON window. Multi-pod operation would require distributed rate-limiter (Redis token bucket); single-pod constraint eliminates that complexity for similar latency budget. Document `HPA.minReplicas=HPA.maxReplicas=1` in deployment manifest.
 
+**Amendment (ADR-087, #3373 D4, 2026-07-29)**: the single-pod constraint is now *presidiato*. A Prometheus tripwire `MultipleApiInstances` (`count(up{job="meepleai-api"}) > 1`, `infra/prometheus/alerts/api-single-instance.yml`) fires if a second `meepleai-api` instance is ever scraped, converting the previously-**silent** ToS-violation risk (in-process 5 RPS limiter + in-memory dead-letter gauge double under multi-pod) into a loud alert. The Compose deployment (`container_name: meepleai-api`) already pins one instance; the tripwire guards a future `replicas:`/HPA scale-out. Hard prevention (Redis fail-closed lease on the batch) + a DB-`COUNT`-backed dead-letter gauge are **deferred** (#3383) — they only matter at >1 instance, which the tripwire now catches. A distributed Redis rate-limiter remains in reserve for an actual HPA roadmap.
+
 ### DEC-3f — Circuit breaker (NEW post-spike, addresses N-002)
 **Decision**: Polly circuit breaker on `WikidataCatalogProvider` AND `IWikimediaCommonsClient`. OPEN circuit after 3 consecutive 5xx within 60s for 5 min.
 

--- a/infra/compose.prod.yml
+++ b/infra/compose.prod.yml
@@ -57,6 +57,10 @@ services:
   # Application Services
   # ===========================================================================
 
+  # DO NOT scale to >1 replica — single-instance BY CONTRACT (ADR-087 / DEC-3e, #3373 D4):
+  # the enrichment tier's in-process Wikimedia rate-limiter (5 RPS) + dead-letter gauge are
+  # correct only at one instance. The `MultipleApiInstances` Prometheus tripwire alerts on a
+  # second scraped instance; promote to the distributed rate-limiter+gauge before scaling.
   api:
     restart: always
     env_file:

--- a/infra/compose.staging.yml
+++ b/infra/compose.staging.yml
@@ -34,6 +34,10 @@ services:
   # Application Services
   # ===========================================================================
 
+  # DO NOT scale to >1 replica — single-instance BY CONTRACT (ADR-087 / DEC-3e, #3373 D4):
+  # the enrichment tier's in-process Wikimedia rate-limiter (5 RPS) + dead-letter gauge are
+  # correct only at one instance. The `MultipleApiInstances` Prometheus tripwire alerts on a
+  # second scraped instance; promote to the distributed rate-limiter+gauge before scaling.
   api:
     restart: always
     # Staging must NEVER fall back to the local `meepleai-api:latest` image

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -57,6 +57,11 @@ services:
           cpus: '0.5'
           memory: 512M
 
+  # Single-instance BY CONTRACT (ADR-087 / DEC-3e, #3373 D4): the enrichment tier's
+  # in-process Wikimedia rate-limiter (5 RPS) + dead-letter gauge are correct ONLY at one
+  # instance. Do NOT add `replicas:` / scale this service without first promoting the
+  # rate-limiter + gauge to the distributed variant (Redis lease + DB-COUNT gauge). The
+  # `MultipleApiInstances` Prometheus tripwire alerts if a second instance is ever scraped.
   api:
     build:
       context: ..

--- a/infra/prometheus/alerts/api-single-instance.test.yml
+++ b/infra/prometheus/alerts/api-single-instance.test.yml
@@ -1,0 +1,65 @@
+# promtool unit tests for api-single-instance.yml (#3373 D4 / ADR-087).
+#
+# Run locally (Windows PowerShell, from repo root — the image entrypoint is `prometheus`,
+# so promtool MUST be selected via --entrypoint):
+#   docker run --rm --entrypoint promtool -v "${PWD}\infra\prometheus\alerts:/work" \
+#     prom/prometheus:v3.7.0 test rules /work/api-single-instance.test.yml
+#
+# count(up{...}) strips the instance label, so the firing alert carries only the
+# rule's own labels (severity, subsystem).
+rule_files:
+  - api-single-instance.yml
+
+evaluation_interval: 1m
+
+tests:
+  # Two scraped api instances (both up) sustained >5m -> MultipleApiInstances fires.
+  - interval: 1m
+    input_series:
+      - series: 'up{job="meepleai-api", instance="api-1:8080"}'
+        values: '1x6'
+      - series: 'up{job="meepleai-api", instance="api-2:8080"}'
+        values: '1x6'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: MultipleApiInstances
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              subsystem: wikidata-enrichment
+            exp_annotations:
+              summary: "More than one meepleai-api instance scraped (sustained 5m) — DEC-3e single-pod contract violated"
+              description: "count(up{job=\"meepleai-api\"}) has stayed above 1 for 5m. The enrichment tier is single-instance by contract (ADR-087 / DEC-3e): the in-process Wikimedia rate-limiter (5 RPS) and the dead-letter gauge are correct only at one instance. Two instances double the request rate to Wikidata/Commons (ToS violation) and skew the dead-letter metric, silently. Scale the meepleai-api service back to one replica, or promote the enrichment rate-limiter + gauge to the distributed variant (Redis lease + DB-COUNT gauge) BEFORE running multiple instances."
+              runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-developers/operations/operations-manual.md#wikidata-enrichment-alerts"
+
+  # A single instance -> count = 1 -> no alert.
+  - interval: 1m
+    input_series:
+      - series: 'up{job="meepleai-api", instance="api-1:8080"}'
+        values: '1x6'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: MultipleApiInstances
+        exp_alerts: []
+
+  # A single instance that is DOWN (up=0) still contributes one series -> count = 1 -> no alert.
+  - interval: 1m
+    input_series:
+      - series: 'up{job="meepleai-api", instance="api-1:8080"}'
+        values: '0x6'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: MultipleApiInstances
+        exp_alerts: []
+
+  # Two instances but only for 3m (rolling-redeploy overlap) -> below the 5m `for` -> no alert.
+  - interval: 1m
+    input_series:
+      - series: 'up{job="meepleai-api", instance="api-1:8080"}'
+        values: '1 1 1 1'
+      - series: 'up{job="meepleai-api", instance="api-2:8080"}'
+        values: '1 1 1 _'
+    alert_rule_test:
+      - eval_time: 3m
+        alertname: MultipleApiInstances
+        exp_alerts: []

--- a/infra/prometheus/alerts/api-single-instance.yml
+++ b/infra/prometheus/alerts/api-single-instance.yml
@@ -1,0 +1,28 @@
+# #3373 D4 — single-pod enforcement tripwire (ADR-087, amends DEC-3e).
+#
+# The Wikidata enrichment tier is single-instance BY CONTRACT: the in-process
+# InMemoryWikimediaRateLimiter (5 RPS token bucket, DEC-3e) and the dead-letter
+# gauge (MeepleAiMetrics.WikidataEnrichment.cs) are correct ONLY at one meepleai-api
+# instance. A second instance would:
+#   - double the request rate to Wikidata SPARQL + Wikimedia Commons (ToS violation), and
+#   - split the in-memory dead-letter gauge across series (sum() doubles, max() drifts),
+# both SILENTLY. This tripwire makes a scale-out loud instead.
+#
+# `count(up{job="meepleai-api"})` counts scraped targets (a down target still contributes
+# its series), so the alert fires on 2+ configured instances regardless of health. `for: 5m`
+# absorbs the brief target overlap of a rolling redeploy.
+#
+# promtool test: infra/prometheus/alerts/api-single-instance.test.yml
+groups:
+  - name: meepleai_api_single_instance_alerts
+    rules:
+      - alert: MultipleApiInstances
+        expr: count(up{job="meepleai-api"}) > 1
+        for: 5m
+        labels:
+          severity: warning
+          subsystem: wikidata-enrichment
+        annotations:
+          summary: "More than one meepleai-api instance scraped (sustained 5m) — DEC-3e single-pod contract violated"
+          description: "count(up{job=\"meepleai-api\"}) has stayed above 1 for 5m. The enrichment tier is single-instance by contract (ADR-087 / DEC-3e): the in-process Wikimedia rate-limiter (5 RPS) and the dead-letter gauge are correct only at one instance. Two instances double the request rate to Wikidata/Commons (ToS violation) and skew the dead-letter metric, silently. Scale the meepleai-api service back to one replica, or promote the enrichment rate-limiter + gauge to the distributed variant (Redis lease + DB-COUNT gauge) BEFORE running multiple instances."
+          runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-developers/operations/operations-manual.md#wikidata-enrichment-alerts"


### PR DESCRIPTION
Formalizza le ratifiche socratiche di #3373 come **ADR-087** e implementa la fetta "subito" di **D4** (single-pod presidiato).

## Contenuto
**Doc / decisioni**
- `adr-087-cover-procedure-design-decisions.md` — record delle 5 decisioni ratificate (D1 contratto unico, D2 runner-boundary [shipped], D3 reconcile+LWW-benigno, D4 single-pod presidiato, D5-C telemetria [shipped], D5-A CoverKind builder) + conseguenze + sequenza.
- Emendamento **DEC-3e** nell'ADR wikidata-enrichment (single-pod ora *presidiato*, riferisce il tripwire).

**D4 tripwire (config)**
- `infra/prometheus/alerts/api-single-instance.yml` — alert `MultipleApiInstances` = `count(up{job="meepleai-api"}) > 1` `for 5m`. Converte il rischio ToS multi-pod (rate-limiter 5 RPS + gauge dead-letter in-process, corretti solo a 1 istanza) da **silenzioso** a **rumoroso**.
- `api-single-instance.test.yml` — **promtool-validato** (4 casi: 2-up→fires, 1-up/1-down/overlap-3m→no).
- Commenti "single-instance BY CONTRACT" in `docker-compose.yml` + `compose.staging.yml` + `compose.prod.yml`.

## Scope / deferred
- Fetta **D4 subito** completata qui. I task **deferiti** (lease Redis fail-closed hard-prevention; gauge dead-letter da COUNT DB) restano in **#3383** — servono solo a >1 istanza, che il tripwire ora intercetta; ridondanti finché single-pod.
- **D1+D3** (#3382) e **D5-A** (#3384) restano da implementare (work-stream successivi).

## Applicazione staging
⚠️ Le regole Prometheus **non** si auto-applicano al deploy: dopo il merge, il file alert va montato e Prometheus ricreato su staging (`docker compose ... up -d --force-recreate prometheus`), non basta il reload.

Refs #3373 #3383

🤖 Generated with [Claude Code](https://claude.com/claude-code)
