### PR TITLE
refactor(catalog): CoverKind key-builder + L3 custom-cover write fix (#3384)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/EventHandlers/PdfDeletedEventHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/EventHandlers/PdfDeletedEventHandler.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.DocumentProcessing.Domain.Events;
 using Api.Services.Pdf;
+using Api.SharedKernel.Domain.Covers;
 using MediatR;
 using Microsoft.Extensions.Logging;
 
@@ -44,7 +45,7 @@ internal sealed class PdfDeletedEventHandler : INotificationHandler<PdfDeletedDo
         // The categorized DeleteAsync cannot be used because it runs
         // PathSecurity.ValidateIdentifier, which rejects '/' and '.'; delete via
         // the raw-key primitive instead (mirrors CoverUrlResolver's raw-key reads).
-        var rawKey = $"{notification.CoverR2Key}-preview.webp";
+        var rawKey = CoverKeyBuilder.PhysicalKeyFor(CoverKind.Pdf, notification.CoverR2Key);
         await TryDeleteRawKeyAsync(rawKey, notification.PdfDocumentId, cancellationToken).ConfigureAwait(false);
     }
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/BackfillPdfCoversJob.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/BackfillPdfCoversJob.cs
@@ -6,6 +6,7 @@ using Api.Infrastructure.Entities;
 using Api.Observability;
 using Api.Services.Pdf;
 using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Domain.Covers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -169,7 +170,8 @@ public sealed class BackfillPdfCoversJob : IJob
                         // physical R2 object "{dbKey}-preview.webp" that the resolver
                         // reconstructs. Only the preview size is uploaded (the
                         // resolver never reads the thumbnail size).
-                        var dbKey = $"covers/pdf/{pdf.Id:D}/cover";
+                        // #3384 D5-A: DB key comes from the single CoverKeyBuilder.
+                        var dbKey = CoverKeyBuilder.ForPdf(pdf.Id).DbKey;
 
                         var persistedKey = await coverUploadPipeline
                             .UploadAsync(dbKey, result.PreviewWebp!, ct)
@@ -233,7 +235,7 @@ public sealed class BackfillPdfCoversJob : IJob
             // R2 will contain an orphan preview under the deterministic key. The
             // entity ends up Failed without a CoverR2Key so cleanup can't reach it.
             // Embed the prospective physical key so operators can grep the bucket.
-            var orphanPhysicalKey = $"covers/pdf/{pdf.Id:D}/cover-preview.webp";
+            var orphanPhysicalKey = CoverKeyBuilder.ForPdf(pdf.Id).PhysicalKey;
             _logger.LogWarning(ex,
                 "BackfillPdfCoversJob: unexpected error processing PDF {PdfId}; marking Failed. " +
                 "Inspect R2 key {OrphanKey} for an orphan preview blob and clean up manually if present.",

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/PdfCoverOrphanRecoveryJob.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/PdfCoverOrphanRecoveryJob.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.Infrastructure;
 using Api.Services.Pdf;
+using Api.SharedKernel.Domain.Covers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -113,7 +114,7 @@ public sealed class PdfCoverOrphanRecoveryJob : IJob
                 // via the RAW-KEY primitive (mirrors CoverUrlResolver): CoverR2Key
                 // is a deterministic key containing '/' (e.g. "covers/pdf/{id:D}/cover"),
                 // which the categorized ExistsAsync cannot validate/resolve.
-                var previewRawKey = $"{pdf.CoverR2Key}-preview.webp";
+                var previewRawKey = CoverKeyBuilder.PhysicalKeyFor(CoverKind.Pdf, pdf.CoverR2Key!);
                 var exists = await blob.GetPresignedUrlForRawKeyAsync(previewRawKey)
                     .ConfigureAwait(false) is not null;
 
@@ -207,7 +208,7 @@ public sealed class PdfCoverOrphanRecoveryJob : IJob
             var pdf = batch[i];
             try
             {
-                var previewRawKey = $"covers/pdf/{pdf.Id:D}/cover-preview.webp";
+                var previewRawKey = CoverKeyBuilder.ForPdf(pdf.Id).PhysicalKey;
                 var orphanExists = await blob.GetPresignedUrlForRawKeyAsync(previewRawKey).ConfigureAwait(false) is not null;
                 if (orphanExists)
                 {

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
@@ -15,6 +15,7 @@ using Api.Observability;
 using Api.Services;
 using Api.Services.Pdf;
 using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Domain.Covers;
 using Microsoft.EntityFrameworkCore;
 using System.Text.Json;
 using KbEntities = Api.BoundedContexts.KnowledgeBase.Domain.Entities;
@@ -583,7 +584,8 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
                         // physical R2 object "{dbKey}-preview.webp" that the resolver
                         // reconstructs. Only the preview size is uploaded (the
                         // resolver never reads the thumbnail size).
-                        var dbKey = $"covers/pdf/{pdfDoc.Id:D}/cover";
+                        // #3384 D5-A: DB key comes from the single CoverKeyBuilder.
+                        var dbKey = CoverKeyBuilder.ForPdf(pdfDoc.Id).DbKey;
 
                         var persistedKey = await _pdfCoverUploadPipeline
                             .UploadAsync(dbKey, result.PreviewWebp!, cancellationToken)

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/PdfCoverUploadPipeline.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/PdfCoverUploadPipeline.cs
@@ -2,6 +2,7 @@ using Amazon.S3;
 using Amazon.S3.Model;
 using Api.BoundedContexts.DocumentProcessing.Application.Services;
 using Api.Services.Pdf;
+using Api.SharedKernel.Domain.Covers;
 using Microsoft.Extensions.Logging;
 
 namespace Api.BoundedContexts.DocumentProcessing.Infrastructure.Services;
@@ -45,10 +46,9 @@ internal sealed class PdfCoverUploadPipeline : IPdfCoverUploadPipeline
             throw new ArgumentException("WebP bytes must be non-null and non-empty.", nameof(webpBytes));
         }
 
-        // The resolver (CoverUrlResolver.ResolvePublicAsync) appends -preview.webp
-        // to the DB-stored key to derive the physical R2 object — this is the
-        // write side of that convention.
-        var objectKey = $"{dbKey}-preview.webp";
+        // #3384 D5-A: the single CoverKeyBuilder owns the "-preview.webp" suffix, so
+        // this write key and CoverUrlResolver's read key coincide by construction.
+        var objectKey = CoverKeyBuilder.PhysicalKeyFor(CoverKind.Pdf, dbKey);
 
         using var stream = new MemoryStream(webpBytes, writable: false);
         var request = new PutObjectRequest

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolver.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolver.cs
@@ -2,6 +2,7 @@ using Api.Infrastructure.Entities.SharedGameCatalog;
 using Api.Infrastructure.Entities.UserLibrary;
 using Api.Observability;
 using Api.Services.Pdf;
+using Api.SharedKernel.Domain.Covers;
 
 namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
 
@@ -50,7 +51,8 @@ internal static class CoverUrlResolver
         if (!string.IsNullOrWhiteSpace(userEntry?.CustomCoverR2Key))
         {
             var url = await blobStorage
-                .GetPresignedUrlForRawKeyAsync($"{userEntry.CustomCoverR2Key}.webp")
+                .GetPresignedUrlForRawKeyAsync(
+                    CoverKeyBuilder.PhysicalKeyFor(CoverKind.User, userEntry.CustomCoverR2Key))
                 .ConfigureAwait(false);
             if (url is not null)
             {
@@ -80,7 +82,8 @@ internal static class CoverUrlResolver
         if (!string.IsNullOrWhiteSpace(sharedGame.PdfCoverR2Key))
         {
             var url = await blobStorage
-                .GetPresignedUrlForRawKeyAsync($"{sharedGame.PdfCoverR2Key}-preview.webp")
+                .GetPresignedUrlForRawKeyAsync(
+                    CoverKeyBuilder.PhysicalKeyFor(CoverKind.Pdf, sharedGame.PdfCoverR2Key))
                 .ConfigureAwait(false);
             if (url is not null)
             {
@@ -99,7 +102,8 @@ internal static class CoverUrlResolver
         if (!string.IsNullOrWhiteSpace(sharedGame.BggCoverR2Key))
         {
             var url = await blobStorage
-                .GetPresignedUrlForRawKeyAsync(sharedGame.BggCoverR2Key)
+                .GetPresignedUrlForRawKeyAsync(
+                    CoverKeyBuilder.PhysicalKeyFor(CoverKind.Bgg, sharedGame.BggCoverR2Key))
                 .ConfigureAwait(false);
             if (url is not null)
             {
@@ -112,7 +116,8 @@ internal static class CoverUrlResolver
         if (!string.IsNullOrWhiteSpace(sharedGame.WikidataCoverR2Key))
         {
             var url = await blobStorage
-                .GetPresignedUrlForRawKeyAsync($"{sharedGame.WikidataCoverR2Key}.webp")
+                .GetPresignedUrlForRawKeyAsync(
+                    CoverKeyBuilder.PhysicalKeyFor(CoverKind.Wikidata, sharedGame.WikidataCoverR2Key))
                 .ConfigureAwait(false);
             if (url is not null)
             {

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/BggCoverUploadPipeline.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/BggCoverUploadPipeline.cs
@@ -2,8 +2,8 @@ using Amazon.S3;
 using Amazon.S3.Model;
 using Api.BoundedContexts.SharedGameCatalog.Application.Services;
 using Api.Services.Pdf;
+using Api.SharedKernel.Domain.Covers;
 using Microsoft.Extensions.Logging;
-using System.Globalization;
 
 namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 
@@ -19,7 +19,6 @@ internal sealed class BggCoverUploadPipeline : IBggCoverUploadPipeline
     // Cover assets are immutable for 1 year; re-uploads reuse the same key so
     // Cloudflare CDN cache stays warm (mirrors CoverR2UploadPipeline).
     private const string ImmutableCacheControl = "public, max-age=31536000, immutable";
-    private const string DefaultExtension = ".jpg";
 
     private readonly IAmazonS3 _s3Client;
     private readonly S3StorageOptions _options;
@@ -42,10 +41,13 @@ internal sealed class BggCoverUploadPipeline : IBggCoverUploadPipeline
             throw new ArgumentException("imageBytes must be non-null and non-empty.", nameof(imageBytes));
         }
 
-        var ext = NormalizeExtension(extension);
+        // #3384 D5-A: the single CoverKeyBuilder owns the key shape + extension
+        // normalization; ContentType is derived from the SAME normalized extension.
+        // For BGG the physical key == DB key (the extension is embedded, no suffix).
+        var ext = CoverKeyBuilder.NormalizeBggExtension(extension);
         var contentType = ContentTypeFor(ext);
-        // Deterministic physical key = DB key (resolver appends NO suffix for L2.5).
-        var objectKey = $"bgg-covers/{bggId.ToString(CultureInfo.InvariantCulture)}/cover{ext}";
+        var coverKey = CoverKeyBuilder.ForBgg(bggId, ext);
+        var objectKey = coverKey.PhysicalKey;
 
         using var stream = new MemoryStream(imageBytes, writable: false);
         var request = new PutObjectRequest
@@ -68,7 +70,7 @@ internal sealed class BggCoverUploadPipeline : IBggCoverUploadPipeline
             _logger.LogInformation(
                 "Uploaded BGG cover to R2: BggId={BggId}, Key={Key}, Size={Size} bytes, ETag={ETag}",
                 bggId, objectKey, imageBytes.Length, response.ETag);
-            return objectKey;
+            return coverKey.DbKey;
         }
         catch (AmazonS3Exception ex)
         {
@@ -78,22 +80,6 @@ internal sealed class BggCoverUploadPipeline : IBggCoverUploadPipeline
                 bggId, objectKey, ex.StatusCode, ex.ErrorCode);
             throw;
         }
-    }
-
-    private static string NormalizeExtension(string extension)
-    {
-        if (string.IsNullOrWhiteSpace(extension))
-        {
-            return DefaultExtension;
-        }
-
-        var ext = extension.StartsWith('.') ? extension : "." + extension;
-        ext = ext.ToLowerInvariant();
-        return ext switch
-        {
-            ".jpg" or ".jpeg" or ".png" or ".gif" or ".webp" => ext,
-            _ => DefaultExtension,
-        };
     }
 
     private static string ContentTypeFor(string normalizedExtension) => normalizedExtension switch

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/CoverR2UploadPipeline.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/CoverR2UploadPipeline.cs
@@ -1,8 +1,8 @@
 using Amazon.S3;
 using Amazon.S3.Model;
 using Api.Services.Pdf;
+using Api.SharedKernel.Domain.Covers;
 using Microsoft.Extensions.Logging;
-using System.Globalization;
 
 namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 
@@ -41,13 +41,12 @@ internal sealed class CoverR2UploadPipeline : ICoverR2UploadPipeline
                 nameof(webpBytes));
         }
 
-        var gameIdSegment = gameId.ToString("D", CultureInfo.InvariantCulture);
-        // Physical R2 object key — INCLUDES .webp suffix (matches Content-Type).
-        var objectKey = $"covers/{gameIdSegment}/cover.webp";
-        // DB-safe key — EXCLUDES .webp suffix. CoverUrlResolver.cs:73-79 will
-        // append ".webp" when minting presigned URLs; storing the suffix here
-        // would yield "covers/.../cover.webp.webp" → 404.
-        var dbKey = $"covers/{gameIdSegment}/cover";
+        // #3384 D5-A: the single CoverKeyBuilder owns the suffix convention, so the
+        // physical key here and CoverUrlResolver's read key coincide by construction
+        // (no more "covers/.../cover.webp.webp" → 404 drift).
+        var coverKey = CoverKeyBuilder.ForWikidata(gameId);
+        var objectKey = coverKey.PhysicalKey;
+        var dbKey = coverKey.DbKey;
 
         using var stream = new MemoryStream(webpBytes, writable: false);
         var request = new PutObjectRequest

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/CustomCover/RemoveCustomCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/CustomCover/RemoveCustomCoverCommandHandler.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.UserLibrary.Domain.Repositories;
 using Api.Middleware.Exceptions;
 using Api.Services.Pdf;
 using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Domain.Covers;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Microsoft.Extensions.Logging;
 
@@ -31,11 +32,6 @@ internal sealed class RemoveCustomCoverCommandHandler : ICommandHandler<RemoveCu
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    /// <summary>
-    /// Centralizes the .webp extension to prevent hardcoding it in multiple places.
-    /// </summary>
-    private static string ToObjectKey(string resourceKey) => $"{resourceKey}.webp";
-
     public async Task Handle(RemoveCustomCoverCommand command, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(command);
@@ -53,13 +49,12 @@ internal sealed class RemoveCustomCoverCommandHandler : ICommandHandler<RemoveCu
 
         var keyToDelete = entry.CustomCoverR2Key;
 
-        // Best-effort R2 cleanup
+        // Best-effort R2 cleanup via the RAW-KEY delete (#3384): the categorized
+        // DeleteAsync rejects the slash-containing deterministic key.
         try
         {
-            await _blobStorage.DeleteAsync(
-                ToObjectKey(keyToDelete),
-                BlobCategory.GameImage,
-                keyToDelete,
+            await _blobStorage.DeleteRawKeyAsync(
+                CoverKeyBuilder.PhysicalKeyFor(CoverKind.User, keyToDelete),
                 cancellationToken
             ).ConfigureAwait(false);
         }

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/CustomCover/UploadCustomCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/CustomCover/UploadCustomCoverCommandHandler.cs
@@ -3,6 +3,7 @@ using Api.BoundedContexts.UserLibrary.Domain.Repositories;
 using Api.Middleware.Exceptions;
 using Api.Services.Pdf;
 using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Domain.Covers;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Microsoft.Extensions.Logging;
 
@@ -32,11 +33,6 @@ internal sealed class UploadCustomCoverCommandHandler : ICommandHandler<UploadCu
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    /// <summary>
-    /// Centralizes the .webp extension to prevent hardcoding it in multiple places.
-    /// </summary>
-    private static string ToObjectKey(string resourceKey) => $"{resourceKey}.webp";
-
     public async Task<CustomCoverUploadResult> Handle(UploadCustomCoverCommand command, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(command);
@@ -47,8 +43,11 @@ internal sealed class UploadCustomCoverCommandHandler : ICommandHandler<UploadCu
             .ConfigureAwait(false)
             ?? throw new ForbiddenException($"Game {command.GameId} is not in user library");
 
-        var resourceKey = $"user-covers/{command.UserId}/{command.GameId}/cover";
-        var objectKey = ToObjectKey(resourceKey);
+        // #3384 D5-A: the single CoverKeyBuilder owns the ".webp" suffix convention
+        // (DbKey stored, PhysicalKey written) so writer and resolver never drift.
+        var coverKey = CoverKeyBuilder.ForUser(command.UserId, command.GameId);
+        var resourceKey = coverKey.DbKey;
+        var objectKey = coverKey.PhysicalKey;
 
         // Best-effort delete old cover so stale R2 objects don't accumulate
         if (entry.HasCustomCover)
@@ -56,7 +55,7 @@ internal sealed class UploadCustomCoverCommandHandler : ICommandHandler<UploadCu
             try
             {
                 await _blobStorage.DeleteAsync(
-                    ToObjectKey(entry.CustomCoverR2Key!),
+                    CoverKeyBuilder.PhysicalKeyFor(CoverKind.User, entry.CustomCoverR2Key!),
                     BlobCategory.GameImage,
                     entry.CustomCoverR2Key!,
                     cancellationToken
@@ -90,7 +89,7 @@ internal sealed class UploadCustomCoverCommandHandler : ICommandHandler<UploadCu
 
         // Return presigned URL valid for 1 hour (3600 seconds)
         var presignedUrl = await _blobStorage.GetPresignedDownloadUrlAsync(
-            ToObjectKey(resourceKey),
+            objectKey,
             BlobCategory.GameImage,
             resourceKey,
             expirySeconds: 3600

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/CustomCover/UploadCustomCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/CustomCover/UploadCustomCoverCommandHandler.cs
@@ -16,6 +16,10 @@ namespace Api.BoundedContexts.UserLibrary.Application.Commands.CustomCover;
 /// </summary>
 internal sealed class UploadCustomCoverCommandHandler : ICommandHandler<UploadCustomCoverCommand, CustomCoverUploadResult>
 {
+    // Custom cover physical keys end in ".webp" (CoverKind.User suffix); the stored
+    // object's Content-Type must match so the CDN serves it correctly.
+    private const string WebpContentType = "image/webp";
+
     private readonly IUserLibraryRepository _libraryRepository;
     private readonly IBlobStorageService _blobStorage;
     private readonly IUnitOfWork _unitOfWork;
@@ -44,20 +48,20 @@ internal sealed class UploadCustomCoverCommandHandler : ICommandHandler<UploadCu
             ?? throw new ForbiddenException($"Game {command.GameId} is not in user library");
 
         // #3384 D5-A: the single CoverKeyBuilder owns the ".webp" suffix convention
-        // (DbKey stored, PhysicalKey written) so writer and resolver never drift.
+        // (suffix-free DbKey persisted, PhysicalKey written) so writer and resolver
+        // never drift.
         var coverKey = CoverKeyBuilder.ForUser(command.UserId, command.GameId);
-        var resourceKey = coverKey.DbKey;
-        var objectKey = coverKey.PhysicalKey;
 
-        // Best-effort delete old cover so stale R2 objects don't accumulate
+        // Best-effort delete old cover so stale R2 objects don't accumulate. Uses the
+        // RAW-KEY delete (mirrors CoverUrlResolver's raw-key reads): the categorized
+        // DeleteAsync runs PathSecurity.ValidateIdentifier which rejects the '/' in the
+        // deterministic key.
         if (entry.HasCustomCover)
         {
             try
             {
-                await _blobStorage.DeleteAsync(
+                await _blobStorage.DeleteRawKeyAsync(
                     CoverKeyBuilder.PhysicalKeyFor(CoverKind.User, entry.CustomCoverR2Key!),
-                    BlobCategory.GameImage,
-                    entry.CustomCoverR2Key!,
                     cancellationToken
                 ).ConfigureAwait(false);
             }
@@ -69,32 +73,39 @@ internal sealed class UploadCustomCoverCommandHandler : ICommandHandler<UploadCu
             }
         }
 
-        // Upload new cover (StoreAsync derives the final path internally)
-        await _blobStorage.StoreAsync(
+        // #3384: write to the EXACT deterministic physical key via the RAW-KEY path.
+        // The categorized StoreAsync rejects the slash-containing key via
+        // PathSecurity.ValidateIdentifier AND generates a random-id key the resolver
+        // cannot reconstruct — either way the cover would never resolve. StoreRawKeyAsync
+        // returns false on a write failure (or in local-storage mode, which does not host
+        // raw keys); surface it instead of persisting an unresolvable key.
+        var stored = await _blobStorage.StoreRawKeyAsync(
+            coverKey.PhysicalKey,
             command.FileStream,
-            objectKey,
-            BlobCategory.GameImage,
-            resourceKey,
+            WebpContentType,
             cancellationToken
         ).ConfigureAwait(false);
 
-        // Persist updated R2 key on domain aggregate
-        entry.SetCustomCoverR2Key(resourceKey);
+        if (!stored)
+        {
+            throw new ExternalServiceException(
+                "Impossibile salvare la cover personalizzata: storage oggetti non disponibile.");
+        }
+
+        // Persist the suffix-free DB key ONLY after the object is confirmed written.
+        entry.SetCustomCoverR2Key(coverKey.DbKey);
         await _libraryRepository.UpdateAsync(entry, cancellationToken).ConfigureAwait(false);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
         _logger.LogInformation(
             "Custom cover uploaded for game {GameId}, user {UserId}, key {Key}",
-            command.GameId, command.UserId, resourceKey);
+            command.GameId, command.UserId, coverKey.DbKey);
 
-        // Return presigned URL valid for 1 hour (3600 seconds)
-        var presignedUrl = await _blobStorage.GetPresignedDownloadUrlAsync(
-            objectKey,
-            BlobCategory.GameImage,
-            resourceKey,
-            expirySeconds: 3600
-        ).ConfigureAwait(false) ?? string.Empty;
+        // Return presigned URL valid for 1 hour (3600 seconds) for the exact object just written.
+        var presignedUrl = await _blobStorage
+            .GetPresignedUrlForRawKeyAsync(coverKey.PhysicalKey, expirySeconds: 3600)
+            .ConfigureAwait(false) ?? string.Empty;
 
-        return new CustomCoverUploadResult(resourceKey, presignedUrl);
+        return new CustomCoverUploadResult(coverKey.DbKey, presignedUrl);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/EventHandlers/GameRemovedFromLibraryCustomCoverHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/EventHandlers/GameRemovedFromLibraryCustomCoverHandler.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.UserLibrary.Domain.Events;
 using Api.Services.Pdf;
+using Api.SharedKernel.Domain.Covers;
 using MediatR;
 
 namespace Api.BoundedContexts.UserLibrary.Application.EventHandlers;
@@ -37,10 +38,10 @@ internal sealed class GameRemovedFromLibraryCustomCoverHandler : INotificationHa
 
         try
         {
-            await _blobStorage.DeleteAsync(
-                ToObjectKey(resourceKey),
-                BlobCategory.GameImage,
-                resourceKey,
+            // #3384: raw-key delete (the categorized DeleteAsync rejects the '/' in the
+            // deterministic key). Mirrors CoverUrlResolver's raw-key reads.
+            await _blobStorage.DeleteRawKeyAsync(
+                CoverKeyBuilder.PhysicalKeyFor(CoverKind.User, resourceKey),
                 cancellationToken
             ).ConfigureAwait(false);
         }
@@ -65,10 +66,4 @@ internal sealed class GameRemovedFromLibraryCustomCoverHandler : INotificationHa
                 notification.GameId);
         }
     }
-
-    /// <summary>
-    /// Derives the R2 object key from the resource key.
-    /// Mirrors the upload convention in <c>UploadCustomCoverCommandHandler</c>.
-    /// </summary>
-    private static string ToObjectKey(string resourceKey) => $"{resourceKey}.webp";
 }

--- a/apps/api/src/Api/DevTools/MockImpls/MockBlobStorageService.cs
+++ b/apps/api/src/Api/DevTools/MockImpls/MockBlobStorageService.cs
@@ -116,4 +116,15 @@ internal sealed class MockBlobStorageService : IBlobStorageService
         // Return true for the same "everything is present" mock semantics as DeleteAsync.
         return Task.FromResult(true);
     }
+
+    /// <inheritdoc />
+    public async Task<bool> StoreRawKeyAsync(string rawKey, Stream stream, string contentType, CancellationToken ct = default)
+    {
+        _ = (contentType);
+        using var ms = new MemoryStream();
+        await stream.CopyToAsync(ms, ct).ConfigureAwait(false);
+        _store[rawKey] = ms.ToArray();
+        // "Everything succeeds" mock semantics (mirrors StoreAsync).
+        return true;
+    }
 }

--- a/apps/api/src/Api/Services/Pdf/BlobStorageService.cs
+++ b/apps/api/src/Api/Services/Pdf/BlobStorageService.cs
@@ -258,6 +258,18 @@ internal class BlobStorageService : IBlobStorageService
         return Task.FromResult(false);
     }
 
+    /// <summary>
+    /// Local storage does not host objects under raw R2-style keys (mirrors
+    /// <see cref="DeleteRawKeyAsync"/>/<see cref="GetPresignedUrlForRawKeyAsync"/>).
+    /// No-op returning false so cover-write callers (#3384) surface a clear failure in
+    /// local mode rather than persisting an unresolvable deterministic key.
+    /// </summary>
+    public Task<bool> StoreRawKeyAsync(string rawKey, Stream stream, string contentType, CancellationToken ct = default)
+    {
+        _ = (rawKey, stream, contentType, ct); // Local storage: raw keys are not supported
+        return Task.FromResult(false);
+    }
+
     private static string SanitizeFileName(string fileName)
     {
         return StringHelper.SanitizeFilename(fileName, maxLength: 200, fallbackName: "file");

--- a/apps/api/src/Api/Services/Pdf/IBlobStorageService.cs
+++ b/apps/api/src/Api/Services/Pdf/IBlobStorageService.cs
@@ -169,6 +169,25 @@ internal interface IBlobStorageService
     /// <param name="ct">Cancellation token.</param>
     /// <returns>True if the delete request was issued successfully (best-effort; local storage returns false as it does not host raw keys).</returns>
     Task<bool> DeleteRawKeyAsync(string rawKey, CancellationToken ct = default);
+
+    /// <summary>
+    /// Stores an object at an EXACT physical storage key — the write-side counterpart
+    /// of <see cref="GetPresignedUrlForRawKeyAsync"/> / <see cref="DeleteRawKeyAsync"/>.
+    /// Unlike <see cref="StoreAsync"/>, this does NOT run
+    /// <c>PathSecurity.ValidateIdentifier</c> and does NOT prepend a category folder
+    /// or a random file-id segment — the object is written verbatim to
+    /// <paramref name="rawKey"/> (slashes and dots allowed). Required by the
+    /// deterministic cover keys (#3384) so the write key and the resolver's raw-key
+    /// read coincide by construction; the categorized <see cref="StoreAsync"/> would
+    /// reject the slash-containing cover key AND generate a random-id key the resolver
+    /// cannot reconstruct.
+    /// </summary>
+    /// <param name="rawKey">The exact physical storage object key to write.</param>
+    /// <param name="stream">The content to store.</param>
+    /// <param name="contentType">MIME content type of the stored object.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>True if the object was written successfully; false on failure or when the backend does not host raw keys (local storage).</returns>
+    Task<bool> StoreRawKeyAsync(string rawKey, Stream stream, string contentType, CancellationToken ct = default);
 }
 
 /// <summary>

--- a/apps/api/src/Api/Services/Pdf/S3BlobStorageService.cs
+++ b/apps/api/src/Api/Services/Pdf/S3BlobStorageService.cs
@@ -465,6 +465,77 @@ internal sealed class S3BlobStorageService : IBlobStorageService
 #pragma warning restore CA1031 // Do not catch general exception types
     }
 
+    /// <summary>
+    /// #3384 — writes an object to an EXACT physical key (write-side counterpart of
+    /// <see cref="GetPresignedUrlForRawKeyAsync"/>). No <c>ValidateIdentifier</c>, no
+    /// category folder, no random file-id segment: the key is written verbatim so the
+    /// resolver's raw-key read reconstructs it deterministically. Mirrors the cover
+    /// upload pipelines' <c>DisablePayloadSigning</c> requirement for S3-compatible
+    /// providers (R2/MinIO) that don't support the streaming payload trailer.
+    /// </summary>
+    public async Task<bool> StoreRawKeyAsync(string rawKey, Stream stream, string contentType, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(rawKey) || stream is null)
+        {
+            return false;
+        }
+
+        MemoryStream? buffered = null;
+        try
+        {
+            // Pre-buffer non-seekable streams so PutObject can declare a length (#2271).
+            Stream uploadStream;
+            if (stream.CanSeek)
+            {
+                uploadStream = stream;
+            }
+            else
+            {
+                buffered = new MemoryStream();
+                await stream.CopyToAsync(buffered, ct).ConfigureAwait(false);
+                buffered.Position = 0;
+                uploadStream = buffered;
+            }
+
+            var request = new PutObjectRequest
+            {
+                BucketName = _options.BucketName,
+                Key = rawKey,
+                InputStream = uploadStream,
+                ContentType = contentType,
+                AutoCloseStream = false,
+                DisablePayloadSigning = true,
+            };
+
+            await _s3Client.PutObjectAsync(request, ct).ConfigureAwait(false);
+            _logger.LogInformation("Stored file in S3 (raw key): {Key}", rawKey);
+            return true;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (AmazonS3Exception ex)
+        {
+            _logger.LogWarning(ex, "S3 error storing raw key {Key}: {ErrorCode}", rawKey, ex.ErrorCode);
+            return false;
+        }
+#pragma warning disable CA1031 // Do not catch general exception types
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Unexpected error storing raw key {Key}", rawKey);
+            return false;
+        }
+#pragma warning restore CA1031 // Do not catch general exception types
+        finally
+        {
+            if (buffered is not null)
+            {
+                await buffered.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+    }
+
     private static string SanitizeFileName(string fileName)
     {
         return StringHelper.SanitizeFilename(fileName, maxLength: 200, fallbackName: "file");

--- a/apps/api/src/Api/SharedKernel/Domain/Covers/CoverKeyBuilder.cs
+++ b/apps/api/src/Api/SharedKernel/Domain/Covers/CoverKeyBuilder.cs
@@ -1,0 +1,112 @@
+using System.Globalization;
+
+namespace Api.SharedKernel.Domain.Covers;
+
+/// <summary>
+/// The four cover sources resolved by <c>CoverUrlResolver</c>, in precedence
+/// order User (L3) → Pdf (L4) → Bgg (L2.5) → Wikidata (L2). Each source uses a
+/// distinct R2 physical-key suffix convention (ADR-087 D5-A, issue #3384).
+/// </summary>
+internal enum CoverKind
+{
+    /// <summary>User-uploaded custom cover — physical key adds <c>.webp</c>.</summary>
+    User,
+
+    /// <summary>PDF-derived cover (rulebook page) — physical key adds <c>-preview.webp</c>.</summary>
+    Pdf,
+
+    /// <summary>BGG re-uploaded cover — physical key IS the DB key (extension already embedded).</summary>
+    Bgg,
+
+    /// <summary>Wikidata/Commons cover — physical key adds <c>.webp</c>.</summary>
+    Wikidata,
+}
+
+/// <summary>
+/// A cover's storage identity: the suffix-free <see cref="DbKey"/> persisted in
+/// the DB column, and the <see cref="PhysicalKey"/> actually PUT to / GET from R2.
+/// </summary>
+internal readonly record struct CoverKey(CoverKind Kind, string DbKey, string PhysicalKey);
+
+/// <summary>
+/// Issue #3384 (ADR-087 D5-A) — the SINGLE source of truth for the cover R2 key
+/// convention. Every writer (<c>CoverR2UploadPipeline</c>,
+/// <c>BggCoverUploadPipeline</c>, <c>PdfCoverUploadPipeline</c>,
+/// <c>UploadCustomCoverCommandHandler</c>) and the read side
+/// (<c>CoverUrlResolver</c> + the PDF orphan / delete / materialize sites)
+/// derive keys through here, so the write-key and the read-key coincide by
+/// construction. This makes the <c>.webp.webp</c> double-suffix drift — the bug
+/// whose root cause (<c>PathSecurity.ValidateIdentifier</c> rejecting the
+/// suffix/slash) recurred three times — structurally impossible.
+/// </summary>
+internal static class CoverKeyBuilder
+{
+    private const string DefaultBggExtension = ".jpg";
+
+    /// <summary>User custom cover (L3): <c>user-covers/{userId:D}/{gameId:D}/cover</c>.</summary>
+    public static CoverKey ForUser(Guid userId, Guid gameId) =>
+        Build(CoverKind.User, $"user-covers/{userId:D}/{gameId:D}/cover");
+
+    /// <summary>PDF-derived cover (L4): <c>covers/pdf/{pdfDocumentId:D}/cover</c>.</summary>
+    public static CoverKey ForPdf(Guid pdfDocumentId) =>
+        Build(CoverKind.Pdf, $"covers/pdf/{pdfDocumentId:D}/cover");
+
+    /// <summary>Wikidata/Commons cover (L2): <c>covers/{gameId:D}/cover</c>.</summary>
+    public static CoverKey ForWikidata(Guid gameId) =>
+        Build(CoverKind.Wikidata, $"covers/{gameId:D}/cover");
+
+    /// <summary>
+    /// BGG re-uploaded cover (L2.5): <c>bgg-covers/{bggId}/cover{ext}</c>. The
+    /// extension is embedded in the key (BGG keeps its original image format), so
+    /// the physical key equals the DB key — no suffix is appended at read time.
+    /// </summary>
+    public static CoverKey ForBgg(int bggId, string sourceExtension) =>
+        Build(
+            CoverKind.Bgg,
+            $"bgg-covers/{bggId.ToString(CultureInfo.InvariantCulture)}/cover{NormalizeBggExtension(sourceExtension)}");
+
+    /// <summary>
+    /// Reconstructs the physical R2 object key from a DB-stored key. This is the
+    /// ONE place the per-kind suffix rule lives — the resolver calls this instead
+    /// of hardcoding <c>+ ".webp"</c> / <c>+ "-preview.webp"</c> / nothing.
+    /// </summary>
+    public static string PhysicalKeyFor(CoverKind kind, string dbKey)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(dbKey);
+        return dbKey + SuffixFor(kind);
+    }
+
+    /// <summary>
+    /// Normalizes a BGG source image extension to a supported, dot-prefixed,
+    /// lowercase form; unsupported or empty extensions fall back to <c>.jpg</c>.
+    /// Exposed so <c>BggCoverUploadPipeline</c> can derive the matching
+    /// Content-Type from the SAME normalized extension that shapes the key.
+    /// </summary>
+    public static string NormalizeBggExtension(string? extension)
+    {
+        if (string.IsNullOrWhiteSpace(extension))
+        {
+            return DefaultBggExtension;
+        }
+
+        var ext = extension.StartsWith('.') ? extension : "." + extension;
+        ext = ext.ToLowerInvariant();
+        return ext switch
+        {
+            ".jpg" or ".jpeg" or ".png" or ".gif" or ".webp" => ext,
+            _ => DefaultBggExtension,
+        };
+    }
+
+    private static string SuffixFor(CoverKind kind) => kind switch
+    {
+        CoverKind.User => ".webp",
+        CoverKind.Pdf => "-preview.webp",
+        CoverKind.Bgg => string.Empty,
+        CoverKind.Wikidata => ".webp",
+        _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, "Unknown cover kind."),
+    };
+
+    private static CoverKey Build(CoverKind kind, string dbKey) =>
+        new(kind, dbKey, dbKey + SuffixFor(kind));
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Infrastructure/Services/GamebookPhotoStorageServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Infrastructure/Services/GamebookPhotoStorageServiceTests.cs
@@ -72,6 +72,12 @@ public sealed class GamebookPhotoStorageServiceTests
             return Task.FromResult(true);
         }
 
+        public Task<bool> StoreRawKeyAsync(string rawKey, Stream stream, string contentType, CancellationToken ct = default)
+        {
+            _ = (rawKey, stream, contentType, ct);
+            return Task.FromResult(true);
+        }
+
         public Task<string?> GetPresignedUrlForRawKeyAsync(string rawKey, int? expirySeconds = null)
         {
             _ = (rawKey, expirySeconds);

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserLibrary/Application/EventHandlers/GameRemovedFromLibraryCustomCoverHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserLibrary/Application/EventHandlers/GameRemovedFromLibraryCustomCoverHandlerTests.cs
@@ -32,17 +32,15 @@ public sealed class GameRemovedFromLibraryCustomCoverHandlerTests
         var expectedObjectKey = $"{resourceKey}.webp";
 
         var evt = new GameRemovedFromLibraryEvent(Guid.NewGuid(), userId, gameId, resourceKey);
-        _blob.Setup(b => b.DeleteAsync(expectedObjectKey, BlobCategory.GameImage, resourceKey, It.IsAny<CancellationToken>()))
+        _blob.Setup(b => b.DeleteRawKeyAsync(expectedObjectKey, It.IsAny<CancellationToken>()))
              .ReturnsAsync(true);
 
         // Act
         await Handler().Handle(evt, default);
 
-        // Assert — DeleteAsync called exactly once with ToObjectKey(resourceKey), GameImage, resourceKey
-        _blob.Verify(b => b.DeleteAsync(
+        // Assert — raw-key delete of the exact physical object (#3384)
+        _blob.Verify(b => b.DeleteRawKeyAsync(
             expectedObjectKey,
-            BlobCategory.GameImage,
-            resourceKey,
             It.IsAny<CancellationToken>()), Times.Once);
     }
 
@@ -58,7 +56,7 @@ public sealed class GameRemovedFromLibraryCustomCoverHandlerTests
 
         // Assert — DeleteAsync must never be called
         _blob.Verify(
-            b => b.DeleteAsync(It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            b => b.DeleteRawKeyAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -73,7 +71,7 @@ public sealed class GameRemovedFromLibraryCustomCoverHandlerTests
 
         // Assert
         _blob.Verify(
-            b => b.DeleteAsync(It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            b => b.DeleteRawKeyAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -84,7 +82,7 @@ public sealed class GameRemovedFromLibraryCustomCoverHandlerTests
         // Arrange
         var resourceKey = $"user-covers/{Guid.NewGuid()}/{Guid.NewGuid()}/cover";
         var evt = MakeEvent(resourceKey);
-        _blob.Setup(b => b.DeleteAsync(It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _blob.Setup(b => b.DeleteRawKeyAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
              .ThrowsAsync(new InvalidOperationException("S3 endpoint unreachable"));
 
         // Act
@@ -114,7 +112,7 @@ public sealed class GameRemovedFromLibraryCustomCoverHandlerTests
         using var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        _blob.Setup(b => b.DeleteAsync(It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), cts.Token))
+        _blob.Setup(b => b.DeleteRawKeyAsync(It.IsAny<string>(), cts.Token))
              .ThrowsAsync(new OperationCanceledException(cts.Token));
 
         // Act

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserLibrary/Application/Handlers/CustomCover/RemoveCustomCoverCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserLibrary/Application/Handlers/CustomCover/RemoveCustomCoverCommandHandlerTests.cs
@@ -116,7 +116,7 @@ public sealed class RemoveCustomCoverCommandHandlerTests
             .ReturnsAsync(entry);
 
         _mockBlobStorage
-            .Setup(b => b.DeleteAsync(It.IsAny<string>(), BlobCategory.GameImage, coverKey, It.IsAny<CancellationToken>()))
+            .Setup(b => b.DeleteRawKeyAsync($"{coverKey}.webp", It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
         var command = CreateCommand(userId, gameId);
@@ -124,13 +124,9 @@ public sealed class RemoveCustomCoverCommandHandlerTests
         // Act
         await _handler.Handle(command, TestContext.Current.CancellationToken);
 
-        // Assert
+        // Assert — raw-key delete of the exact physical object (#3384)
         _mockBlobStorage.Verify(
-            b => b.DeleteAsync(
-                $"{coverKey}.webp",
-                BlobCategory.GameImage,
-                coverKey,
-                It.IsAny<CancellationToken>()),
+            b => b.DeleteRawKeyAsync($"{coverKey}.webp", It.IsAny<CancellationToken>()),
             Times.Once);
 
         // Verify SetCustomCoverR2Key was called with null
@@ -162,7 +158,7 @@ public sealed class RemoveCustomCoverCommandHandlerTests
 
         var deleteException = new InvalidOperationException("R2 service unavailable");
         _mockBlobStorage
-            .Setup(b => b.DeleteAsync(It.IsAny<string>(), BlobCategory.GameImage, coverKey, It.IsAny<CancellationToken>()))
+            .Setup(b => b.DeleteRawKeyAsync($"{coverKey}.webp", It.IsAny<CancellationToken>()))
             .ThrowsAsync(deleteException);
 
         var command = CreateCommand(userId, gameId);
@@ -172,11 +168,7 @@ public sealed class RemoveCustomCoverCommandHandlerTests
 
         // Assert: handler should NOT propagate exception
         _mockBlobStorage.Verify(
-            b => b.DeleteAsync(
-                $"{coverKey}.webp",
-                BlobCategory.GameImage,
-                coverKey,
-                It.IsAny<CancellationToken>()),
+            b => b.DeleteRawKeyAsync($"{coverKey}.webp", It.IsAny<CancellationToken>()),
             Times.Once);
 
         // DB should still be updated despite R2 failure

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserLibrary/Application/Handlers/CustomCover/UploadCustomCoverCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserLibrary/Application/Handlers/CustomCover/UploadCustomCoverCommandHandlerTests.cs
@@ -67,7 +67,8 @@ public sealed class UploadCustomCoverCommandHandlerTests
     }
 
     // -------------------------------------------------------
-    // T2-2: happy path — uploads to R2, saves DB, returns URL
+    // T2-2: happy path — writes to R2 via the RAW-KEY deterministic path (#3384),
+    // saves DB, returns presigned URL for the exact physical key.
     // -------------------------------------------------------
 
     [Fact]
@@ -79,17 +80,18 @@ public sealed class UploadCustomCoverCommandHandlerTests
         var entry = CreateEntry(userId, gameId);
         var expectedUrl = "https://r2.example.com/presigned-url";
         var expectedKey = $"user-covers/{userId}/{gameId}/cover";
+        var physicalKey = $"{expectedKey}.webp";
 
         _mockLibraryRepo
             .Setup(r => r.GetByUserAndGameAsync(userId, gameId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(entry);
 
         _mockBlobStorage
-            .Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), BlobCategory.GameImage, expectedKey, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BlobStorageResult(true, "file-id", "/path", 1024));
+            .Setup(b => b.StoreRawKeyAsync(physicalKey, It.IsAny<Stream>(), "image/webp", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
 
         _mockBlobStorage
-            .Setup(b => b.GetPresignedDownloadUrlAsync(It.IsAny<string>(), BlobCategory.GameImage, expectedKey, 3600))
+            .Setup(b => b.GetPresignedUrlForRawKeyAsync(physicalKey, 3600))
             .ReturnsAsync(expectedUrl);
 
         var command = CreateCommand(userId, gameId);
@@ -101,21 +103,22 @@ public sealed class UploadCustomCoverCommandHandlerTests
         result.CoverR2Key.Should().Be(expectedKey);
         result.PresignedUrl.Should().Be(expectedUrl);
 
+        // The deterministic physical key is written verbatim — NOT the categorized
+        // StoreAsync (which would reject the '/' and mint a random-id key the resolver
+        // cannot reconstruct).
         _mockBlobStorage.Verify(
-            b => b.StoreAsync(
-                It.IsAny<Stream>(),
-                $"{expectedKey}.webp",
-                BlobCategory.GameImage,
-                expectedKey,
-                It.IsAny<CancellationToken>()),
+            b => b.StoreRawKeyAsync(physicalKey, It.IsAny<Stream>(), "image/webp", It.IsAny<CancellationToken>()),
             Times.Once);
+        _mockBlobStorage.Verify(
+            b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
 
         _mockLibraryRepo.Verify(r => r.UpdateAsync(entry, It.IsAny<CancellationToken>()), Times.Once);
         _mockUnitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 
     // -------------------------------------------------------
-    // T2-3: replace flow — DeleteAsync called before StoreAsync
+    // T2-3: replace flow — raw-key delete of the old cover before the raw-key write.
     // -------------------------------------------------------
 
     [Fact]
@@ -125,27 +128,26 @@ public sealed class UploadCustomCoverCommandHandlerTests
         var userId = Guid.NewGuid();
         var gameId = Guid.NewGuid();
         var entry = CreateEntry(userId, gameId);
-        var oldKey = $"user-covers/{userId}/{gameId}/cover";
+        var key = $"user-covers/{userId}/{gameId}/cover";
+        var physicalKey = $"{key}.webp";
 
         // Seed an existing custom cover on the entry
-        entry.SetCustomCoverR2Key(oldKey);
-
-        var newKey = $"user-covers/{userId}/{gameId}/cover";
+        entry.SetCustomCoverR2Key(key);
 
         _mockLibraryRepo
             .Setup(r => r.GetByUserAndGameAsync(userId, gameId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(entry);
 
         _mockBlobStorage
-            .Setup(b => b.DeleteAsync(It.IsAny<string>(), BlobCategory.GameImage, oldKey, It.IsAny<CancellationToken>()))
+            .Setup(b => b.DeleteRawKeyAsync(physicalKey, It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
         _mockBlobStorage
-            .Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), BlobCategory.GameImage, newKey, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BlobStorageResult(true, "file-id", "/path", 1024));
+            .Setup(b => b.StoreRawKeyAsync(physicalKey, It.IsAny<Stream>(), "image/webp", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
 
         _mockBlobStorage
-            .Setup(b => b.GetPresignedDownloadUrlAsync(It.IsAny<string>(), BlobCategory.GameImage, newKey, 3600))
+            .Setup(b => b.GetPresignedUrlForRawKeyAsync(physicalKey, 3600))
             .ReturnsAsync("https://r2.example.com/new-url");
 
         var command = CreateCommand(userId, gameId);
@@ -153,22 +155,48 @@ public sealed class UploadCustomCoverCommandHandlerTests
         // Act
         await _handler.Handle(command, TestContext.Current.CancellationToken);
 
-        // Assert: delete called before store (verify both were called; ordering guaranteed by sequential await)
+        // Assert: delete before store (both via the raw-key path; ordering guaranteed by sequential await)
         _mockBlobStorage.Verify(
-            b => b.DeleteAsync(
-                $"{oldKey}.webp",
-                BlobCategory.GameImage,
-                oldKey,
-                It.IsAny<CancellationToken>()),
+            b => b.DeleteRawKeyAsync(physicalKey, It.IsAny<CancellationToken>()),
             Times.Once);
+        _mockBlobStorage.Verify(
+            b => b.StoreRawKeyAsync(physicalKey, It.IsAny<Stream>(), "image/webp", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
 
-        _mockBlobStorage.Verify(
-            b => b.StoreAsync(
-                It.IsAny<Stream>(),
-                $"{newKey}.webp",
-                BlobCategory.GameImage,
-                newKey,
-                It.IsAny<CancellationToken>()),
-            Times.Once);
+    // -------------------------------------------------------
+    // T2-4 (#3384): a failed raw-key write (false — S3 error or local-storage mode)
+    // must NOT persist an unresolvable key. Throw ExternalServiceException and leave
+    // the DB untouched.
+    // -------------------------------------------------------
+
+    [Fact]
+    public async Task Handle_RawKeyWriteFails_ThrowsAndDoesNotPersist()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+        var entry = CreateEntry(userId, gameId);
+        var physicalKey = $"user-covers/{userId}/{gameId}/cover.webp";
+
+        _mockLibraryRepo
+            .Setup(r => r.GetByUserAndGameAsync(userId, gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(entry);
+
+        _mockBlobStorage
+            .Setup(b => b.StoreRawKeyAsync(physicalKey, It.IsAny<Stream>(), "image/webp", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var command = CreateCommand(userId, gameId);
+
+        // Act
+        var act = () => _handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        await act.Should().ThrowAsync<ExternalServiceException>();
+
+        entry.CustomCoverR2Key.Should().BeNull("no key is persisted when the object write failed");
+        _mockLibraryRepo.Verify(r => r.UpdateAsync(It.IsAny<UserLibraryEntry>(), It.IsAny<CancellationToken>()), Times.Never);
+        _mockUnitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/GameNightPhotoUploadTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/GameNightPhotoUploadTests.cs
@@ -72,6 +72,9 @@ public sealed class GameNightPhotoUploadTests : IAsyncLifetime
             => Task.FromResult<string?>(null);
         public Task<bool> DeleteRawKeyAsync(string rawKey, CancellationToken ct = default)
             => Task.FromResult(true);
+
+        public Task<bool> StoreRawKeyAsync(string rawKey, Stream stream, string contentType, CancellationToken ct = default)
+            => Task.FromResult(true);
     }
 
     public async ValueTask InitializeAsync()

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/PlayRecordPhotoUploadTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/PlayRecordPhotoUploadTests.cs
@@ -98,6 +98,9 @@ public sealed class PlayRecordPhotoUploadTests : IAsyncLifetime
             => Task.FromResult<string?>(null);
         public Task<bool> DeleteRawKeyAsync(string rawKey, CancellationToken ct = default)
             => Task.FromResult(true);
+
+        public Task<bool> StoreRawKeyAsync(string rawKey, Stream stream, string contentType, CancellationToken ct = default)
+            => Task.FromResult(true);
     }
 
     // ---------------------------------------------------------------------------

--- a/apps/api/tests/Api.Tests/SharedKernel/Domain/Covers/CoverKeyContractTests.cs
+++ b/apps/api/tests/Api.Tests/SharedKernel/Domain/Covers/CoverKeyContractTests.cs
@@ -1,0 +1,112 @@
+using Api.SharedKernel.Domain.Covers;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.SharedKernel.Domain.Covers;
+
+/// <summary>
+/// Issue #3384 (ADR-087 D5-A) — the Docker-free contract test the issue asks for.
+/// Asserts that the SINGLE key-builder makes write-key and read-key coincide
+/// by construction for every <see cref="CoverKind"/>, so the recurring
+/// <c>.webp.webp</c> double-suffix / writer↔resolver drift bug is structurally
+/// impossible. Replaces the value of <c>CoverR2ConventionIntegrationTests</c>
+/// (which needs MinIO and skips locally) with a pure, always-runnable check.
+///
+/// The golden keys also pin the EXACT production convention — this refactor must
+/// remain byte-compatible with keys already stored in R2/DB (no data migration).
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedKernel")]
+public sealed class CoverKeyContractTests
+{
+    private static readonly Guid UserId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly Guid GameId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static readonly Guid PdfId = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+    private const int BggId = 13;
+
+    [Fact]
+    public void ForUser_MatchesProductionConvention()
+    {
+        var key = CoverKeyBuilder.ForUser(UserId, GameId);
+
+        key.Kind.Should().Be(CoverKind.User);
+        key.DbKey.Should().Be($"user-covers/{UserId:D}/{GameId:D}/cover");
+        key.PhysicalKey.Should().Be($"user-covers/{UserId:D}/{GameId:D}/cover.webp");
+    }
+
+    [Fact]
+    public void ForPdf_MatchesProductionConvention()
+    {
+        var key = CoverKeyBuilder.ForPdf(PdfId);
+
+        key.Kind.Should().Be(CoverKind.Pdf);
+        key.DbKey.Should().Be($"covers/pdf/{PdfId:D}/cover");
+        key.PhysicalKey.Should().Be($"covers/pdf/{PdfId:D}/cover-preview.webp");
+    }
+
+    [Fact]
+    public void ForWikidata_MatchesProductionConvention()
+    {
+        var key = CoverKeyBuilder.ForWikidata(GameId);
+
+        key.Kind.Should().Be(CoverKind.Wikidata);
+        key.DbKey.Should().Be($"covers/{GameId:D}/cover");
+        key.PhysicalKey.Should().Be($"covers/{GameId:D}/cover.webp");
+    }
+
+    [Theory]
+    [InlineData(".jpg", "bgg-covers/13/cover.jpg")]
+    [InlineData("jpg", "bgg-covers/13/cover.jpg")]    // normalizes a missing leading dot
+    [InlineData(".JPG", "bgg-covers/13/cover.jpg")]   // normalizes case
+    [InlineData(".jpeg", "bgg-covers/13/cover.jpeg")]
+    [InlineData(".png", "bgg-covers/13/cover.png")]
+    [InlineData(".webp", "bgg-covers/13/cover.webp")]
+    [InlineData("", "bgg-covers/13/cover.jpg")]        // empty → default extension
+    [InlineData(".bmp", "bgg-covers/13/cover.jpg")]    // unsupported → default extension
+    public void ForBgg_MatchesProductionConventionAndNormalizesExtension(string ext, string expected)
+    {
+        var key = CoverKeyBuilder.ForBgg(BggId, ext);
+
+        key.Kind.Should().Be(CoverKind.Bgg);
+        // BGG stores its source extension IN the key → physical == db (no suffix appended).
+        key.DbKey.Should().Be(expected);
+        key.PhysicalKey.Should().Be(expected);
+    }
+
+    /// <summary>
+    /// THE core contract: a key stored in the DB (the suffix-free <c>DbKey</c>),
+    /// re-read and passed to <see cref="CoverKeyBuilder.PhysicalKeyFor"/>, must
+    /// reconstruct EXACTLY the physical key the writer PUT — for every kind,
+    /// including the BGG-with-.webp-source edge case where the ext equals the
+    /// suffix (must NOT produce <c>cover.webp.webp</c>).
+    /// </summary>
+    [Fact]
+    public void PhysicalKeyFor_FromStoredDbKey_ReconstructsWriterPhysicalKey_ForEveryKind()
+    {
+        var keys = new[]
+        {
+            CoverKeyBuilder.ForUser(UserId, GameId),
+            CoverKeyBuilder.ForPdf(PdfId),
+            CoverKeyBuilder.ForWikidata(GameId),
+            CoverKeyBuilder.ForBgg(BggId, ".jpg"),
+            CoverKeyBuilder.ForBgg(BggId, ".webp"),
+        };
+
+        foreach (var k in keys)
+        {
+            CoverKeyBuilder.PhysicalKeyFor(k.Kind, k.DbKey).Should().Be(
+                k.PhysicalKey,
+                $"the resolver must reconstruct the writer's physical key for {k.Kind}");
+            k.PhysicalKey.Should().NotContain(".webp.webp");
+            k.PhysicalKey.Should().NotContain("-preview.webp-preview.webp");
+        }
+    }
+
+    [Fact]
+    public void PhysicalKeyFor_RejectsBlankDbKey()
+    {
+        var act = () => CoverKeyBuilder.PhysicalKeyFor(CoverKind.Pdf, "  ");
+
+        act.Should().Throw<ArgumentException>();
+    }
+}


### PR DESCRIPTION
## Cosa

Implementa **D5-A** (ADR-087, umbrella #3373): centralizza la convenzione delle chiavi R2 delle cover in un **unico `CoverKeyBuilder`**, così che write-key e read-key coincidano *by construction* — il bug ricorrente del doppio-suffisso `.webp.webp` / drift writer↔resolver (root cause `PathSecurity.ValidateIdentifier` che rifiuta slash/dot, ricomparso 3×) diventa **strutturalmente impossibile**.

Include il fix di un bug **Critical pre-esistente** emerso dalla review olistica (write L3 custom-cover).

## Commit 1 — `CoverKind` key-builder (D5-A)

- **Nuovo** `SharedKernel/Domain/Covers/CoverKeyBuilder.cs`: enum `CoverKind {User, Pdf, Bgg, Wikidata}`, record `CoverKey(DbKey, PhysicalKey)`, `ForUser/ForPdf/ForWikidata/ForBgg` + `PhysicalKeyFor(kind, dbKey)`. La regola suffisso per-kind (User/Wikidata `.webp`, Pdf `-preview.webp`, Bgg nessuno) vive in **un solo metodo**.
- `CoverUrlResolver`: tutti e 4 i rami risolvono via `PhysicalKeyFor(kind, storedKey)`.
- Writer cablati: `CoverR2UploadPipeline` (Wikidata), `BggCoverUploadPipeline` (BGG; `NormalizeExtension` spostata nel builder), `PdfCoverUploadPipeline` (PDF), `UploadCustomCoverCommandHandler` (User).
- Siti PDF ausiliari: `PdfProcessingPipelineService`, `BackfillPdfCoversJob`, `PdfCoverOrphanRecoveryJob`, `PdfDeletedEventHandler`.
- **Contract-test Docker-free** (`CoverKeyContractTests`): asserisce la coincidenza write↔read per ogni `CoverKind` (incl. edge BGG-con-`.webp` che non deve produrre `cover.webp.webp`), + golden key byte-compatibili con la produzione. Sostituisce il valore del test integration MinIO-gated.
- **Byte-compatibile** con le chiavi già in R2/DB (nessuna migrazione dati) — provato dai golden + dai `CoverUrlResolverTests`/writer test invariati.
- Fuori scope (intenzionale): `ProposeCoverChangeCommand` (chiave unica-per-proposta) e `MaterializePdfCoverCommandHandler` (delega alla pipeline).

## Commit 2 — Fix L3 custom-cover write (dalla review olistica)

**Bug Critical pre-esistente e latente** (staging ha 0 custom cover): l'upload L3 non atterrava **mai** in R2. `resourceKey = user-covers/{u}/{g}/cover` contiene `/` → i metodi *categorized* (`StoreAsync`/`DeleteAsync`/`GetPresignedDownloadUrlAsync`) eseguono `PathSecurity.ValidateIdentifier` (regex `^[A-Za-z0-9_-]+$`) → `ArgumentException` catturata → `Success=false` silenzioso mai controllato → la DB-key veniva persistita → il resolver raw-key faceva 404 per sempre. Anche senza la validazione, `StoreAsync` genera una chiave con GUID random che il resolver deterministico non può ricostruire. I fix P1 (#2943/#2947) migrarono al pattern raw-key la lettura e i writer L2/L4/L2.5, ma **non** il writer L3.

- **Nuovo** `IBlobStorageService.StoreRawKeyAsync(rawKey, stream, contentType, ct)` — controparte write di `GetPresignedUrlForRawKeyAsync`/`DeleteRawKeyAsync`. S3 scrive verbatim (`DisablePayloadSigning` per R2/MinIO); locale = no-op `false`; Mock in-memory; 3 fake test = `true`.
- `UploadCustomCoverCommandHandler`: scrive via `StoreRawKeyAsync(coverKey.PhysicalKey)`, **controlla** il risultato e lancia `ExternalServiceException` (503) su fallimento **prima** di persistere (niente più chiave fantasma). Delete-old + presign via raw-key.
- `RemoveCustomCoverCommandHandler` + `GameRemovedFromLibraryCustomCoverHandler`: delete via `DeleteRawKeyAsync(PhysicalKeyFor(User, key))`.
- Test aggiornati al path raw-key + nuovo T2-4 (write-fallita → throw + no-persist).

## Test

**88/88 verdi** nella run mirata (custom-cover Upload/Remove/GameRemoved, `CoverKeyContractTests`, `CoverUrlResolverTests`, `CoverR2/Bgg` pipeline). Interfaccia estesa → build verifica tutte e 6 le impl di `IBlobStorageService`.

## Note

`PdfCoverPropagationIntegrationTests.PdfCoverGeneratedEvent_Propagates…` fallisce sul baseline `main-dev` (`41aeb7eab`) indipendentemente da questa PR (dispatch MediatR domain-event sotto Testcontainers locale) — verificato con stash-and-rerun; non è una regressione.

Refs #3384 #3373

🤖 Generated with [Claude Code](https://claude.com/claude-code)
