### PR TITLE
feat(rag-citation): coordinate pipeline for region grounding (SP-B, #3406)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs
@@ -923,7 +923,9 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
                 ElementType = chunk.ElementType,
                 // SP-A (#3405): persist char offsets for citation grounding
                 CharStart = chunk.CharStart,
-                CharEnd = chunk.CharEnd
+                CharEnd = chunk.CharEnd,
+                // SP-B (#3406): persist the normalized region for citation grounding
+                BoundingBoxesJson = ChunkBoundingBoxJson.Serialize(chunk.BBox, chunk.Page)
             })
             .ToList();
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/IndexPdfCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/IndexPdfCommandHandler.cs
@@ -579,7 +579,9 @@ internal class IndexPdfCommandHandler : ICommandHandler<IndexPdfCommand, Indexin
                 ElementType = chunk.ElementType,
                 // SP-A (#3405): persist char offsets for citation grounding
                 CharStart = chunk.CharStart,
-                CharEnd = chunk.CharEnd
+                CharEnd = chunk.CharEnd,
+                // SP-B (#3406): persist the normalized region for citation grounding
+                BoundingBoxesJson = ChunkBoundingBoxJson.Serialize(chunk.BBox, chunk.Page)
             })
             .ToList();
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
@@ -668,7 +668,9 @@ internal partial class UploadPdfCommandHandler
                 ElementType = chunk.ElementType,
                 // SP-A (#3405): persist char offsets for citation grounding
                 CharStart = chunk.CharStart,
-                CharEnd = chunk.CharEnd
+                CharEnd = chunk.CharEnd,
+                // SP-B (#3406): persist the normalized region for citation grounding
+                BoundingBoxesJson = ChunkBoundingBoxJson.Serialize(chunk.BBox, chunk.Page)
             })
             .ToList();
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/Chunking/HeadingAwareChunkAdapter.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/Chunking/HeadingAwareChunkAdapter.cs
@@ -27,6 +27,7 @@ internal static class HeadingAwareChunkAdapter
                 Level = c.Level,
                 ParentChunkId = c.ParentChunkId,
                 ElementType = c.ElementType,
+                BBox = c.BBox,  // SP-B (#3406): propagate the region to persistence
             })
             .ToList();
     }

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
@@ -970,7 +970,9 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
                 ElementType = chunk.ElementType,
                 // SP-A (#3405): persist char offsets for citation grounding
                 CharStart = chunk.CharStart,
-                CharEnd = chunk.CharEnd
+                CharEnd = chunk.CharEnd,
+                // SP-B (#3406): persist the normalized region for citation grounding
+                BoundingBoxesJson = ChunkBoundingBoxJson.Serialize(chunk.BBox, chunk.Page)
             })
             .ToList();
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Services/ExtractedElement.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Services/ExtractedElement.cs
@@ -9,4 +9,16 @@ namespace Api.BoundedContexts.DocumentProcessing.Domain.Services;
 public record ExtractedElement(
     string Text,
     int PageNumber,
-    string ElementType);
+    string ElementType,
+    ElementBoundingBox? BoundingBox = null);
+
+/// <summary>
+/// Normalized bounding box of a PDF element (SP-B #3406): [0,1] fractions of the page
+/// layout, top-left origin (y grows downward), independent of strategy/DPI/zoom. Null when
+/// the extractor emitted no coordinates. Defined here in DocumentProcessing (the published
+/// extraction contract); KnowledgeBase maps it to its own BoundingBox VO — the dependency
+/// arrow is KB → DocumentProcessing, never the reverse. Optional trailing param keeps the
+/// record backward-compatible with StructuredElementsJson already persisted (member absent
+/// deserializes to null).
+/// </summary>
+public sealed record ElementBoundingBox(float X, float Y, float Width, float Height);

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/External/UnstructuredPdfTextExtractor.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/External/UnstructuredPdfTextExtractor.cs
@@ -292,7 +292,10 @@ internal class UnstructuredPdfTextExtractor : IPdfTextExtractor
             .Select(e => new ExtractedElement(
                 Text: e.Text!,
                 PageNumber: e.PageNumber > 0 ? e.PageNumber : 1,
-                ElementType: string.IsNullOrWhiteSpace(e.Category) ? "NarrativeText" : e.Category!))
+                ElementType: string.IsNullOrWhiteSpace(e.Category) ? "NarrativeText" : e.Category!,
+                BoundingBox: e.Bbox is null
+                    ? null
+                    : new ElementBoundingBox(e.Bbox.X, e.Bbox.Y, e.Bbox.Width, e.Bbox.Height)))
             .ToList();
 
         return mapped.Count > 0 ? mapped : null;
@@ -369,7 +372,15 @@ internal record UnstructuredChunk(
 internal record UnstructuredElement(
     [property: JsonPropertyName("text")] string? Text,
     [property: JsonPropertyName("page_number")] int PageNumber,
-    [property: JsonPropertyName("category")] string? Category);
+    [property: JsonPropertyName("category")] string? Category,
+    [property: JsonPropertyName("bbox")] UnstructuredBbox? Bbox = null);
+
+/// <summary>SP-B (#3406): normalized [0,1] bounding box emitted by the Python service.</summary>
+internal record UnstructuredBbox(
+    [property: JsonPropertyName("x")] float X,
+    [property: JsonPropertyName("y")] float Y,
+    [property: JsonPropertyName("width")] float Width,
+    [property: JsonPropertyName("height")] float Height);
 
 internal record UnstructuredMetadata(
     [property: JsonPropertyName("extraction_duration_ms")] int? ExtractionDurationMs,

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/AdvancedChunkingService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/AdvancedChunkingService.cs
@@ -121,6 +121,7 @@ internal sealed class AdvancedChunkingService : IAdvancedChunkingService
                 section.Page,
                 section.Heading,
                 section.CharStart,
+                section.BBox,
                 config);
 
             // Link children to parent
@@ -199,7 +200,8 @@ internal sealed class AdvancedChunkingService : IAdvancedChunkingService
                     parentMetadata.Page,
                     heading: null,
                     parentMetadata.CharStart,
-                    config);
+                    baseBBox: null,
+                    config: config);
 
                 foreach (var child in childChunks)
                 {
@@ -226,6 +228,7 @@ internal sealed class AdvancedChunkingService : IAdvancedChunkingService
         int basePage,
         string? heading,
         int baseCharStart,
+        BoundingBox? baseBBox,
         ChunkingConfiguration config)
     {
         var childChunks = new List<HierarchicalChunk>();
@@ -246,7 +249,8 @@ internal sealed class AdvancedChunkingService : IAdvancedChunkingService
                 GameId = gameId,
                 DocumentId = documentId,
                 CharStart = baseCharStart + textChunk.CharStart,
-                CharEnd = baseCharStart + textChunk.CharEnd
+                CharEnd = baseCharStart + textChunk.CharEnd,
+                BBox = baseBBox  // SP-B (#3406): children inherit the parent section's region
             };
 
             var childChunk = HierarchicalChunk.CreateChild(

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/EmbeddedTitleSplitter.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/EmbeddedTitleSplitter.cs
@@ -72,7 +72,7 @@ internal static class EmbeddedTitleSplitter
                 {
                     result.Add(el with { Text = head });
                 }
-                result.Add(new ExtractedElement(token, el.PageNumber, TitleCategory));
+                result.Add(new ExtractedElement(token, el.PageNumber, TitleCategory, el.BoundingBox));
                 if (tail.Length > 0)
                 {
                     result.Add(el with { Text = tail });

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/ExtractedDocumentFactory.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/ExtractedDocumentFactory.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.DocumentProcessing.Domain.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.Chunking;
 
 namespace Api.BoundedContexts.KnowledgeBase.Application.Services.Chunking;
 
@@ -48,6 +49,7 @@ internal static class ExtractedDocumentFactory
                 ElementType = NormalizeElementType(group.Elements[0].ElementType),
                 CharStart = sectionStart,
                 CharEnd = sectionEnd,
+                BBox = ComputeSectionBBox(group.Elements),
             });
 
             // Inter-section separator: lands in the GAP between this section's CharEnd and the
@@ -127,4 +129,33 @@ internal static class ExtractedDocumentFactory
         "ListItem" => "list",
         _ => "text",
     };
+
+    /// <summary>
+    /// SP-B (#3406): the section's region = union (min/max) of its elements' normalized boxes on the
+    /// section start page. Elements without coordinates — or on later pages of a multi-page section —
+    /// are skipped; returns null when none carry a box. Single box per section (MVP): multi-page
+    /// sections are anchored to the start page. Maps the DocumentProcessing ElementBoundingBox to the
+    /// KnowledgeBase BoundingBox VO (dependency arrow KB → DocumentProcessing).
+    /// </summary>
+    private static BoundingBox? ComputeSectionBBox(IReadOnlyList<ExtractedElement> elements)
+    {
+        var startPage = elements[0].PageNumber;
+        float minX = float.MaxValue, minY = float.MaxValue, maxX = float.MinValue, maxY = float.MinValue;
+        var found = false;
+        foreach (var el in elements)
+        {
+            if (el.PageNumber != startPage || el.BoundingBox is null)
+            {
+                continue;
+            }
+            var b = el.BoundingBox;
+            found = true;
+            if (b.X < minX) minX = b.X;
+            if (b.Y < minY) minY = b.Y;
+            if (b.X + b.Width > maxX) maxX = b.X + b.Width;
+            if (b.Y + b.Height > maxY) maxY = b.Y + b.Height;
+        }
+
+        return found ? BoundingBox.FromCoordinates(minX, minY, maxX - minX, maxY - minY) : null;
+    }
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/HierarchicalChunkMapper.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/HierarchicalChunkMapper.cs
@@ -40,6 +40,7 @@ internal static class HierarchicalChunkMapper
                 Page = chunk.Metadata.Page,
                 CharStart = chunk.Metadata.CharStart,
                 CharEnd = chunk.Metadata.CharEnd,
+                BBox = chunk.Metadata.BBox,  // SP-B (#3406): carry the region to the sink
                 Embedding = Array.Empty<float>()
             });
         }

--- a/apps/api/src/Api/Infrastructure/Entities/KnowledgeBase/ChunkBoundingBoxJson.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/KnowledgeBase/ChunkBoundingBoxJson.cs
@@ -1,0 +1,30 @@
+using System.Text.Json;
+using Api.BoundedContexts.KnowledgeBase.Domain.Chunking;
+
+// Namespace matches TextChunkEntity (Api.Infrastructure.Entities, not the folder) so the helper is
+// in scope wherever the entity is constructed, without an extra using at the 4 insert sites.
+namespace Api.Infrastructure.Entities;
+
+/// <summary>
+/// SP-B (#3406, epic #3403): serializes a chunk's normalized region to the
+/// <c>text_chunks.bounding_boxes_json</c> column. Format is a JSON array of page-aware boxes
+/// <c>[{page,x,y,width,height}]</c> — MVP emits 0 or 1 box per chunk (the union computed upstream by
+/// <c>ExtractedDocumentFactory</c>); the array shape leaves room for future multi-region chunks.
+/// Returns <c>null</c> when the chunk carries no region, so the column stays NULL for the
+/// pre-coordinate corpus (backfilled by SP-E re-extraction).
+/// </summary>
+internal static class ChunkBoundingBoxJson
+{
+    public static string? Serialize(BoundingBox? bbox, int page)
+    {
+        if (bbox is null)
+        {
+            return null;
+        }
+
+        return JsonSerializer.Serialize(new[]
+        {
+            new { page, x = bbox.X, y = bbox.Y, width = bbox.Width, height = bbox.Height },
+        });
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Entities/KnowledgeBase/TextChunkEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/KnowledgeBase/TextChunkEntity.cs
@@ -36,6 +36,11 @@ public class TextChunkEntity
     public int? CharStart { get; set; }
     public int? CharEnd { get; set; }
 
+    // SP-B (#3406): normalized region(s) of the chunk as JSON array [{page,x,y,width,height}]
+    // ([0,1] top-left). Nullable — NULL for chunks without coordinates (SmolDocling/Docnet path,
+    // or pre-coordinate corpus backfilled by SP-E re-extraction).
+    public string? BoundingBoxesJson { get; set; }
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
     // Issue #730: Chunk hierarchy fields (heading_path derivation)

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/KnowledgeBase/TextChunkEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/KnowledgeBase/TextChunkEntityConfiguration.cs
@@ -25,6 +25,12 @@ internal class TextChunkEntityConfiguration : IEntityTypeConfiguration<TextChunk
         builder.Property(e => e.CharStart).HasColumnName("char_start").IsRequired(false);
         builder.Property(e => e.CharEnd).HasColumnName("char_end").IsRequired(false);
 
+        // SP-B (#3406): normalized region(s) as jsonb (nullable; NULL when no coordinates)
+        builder.Property(e => e.BoundingBoxesJson)
+               .HasColumnName("bounding_boxes_json")
+               .HasColumnType("jsonb")
+               .IsRequired(false);
+
         builder.Property(e => e.CreatedAt).IsRequired();
 
         // Issue #730: Chunk hierarchy fields

--- a/apps/api/src/Api/Infrastructure/Migrations/20260730125719_AddChunkBoundingBoxes.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260730125719_AddChunkBoundingBoxes.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260730125719_AddChunkBoundingBoxes")]
+    partial class AddChunkBoundingBoxes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260730125719_AddChunkBoundingBoxes.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260730125719_AddChunkBoundingBoxes.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddChunkBoundingBoxes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "bounding_boxes_json",
+                table: "text_chunks",
+                type: "jsonb",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "bounding_boxes_json",
+                table: "text_chunks");
+        }
+    }
+}

--- a/apps/api/src/Api/Services/TextChunkingService.cs
+++ b/apps/api/src/Api/Services/TextChunkingService.cs
@@ -1,4 +1,5 @@
 using Api.Constants;
+using Api.BoundedContexts.KnowledgeBase.Domain.Chunking;
 
 #pragma warning disable MA0048 // File name must match type name - Contains Service with Configuration classes
 namespace Api.Services;
@@ -403,4 +404,6 @@ internal record DocumentChunkInput
     public short Level { get; init; } = 1;
     public Guid? ParentChunkId { get; init; }
     public string ElementType { get; init; } = "NarrativeText";
+    // SP-B (#3406): normalized region [0,1] top-left; null when unavailable.
+    public BoundingBox? BBox { get; init; }
 }

--- a/apps/api/src/Api/Services/VectorSearchModels.cs
+++ b/apps/api/src/Api/Services/VectorSearchModels.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.BoundedContexts.KnowledgeBase.Domain.Chunking;
 
 namespace Api.Services;
 
@@ -22,6 +23,9 @@ internal record DocumentChunk
     public short Level { get; init; } = 1;
     public Guid? ParentChunkId { get; init; }
     public string ElementType { get; init; } = "NarrativeText";
+    // SP-B (#3406): normalized region [0,1] top-left (union of the section's element boxes on
+    // the start page); null when the extractor emitted no coordinates.
+    public BoundingBox? BBox { get; init; }
 }
 
 /// <summary>

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/Chunking/ExtractedDocumentFactoryTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/Chunking/ExtractedDocumentFactoryTests.cs
@@ -10,6 +10,8 @@ namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Services.Chunking;
 public class ExtractedDocumentFactoryTests
 {
     private static ExtractedElement El(string text, string type, int page = 1) => new(text, page, type);
+    private static ExtractedElement ElBox(string text, string type, int page, float x, float y, float w, float h) =>
+        new(text, page, type, new ElementBoundingBox(x, y, w, h));
     private static readonly Guid Doc = Guid.NewGuid();
 
     [Fact]
@@ -22,6 +24,49 @@ public class ExtractedDocumentFactoryTests
         doc.Sections[0].Heading.Should().Be("Preparazione");
         doc.Sections[0].ElementType.Should().Be("heading");
         doc.Sections[0].Content.Should().Be("Preparazione\n\nDisponi le tessere.");
+    }
+
+    // ── SP-B #3406: section bounding-box union ─────────────────────────────────
+
+    [Fact]
+    public void SectionBBox_IsUnionOfElementBoxesOnStartPage()
+    {
+        var doc = ExtractedDocumentFactory.FromExtraction(Doc, null, new[]
+        {
+            ElBox("Setup", "Title", 1, 0.1f, 0.1f, 0.2f, 0.05f),
+            ElBox("body", "NarrativeText", 1, 0.1f, 0.2f, 0.6f, 0.1f),
+        }, "x");
+
+        var bbox = doc.Sections[0].BBox;
+        bbox.Should().NotBeNull();
+        bbox!.X.Should().BeApproximately(0.1f, 1e-4f);
+        bbox.Y.Should().BeApproximately(0.1f, 1e-4f);
+        bbox.Width.Should().BeApproximately(0.6f, 1e-4f); // maxX=max(0.3,0.7)=0.7 → 0.7-0.1
+        bbox.Height.Should().BeApproximately(0.2f, 1e-4f); // maxY=max(0.15,0.3)=0.3 → 0.3-0.1
+    }
+
+    [Fact]
+    public void SectionBBox_IsNullWhenNoElementHasCoordinates()
+    {
+        var doc = ExtractedDocumentFactory.FromExtraction(Doc, null,
+            new[] { El("Setup", "Title"), El("body", "NarrativeText") }, "x");
+
+        doc.Sections[0].BBox.Should().BeNull();
+    }
+
+    [Fact]
+    public void SectionBBox_SkipsElementsNotOnStartPage()
+    {
+        var doc = ExtractedDocumentFactory.FromExtraction(Doc, null, new[]
+        {
+            ElBox("Setup", "Title", 1, 0.1f, 0.1f, 0.2f, 0.05f),
+            ElBox("later", "NarrativeText", 2, 0.9f, 0.9f, 0.1f, 0.1f), // page 2 → ignored
+        }, "x");
+
+        var bbox = doc.Sections[0].BBox;
+        bbox.Should().NotBeNull();
+        bbox!.X.Should().BeApproximately(0.1f, 1e-4f);
+        bbox.Width.Should().BeApproximately(0.2f, 1e-4f); // only the start-page box counts
     }
 
     [Fact]

--- a/apps/unstructured-service/src/api/coordinates.py
+++ b/apps/unstructured-service/src/api/coordinates.py
@@ -1,0 +1,48 @@
+"""Coordinate normalization for PDF elements (SP-B #3406, epic #3403).
+
+unstructured `partition_pdf` attaches `element.metadata.coordinates` — a
+CoordinatesMetadata carrying `.points` (list of (x, y)) and `.system`
+(CoordinateSystem with `.width`/`.height`). PixelSpace uses a top-left origin
+(y grows downward), so no Y flip is needed. We normalize to [0,1] fractions of the
+page layout so the value is independent of strategy (fast vs hi_res), DPI, and the
+viewer zoom — the C# side receives an already-normalized box and the FE overlay is
+zero-math.
+"""
+from typing import Any, Optional
+
+from .schemas import BBoxSchema
+
+
+def _clamp_unit(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
+def normalized_bbox(element: Any) -> Optional[BBoxSchema]:
+    """Return the element's bounding box normalized to [0,1] (top-left origin),
+    or None when the element carries no usable coordinates (e.g. PageBreak, or an
+    OCR element without a layout box)."""
+    coordinates = getattr(getattr(element, "metadata", None), "coordinates", None)
+    if coordinates is None:
+        return None
+
+    points = getattr(coordinates, "points", None)
+    system = getattr(coordinates, "system", None)
+    if not points or system is None:
+        return None
+
+    width = getattr(system, "width", None)
+    height = getattr(system, "height", None)
+    if not width or not height:
+        return None
+
+    xs = [point[0] for point in points]
+    ys = [point[1] for point in points]
+    x_min, x_max = min(xs), max(xs)
+    y_min, y_max = min(ys), max(ys)
+
+    return BBoxSchema(
+        x=_clamp_unit(x_min / width),
+        y=_clamp_unit(y_min / height),
+        width=_clamp_unit((x_max - x_min) / width),
+        height=_clamp_unit((y_max - y_min) / height),
+    )

--- a/apps/unstructured-service/src/api/schemas.py
+++ b/apps/unstructured-service/src/api/schemas.py
@@ -26,6 +26,19 @@ class TextChunkSchema(BaseModel):
     metadata: Dict[str, Any] = Field(default_factory=dict, description="Additional metadata")
 
 
+class BBoxSchema(BaseModel):
+    """Normalized bounding box of an element (SP-B #3406, epic #3403).
+
+    Fractions in [0,1] of the page layout, top-left origin (y grows downward), so
+    the value is independent of strategy (fast vs hi_res), DPI, and viewer zoom.
+    """
+
+    x: float = Field(description="Left edge, normalized 0..1")
+    y: float = Field(description="Top edge, normalized 0..1 (top-left origin)")
+    width: float = Field(description="Width, normalized 0..1")
+    height: float = Field(description="Height, normalized 0..1")
+
+
 class ElementSchema(BaseModel):
     """Raw partition element (pre-chunking), preserving its structural category."""
 
@@ -33,6 +46,10 @@ class ElementSchema(BaseModel):
     page_number: int = Field(description="Page number (1-indexed)", ge=1)
     category: Optional[str] = Field(
         default=None, description="Raw Unstructured category (Title, NarrativeText, Table, …)"
+    )
+    bbox: Optional[BBoxSchema] = Field(
+        default=None,
+        description="Normalized bounding box [0,1] top-left; None if the extractor emitted no coordinates",
     )
 
 

--- a/apps/unstructured-service/src/main.py
+++ b/apps/unstructured-service/src/main.py
@@ -20,6 +20,7 @@ from .api.schemas import (
     ErrorResponse,
     HealthCheckResponse,
 )
+from .api.coordinates import normalized_bbox
 
 # Configure logging
 logging.basicConfig(
@@ -219,6 +220,7 @@ async def extract_pdf(
                     text=el.text,
                     page_number=getattr(getattr(el, "metadata", None), "page_number", 1) or 1,
                     category=getattr(el, "category", None),
+                    bbox=normalized_bbox(el),  # SP-B (#3406): normalized [0,1] bbox, None if absent
                 )
                 for el in result.elements
                 if getattr(el, "text", None)

--- a/apps/unstructured-service/tests/test_coordinates.py
+++ b/apps/unstructured-service/tests/test_coordinates.py
@@ -1,0 +1,66 @@
+"""Unit tests for coordinate normalization (SP-B #3406, epic #3403).
+
+The unstructured `partition_pdf` output carries `element.metadata.coordinates`
+(points + system with width/height, PixelSpace = top-left origin). We normalize
+each element's bounding box to [0,1] fractions of the page layout so the value is
+independent of strategy (fast vs hi_res), DPI, and the viewer zoom.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from src.api.coordinates import normalized_bbox
+
+
+def _element(points, width, height):
+    """Build a mock unstructured element carrying metadata.coordinates."""
+    system = SimpleNamespace(width=width, height=height)
+    coordinates = SimpleNamespace(points=points, system=system)
+    return SimpleNamespace(metadata=SimpleNamespace(coordinates=coordinates))
+
+
+class TestNormalizedBbox:
+    def test_pixelspace_points_are_normalized_top_left(self):
+        # 4 points TL->BL->BR->TR in a 1000x2000 PixelSpace layout
+        el = _element([(100, 200), (100, 400), (500, 400), (500, 200)], 1000, 2000)
+        bbox = normalized_bbox(el)
+        assert bbox is not None
+        assert bbox.x == pytest.approx(0.1)  # 100/1000
+        assert bbox.y == pytest.approx(0.1)  # 200/2000, top-left origin (no Y flip)
+        assert bbox.width == pytest.approx(0.4)  # (500-100)/1000
+        assert bbox.height == pytest.approx(0.1)  # (400-200)/2000
+
+    def test_returns_none_when_coordinates_absent(self):
+        el = SimpleNamespace(metadata=SimpleNamespace(coordinates=None))
+        assert normalized_bbox(el) is None
+
+    def test_returns_none_when_metadata_absent(self):
+        el = SimpleNamespace()
+        assert normalized_bbox(el) is None
+
+    def test_returns_none_when_points_empty(self):
+        el = _element([], 1000, 2000)
+        assert normalized_bbox(el) is None
+
+    def test_returns_none_when_layout_dims_missing(self):
+        el = _element([(100, 200), (500, 400)], 0, 0)
+        assert normalized_bbox(el) is None
+
+    def test_layout_dimension_independent(self):
+        # Same relative box at two different layout scales → identical normalized result.
+        # min/max makes it robust to point ordering and count (2 or 4 points).
+        el_small = _element([(100, 200), (500, 400)], 1000, 2000)
+        el_large = _element([(200, 400), (1000, 800)], 2000, 4000)
+        b1 = normalized_bbox(el_small)
+        b2 = normalized_bbox(el_large)
+        assert b1.x == pytest.approx(b2.x)
+        assert b1.y == pytest.approx(b2.y)
+        assert b1.width == pytest.approx(b2.width)
+        assert b1.height == pytest.approx(b2.height)
+
+    def test_clamps_components_to_unit_interval(self):
+        # Points beyond layout bounds get clamped into [0,1].
+        el = _element([(-10, -20), (1100, 2100)], 1000, 2000)
+        bbox = normalized_bbox(el)
+        for value in (bbox.x, bbox.y, bbox.width, bbox.height):
+            assert 0.0 <= value <= 1.0


### PR DESCRIPTION
**Epic**: #3403 — RAG citation region grounding · **SP-B** (coordinate pipeline)
Closes #3406

Porta le coordinate degli element PDF, **normalizzate [0,1] top-left**, dal servizio Python fino a `text_chunks.bounding_boxes_json`, così i chunk citati portano la regione sorgente (consumata dal FE in SP-D).

## B1 — coordinate Python (commit `660f526c4`)
- `normalized_bbox()` + `BBoxSchema` + `ElementSchema.bbox`; cablato in `main.py`.
- Normalizzazione al boundary Python (DA-1): indipendente da strategy/DPI/zoom, no Y flip.
- 7 unit test (`tests/test_coordinates.py`), pytest **31 passed** cov 83.58%.

## B2 — plumbing C# (commit `be03f763a`)
- `ExtractedElement.BoundingBox` + record `ElementBoundingBox` (in DocumentProcessing — dipendenza KB→DocumentProcessing, mai il contrario).
- `UnstructuredElement.Bbox` DTO + map in `MapStructuredElements`.
- `EmbeddedTitleSplitter`: il Title sintetico eredita la bbox del body.
- `ExtractedDocumentFactory`: **union** dei box degli element sulla start page → `DocumentSection.BBox` (map a `KB.BoundingBox`).
- `AdvancedChunkingService`: i child chunk ereditano la region del parent.
- `DocumentChunk.BBox` + `DocumentChunkInput.BBox` + `HierarchicalChunkMapper` + `HeadingAwareChunkAdapter`.

## B3 — persistenza (commit `be03f763a`)
- `TextChunkEntity.BoundingBoxesJson` + config `jsonb` + migration `AddChunkBoundingBoxes`.
- 4 siti insert serializzano via `ChunkBoundingBoxJson` → `[{page,x,y,width,height}]`.

## Scoping / limiti
- **IndexerVersion v1.2 rimandato a SP-E** (#3409), dove serve per selezionare il corpus da re-indicizzare; le bbox si popolano comunque sui nuovi ingest.
- Grounding a regione disponibile solo sul ramo **Unstructured**; SmolDocling/Docnet → `BoundingBoxesJson=NULL` (degradazione).
- Verifica **end-to-end** (rebuild container `unstructured` + PDF reale) e il **surfacing FE** sono SP-D/SP-E.

## Verifica
- `pytest` 31 passed (B1); `dotnet build` solution **0 errori**; migration corretta; **15 test** `ExtractedDocumentFactory` (3 nuovi per la union) verdi.
- Il test integration `Handle_RealPostgres_CountsChunksAndRaptorScopedPerPdf` fallisce **identico su main-dev** (FK `RaptorSummaries` pre-esistente, scorrelato dalle mie modifiche, non nel gate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)