### PR TITLE
fix(catalog): round-trip PDF cover fields in PdfDocumentRepository (#3401)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Entities/PdfDocument.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Entities/PdfDocument.cs
@@ -102,6 +102,15 @@ internal sealed class PdfDocument : AggregateRoot<Guid>
     public int? CoverPageIndex { get; private set; }
     public string? CoverGenerationError { get; private set; }
 
+    /// <summary>
+    /// #3373 D1 / #3401: transient-failure retry budget counter, mirrored from
+    /// <c>PdfDocumentEntity.CoverGenerationAttempts</c>. Managed by the cover jobs
+    /// directly on the entity; carried on the aggregate purely so the repository
+    /// round-trip (<c>UpdateAsync</c> rebuilds + <c>DbSet.Update</c> the whole row)
+    /// does not silently zero it.
+    /// </summary>
+    public int CoverGenerationAttempts { get; private set; }
+
     // Issue #4219: Per-state timing tracking for metrics and ETA
     public DateTime? UploadingStartedAt { get; private set; }
     public DateTime? ExtractingStartedAt { get; private set; }
@@ -220,7 +229,8 @@ internal sealed class PdfDocument : AggregateRoot<Guid>
         string? coverR2Key = null,
         string? coverGenerationStatus = null,
         int? coverPageIndex = null,
-        string? coverGenerationError = null)
+        string? coverGenerationError = null,
+        int coverGenerationAttempts = 0)
     {
         var document = new PdfDocument
         {
@@ -294,7 +304,8 @@ internal sealed class PdfDocument : AggregateRoot<Guid>
                 ? PdfCoverGenerationStatus.Pending
                 : Enum.Parse<PdfCoverGenerationStatus>(coverGenerationStatus, ignoreCase: true),
             CoverPageIndex = coverPageIndex,
-            CoverGenerationError = coverGenerationError
+            CoverGenerationError = coverGenerationError,
+            CoverGenerationAttempts = coverGenerationAttempts
         };
 
         if (tags is { Count: > 0 })

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Persistence/PdfDocumentRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Persistence/PdfDocumentRepository.cs
@@ -259,7 +259,14 @@ internal class PdfDocumentRepository : RepositoryBase, IPdfDocumentRepository
             title: entity.Title, // Issue #1687
             tags: entity.Tags, // Issue #1687
             updatedAt: entity.UpdatedAt, // Issue #1687
-            updatedBy: entity.UpdatedBy // Issue #1687
+            updatedBy: entity.UpdatedBy, // Issue #1687
+            // Issue #3401: cover state round-trip — without these the read path defaults
+            // cover fields (null / Pending) and UpdateAsync then zeroes the DB row.
+            coverR2Key: entity.CoverR2Key,
+            coverGenerationStatus: entity.CoverGenerationStatus,
+            coverPageIndex: entity.CoverPageIndex,
+            coverGenerationError: entity.CoverGenerationError,
+            coverGenerationAttempts: entity.CoverGenerationAttempts
         );
     }
 
@@ -307,7 +314,15 @@ internal class PdfDocumentRepository : RepositoryBase, IPdfDocumentRepository
             Title = domain.Title, // Issue #1687
             Tags = domain.Tags.ToList(), // Issue #1687
             UpdatedAt = domain.UpdatedAt, // Issue #1687
-            UpdatedBy = domain.UpdatedBy // Issue #1687
+            UpdatedBy = domain.UpdatedBy, // Issue #1687
+            // Issue #3401: cover state round-trip. UpdateAsync rebuilds the entity and
+            // calls DbSet.Update (all columns modified), so omitting these silently
+            // zeroed the persisted cover key/status/attempts (broke MaterializePdfCover).
+            CoverR2Key = domain.CoverR2Key,
+            CoverGenerationStatus = domain.CoverGenerationStatus.ToString(),
+            CoverPageIndex = domain.CoverPageIndex,
+            CoverGenerationError = domain.CoverGenerationError,
+            CoverGenerationAttempts = domain.CoverGenerationAttempts
         };
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/Persistence/PdfDocumentRepositoryCoverMappingTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/Persistence/PdfDocumentRepositoryCoverMappingTests.cs
@@ -1,0 +1,148 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.SharedKernel.Application.Services;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Infrastructure.Persistence;
+
+/// <summary>
+/// Issue #3401 — <see cref="PdfDocumentRepository"/> must round-trip the L4 PDF
+/// cover fields (CoverR2Key, CoverGenerationStatus, CoverPageIndex,
+/// CoverGenerationError, CoverGenerationAttempts) through both MapToDomain and
+/// MapToPersistence. Before the fix, both mappers silently dropped these columns,
+/// so <c>UpdateAsync</c> (which rebuilds the entity and calls DbSet.Update, marking
+/// every column modified) zeroed the persisted cover state — a data-loss bug that
+/// broke <c>MaterializePdfCoverCommandHandler</c>.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "DocumentProcessing")]
+public sealed class PdfDocumentRepositoryCoverMappingTests : IDisposable
+{
+    private readonly MeepleAiDbContext _db;
+
+    public PdfDocumentRepositoryCoverMappingTests()
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase($"PdfDocRepoCover_{Guid.NewGuid()}")
+            .Options;
+        _db = new MeepleAiDbContext(
+            options,
+            new Mock<IMediator>().Object,
+            new Mock<IDomainEventCollector>().Object);
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private PdfDocumentRepository CreateRepository() =>
+        new(_db, new Mock<IDomainEventCollector>().Object);
+
+    private PdfDocumentEntity SeedEntity(
+        string? coverR2Key,
+        string coverStatus,
+        int? coverPageIndex,
+        string? coverError,
+        int coverAttempts)
+    {
+        var pdf = new PdfDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            FileName = "rules.pdf",
+            FilePath = "/tmp/rules.pdf",
+            FileSizeBytes = 2048,
+            ContentType = "application/pdf",
+            UploadedByUserId = Guid.NewGuid(),
+            UploadedAt = DateTime.UtcNow,
+            ProcessingState = "Ready",
+            CoverR2Key = coverR2Key,
+            CoverGenerationStatus = coverStatus,
+            CoverPageIndex = coverPageIndex,
+            CoverGenerationError = coverError,
+            CoverGenerationAttempts = coverAttempts,
+        };
+        _db.PdfDocuments.Add(pdf);
+        _db.SaveChanges();
+        _db.ChangeTracker.Clear();
+        return pdf;
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_MapsAllCoverFieldsToDomain()
+    {
+        var seeded = SeedEntity(
+            coverR2Key: "covers/pdf/00000000-0000-0000-0000-000000000001/cover",
+            coverStatus: nameof(PdfCoverGenerationStatus.Generated),
+            coverPageIndex: 2,
+            coverError: null,
+            coverAttempts: 1);
+
+        var domain = await CreateRepository().GetByIdAsync(seeded.Id);
+
+        domain.Should().NotBeNull();
+        domain!.CoverR2Key.Should().Be(seeded.CoverR2Key);
+        domain.CoverGenerationStatus.Should().Be(PdfCoverGenerationStatus.Generated);
+        domain.CoverPageIndex.Should().Be(2);
+        domain.CoverGenerationError.Should().BeNull();
+        domain.CoverGenerationAttempts.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_PreservesAllCoverFields_RoundTrip()
+    {
+        // A Failed cover mid-retry: attempts must NOT be zeroed by the round-trip.
+        var seeded = SeedEntity(
+            coverR2Key: null,
+            coverStatus: nameof(PdfCoverGenerationStatus.Failed),
+            coverPageIndex: 4,
+            coverError: "boom",
+            coverAttempts: 2);
+
+        var repo = CreateRepository();
+        var domain = await repo.GetByIdAsync(seeded.Id);
+        domain.Should().NotBeNull();
+
+        // Simulate a metadata edit that goes through the repository's UpdateAsync
+        // (the exact path MaterializePdfCoverCommandHandler uses).
+        await repo.UpdateAsync(domain!);
+        await _db.SaveChangesAsync();
+        _db.ChangeTracker.Clear();
+
+        var reloaded = await _db.PdfDocuments.AsNoTracking().SingleAsync(p => p.Id == seeded.Id);
+        reloaded.CoverGenerationStatus.Should().Be(nameof(PdfCoverGenerationStatus.Failed),
+            "the persisted cover status must survive an UpdateAsync round-trip");
+        reloaded.CoverPageIndex.Should().Be(4);
+        reloaded.CoverGenerationError.Should().Be("boom");
+        reloaded.CoverGenerationAttempts.Should().Be(2,
+            "the retry budget must not be silently zeroed by MapToPersistence");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_AfterMarkCoverGenerated_PersistsGeneratedState()
+    {
+        // The concrete MaterializePdfCoverCommandHandler flow: MarkCoverGenerated then UpdateAsync.
+        var seeded = SeedEntity(
+            coverR2Key: null,
+            coverStatus: nameof(PdfCoverGenerationStatus.Pending),
+            coverPageIndex: null,
+            coverError: null,
+            coverAttempts: 0);
+
+        var repo = CreateRepository();
+        var domain = await repo.GetByIdAsync(seeded.Id);
+        domain!.MarkCoverGenerated("covers/pdf/aaaa/cover", pageIndex: 0);
+
+        await repo.UpdateAsync(domain);
+        await _db.SaveChangesAsync();
+        _db.ChangeTracker.Clear();
+
+        var reloaded = await _db.PdfDocuments.AsNoTracking().SingleAsync(p => p.Id == seeded.Id);
+        reloaded.CoverGenerationStatus.Should().Be(nameof(PdfCoverGenerationStatus.Generated));
+        reloaded.CoverR2Key.Should().Be("covers/pdf/aaaa/cover");
+        reloaded.CoverPageIndex.Should().Be(0);
+    }
+}


### PR DESCRIPTION
## Cosa

Chiude **#3401** (follow-up di ADR-087 / #3373): `PdfDocumentRepository` scartava **silenziosamente tutti** i campi cover nel mapping domain↔persistence.

## Bug

- `MapToDomain` non passava mai gli argomenti cover a `PdfDocument.Reconstitute` → le letture via repo defaultavano i campi cover a `null`/`Pending`.
- `MapToPersistence` non scriveva mai i campi cover.

Poiché `UpdateAsync` ricostruisce una entity nuova e chiama `DbSet.Update` (marca **tutte** le colonne come modificate), qualsiasi handler che passa per `IPdfDocumentRepository.UpdateAsync` **azzerava lo stato cover persistito**. In particolare `MaterializePdfCoverCommandHandler` (`MarkCoverGenerated` → `UpdateAsync`) non persisteva **mai** la cover materializzata (key/status/pageIndex).

**Latente** finora perché i job cover D1/D3 mutano `DbContext.PdfDocuments` direttamente; il gap **pre-esisteva** i 4 campi cover storici e #3382 (D1) ne ha solo aggiunto un 5° (`CoverGenerationAttempts`).

## Fix

- **`PdfDocument` (dominio)**: aggiunto `CoverGenerationAttempts` (int, carried per il round-trip — il budget retry è job-managed sull'entity, l'aggregate lo preserva solo così l'overwrite full-row di `UpdateAsync` non lo azzera) + param in `Reconstitute`.
- **`MapToDomain`**: passa tutti e 5 i campi cover a `Reconstitute`.
- **`MapToPersistence`**: scrive tutti e 5 i campi cover.

## Test

Nuovo `PdfDocumentRepositoryCoverMappingTests` (Docker-free, in-memory):
1. `GetByIdAsync` mappa tutti e 5 i campi al dominio.
2. `UpdateAsync` round-trip preserva tutti e 5 (incl. un `Failed`-mid-retry `attempts=2` che NON deve essere azzerato).
3. `MarkCoverGenerated` → `UpdateAsync` persiste lo stato `Generated` (il flusso reale di `MaterializePdfCover`).

**1468 unit test DocumentProcessing verdi, 0 regressione.**

Closes #3401

🤖 Generated with [Claude Code](https://claude.com/claude-code)
