### PR TITLE
fix(cover): D1 bounded retry + D3 orphan reconcile & concurrency guard (#3382)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/BackfillPdfCoversJob.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/BackfillPdfCoversJob.cs
@@ -148,7 +148,10 @@ public sealed class BackfillPdfCoversJob : IJob
                 pdf.CoverGenerationStatus = missStatus.ToString();
                 pdf.CoverGenerationAttempts = missAttempts;
                 pdf.CoverGenerationError = "PDF binary not found in blob storage";
-                MeepleAiMetrics.RecordPdfCoverGeneration(MeepleAiMetrics.CoverGenerationOutcomeFailed);
+                // #3373 D1/D5-C: tag terminal vs still-retrying so the failed-ratio alert stays diagnostic.
+                MeepleAiMetrics.RecordPdfCoverGeneration(missAttempts >= PdfCoverRetryPolicy.MaxAttempts
+                    ? MeepleAiMetrics.CoverGenerationOutcomeFailed
+                    : MeepleAiMetrics.CoverGenerationOutcomeRetrying);
                 _logger.LogWarning(
                     "BackfillPdfCoversJob: PDF {PdfId} binary missing from blob storage; marking Failed",
                     pdf.Id);
@@ -176,6 +179,9 @@ public sealed class BackfillPdfCoversJob : IJob
                         pdf.CoverGenerationStatus = nameof(PdfCoverGenerationStatus.Generated);
                         pdf.CoverPageIndex = result.SelectedPageIndex;
                         pdf.CoverGenerationError = null;
+                        // #3373 D1: a successful generation closes the retry cycle — reset the budget
+                        // so a later orphan-reset (Generated→Pending) starts fresh, not pre-exhausted.
+                        pdf.CoverGenerationAttempts = 0;
                         MeepleAiMetrics.RecordPdfCoverGeneration(MeepleAiMetrics.CoverGenerationOutcomeGenerated);
 
                         eventCollector?.Collect(new PdfCoverGeneratedEvent(
@@ -239,7 +245,10 @@ public sealed class BackfillPdfCoversJob : IJob
             pdf.CoverGenerationAttempts = catchAttempts;
             var detail = ex.GetType().Name + ": orphan-check-key=" + orphanPhysicalKey;
             pdf.CoverGenerationError = detail.Length > 500 ? detail[..500] : detail;
-            MeepleAiMetrics.RecordPdfCoverGeneration(MeepleAiMetrics.CoverGenerationOutcomeFailed);
+            // #3373 D1/D5-C: tag terminal vs still-retrying so the failed-ratio alert stays diagnostic.
+            MeepleAiMetrics.RecordPdfCoverGeneration(catchAttempts >= PdfCoverRetryPolicy.MaxAttempts
+                ? MeepleAiMetrics.CoverGenerationOutcomeFailed
+                : MeepleAiMetrics.CoverGenerationOutcomeRetrying);
             try
             {
                 await db.SaveChangesAsync(ct).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/BackfillPdfCoversJob.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/BackfillPdfCoversJob.cs
@@ -142,7 +142,11 @@ public sealed class BackfillPdfCoversJob : IJob
             var pdfBytes = await LoadPdfBytesAsync(pdf, blob, ct).ConfigureAwait(false);
             if (pdfBytes is null)
             {
-                pdf.CoverGenerationStatus = nameof(PdfCoverGenerationStatus.Failed);
+                // #3373 D1: a missing binary can be a transient storage blip — TRANSIENT,
+                // retry-eligible until PdfCoverRetryPolicy.MaxAttempts, then terminal Failed.
+                var (missStatus, missAttempts) = PdfCoverRetryPolicy.NextAfterTransientFailure(pdf.CoverGenerationAttempts);
+                pdf.CoverGenerationStatus = missStatus.ToString();
+                pdf.CoverGenerationAttempts = missAttempts;
                 pdf.CoverGenerationError = "PDF binary not found in blob storage";
                 MeepleAiMetrics.RecordPdfCoverGeneration(MeepleAiMetrics.CoverGenerationOutcomeFailed);
                 _logger.LogWarning(
@@ -228,7 +232,11 @@ public sealed class BackfillPdfCoversJob : IJob
                 "BackfillPdfCoversJob: unexpected error processing PDF {PdfId}; marking Failed. " +
                 "Inspect R2 key {OrphanKey} for an orphan preview blob and clean up manually if present.",
                 pdf.Id, orphanPhysicalKey);
-            pdf.CoverGenerationStatus = nameof(PdfCoverGenerationStatus.Failed);
+            // #3373 D1: an unexpected exception here is infra (R2/DB) — TRANSIENT, retry-eligible
+            // until PdfCoverRetryPolicy.MaxAttempts, then terminal Failed.
+            var (catchStatus, catchAttempts) = PdfCoverRetryPolicy.NextAfterTransientFailure(pdf.CoverGenerationAttempts);
+            pdf.CoverGenerationStatus = catchStatus.ToString();
+            pdf.CoverGenerationAttempts = catchAttempts;
             var detail = ex.GetType().Name + ": orphan-check-key=" + orphanPhysicalKey;
             pdf.CoverGenerationError = detail.Length > 500 ? detail[..500] : detail;
             MeepleAiMetrics.RecordPdfCoverGeneration(MeepleAiMetrics.CoverGenerationOutcomeFailed);

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/PdfCoverOrphanRecoveryJob.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/PdfCoverOrphanRecoveryJob.cs
@@ -93,12 +93,8 @@ public sealed class PdfCoverOrphanRecoveryJob : IJob
             .ToListAsync(ct)
             .ConfigureAwait(false);
 
-        if (batch.Count == 0)
-        {
-            _logger.LogDebug("PdfCoverOrphanRecoveryJob: no eligible PDFs to check");
-            return;
-        }
-
+        // NOTE: do NOT early-return when the Generated batch is empty — the D3
+        // reconcile scan below (Failed-without-key) must still run.
         _logger.LogDebug(
             "PdfCoverOrphanRecoveryJob: checking {Count} Generated PDFs for orphan covers",
             batch.Count);
@@ -158,16 +154,87 @@ public sealed class PdfCoverOrphanRecoveryJob : IJob
             }
         }
 
-        if (orphanCount > 0)
+        // #3373 D3: reconcile the INVERSE orphan — a Failed row WITHOUT a CoverR2Key whose
+        // deterministic preview blob exists in R2 (the upload succeeded but the DB save failed,
+        // per the BackfillPdfCoversJob save-failure comment). Reset it to Pending so
+        // BackfillPdfCoversJob regenerates it: the re-upload overwrites the orphan and raises the
+        // propagation event. A Failed row with no orphan blob is a genuine failure, left as-is.
+        var reconciledCount = await ReconcileFailedOrphansAsync(db, blob, ct).ConfigureAwait(false);
+
+        if (orphanCount > 0 || reconciledCount > 0)
         {
             await db.SaveChangesAsync(ct).ConfigureAwait(false);
             _logger.LogInformation(
-                "PdfCoverOrphanRecoveryJob: reset {Count} orphan cover(s) to Pending for re-generation",
-                orphanCount);
+                "PdfCoverOrphanRecoveryJob: reset {OrphanCount} orphan Generated cover(s) + reconciled " +
+                "{ReconciledCount} Failed-with-orphan cover(s) to Pending",
+                orphanCount, reconciledCount);
         }
         else
         {
             _logger.LogDebug("PdfCoverOrphanRecoveryJob: no orphan covers found in this batch");
         }
+    }
+
+    /// <summary>
+    /// #3373 D3: scans Failed rows with no <c>CoverR2Key</c> and, when the deterministic preview
+    /// blob exists in R2 (an orphan from a save-failure-after-upload), resets them to Pending with
+    /// a cleared attempt budget so <see cref="BackfillPdfCoversJob"/> regenerates them. Returns the
+    /// number reconciled.
+    /// </summary>
+    private async Task<int> ReconcileFailedOrphansAsync(
+        MeepleAiDbContext db,
+        IBlobStorageService blob,
+        CancellationToken ct)
+    {
+        var failedStatus = nameof(PdfCoverGenerationStatus.Failed);
+        var batch = await db.PdfDocuments
+            .AsTracking()
+            .Where(p => p.CoverGenerationStatus == failedStatus && p.CoverR2Key == null)
+            .OrderBy(p => p.UpdatedAt)
+            .Take(BatchSize)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        var reconciled = 0;
+        for (var i = 0; i < batch.Count; i++)
+        {
+            ct.ThrowIfCancellationRequested();
+            var pdf = batch[i];
+            try
+            {
+                var previewRawKey = $"covers/pdf/{pdf.Id:D}/cover-preview.webp";
+                var orphanExists = await blob.GetPresignedUrlForRawKeyAsync(previewRawKey).ConfigureAwait(false) is not null;
+                if (orphanExists)
+                {
+                    _logger.LogWarning(
+                        "PdfCoverOrphanRecoveryJob: orphan preview exists for Failed PDF {Id} (key {Key}) — " +
+                        "resetting to Pending for regeneration (the re-upload overwrites the orphan)",
+                        pdf.Id, previewRawKey);
+                    pdf.CoverGenerationStatus = nameof(PdfCoverGenerationStatus.Pending);
+                    pdf.CoverGenerationAttempts = 0;
+                    pdf.CoverGenerationError = null;
+                    pdf.UpdatedAt = DateTime.UtcNow;
+                    reconciled++;
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception ex)
+#pragma warning restore CA1031
+            {
+                _logger.LogWarning(ex,
+                    "PdfCoverOrphanRecoveryJob: failed reconcile check for Failed PDF {Id}; skipping", pdf.Id);
+            }
+
+            if (i < batch.Count - 1)
+            {
+                await Task.Delay(DelayBetweenItemsMs, ct).ConfigureAwait(false);
+            }
+        }
+
+        return reconciled;
     }
 }

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/PdfCoverOrphanRecoveryJob.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/PdfCoverOrphanRecoveryJob.cs
@@ -128,6 +128,11 @@ public sealed class PdfCoverOrphanRecoveryJob : IJob
                     pdf.CoverR2Key = null;
                     pdf.CoverGenerationError = null;
                     pdf.CoverPageIndex = null;
+                    // #3373 D1: the re-opened generation cycle must start with a clean retry budget,
+                    // mirroring ReconcileFailedOrphansAsync — otherwise a Generated cover that had
+                    // succeeded after 1-2 transient retries would carry the residual count and could
+                    // go terminal on the very first failure of the new cycle.
+                    pdf.CoverGenerationAttempts = 0;
                     pdf.UpdatedAt = DateTime.UtcNow;
                     orphanCount++;
                 }

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfCoverRetryPolicy.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfCoverRetryPolicy.cs
@@ -1,0 +1,38 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Services;
+
+/// <summary>
+/// #3373 D1 (ADR-087): bounded-retry classification for PDF cover generation.
+///
+/// The two cover generators — <c>PdfProcessingPipelineService</c> (inline ingest) and
+/// <c>BackfillPdfCoversJob</c> — distinguish a TRANSIENT infra failure (R2 upload / DB
+/// save threw, PDF binary transiently unreachable) from a PERMANENT one (extractor
+/// rejected the pages, corrupt image). A transient failure is retry-eligible: the PDF
+/// returns to <see cref="PdfCoverGenerationStatus.Pending"/> so <c>BackfillPdfCoversJob</c>
+/// re-picks it on its next 30-min tick (a natural backoff), until <see cref="MaxAttempts"/>
+/// is reached — then it becomes terminal <see cref="PdfCoverGenerationStatus.Failed"/>.
+/// Permanent failures call the Failed transition directly and never reach this policy.
+///
+/// This replaces the pre-D1 behaviour where every failure was immediately terminal, so a
+/// momentary R2 blip during ingest permanently blocked a cover until a manual operator reset.
+/// </summary>
+public static class PdfCoverRetryPolicy
+{
+    /// <summary>Retry budget before a transient failure becomes terminal (DEC-3j mirror: 3).</summary>
+    public const int MaxAttempts = 3;
+
+    /// <summary>
+    /// Given the attempt count BEFORE this failure, returns the incremented count and the
+    /// resulting status: <see cref="PdfCoverGenerationStatus.Pending"/> (retry-eligible) while
+    /// under <see cref="MaxAttempts"/>, else terminal <see cref="PdfCoverGenerationStatus.Failed"/>.
+    /// </summary>
+    public static (PdfCoverGenerationStatus Status, int Attempts) NextAfterTransientFailure(int currentAttempts)
+    {
+        var attempts = currentAttempts + 1;
+        var status = attempts >= MaxAttempts
+            ? PdfCoverGenerationStatus.Failed
+            : PdfCoverGenerationStatus.Pending;
+        return (status, attempts);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
@@ -632,7 +632,12 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
         }
         catch (Exception ex)
         {
-            pdfDoc.CoverGenerationStatus = "Failed";
+            // #3373 D1: an exception here is an infra failure (R2 upload / DB) — TRANSIENT.
+            // Return to Pending (retry-eligible via BackfillPdfCoversJob) until
+            // PdfCoverRetryPolicy.MaxAttempts, then terminal Failed.
+            var (retryStatus, retryAttempts) = PdfCoverRetryPolicy.NextAfterTransientFailure(pdfDoc.CoverGenerationAttempts);
+            pdfDoc.CoverGenerationStatus = retryStatus.ToString();
+            pdfDoc.CoverGenerationAttempts = retryAttempts;
             pdfDoc.CoverGenerationError = ex.Message.Length > 500 ? ex.Message[..500] : ex.Message;
             MeepleAiMetrics.RecordPdfCoverGeneration(MeepleAiMetrics.CoverGenerationOutcomeFailed);
             _logger.LogWarning(ex,

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
@@ -593,6 +593,9 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
                         pdfDoc.CoverGenerationStatus = "Generated";
                         pdfDoc.CoverPageIndex = result.SelectedPageIndex;
                         pdfDoc.CoverGenerationError = null;
+                        // #3373 D1: a successful generation closes the retry cycle — reset the budget
+                        // so a later orphan-reset (Generated→Pending) starts fresh, not pre-exhausted.
+                        pdfDoc.CoverGenerationAttempts = 0;
                         MeepleAiMetrics.RecordPdfCoverGeneration(MeepleAiMetrics.CoverGenerationOutcomeGenerated);
 
                         // Issue #1852 (Gap A): raise the propagation event so
@@ -639,7 +642,10 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
             pdfDoc.CoverGenerationStatus = retryStatus.ToString();
             pdfDoc.CoverGenerationAttempts = retryAttempts;
             pdfDoc.CoverGenerationError = ex.Message.Length > 500 ? ex.Message[..500] : ex.Message;
-            MeepleAiMetrics.RecordPdfCoverGeneration(MeepleAiMetrics.CoverGenerationOutcomeFailed);
+            // #3373 D1/D5-C: tag terminal vs still-retrying so the failed-ratio alert stays diagnostic.
+            MeepleAiMetrics.RecordPdfCoverGeneration(retryAttempts >= PdfCoverRetryPolicy.MaxAttempts
+                ? MeepleAiMetrics.CoverGenerationOutcomeFailed
+                : MeepleAiMetrics.CoverGenerationOutcomeRetrying);
             _logger.LogWarning(ex,
                 "[PdfPipeline] Cover extraction threw for PDF {PdfId} — continuing pipeline without cover",
                 pdfDoc.Id);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommandHandler.cs
@@ -8,6 +8,7 @@ using Api.Observability;
 using Api.Services;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
 namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
@@ -58,6 +59,10 @@ internal sealed class EnrichCatalogCoverCommandHandler
     public const string SkipReasonImageNotAvailable = "image-not-available-p18";
     public const string SkipReasonLicenseNotWhitelisted = "license-not-whitelisted";
     public const string SkipReasonImageBytesNotAvailable = "image-bytes-not-available";
+
+    /// <summary>#3373 D3: the game was soft-deleted concurrently between the enrichment
+    /// load and a retry after a <see cref="DbUpdateConcurrencyException"/> — nothing to persist.</summary>
+    public const string SkipReasonConcurrentDelete = "concurrent-delete";
     public const string FailReasonImageProcessing = "image-processing-error";
     public const string FailReasonR2Upload = "r2-upload-error";
     /// <summary>Issue #1823 Wave 3 M13 (M10 follow-up): Polly circuit OPEN — short-circuit retry until breaker recovers.</summary>
@@ -249,7 +254,41 @@ internal sealed class EnrichCatalogCoverCommandHandler
             nowUtc);
 
         _repository.Update(game);
-        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (DbUpdateConcurrencyException ex)
+        {
+            // #3373 D3 (ADR-087): M9 cron and admin force-refresh can write the same game
+            // concurrently. The enrichment is idempotent (deterministic R2 key + same
+            // license/attribution), so reload the fresh aggregate, re-apply the cover, and
+            // save once more — last-writer-wins is benign by design.
+            var fresh = await _repository
+                .GetByIdAsync(request.GameId, cancellationToken)
+                .ConfigureAwait(false);
+            if (fresh is null)
+            {
+                // Game soft-deleted concurrently — nothing to persist. The R2 object becomes
+                // an orphan the cover-cleanup path reconciles.
+                _logger.LogWarning(
+                    ex,
+                    "SharedGame {GameId} was deleted concurrently during cover enrichment; skipping persistence.",
+                    request.GameId);
+                EmitOutcomeMetric(OutcomeSkipped, SkipReasonConcurrentDelete);
+                return new EnrichCatalogCoverResult.Skipped(SkipReasonConcurrentDelete);
+            }
+
+            fresh.SetWikidataCover(
+                r2Key,
+                licenseResult.RawLicense,
+                licenseResult.Attribution,
+                coverImage.SourceUrl,
+                nowUtc);
+            _repository.Update(fresh);
+            await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            game = fresh;
+        }
 
         // Issue #3138: the cover columns changed — evict the SharedGameCatalog read-model
         // caches so /shared-games (list) and /shared-games/{id} (detail) reflect the new

--- a/apps/api/src/Api/Infrastructure/Entities/DocumentProcessing/PdfDocumentEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/DocumentProcessing/PdfDocumentEntity.cs
@@ -176,4 +176,9 @@ public class PdfDocumentEntity
 
     // Last error string when CoverGenerationStatus = Failed; for diagnostics + retry.
     public string? CoverGenerationError { get; set; }
+
+    // #3373 D1: bounded-retry counter. Incremented on each TRANSIENT cover-generation
+    // failure (R2/DB infra); at PdfCoverRetryPolicy.MaxAttempts the status becomes terminal
+    // Failed instead of returning to Pending. 0 for never-failed / permanently-failed rows.
+    public int CoverGenerationAttempts { get; set; }
 }

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/DocumentProcessing/PdfDocumentEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/DocumentProcessing/PdfDocumentEntityConfiguration.cs
@@ -275,6 +275,12 @@ internal class PdfDocumentEntityConfiguration : IEntityTypeConfiguration<PdfDocu
             .HasColumnName("cover_generation_error")
             .IsRequired(false);
 
+        // #3373 D1: bounded-retry counter for transient cover-generation failures.
+        builder.Property(e => e.CoverGenerationAttempts)
+            .IsRequired()
+            .HasColumnName("cover_generation_attempts")
+            .HasDefaultValue(0);
+
         builder.HasIndex(e => e.CoverGenerationStatus)
             .HasDatabaseName("ix_pdf_documents_cover_generation_status");
     }

--- a/apps/api/src/Api/Infrastructure/Migrations/20260729155835_AddPdfCoverGenerationAttempts.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260729155835_AddPdfCoverGenerationAttempts.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260729155835_AddPdfCoverGenerationAttempts")]
+    partial class AddPdfCoverGenerationAttempts
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260729155835_AddPdfCoverGenerationAttempts.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260729155835_AddPdfCoverGenerationAttempts.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPdfCoverGenerationAttempts : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "cover_generation_attempts",
+                table: "pdf_documents",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "cover_generation_attempts",
+                table: "pdf_documents");
+        }
+    }
+}

--- a/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.CatalogCovers.cs
+++ b/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.CatalogCovers.cs
@@ -62,8 +62,16 @@ internal static partial class MeepleAiMetrics
     /// <summary>Wire value for the <c>outcome</c> tag: generation skipped (heuristic rejected pages).</summary>
     public const string CoverGenerationOutcomeSkipped = "skipped";
 
-    /// <summary>Wire value for the <c>outcome</c> tag: generation failed (extraction/upload/save error).</summary>
+    /// <summary>Wire value for the <c>outcome</c> tag: generation failed TERMINALLY (retry budget exhausted, or a permanent extractor failure).</summary>
     public const string CoverGenerationOutcomeFailed = "failed";
+
+    /// <summary>
+    /// Wire value for the <c>outcome</c> tag: a TRANSIENT generation failure that stays retry-eligible
+    /// (returned to <c>Pending</c> with attempts still below <c>PdfCoverRetryPolicy.MaxAttempts</c>; #3373 D1).
+    /// Kept distinct from <see cref="CoverGenerationOutcomeFailed"/> so the degradation alert on
+    /// <c>outcome="failed"</c> tracks only terminal failures — a self-healing infra blip must not inflate it.
+    /// </summary>
+    public const string CoverGenerationOutcomeRetrying = "retrying";
 
     /// <summary>
     /// Counter of PDF cover-GENERATION outcomes (as opposed to <see cref="CoverResolution"/>,
@@ -72,13 +80,16 @@ internal static partial class MeepleAiMetrics
     /// <c>MaterializePdfCoverCommandHandler</c> — so ops can see generation health
     /// (generated/skipped/failed rate) directly instead of waiting for the lagging
     /// read-time <c>placeholder&gt;80%</c> signal. Tags: <c>source</c> (currently <c>pdf</c>),
-    /// <c>outcome</c> (<c>generated</c>|<c>skipped</c>|<c>failed</c>). Decision D5-C, umbrella #3373.
+    /// <c>outcome</c> (<c>generated</c>|<c>skipped</c>|<c>failed</c>|<c>retrying</c>). Decision D5-C, umbrella #3373.
     ///
     /// Suggested alerting:
     /// <list type="bullet">
     ///   <item><c>rate(meepleai_cover_generation_total{outcome="failed"}[15m]) / rate(meepleai_cover_generation_total[15m]) &gt; 0.20</c>
     ///     sustained → PDF cover generation is degrading (extraction, R2 upload or DB save
-    ///     failing); investigate before the read-time placeholder&gt;80% alert fires.</item>
+    ///     failing); investigate before the read-time placeholder&gt;80% alert fires.
+    ///     Post-#3373 D1 <c>outcome="failed"</c> counts only TERMINAL failures; a transient
+    ///     blip that self-heals within the retry budget is tagged <c>retrying</c> instead, so
+    ///     this ratio stays diagnostic rather than firing on recoverable infra hiccups.</item>
     /// </list>
     /// </summary>
     public static readonly Counter<long> CoverGeneration = Meter.CreateCounter<long>(
@@ -89,7 +100,7 @@ internal static partial class MeepleAiMetrics
     /// <summary>
     /// Records one PDF cover-generation outcome. <paramref name="outcome"/> must be one of
     /// <see cref="CoverGenerationOutcomeGenerated"/> / <see cref="CoverGenerationOutcomeSkipped"/> /
-    /// <see cref="CoverGenerationOutcomeFailed"/>.
+    /// <see cref="CoverGenerationOutcomeFailed"/> / <see cref="CoverGenerationOutcomeRetrying"/>.
     /// </summary>
     public static void RecordPdfCoverGeneration(string outcome) =>
         CoverGeneration.Add(

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Jobs/BackfillPdfCoversJobTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Jobs/BackfillPdfCoversJobTests.cs
@@ -53,7 +53,8 @@ public sealed class BackfillPdfCoversJobTests : IDisposable
         string coverStatus = "Pending",
         string processingState = "Ready",
         DateTime? uploadedAt = null,
-        Guid? sharedGameId = null)
+        Guid? sharedGameId = null,
+        int coverAttempts = 0)
     {
         var pdf = new PdfDocumentEntity
         {
@@ -66,6 +67,7 @@ public sealed class BackfillPdfCoversJobTests : IDisposable
             UploadedAt = uploadedAt ?? DateTime.UtcNow,
             ProcessingState = processingState,
             CoverGenerationStatus = coverStatus,
+            CoverGenerationAttempts = coverAttempts,
             SharedGameId = sharedGameId,
         };
         _db.PdfDocuments.Add(pdf);
@@ -106,9 +108,9 @@ public sealed class BackfillPdfCoversJobTests : IDisposable
     }
 
     [Fact]
-    public async Task RunBatchAsync_PdfBytesNullFromBlob_MarksFailedWithoutCallingExtractor()
+    public async Task RunBatchAsync_PdfBytesNullFromBlob_TransientRetry_MarksPendingWithIncrementedAttempt()
     {
-        var pdf = SeedPdf();
+        var pdf = SeedPdf(); // attempts = 0
 
         _blob.Setup(b => b.RetrieveAsync(It.IsAny<string>(), BlobCategory.Pdf, It.IsAny<string>(), It.IsAny<CancellationToken>()))
              .ReturnsAsync((Stream?)null);
@@ -118,8 +120,27 @@ public sealed class BackfillPdfCoversJobTests : IDisposable
         _extractor.Verify(e => e.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Never);
 
         var refreshed = _db.PdfDocuments.AsNoTracking().Single(p => p.Id == pdf.Id);
-        refreshed.CoverGenerationStatus.Should().Be(nameof(PdfCoverGenerationStatus.Failed));
+        refreshed.CoverGenerationStatus.Should().Be(nameof(PdfCoverGenerationStatus.Pending),
+            "#3373 D1: a missing binary is a transient storage failure — retry-eligible, not immediately terminal");
+        refreshed.CoverGenerationAttempts.Should().Be(1);
         refreshed.CoverGenerationError.Should().Contain("not found");
+    }
+
+    [Fact]
+    public async Task RunBatchAsync_PdfBytesNull_AtMaxAttempts_MarksTerminalFailed()
+    {
+        // attempts already at Max-1: this transient failure exhausts the budget → terminal Failed.
+        var pdf = SeedPdf(coverAttempts: PdfCoverRetryPolicy.MaxAttempts - 1);
+
+        _blob.Setup(b => b.RetrieveAsync(It.IsAny<string>(), BlobCategory.Pdf, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+             .ReturnsAsync((Stream?)null);
+
+        await CreateJob().RunBatchAsync(_db, _extractor.Object, _blob.Object, _coverPipeline.Object, _eventCollector.Object, default);
+
+        var refreshed = _db.PdfDocuments.AsNoTracking().Single(p => p.Id == pdf.Id);
+        refreshed.CoverGenerationStatus.Should().Be(nameof(PdfCoverGenerationStatus.Failed),
+            "at MaxAttempts the transient retry budget is exhausted → terminal");
+        refreshed.CoverGenerationAttempts.Should().Be(PdfCoverRetryPolicy.MaxAttempts);
     }
 
     [Fact]
@@ -211,7 +232,7 @@ public sealed class BackfillPdfCoversJobTests : IDisposable
     }
 
     [Fact]
-    public async Task RunBatchAsync_ExtractorThrows_MarksFailedAndContinuesNextItem()
+    public async Task RunBatchAsync_ExtractorThrows_TransientRetry_MarksPendingAndContinuesNextItem()
     {
         var first = SeedPdf(uploadedAt: DateTime.UtcNow.AddMinutes(-10));
         var second = SeedPdf(uploadedAt: DateTime.UtcNow);
@@ -230,7 +251,9 @@ public sealed class BackfillPdfCoversJobTests : IDisposable
         await CreateJob().RunBatchAsync(_db, _extractor.Object, _blob.Object, _coverPipeline.Object, _eventCollector.Object, default);
 
         var refreshedFirst = _db.PdfDocuments.AsNoTracking().Single(p => p.Id == first.Id);
-        refreshedFirst.CoverGenerationStatus.Should().Be(nameof(PdfCoverGenerationStatus.Failed));
+        refreshedFirst.CoverGenerationStatus.Should().Be(nameof(PdfCoverGenerationStatus.Pending),
+            "#3373 D1: an unexpected exception is transient infra — retry-eligible, not terminal");
+        refreshedFirst.CoverGenerationAttempts.Should().Be(1);
         // Error message encodes the orphan-check hint (#1873 review fix H2): contains the
         // exception type name and the resourceKey operators must inspect for orphan blobs.
         refreshedFirst.CoverGenerationError.Should().Contain(nameof(InvalidOperationException));

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Jobs/PdfCoverOrphanRecoveryJobTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Jobs/PdfCoverOrphanRecoveryJobTests.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.DocumentProcessing.Application.Jobs;
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
 using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
@@ -39,7 +40,8 @@ public sealed class PdfCoverOrphanRecoveryJobTests : IDisposable
     private PdfDocumentEntity SeedPdf(
         string? coverR2Key = null,
         string coverStatus = "Generated",
-        DateTime? updatedAt = null)
+        DateTime? updatedAt = null,
+        int coverAttempts = 0)
     {
         var pdf = new PdfDocumentEntity
         {
@@ -53,6 +55,7 @@ public sealed class PdfCoverOrphanRecoveryJobTests : IDisposable
             ProcessingState = "Ready",
             CoverGenerationStatus = coverStatus,
             CoverR2Key = coverR2Key,
+            CoverGenerationAttempts = coverAttempts,
             UpdatedAt = updatedAt ?? DateTime.UtcNow,
         };
         _db.PdfDocuments.Add(pdf);
@@ -193,5 +196,44 @@ public sealed class PdfCoverOrphanRecoveryJobTests : IDisposable
         var result = _db.PdfDocuments.AsNoTracking().Single(p => p.Id == pdf.Id);
         result.CoverGenerationStatus.Should().Be(nameof(PdfCoverGenerationStatus.Pending));
         result.CoverR2Key.Should().BeNull();
+    }
+
+    // #3373 D3 — reconcile the inverse orphan: Failed rows WITHOUT a CoverR2Key whose
+    // deterministic preview blob exists in R2 (upload succeeded, DB save failed).
+
+    [Fact]
+    public async Task RunBatchAsync_FailedWithoutKey_OrphanExists_ResetsToPendingAndClearsAttempts()
+    {
+        var pdf = SeedPdf(coverR2Key: null, coverStatus: "Failed", coverAttempts: PdfCoverRetryPolicy.MaxAttempts);
+        pdf.CoverGenerationError = "exhausted";
+        _db.SaveChanges();
+
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync(
+                $"covers/pdf/{pdf.Id:D}/cover-preview.webp", It.IsAny<int?>()))
+             .ReturnsAsync("https://presigned.example/cover-preview.webp");
+
+        await CreateJob().RunBatchAsync(_db, _blob.Object, CancellationToken.None);
+
+        var reconciled = _db.PdfDocuments.AsNoTracking().Single(p => p.Id == pdf.Id);
+        reconciled.CoverGenerationStatus.Should().Be(nameof(PdfCoverGenerationStatus.Pending),
+            "an orphan-backed Failed cover is reset for regeneration (the re-upload overwrites the orphan)");
+        reconciled.CoverGenerationAttempts.Should().Be(0,
+            "the retry budget resets so regeneration is not immediately terminal");
+        reconciled.CoverGenerationError.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task RunBatchAsync_FailedWithoutKey_NoOrphan_LeftFailed()
+    {
+        var pdf = SeedPdf(coverR2Key: null, coverStatus: "Failed", coverAttempts: PdfCoverRetryPolicy.MaxAttempts);
+
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync(It.IsAny<string>(), It.IsAny<int?>()))
+             .ReturnsAsync((string?)null);
+
+        await CreateJob().RunBatchAsync(_db, _blob.Object, CancellationToken.None);
+
+        var result = _db.PdfDocuments.AsNoTracking().Single(p => p.Id == pdf.Id);
+        result.CoverGenerationStatus.Should().Be(nameof(PdfCoverGenerationStatus.Failed),
+            "no orphan blob to reconcile — leave the genuine failure terminal");
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Jobs/PdfCoverOrphanRecoveryJobTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Jobs/PdfCoverOrphanRecoveryJobTests.cs
@@ -105,8 +105,11 @@ public sealed class PdfCoverOrphanRecoveryJobTests : IDisposable
     [Fact]
     public async Task RunBatchAsync_OrphanDetected_ResetsToPending()
     {
-        // 1 PDF with key, raw-key check returns null (object absent) → orphan → reset all 4 fields
-        var orphan = SeedPdf(coverR2Key: "pdf-cover-missing");
+        // 1 PDF with key, raw-key check returns null (object absent) → orphan → reset all fields.
+        // Seed a NON-zero attempt count (the cover succeeded after 2 transient retries, then its blob
+        // vanished): the re-opened generation cycle must start with a clean retry budget, else the very
+        // first transient failure of the new cycle would go immediately terminal (#3373 D1).
+        var orphan = SeedPdf(coverR2Key: "pdf-cover-missing", coverAttempts: PdfCoverRetryPolicy.MaxAttempts);
         orphan.CoverGenerationError = "stale-error";
         orphan.CoverPageIndex = 2;
         _db.SaveChanges();
@@ -121,6 +124,8 @@ public sealed class PdfCoverOrphanRecoveryJobTests : IDisposable
         reset.CoverR2Key.Should().BeNull();
         reset.CoverGenerationError.Should().BeNull();
         reset.CoverPageIndex.Should().BeNull();
+        reset.CoverGenerationAttempts.Should().Be(0,
+            "the retry budget resets so regeneration of the re-opened cycle is not immediately terminal");
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfCoverRetryPolicyTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfCoverRetryPolicyTests.cs
@@ -1,0 +1,37 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Services;
+
+/// <summary>
+/// #3373 D1 (ADR-087): bounded-retry classification for PDF cover generation.
+/// A transient failure (R2/DB infra) is retry-eligible — the PDF returns to Pending so
+/// BackfillPdfCoversJob re-picks it — until MaxAttempts, after which it is terminal Failed.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "DocumentProcessing")]
+public class PdfCoverRetryPolicyTests
+{
+    [Theory]
+    [InlineData(0, PdfCoverGenerationStatus.Pending, 1)]  // first transient failure → retry
+    [InlineData(1, PdfCoverGenerationStatus.Pending, 2)]  // second → retry
+    [InlineData(2, PdfCoverGenerationStatus.Failed, 3)]   // third reaches the budget → terminal
+    [InlineData(5, PdfCoverGenerationStatus.Failed, 6)]   // already past → stays terminal
+    public void NextAfterTransientFailure_RetriesUntilMaxThenTerminal(
+        int currentAttempts, PdfCoverGenerationStatus expectedStatus, int expectedAttempts)
+    {
+        var (status, attempts) = PdfCoverRetryPolicy.NextAfterTransientFailure(currentAttempts);
+
+        attempts.Should().Be(expectedAttempts, "each transient failure increments the counter");
+        status.Should().Be(expectedStatus,
+            "retry-eligible (Pending) while under MaxAttempts, terminal (Failed) once reached");
+    }
+
+    [Fact]
+    public void MaxAttempts_IsThree()
+    {
+        PdfCoverRetryPolicy.MaxAttempts.Should().Be(3, "DEC-3j mirror: 3 attempts before terminal");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineServiceCoverTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineServiceCoverTests.cs
@@ -129,4 +129,93 @@ public sealed class PdfProcessingPipelineServiceCoverTests : IDisposable
         pdf.CoverR2Key.Should().BeNull();
         _collected.Should().BeEmpty();
     }
+
+    // #3373 D1: an exception thrown during extract/upload/save is an INFRA failure (R2/DB) — TRANSIENT.
+    // The cover step must return the PDF to Pending (retry-eligible via BackfillPdfCoversJob) while the
+    // attempt budget has room, then terminal Failed once it is exhausted. These two tests give this
+    // call-site the same coverage BackfillPdfCoversJob already has for its transient paths.
+
+    [Fact]
+    public async Task ExtractCoverImageAsync_UploadThrows_TransientRetryPendingAndIncrementsAttempts()
+    {
+        var pdf = new PdfDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            FileName = "rules.pdf",
+            FilePath = "/tmp/rules.pdf",
+            FileSizeBytes = 1,
+            ContentType = "application/pdf",
+            UploadedByUserId = Guid.NewGuid(),
+            UploadedAt = DateTime.UtcNow,
+            ProcessingState = "Extracting",
+            CoverGenerationStatus = "Pending",
+            CoverGenerationAttempts = 0,
+            SharedGameId = Guid.NewGuid(),
+        };
+
+        _blob.Setup(b => b.RetrieveAsync(It.IsAny<string>(), BlobCategory.Pdf, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+             .ReturnsAsync(() => new MemoryStream(new byte[] { 0x25, 0x50, 0x44, 0x46 }));
+        _coverExtractor.Setup(e => e.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+                       .ReturnsAsync(new PdfCoverExtractionResult
+                       {
+                           Outcome = PdfCoverExtractionOutcome.Generated,
+                           ThumbnailWebp = new byte[] { 1 },
+                           PreviewWebp = new byte[] { 9, 9, 9 },
+                           SelectedPageIndex = 0,
+                       });
+        // R2 upload throws — the realistic transient infra failure the catch protects against.
+        _coverPipeline.Setup(p => p.UploadAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+                      .ThrowsAsync(new InvalidOperationException("R2 upload transient failure"));
+
+        var sut = PdfProcessingPipelineServiceCoverTestFactory.Create(
+            _db, _blob.Object, _coverExtractor.Object, _coverPipeline.Object, _eventCollector.Object);
+
+        var act = () => sut.InvokeExtractCoverImageForTestAsync(pdf, "/tmp/rules.pdf", CancellationToken.None);
+
+        await act.Should().NotThrowAsync("a transient cover failure must not abort PDF ingestion");
+        pdf.CoverGenerationStatus.Should().Be("Pending", "the failure is retry-eligible while budget remains");
+        pdf.CoverGenerationAttempts.Should().Be(1, "the attempt counter advances on each transient failure");
+        pdf.CoverR2Key.Should().BeNull();
+        _collected.Should().BeEmpty("no propagation event on a failed generation");
+    }
+
+    [Fact]
+    public async Task ExtractCoverImageAsync_UploadThrowsAtLastAttempt_TerminalFailed()
+    {
+        var pdf = new PdfDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            FileName = "rules.pdf",
+            FilePath = "/tmp/rules.pdf",
+            FileSizeBytes = 1,
+            ContentType = "application/pdf",
+            UploadedByUserId = Guid.NewGuid(),
+            UploadedAt = DateTime.UtcNow,
+            ProcessingState = "Extracting",
+            CoverGenerationStatus = "Pending",
+            CoverGenerationAttempts = PdfCoverRetryPolicy.MaxAttempts - 1,
+            SharedGameId = Guid.NewGuid(),
+        };
+
+        _blob.Setup(b => b.RetrieveAsync(It.IsAny<string>(), BlobCategory.Pdf, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+             .ReturnsAsync(() => new MemoryStream(new byte[] { 0x25, 0x50, 0x44, 0x46 }));
+        _coverExtractor.Setup(e => e.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+                       .ReturnsAsync(new PdfCoverExtractionResult
+                       {
+                           Outcome = PdfCoverExtractionOutcome.Generated,
+                           ThumbnailWebp = new byte[] { 1 },
+                           PreviewWebp = new byte[] { 9, 9, 9 },
+                           SelectedPageIndex = 0,
+                       });
+        _coverPipeline.Setup(p => p.UploadAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+                      .ThrowsAsync(new InvalidOperationException("R2 upload transient failure"));
+
+        var sut = PdfProcessingPipelineServiceCoverTestFactory.Create(
+            _db, _blob.Object, _coverExtractor.Object, _coverPipeline.Object, _eventCollector.Object);
+
+        await sut.InvokeExtractCoverImageForTestAsync(pdf, "/tmp/rules.pdf", CancellationToken.None);
+
+        pdf.CoverGenerationStatus.Should().Be("Failed", "the retry budget is exhausted — the failure is now terminal");
+        pdf.CoverGenerationAttempts.Should().Be(PdfCoverRetryPolicy.MaxAttempts);
+    }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommandHandlerTests.cs
@@ -16,6 +16,7 @@ using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.TestHelpers;
 using FluentAssertions;
 using ImageMagick;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Time.Testing;
 using Moq;
@@ -93,6 +94,79 @@ public class EnrichCatalogCoverCommandHandlerTests
         capturedRequest.Should().NotBeNull();
         capturedRequest!.Key.Should().Be($"covers/{game.Id}/cover.webp",
             "physical R2 object key INCLUDES .webp suffix");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // #3373 D3 — concurrency: M9 cron vs admin force-refresh on the same game
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_ConcurrencyConflictOnSave_ReloadsReappliesAndRetriesOnce()
+    {
+        // The enrichment is idempotent (deterministic R2 key + same license), so a
+        // DbUpdateConcurrencyException on the first save must be handled by reloading the
+        // fresh aggregate, re-applying the cover, and saving once more — last-writer-wins
+        // is benign by design (ADR-087 D3).
+        var harness = BuildHarness();
+        var game = BuildGame(qid: TestQid);
+
+        harness.RepoMock
+            .Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(game);
+
+        harness.WikidataHandler.SparqlJson = BuildSparqlImageResponse(TestFilename);
+        harness.CommonsHandler.LicenseJson = BuildImageInfoResponse("CC BY-SA 4.0", artistHtml: "John Doe");
+        harness.CommonsHandler.ImageBytes = await CreateSolidImagePngAsync(800, 600);
+        harness.S3Mock
+            .Setup(s => s.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PutObjectResponse { HttpStatusCode = HttpStatusCode.OK });
+
+        harness.UowMock
+            .SetupSequence(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new DbUpdateConcurrencyException())
+            .ReturnsAsync(1);
+
+        var result = await harness.Sut.Handle(
+            new EnrichCatalogCoverCommand(game.Id), CancellationToken.None);
+
+        result.Should().BeOfType<EnrichCatalogCoverResult.Success>();
+        harness.UowMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Exactly(2),
+            "the first save conflicts; the reload+re-apply save is the second");
+        harness.RepoMock.Verify(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>()), Times.Exactly(2),
+            "initial load + one reload after the concurrency conflict");
+    }
+
+    [Fact]
+    public async Task Handle_ConcurrencyConflictThenGameDeleted_ReturnsSkippedConcurrentDelete()
+    {
+        // If the reload after a concurrency conflict finds the game gone (soft-deleted
+        // concurrently), there is nothing to persist — return Skipped rather than crash.
+        var harness = BuildHarness();
+        var game = BuildGame(qid: TestQid);
+
+        harness.RepoMock
+            .SetupSequence(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(game)
+            .ReturnsAsync((SharedGame?)null);
+
+        harness.WikidataHandler.SparqlJson = BuildSparqlImageResponse(TestFilename);
+        harness.CommonsHandler.LicenseJson = BuildImageInfoResponse("CC BY-SA 4.0", artistHtml: "John Doe");
+        harness.CommonsHandler.ImageBytes = await CreateSolidImagePngAsync(800, 600);
+        harness.S3Mock
+            .Setup(s => s.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PutObjectResponse { HttpStatusCode = HttpStatusCode.OK });
+
+        harness.UowMock
+            .Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new DbUpdateConcurrencyException());
+
+        var result = await harness.Sut.Handle(
+            new EnrichCatalogCoverCommand(game.Id), CancellationToken.None);
+
+        result.Should().BeOfType<EnrichCatalogCoverResult.Skipped>();
+        ((EnrichCatalogCoverResult.Skipped)result).Reason.Should().Be("concurrent-delete");
+        harness.UowMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once,
+            "only the first (conflicting) save is attempted; the reload finds no game to re-save");
     }
 
     // ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Cosa

Implementa il work-stream **D1 + D3** dell'ADR-087 (umbrella #3373, issue #3382) — resilienza della generazione cover PDF e riconciliazione degli orfani — più i fix dalla review olistica pre-merge.

Chiude la lacuna per cui un fallimento **transitorio** (blip R2/DB) durante la generazione della cover era immediatamente terminale (`Failed`), lasciando la cover irrisolvibile fino a un reset manuale.

## Decisioni (ADR-087)

- **D1 — Bounded retry**: un'eccezione infra (R2 upload / DB save) o un binario PDF mancante è ora **transitoria** → la riga torna a `Pending` (retry-eligible via `BackfillPdfCoversJob`) fino a `PdfCoverRetryPolicy.MaxAttempts` (=3), poi terminale `Failed`. Il fallimento **permanente** (extractor che ritorna `Failed`: PDF corrotto, decodifica) resta terminale immediato — nessuna misclassificazione (l'extractor cattura internamente le eccezioni di rendering).
- **D3 — Concurrency guard**: `EnrichCatalogCoverCommandHandler` cattura `DbUpdateConcurrencyException`, ricarica lo stato fresco, ri-applica la cover Wikidata deterministica e ri-salva (o `Skipped("concurrent-delete")` se il gioco è stato cancellato in concorrenza).
- **D3 — Orphan reconcile**: `PdfCoverOrphanRecoveryJob` ora riconcilia anche l'**orfano inverso** — riga `Failed` **senza** `CoverR2Key` il cui blob preview deterministico esiste in R2 (upload riuscito, save DB fallito) → reset a `Pending` con budget azzerato. La riga `Failed` senza blob orfano resta terminale.

## Schema

Nuova colonna `pdf_documents.cover_generation_attempts int NOT NULL DEFAULT 0` (migration `20260729155835_AddPdfCoverGenerationAttempts`) — sicura per le righe esistenti, `Down` simmetrico.

## Fix dalla review olistica (commit `bb1618a9e`)

1. **Retry budget per-ciclo, non a-vita**: `CoverGenerationAttempts` viene azzerato su ogni path che chiude o riapre un ciclo (i due siti Generated-success + l'orphan-reset `Generated→Pending`), non solo nel `ReconcileFailedOrphansAsync`. Senza, una cover riuscita dopo 1-2 retry avrebbe portato il contatore residuo in un ciclo riaperto, andando terminale al primo fallimento.
2. **Metrica D5-C diagnostica**: nuovo `outcome="retrying"` per i fallimenti transitori che restano `Pending`; `outcome="failed"` è riservato all'esaurimento terminale. L'alert `failed-ratio > 20%` non scatta più su blip infra auto-risolti.
3. **Copertura pipeline-catch**: aggiunti i 2 test mancanti su `PdfProcessingPipelineService` (transient → `Pending`+attempts++; terminale a `MaxAttempts` → `Failed`), simmetrici a quelli già presenti per `BackfillPdfCoversJob`.

## Test

Tutte le classi cover verdi (45/45 nella run mirata):
- `PdfCoverRetryPolicyTests` (helper puro, 5)
- `BackfillPdfCoversJobTests` (transient → Pending/attempts + terminale a max)
- `PdfCoverOrphanRecoveryJobTests` (9, incl. reconcile + orphan-reset con budget azzerato)
- `EnrichCatalogCoverCommandHandlerTests` (17, incl. i 2 scenari concurrency)
- `PdfProcessingPipelineServiceCoverTests` (4, incl. i 2 nuovi transient/terminale)

## Note di scope (fuori PR, pre-esistente)

`PdfDocumentRepository.MapToPersistence` non mappa i campi cover (inclusa la nuova colonna) — ma i tre siti toccati operano tutti direttamente su `DbContext.PdfDocuments`, quindi non è una regressione introdotta qui. Gap pre-esistente, segnalato come contesto.

Refs #3382 #3373

🤖 Generated with [Claude Code](https://claude.com/claude-code)
