### PR TITLE
feat(rag-citation): persist chunk char offsets (SP-A, #3405)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs
@@ -920,7 +920,10 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
                 Heading = chunk.Heading,
                 Level = chunk.Level,
                 ParentChunkId = chunk.ParentChunkId,
-                ElementType = chunk.ElementType
+                ElementType = chunk.ElementType,
+                // SP-A (#3405): persist char offsets for citation grounding
+                CharStart = chunk.CharStart,
+                CharEnd = chunk.CharEnd
             })
             .ToList();
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/IndexPdfCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/IndexPdfCommandHandler.cs
@@ -576,7 +576,10 @@ internal class IndexPdfCommandHandler : ICommandHandler<IndexPdfCommand, Indexin
                 Heading = chunk.Heading,
                 Level = chunk.Level,
                 ParentChunkId = chunk.ParentChunkId,
-                ElementType = chunk.ElementType
+                ElementType = chunk.ElementType,
+                // SP-A (#3405): persist char offsets for citation grounding
+                CharStart = chunk.CharStart,
+                CharEnd = chunk.CharEnd
             })
             .ToList();
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
@@ -665,7 +665,10 @@ internal partial class UploadPdfCommandHandler
                 Heading = chunk.Heading,
                 Level = chunk.Level,
                 ParentChunkId = chunk.ParentChunkId,
-                ElementType = chunk.ElementType
+                ElementType = chunk.ElementType,
+                // SP-A (#3405): persist char offsets for citation grounding
+                CharStart = chunk.CharStart,
+                CharEnd = chunk.CharEnd
             })
             .ToList();
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
@@ -967,7 +967,10 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
                 Heading = chunk.Heading,
                 Level = chunk.Level,
                 ParentChunkId = chunk.ParentChunkId,
-                ElementType = chunk.ElementType
+                ElementType = chunk.ElementType,
+                // SP-A (#3405): persist char offsets for citation grounding
+                CharStart = chunk.CharStart,
+                CharEnd = chunk.CharEnd
             })
             .ToList();
 

--- a/apps/api/src/Api/Infrastructure/Entities/KnowledgeBase/TextChunkEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/KnowledgeBase/TextChunkEntity.cs
@@ -27,6 +27,15 @@ public class TextChunkEntity
     public int ChunkIndex { get; set; }
     public int? PageNumber { get; set; }
     public int CharacterCount { get; set; }
+
+    // SP-A (#3405, epic #3403): char offsets del chunk nel testo ricostruito dal chunker,
+    // per il grounding/highlight della citazione. Nullable: le righe indicizzate prima di
+    // questa feature non hanno il dato (backfill via re-index — il valore è derivabile da
+    // StructuredElementsJson/ExtractedText). Reference frame: content ricostruito della
+    // sezione (non l'ExtractedText grezzo né il PDF originale).
+    public int? CharStart { get; set; }
+    public int? CharEnd { get; set; }
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
     // Issue #730: Chunk hierarchy fields (heading_path derivation)

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/KnowledgeBase/TextChunkEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/KnowledgeBase/TextChunkEntityConfiguration.cs
@@ -20,6 +20,11 @@ internal class TextChunkEntityConfiguration : IEntityTypeConfiguration<TextChunk
         builder.Property(e => e.ChunkIndex).IsRequired();
         builder.Property(e => e.PageNumber);
         builder.Property(e => e.CharacterCount).IsRequired();
+
+        // SP-A (#3405): char offsets nullable (backfill via re-index; NULL per righe pre-esistenti)
+        builder.Property(e => e.CharStart).HasColumnName("char_start").IsRequired(false);
+        builder.Property(e => e.CharEnd).HasColumnName("char_end").IsRequired(false);
+
         builder.Property(e => e.CreatedAt).IsRequired();
 
         // Issue #730: Chunk hierarchy fields

--- a/apps/api/src/Api/Infrastructure/Migrations/20260730092605_AddChunkCharOffsets.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260730092605_AddChunkCharOffsets.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260730092605_AddChunkCharOffsets")]
+    partial class AddChunkCharOffsets
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260730092605_AddChunkCharOffsets.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260730092605_AddChunkCharOffsets.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddChunkCharOffsets : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "char_end",
+                table: "text_chunks",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "char_start",
+                table: "text_chunks",
+                type: "integer",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "char_end",
+                table: "text_chunks");
+
+            migrationBuilder.DropColumn(
+                name: "char_start",
+                table: "text_chunks");
+        }
+    }
+}


### PR DESCRIPTION
**Epic**: #3403 — RAG citation region grounding · **SP-A** (Slice A1: persistenza)
Closes #3405

## Cosa

Persiste gli offset di carattere del chunk (`CharStart`/`CharEnd`) su `text_chunks`. Il dato è **già calcolato** dalla pipeline di chunking (`DocumentChunk.CharStart/CharEnd`) ma finora veniva **scartato** in tutti i siti di insert. È il fondamento per il grounding/highlight della citazione ed è **backfillabile via re-index** (derivabile da `StructuredElementsJson`/`ExtractedText`).

## Modifiche

- `TextChunkEntity`: `+ int? CharStart, int? CharEnd` (nullable — NULL per righe pre-esistenti).
- `TextChunkEntityConfiguration`: colonne `char_start`/`char_end` (nullable).
- Migration `AddChunkCharOffsets`: 2 colonne `integer` nullable (no backfill/lock lunghi).
- 4 siti insert della pipeline PDF mappano `chunk.CharStart/CharEnd`: `PdfProcessingPipelineService`, `UploadPdfCommandHandler.Processing`, `CompleteChunkedUploadCommandHandler`, `IndexPdfCommandHandler`.

## Scoping

- `ImportRagDataCommandHandler` **escluso**: il DTO di backup/export non espone i char-offset (versionare l'export format è un follow-up separato).
- Il **surfacing DTO/FE** (Slice A2 originale: `SearchResultDto.FromDomain`, `CitationDto`, FE `Citation`) è **accorpato a SP-C** (#3407), che tocca gli stessi handler citazione per esporre anche le `regions[]` — evita doppio lavoro e conflitti.

## Verifica

- `dotnet build` solution completa: **0 errori** (244 warning pre-esistenti).
- Migration generata corretta (`char_start`/`char_end` integer nullable, Down = DropColumn).
- Nessun test unit dedicato: un EF-InMemory round-trip testerebbe il framework, non il mapping (i char-offset si perdono solo se un sito insert smette di mapparli o la config SQL cambia). Il test end-to-end del grounding arriva con SP-C/SP-D, quando il dato è esposto e osservabile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)