### PR TITLE
feat(rag-citation): region DTO surfacing + copyright gate (SP-C, #3407)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentCommandHandler.cs
@@ -650,7 +650,12 @@ internal sealed class ChatWithSessionAgentCommandHandler : IStreamingQueryHandle
             c.CopyrightTier == CopyrightTier.Full ? c.SnippetPreview : null,
             c.CopyrightTier.ToString().ToLowerInvariant(),
             c.ParaphrasedSnippet,
-            c.IsPublic)).ToList();
+            c.IsPublic,
+            // SP-C (#3407): region overlay + char offsets are Full-gated (same rule as SnippetPreview) —
+            // parsed from the raw bbox JSON only for Full-tier citations (DA-4: no verbatim highlight leak).
+            Regions: c.CopyrightTier == CopyrightTier.Full ? CitationRegion.Parse(c.BoundingBoxesJson) : null,
+            CharStart: c.CopyrightTier == CopyrightTier.Full ? c.CharStart : null,
+            CharEnd: c.CopyrightTier == CopyrightTier.Full ? c.CharEnd : null)).ToList();
 
         // SP5-b T2: record citations-per-answer ONCE, post-stream, using citationDtos.Count
         // (the broadcast-authoritative list — NOT the earlier assembled.Citations or resolvedCitations).

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/SearchResultDto.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/SearchResultDto.cs
@@ -12,7 +12,12 @@ internal record SearchResultDto(
     int PageNumber,
     double RelevanceScore,
     int Rank,
-    string? SearchMethod
+    string? SearchMethod,
+    // SP-C (#3407): region-grounding carriers (primitives, no layer dep). Null for the keyword arm /
+    // pre-coordinate corpus. Parsed to CitationRegion + Full-gated at the StreamQa handler boundary.
+    string? BoundingBoxesJson = null,
+    int? CharStart = null,
+    int? CharEnd = null
 )
 {
     /// <summary>
@@ -28,7 +33,10 @@ internal record SearchResultDto(
             PageNumber: searchResult.PageNumber,
             RelevanceScore: searchResult.RelevanceScore.Value,
             Rank: searchResult.Rank,
-            SearchMethod: searchResult.SearchMethod
+            SearchMethod: searchResult.SearchMethod,
+            BoundingBoxesJson: searchResult.BoundingBoxesJson,
+            CharStart: searchResult.CharStart,
+            CharEnd: searchResult.CharEnd
         );
     }
 };

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Models/AssembledPrompt.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Models/AssembledPrompt.cs
@@ -51,4 +51,23 @@ internal sealed record ChunkCitation(
     /// best-effort no-op.
     /// </summary>
     public int? ChunkIndex { get; init; }
+
+    /// <summary>
+    /// SP-C (#3407): raw bounding-box JSON of the cited chunk (<c>text_chunks.bounding_boxes_json</c>),
+    /// carried from the vector arm. <see cref="JsonIgnoreAttribute"/> like <see cref="FullText"/>:
+    /// transient per-request retrieval metadata that MUST NOT persist in <c>CitationsJson</c>. Raw bbox
+    /// is verbatim-equivalent (highlights the exact cited text), so persisting it ungated would leak on
+    /// history reload for Protected content (DA-4). The live path parses + Full-gates it into
+    /// <c>CitationDto.Regions</c> at the handler boundary; reloaded citations fall back to the text-quote
+    /// highlight (SP0 Pattern A).
+    /// </summary>
+    [JsonIgnore]
+    public string? BoundingBoxesJson { get; init; }
+
+    /// <summary>SP-C (#3407): chunk char offsets in the source PDF text. Transient ([JsonIgnore]) — see <see cref="BoundingBoxesJson"/>.</summary>
+    [JsonIgnore]
+    public int? CharStart { get; init; }
+
+    [JsonIgnore]
+    public int? CharEnd { get; init; }
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchQueryHandler.cs
@@ -120,7 +120,10 @@ internal class SearchQueryHandler : IQueryHandler<SearchQuery, List<SearchResult
             PageNumber: sr.PageNumber,
             RelevanceScore: sr.RelevanceScore.Value,
             Rank: sr.Rank,
-            SearchMethod: sr.SearchMethod
+            SearchMethod: sr.SearchMethod,
+            BoundingBoxesJson: sr.BoundingBoxesJson,   // SP-C (#3407)
+            CharStart: sr.CharStart,
+            CharEnd: sr.CharEnd
         )).ToList();
 
         _logger.LogInformation(
@@ -167,7 +170,10 @@ internal class SearchQueryHandler : IQueryHandler<SearchQuery, List<SearchResult
                 pdfDocumentId: scored.Embedding.PdfDocumentId,                       // real (JOIN-resolved)
                 chunkIndex: scored.Embedding.ChunkIndex,
                 roleTags: (GameBookRole)scored.Embedding.RoleTags,                   // int → enum
-                heading: scored.Embedding.Heading                                     // #3270
+                heading: scored.Embedding.Heading,                                    // #3270
+                boundingBoxesJson: scored.Embedding.BoundingBoxesJson,               // SP-C (#3407)
+                charStart: scored.Embedding.CharStart,
+                charEnd: scored.Embedding.CharEnd
             );
         }).ToList();
 

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamQaQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamQaQueryHandler.cs
@@ -138,9 +138,13 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
             yield return CreateEvent(StreamingEventType.StateUpdate,
                 new StreamingStateUpdate("Retrieved from cache"));
 
-            // Emit citations
+            // Emit citations — SP-C (#3407): STRIP regions/char offsets from cache-served snippets.
+            // The QA cache key is (game, query) only, NOT user/tier (AiResponseCacheService), so a
+            // Full-tier user's cached Full-gated regions must NOT be replayed to a later Protected-tier
+            // user (DA-4). Regions are transient per-request data; fresh, correctly-gated regions are
+            // emitted only on a cache MISS. Cache hits gracefully fall back to the text-quote highlight.
             yield return CreateEvent(StreamingEventType.Citations,
-                new StreamingCitations(cachedResponse.snippets));
+                new StreamingCitations(StripRegions(cachedResponse.snippets)));
 
             // Emit answer as tokens (simulate streaming for consistency)
             var words = cachedResponse.answer.Split(' ', StringSplitOptions.RemoveEmptyEntries);
@@ -395,8 +399,13 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
         {
             var isFull = c.CopyrightTier == CopyrightTier.Full;
             return new Snippet(
-                // Redact the verbatim excerpt for non-Full tiers (parity with the session-agent gate).
-                isFull ? c.SnippetPreview : string.Empty,
+                // Verbatim text is preserved for ALL tiers on purpose: this SAME snippets list grounds
+                // the LLM prompt (BuildLlmPromptsAsync) and feeds the inline-citation matcher, so
+                // redacting it here would starve the model of retrieved context. Only the NEW SP-C
+                // region-grounding surface is Full-gated. (The pre-existing verbatim-text-to-FE
+                // behavior is intentionally unchanged; closing that #447 gap needs a separate
+                // LLM-prompt/FE-citation source split — out of SP-C scope.)
+                c.SnippetPreview,
                 $"PDF:{c.DocumentId}",
                 c.PageNumber,
                 0,
@@ -412,6 +421,15 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
 
         return (true, snippets, domainSearchResults, searchConfidence);
     }
+
+    /// <summary>
+    /// SP-C (#3407): returns a copy of <paramref name="snippets"/> with the Full-gated region-grounding
+    /// fields (regions/charStart/charEnd) removed. Used on the cache-hit path because the QA cache is
+    /// keyed only by (game, query) — not by user/tier — so cached regions must never be replayed across
+    /// tiers (DA-4). Verbatim text is left intact (its cross-tier caching is pre-existing behavior).
+    /// </summary>
+    private static IReadOnlyList<Snippet> StripRegions(IReadOnlyList<Snippet> snippets) =>
+        snippets.Select(s => s with { regions = null, charStart = null, charEnd = null }).ToList();
 
     /// <summary>
     /// Loads chat thread context if ThreadId provided.

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamQaQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamQaQueryHandler.cs
@@ -544,10 +544,14 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
             searchConfidence,
             llmConfidence);
 
-        // Build and cache response
+        // Build and cache response — SP-C (#3407): NEVER cache the Full-gated regions/char offsets.
+        // The cache key is (game, query) only (not user/tier), so caching gated data risks a
+        // cross-tier replay leak (DA-4). Fresh, correctly-gated regions are emitted per-request on a
+        // cache MISS; cache hits fall back to the text-quote highlight. (StripRegions on the read path
+        // stays as defense-in-depth for any entry cached before this line shipped.)
         var response = new QaResponse(
             answer,
-            snippets,
+            StripRegions(snippets),
             0,
             tokenCount,
             tokenCount,

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamQaQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamQaQueryHandler.cs
@@ -1,8 +1,10 @@
 using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.BoundedContexts.KnowledgeBase.Application.Models;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries;
 using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services.Reranking;
@@ -50,6 +52,7 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
     private readonly InlineCitationMatcherService _citationMatcher;
     private readonly IIntentClassifierService _intentClassifier;
     private readonly IRagAccessService _ragAccessService;
+    private readonly ICopyrightTierResolver _copyrightTierResolver;
     private readonly ILogger<StreamQaQueryHandler> _logger;
     private readonly TimeProvider _timeProvider;
 
@@ -67,6 +70,7 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
         InlineCitationMatcherService citationMatcher,
         IIntentClassifierService intentClassifier,
         IRagAccessService ragAccessService,
+        ICopyrightTierResolver copyrightTierResolver,
         ILogger<StreamQaQueryHandler> logger,
         TimeProvider? timeProvider = null)
     {
@@ -83,6 +87,7 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
         _citationMatcher = citationMatcher ?? throw new ArgumentNullException(nameof(citationMatcher));
         _intentClassifier = intentClassifier ?? throw new ArgumentNullException(nameof(intentClassifier));
         _ragAccessService = ragAccessService ?? throw new ArgumentNullException(nameof(ragAccessService));
+        _copyrightTierResolver = copyrightTierResolver ?? throw new ArgumentNullException(nameof(copyrightTierResolver));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _timeProvider = timeProvider ?? TimeProvider.System;
     }
@@ -200,7 +205,7 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
             new StreamingStateUpdate("Searching knowledge base..."));
 
         var (searchSuccess, snippets, domainSearchResults, searchConfidence) = await PerformSearchAndBuildCitationsAsync(
-            query.GameId, query.Query, query.DocumentIds, cancellationToken).ConfigureAwait(false);
+            query.GameId, query.Query, query.DocumentIds, query.UserId ?? Guid.Empty, cancellationToken).ConfigureAwait(false);
 
         if (!searchSuccess)
         {
@@ -301,6 +306,7 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
         string gameId,
         string queryText,
         IReadOnlyList<Guid>? documentIds,
+        Guid userId,
         CancellationToken cancellationToken)
     {
         // Issue #3270 (Task 7): classify user intent into GameBookRole tag(s) so the hybrid
@@ -358,7 +364,11 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
             .GetByGameIdAsync(Guid.Parse(gameId), cancellationToken).ConfigureAwait(false);
         var pdfIdByVectorId = vectorDocs.ToDictionary(v => v.Id, v => v.PdfDocumentId);
 
-        var snippets = searchResults.Select(r =>
+        // SP-C (#3407): resolve the copyright tier per citation and gate BOTH the verbatim excerpt and
+        // the region overlay to Full — StreamQa previously emitted verbatim text with NO gate (a leak,
+        // #447/DA-4). The resolver keys on ChunkCitation.DocumentId = the resolved pdf id string (NOT
+        // the vector id, NOT the "PDF:"-prefixed source), matching the session-agent chain.
+        var rawCitations = searchResults.Select(r =>
         {
             // Fall back to the vector id if resolution fails (keeps a stable source string).
             var citationDocId =
@@ -366,12 +376,38 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
                 && pdfIdByVectorId.TryGetValue(vecId, out var pdfId)
                     ? pdfId.ToString()
                     : r.VectorDocumentId;
+            return new ChunkCitation(
+                DocumentId: citationDocId,
+                PageNumber: r.PageNumber,
+                RelevanceScore: (float)r.RelevanceScore,
+                SnippetPreview: r.TextContent)
+            {
+                BoundingBoxesJson = r.BoundingBoxesJson,
+                CharStart = r.CharStart,
+                CharEnd = r.CharEnd,
+            };
+        }).ToList();
+
+        var resolvedCitations = await _copyrightTierResolver
+            .ResolveAsync(rawCitations, userId, cancellationToken).ConfigureAwait(false);
+
+        var snippets = resolvedCitations.Select(c =>
+        {
+            var isFull = c.CopyrightTier == CopyrightTier.Full;
             return new Snippet(
-                r.TextContent,
-                $"PDF:{citationDocId}",
-                r.PageNumber,
+                // Redact the verbatim excerpt for non-Full tiers (parity with the session-agent gate).
+                isFull ? c.SnippetPreview : string.Empty,
+                $"PDF:{c.DocumentId}",
+                c.PageNumber,
                 0,
-                (float)r.RelevanceScore);
+                c.RelevanceScore)
+            {
+                // Region overlay + char offsets are Full-gated: drawing the verbatim region on a
+                // Protected doc would leak (DA-4). Null → key omitted (additive-only wire, D-4).
+                regions = isFull ? CitationRegion.Parse(c.BoundingBoxesJson) : null,
+                charStart = isFull ? c.CharStart : null,
+                charEnd = isFull ? c.CharEnd : null,
+            };
         }).ToList();
 
         return (true, snippets, domainSearchResults, searchConfidence);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyService.cs
@@ -358,7 +358,19 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
                         filteredChunks = filteredChunks
                             .Concat(expandedChunks)
                             .GroupBy(c => $"{c.PdfId}:{c.ChunkIndex}", StringComparer.Ordinal)
-                            .Select(g => g.OrderByDescending(c => c.Score).First())
+                            .Select(g =>
+                            {
+                                var best = g.OrderByDescending(c => c.Score).First();
+                                // SP-C (#3407): this GroupBy is a DROP SITE (mirrors the hybrid-fusion
+                                // merge). The expanded arm is FTS-only (no bbox); coalesce the region
+                                // carriers across the group so the original vector chunk's bbox survives.
+                                return best with
+                                {
+                                    BoundingBoxesJson = g.Select(c => c.BoundingBoxesJson).FirstOrDefault(b => b != null),
+                                    CharStart = g.Select(c => c.CharStart).FirstOrDefault(v => v != null),
+                                    CharEnd = g.Select(c => c.CharEnd).FirstOrDefault(v => v != null),
+                                };
+                            })
                             .OrderByDescending(c => c.Score)
                             .Take(profile.TopK * 2)
                             .ToList();

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyService.cs
@@ -285,7 +285,11 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
                         Text = scored.Embedding.TextContent,
                         PdfId = scored.Embedding.VectorDocumentId.ToString(),
                         Page = scored.Embedding.PageNumber,
-                        ChunkIndex = scored.Embedding.ChunkIndex
+                        ChunkIndex = scored.Embedding.ChunkIndex,
+                        // SP-C (#3407): carry region-grounding primitives from the vector arm.
+                        BoundingBoxesJson = scored.Embedding.BoundingBoxesJson,
+                        CharStart = scored.Embedding.CharStart,
+                        CharEnd = scored.Embedding.CharEnd,
                     });
                 }
             }
@@ -444,6 +448,11 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
                 {
                     FullText = chunk.Text,  // #447: preserve full text for copyright leak guard
                     ChunkIndex = chunk.ChunkIndex,
+                    // SP-C (#3407): raw region carriers (transient, [JsonIgnore]) — parsed + Full-gated
+                    // into CitationDto.Regions at the handler boundary.
+                    BoundingBoxesJson = chunk.BoundingBoxesJson,
+                    CharStart = chunk.CharStart,
+                    CharEnd = chunk.CharEnd,
                 };
 
                 citations.Add(citation);
@@ -610,7 +619,13 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
                         Text = best.Text,
                         PdfId = best.PdfId,
                         Page = best.Page,
-                        ChunkIndex = best.ChunkIndex
+                        ChunkIndex = best.ChunkIndex,
+                        // SP-C (#3407): this GroupBy rebuild is a DROP SITE. Coalesce the region
+                        // carriers across the group (the vector arm has them; the FTS arm never
+                        // does) so bbox survives even when the FTS copy wins `best` on score.
+                        BoundingBoxesJson = g.Select(c => c.BoundingBoxesJson).FirstOrDefault(b => b != null),
+                        CharStart = g.Select(c => c.CharStart).FirstOrDefault(v => v != null),
+                        CharEnd = g.Select(c => c.CharEnd).FirstOrDefault(v => v != null),
                     };
                 })
                 .ToList();

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/Embedding.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/Embedding.cs
@@ -46,6 +46,20 @@ internal sealed class Embedding : Entity<Guid>
     public string? Heading { get; private set; }
 
     /// <summary>
+    /// SP-C (#3407): raw bounding-box JSON (<c>text_chunks.bounding_boxes_json</c>) resolved via the
+    /// same <c>source_chunk_id</c> JOIN as <see cref="Heading"/>. Carried as a primitive string (no
+    /// layer dep) — parsed to <c>CitationRegion</c> and Full-gated only at the API handler boundary.
+    /// Null for the pre-coordinate corpus / non-Unstructured branch / reads that don't project it.
+    /// </summary>
+    public string? BoundingBoxesJson { get; private set; }
+
+    /// <summary>SP-C (#3407): char offset (inclusive) of the chunk in the source PDF text (<c>text_chunks.char_start</c>). Null when unavailable.</summary>
+    public int? CharStart { get; private set; }
+
+    /// <summary>SP-C (#3407): char offset (exclusive) of the chunk in the source PDF text (<c>text_chunks.char_end</c>). Null when unavailable.</summary>
+    public int? CharEnd { get; private set; }
+
+    /// <summary>
     /// Private constructor for EF Core.
     /// </summary>
 #pragma warning disable CS8618
@@ -70,7 +84,10 @@ internal sealed class Embedding : Entity<Guid>
         bool isTranslation = false,
         int roleTags = 0,
         Guid pdfDocumentId = default,
-        string? heading = null) : base(id)
+        string? heading = null,
+        string? boundingBoxesJson = null,
+        int? charStart = null,
+        int? charEnd = null) : base(id)
     {
         if (string.IsNullOrWhiteSpace(textContent))
             throw new ArgumentException("Text content cannot be empty", nameof(textContent));
@@ -97,6 +114,9 @@ internal sealed class Embedding : Entity<Guid>
         RoleTags = roleTags;
         PdfDocumentId = pdfDocumentId;
         Heading = heading;
+        BoundingBoxesJson = boundingBoxesJson;
+        CharStart = charStart;
+        CharEnd = charEnd;
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/SearchResult.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/SearchResult.cs
@@ -24,6 +24,14 @@ internal sealed class SearchResult : Entity<Guid>
     public string? Heading { get; private set; }
 
     /// <summary>
+    /// SP-C (#3407): raw bounding-box JSON + char offsets carried from the vector arm to the citation
+    /// surface (parsed + Full-gated at the API boundary). Null for the keyword arm / pre-coordinate corpus.
+    /// </summary>
+    public string? BoundingBoxesJson { get; private set; }
+    public int? CharStart { get; private set; }
+    public int? CharEnd { get; private set; }
+
+    /// <summary>
     /// Private constructor for EF Core.
     /// </summary>
 #pragma warning disable CS8618
@@ -46,7 +54,10 @@ internal sealed class SearchResult : Entity<Guid>
         Guid pdfDocumentId = default,
         int chunkIndex = 0,
         GameBookRole roleTags = GameBookRole.None,
-        string? heading = null) : base(id)
+        string? heading = null,
+        string? boundingBoxesJson = null,
+        int? charStart = null,
+        int? charEnd = null) : base(id)
     {
         if (string.IsNullOrWhiteSpace(textContent))
             throw new ArgumentException("Text content cannot be empty", nameof(textContent));
@@ -67,6 +78,9 @@ internal sealed class SearchResult : Entity<Guid>
         ChunkIndex = chunkIndex;
         RoleTags = roleTags;
         Heading = heading;
+        BoundingBoxesJson = boundingBoxesJson;
+        CharStart = charStart;
+        CharEnd = charEnd;
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/RrfFusionDomainService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/RrfFusionDomainService.cs
@@ -69,7 +69,12 @@ internal class RrfFusionDomainService
                     pdfDocumentId: original.PdfDocumentId,
                     chunkIndex: original.ChunkIndex,
                     roleTags: f.RoleTags,
-                    heading: f.Heading);
+                    heading: f.Heading,
+                    // SP-C (#3407): carry the region-grounding primitives from the (vector-preferred)
+                    // original, else the fused result drops the bbox/char offsets before the citation.
+                    boundingBoxesJson: original.BoundingBoxesJson,
+                    charStart: original.CharStart,
+                    charEnd: original.CharEnd);
             })
             .ToList();
     }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/PgVectorStoreAdapter.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/PgVectorStoreAdapter.cs
@@ -142,11 +142,15 @@ internal sealed class PgVectorStoreAdapter : IVectorStoreAdapter
         // heading-match boost — LEFT (not INNER) so a pre-SP2 embedding with a null source_chunk_id
         // still returns its row with heading=null instead of being dropped. text_chunks."Id" is the
         // PK, so the join is 1:0-or-1 (no row fan-out).
+        // SP-C (#3407): reuse the SAME LEFT JOIN to carry the chunk's char offsets and normalized
+        // bounding boxes (columns 10/11/12) for citation region grounding. NOTE these are snake_case
+        // columns (HasColumnName) → UNQUOTED, unlike the default-PascalCase tc."Heading".
         var sql = $"""
             SELECT e.id, e.vector_document_id, e.text_content, e.model, e.chunk_index, e.page_number, e.role_tags,
                    vd."PdfDocumentId",
                    1 - (e.vector <=> @queryVector) AS similarity,
-                   tc."Heading"
+                   tc."Heading",
+                   tc.char_start, tc.char_end, tc.bounding_boxes_json
             FROM {TableName} e
             JOIN vector_documents vd ON vd."Id" = e.vector_document_id
             LEFT JOIN text_chunks tc ON tc."Id" = e.source_chunk_id
@@ -202,6 +206,18 @@ internal sealed class PgVectorStoreAdapter : IVectorStoreAdapter
                     var heading = await reader.IsDBNullAsync(9, cancellationToken).ConfigureAwait(false)
                         ? null
                         : reader.GetString(9);
+                    // SP-C (#3407) Columns 10/11/12: chunk char offsets + normalized bounding boxes
+                    // via the same LEFT JOIN (all nullable — null for the pre-coordinate corpus or a
+                    // null source_chunk_id). bounding_boxes_json is jsonb → read as string.
+                    var charStart = await reader.IsDBNullAsync(10, cancellationToken).ConfigureAwait(false)
+                        ? (int?)null
+                        : reader.GetInt32(10);
+                    var charEnd = await reader.IsDBNullAsync(11, cancellationToken).ConfigureAwait(false)
+                        ? (int?)null
+                        : reader.GetInt32(11);
+                    var boundingBoxesJson = await reader.IsDBNullAsync(12, cancellationToken).ConfigureAwait(false)
+                        ? null
+                        : reader.GetString(12);
 
                     var placeholderVector = DomainVector.CreatePlaceholder(queryVector.Dimensions);
                     var embedding = new Embedding(
@@ -214,7 +230,10 @@ internal sealed class PgVectorStoreAdapter : IVectorStoreAdapter
                         pageNumber: Math.Max(1, pageNumber),
                         roleTags: roleTags,
                         pdfDocumentId: pdfDocumentId,
-                        heading: heading);
+                        heading: heading,
+                        boundingBoxesJson: boundingBoxesJson,
+                        charStart: charStart,
+                        charEnd: charEnd);
 
                     results.Add(new ScoredEmbedding(embedding, score));
                 }

--- a/apps/api/src/Api/Models/Contracts.cs
+++ b/apps/api/src/Api/Models/Contracts.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -42,6 +43,30 @@ internal record Snippet(string text, string source, int page, int line, float sc
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public int? chunkPosition { get; init; }
+
+    /// <summary>
+    /// SP-C (#3407): normalized [0,1] top-left bounding boxes of the cited chunk, for the
+    /// FE PDF region overlay. Full-gated: populated ONLY when CopyrightTier=Full (drawing
+    /// the verbatim region on a Protected doc would leak, DA-4). Null for the pre-coordinate
+    /// corpus / non-Unstructured branch / Protected tier → key omitted (additive-only, D-4).
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<CitationRegion>? regions { get; init; }
+
+    /// <summary>
+    /// SP-C (#3407): char offset (inclusive) of the chunk within the source PDF text.
+    /// Full-gated; null when unavailable. NOT to be confused with InlineCitationMatch
+    /// offsets, which index into the ANSWER text.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? charStart { get; init; }
+
+    /// <summary>
+    /// SP-C (#3407): char offset (exclusive) of the chunk within the source PDF text.
+    /// Full-gated; null when unavailable.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? charEnd { get; init; }
 }
 
 /// <summary>
@@ -139,7 +164,51 @@ internal record CitationDto(
     string? SnippetPreview,
     string CopyrightTier,
     string? ParaphrasedSnippet = null,
-    bool IsPublic = false);
+    bool IsPublic = false,
+    IReadOnlyList<CitationRegion>? Regions = null,
+    int? CharStart = null,
+    int? CharEnd = null);
+
+/// <summary>
+/// SP-C (#3407): FE-facing, Full-gated region of a citation on the source PDF.
+/// Coordinates are normalized to [0,1] top-left (page-relative), enabling a
+/// scale/DPR-independent %-based overlay (SP-D). Parsed at the handler boundary from
+/// the persisted <c>text_chunks.bounding_boxes_json</c> array; never carried through the
+/// domain/application layers (those hold the raw JSON string only — no layer deps).
+/// </summary>
+internal record CitationRegion(int Page, double X, double Y, double Width, double Height)
+{
+    /// <summary>
+    /// Parses the persisted bounding-box JSON (<c>[{page,x,y,width,height}]</c>, lowercase
+    /// keys) into regions. Returns null for null/blank/empty/malformed input — never throws,
+    /// so a corrupt column can never break a citation response.
+    /// </summary>
+    public static IReadOnlyList<CitationRegion>? Parse(string? boundingBoxesJson)
+    {
+        if (string.IsNullOrWhiteSpace(boundingBoxesJson))
+        {
+            return null;
+        }
+
+        try
+        {
+            var regions = JsonSerializer.Deserialize<List<CitationRegion>>(
+                boundingBoxesJson, RegionParseOptions);
+            return regions is { Count: > 0 } ? regions : null;
+        }
+        catch (JsonException)
+        {
+            // Defensive: a corrupt/unexpected column must never break a citation response.
+            return null;
+        }
+    }
+
+    private static readonly JsonSerializerOptions RegionParseOptions = new()
+    {
+        // Persisted keys are lowercase (page/x/y/width/height) — the record members are PascalCase.
+        PropertyNameCaseInsensitive = true,
+    };
+}
 internal record StreamingError(string errorMessage, string? errorCode = null);
 internal record StreamingToken(string token); // CHAT-01: Individual LLM token
 internal record StreamingSetupStep(SetupGuideStep step); // AI-03: Individual setup step

--- a/apps/api/src/Api/Services/VectorSearchModels.cs
+++ b/apps/api/src/Api/Services/VectorSearchModels.cs
@@ -76,6 +76,17 @@ internal record SearchResultItem
 
     /// <summary>#3270: chunk heading-path label for the heading-match boost (nullable).</summary>
     public string? Heading { get; init; }
+
+    /// <summary>
+    /// SP-C (#3407): raw bounding-box JSON carried from the vector arm (<c>Embedding.BoundingBoxesJson</c>).
+    /// Primitive string (no layer dep); parsed + Full-gated at the API handler boundary. Null for the
+    /// keyword/FTS/RAPTOR arms and the pre-coordinate corpus.
+    /// </summary>
+    public string? BoundingBoxesJson { get; init; }
+
+    /// <summary>SP-C (#3407): chunk char offsets in the source PDF text (nullable).</summary>
+    public int? CharStart { get; init; }
+    public int? CharEnd { get; init; }
 }
 
 /// <summary>

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatSessionAgentBroadcastTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatSessionAgentBroadcastTests.cs
@@ -127,6 +127,93 @@ public class ChatSessionAgentBroadcastTests
     }
 
     // -----------------------------------------------------------------------
+    // SP-C (#3407): region overlay is Full-gated (same as SnippetPreview)
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task Chat_WithLiveSession_FullTierCitation_BroadcastsRegions()
+    {
+        // Arrange — Full-tier citation carrying a bounding box.
+        var liveSessionId = Guid.NewGuid();
+        var liveSession = BuildLiveSession(liveSessionId);
+
+        var citation = new ChunkCitation(
+            DocumentId: "doc-1",
+            PageNumber: 2,
+            RelevanceScore: 0.95f,
+            SnippetPreview: "verbatim rule text",
+            CopyrightTier: CopyrightTier.Full,
+            IsPublic: true)
+        {
+            BoundingBoxesJson = "[{\"page\":2,\"x\":0.1,\"y\":0.2,\"width\":0.3,\"height\":0.4}]",
+            CharStart = 100,
+            CharEnd = 250,
+        };
+
+        var gateway = new Mock<ILiveSessionStreamGateway>();
+        var handler = BuildHandler(
+            liveSession: liveSession,
+            resolvedCitations: new List<ChunkCitation> { citation },
+            gateway: gateway.Object);
+        var command = BuildCommand();
+
+        // Act
+        await foreach (var _ in handler.Handle(command, CancellationToken.None)) { }
+
+        // Assert — the region overlay is surfaced for Full-tier content.
+        gateway.Verify(
+            g => g.BroadcastAsync(
+                liveSessionId,
+                It.Is<LiveSessionStreamEvent>(e =>
+                    e.Type == "session:chat" &&
+                    HasRegions(e.Data)),
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "Full tier: broadcast citation must carry parsed regions[]");
+    }
+
+    [Fact]
+    public async Task Chat_WithLiveSession_ProtectedTierCitation_BroadcastsWithNullRegions()
+    {
+        // Arrange — same bounding box, but Protected tier → regions MUST be withheld (DA-4).
+        var liveSessionId = Guid.NewGuid();
+        var liveSession = BuildLiveSession(liveSessionId);
+
+        var citation = new ChunkCitation(
+            DocumentId: "doc-2",
+            PageNumber: 1,
+            RelevanceScore: 0.80f,
+            SnippetPreview: "this should be suppressed",
+            CopyrightTier: CopyrightTier.Protected)
+        {
+            BoundingBoxesJson = "[{\"page\":1,\"x\":0.1,\"y\":0.2,\"width\":0.3,\"height\":0.4}]",
+            CharStart = 100,
+            CharEnd = 250,
+        };
+
+        var gateway = new Mock<ILiveSessionStreamGateway>();
+        var handler = BuildHandler(
+            liveSession: liveSession,
+            resolvedCitations: new List<ChunkCitation> { citation },
+            gateway: gateway.Object);
+        var command = BuildCommand();
+
+        // Act
+        await foreach (var _ in handler.Handle(command, CancellationToken.None)) { }
+
+        // Assert — no verbatim region highlight for Protected content.
+        gateway.Verify(
+            g => g.BroadcastAsync(
+                liveSessionId,
+                It.Is<LiveSessionStreamEvent>(e =>
+                    e.Type == "session:chat" &&
+                    NoRegions(e.Data)),
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "Protected tier: regions must be null on the broadcast payload (no verbatim highlight leak)");
+    }
+
+    // -----------------------------------------------------------------------
     // AC-CHAT-3: Non-grounded / no citations → still broadcasts with citations == []
     // -----------------------------------------------------------------------
 
@@ -458,6 +545,33 @@ public class ChatSessionAgentBroadcastTests
         var doc = ToJsonDocument(data);
         if (!doc.RootElement.TryGetProperty("citations", out var citations)) return true;
         return citations.GetArrayLength() == 0;
+    }
+
+    private static bool HasRegions(object data)
+    {
+        var doc = ToJsonDocument(data);
+        if (!doc.RootElement.TryGetProperty("citations", out var citations)) return false;
+        if (citations.GetArrayLength() == 0) return false;
+        var first = citations[0];
+        return first.TryGetProperty("regions", out var regions) &&
+               regions.ValueKind == JsonValueKind.Array &&
+               regions.GetArrayLength() > 0;
+    }
+
+    private static bool NoRegions(object data)
+    {
+        var doc = ToJsonDocument(data);
+        if (!doc.RootElement.TryGetProperty("citations", out var citations)) return true;
+        foreach (var item in citations.EnumerateArray())
+        {
+            if (item.TryGetProperty("regions", out var regions) &&
+                regions.ValueKind == JsonValueKind.Array &&
+                regions.GetArrayLength() > 0)
+            {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static JsonDocument ToJsonDocument(object data)

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/StreamQaQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/StreamQaQueryHandlerTests.cs
@@ -5,7 +5,9 @@ using Api.BoundedContexts.KnowledgeBase.Application.Services;
 using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 using Api.BoundedContexts.KnowledgeBase.Application.Commands;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries;
+using Api.BoundedContexts.KnowledgeBase.Application.Models;
 using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services.Reranking;
@@ -48,6 +50,7 @@ public class StreamQaQueryHandlerTests
     private readonly Mock<IAiResponseCacheService> _cacheMock;
     private readonly Mock<IPromptTemplateService> _promptTemplateServiceMock;
     private readonly Mock<IIntentClassifierService> _intentClassifierMock;
+    private readonly Mock<ICopyrightTierResolver> _copyrightTierResolverMock;
     private readonly Mock<ILogger<StreamQaQueryHandler>> _loggerMock;
     private readonly FakeTimeProvider _fakeTimeProvider;
     private readonly StreamQaQueryHandler _handler;
@@ -96,6 +99,14 @@ public class StreamQaQueryHandlerTests
         _intentClassifierMock
             .Setup(x => x.ClassifyIntent(It.IsAny<string>()))
             .Returns(GameBookRole.None);
+        // SP-C (#3407): default permissive resolver — echoes citations resolved to Full so existing
+        // tests keep their verbatim snippet text (pre-SP-C behavior = no gate = everything verbatim).
+        // Gate tests override this with a Protected-tier resolver.
+        _copyrightTierResolverMock = new Mock<ICopyrightTierResolver>();
+        _copyrightTierResolverMock
+            .Setup(x => x.ResolveAsync(It.IsAny<IReadOnlyList<ChunkCitation>>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<ChunkCitation> cits, Guid _, CancellationToken _) =>
+                cits.Select(c => c with { CopyrightTier = CopyrightTier.Full }).ToList());
         _loggerMock = new Mock<ILogger<StreamQaQueryHandler>>();
         _fakeTimeProvider = new FakeTimeProvider();
         _fakeTimeProvider.SetUtcNow(new DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero));
@@ -122,6 +133,7 @@ public class StreamQaQueryHandlerTests
             new InlineCitationMatcherService(),
             _intentClassifierMock.Object,
             CreatePermissiveRagAccessServiceMock(),
+            _copyrightTierResolverMock.Object,
             _loggerMock.Object,
             _fakeTimeProvider
         );
@@ -257,6 +269,95 @@ public class StreamQaQueryHandlerTests
         var complete = completeEvent.Data.Should().BeOfType<StreamingComplete>().Which;
         (complete.totalTokens > 0).Should().BeTrue();
         complete.confidence.HasValue.Should().BeTrue();
+    }
+
+    // ─── SP-C (#3407): citation region grounding + copyright gate ───
+
+    [Fact]
+    public async Task Handle_FullTierCitation_EmitsRegions_AndVerbatimText()
+    {
+        // Arrange: fused result carries a bbox + char offsets; default resolver resolves to Full.
+        var gameId = Guid.NewGuid().ToString();
+        var query = new StreamQaQuery(gameId, "how do I score?", null);
+        SetupHappyPathMocks(gameId, query.Query);
+        SetupFusedResultWithRegion();
+
+        // Act
+        var snippet = FirstCitation(await CollectEventsAsync(query));
+
+        // Assert: region overlay + verbatim snippet are surfaced for Full-tier content.
+        snippet.regions.Should().NotBeNull();
+        snippet.regions!.Should().ContainSingle();
+        snippet.regions![0].Page.Should().Be(2);
+        snippet.regions![0].X.Should().BeApproximately(0.1, 1e-9);
+        snippet.charStart.Should().Be(100);
+        snippet.charEnd.Should().Be(250);
+        snippet.text.Should().Be("Sample rule text");
+    }
+
+    [Fact]
+    public async Task Handle_ProtectedTierCitation_NullsRegions_AndRedactsText()
+    {
+        // Arrange: same bbox-carrying result, but the resolver resolves to Protected.
+        var gameId = Guid.NewGuid().ToString();
+        var query = new StreamQaQuery(gameId, "how do I score?", null);
+        SetupHappyPathMocks(gameId, query.Query);
+        SetupFusedResultWithRegion();
+        _copyrightTierResolverMock
+            .Setup(x => x.ResolveAsync(It.IsAny<IReadOnlyList<ChunkCitation>>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<ChunkCitation> cits, Guid _, CancellationToken _) =>
+                cits.Select(c => c with { CopyrightTier = CopyrightTier.Protected }).ToList());
+
+        // Act
+        var snippet = FirstCitation(await CollectEventsAsync(query));
+
+        // Assert: no verbatim region highlight nor verbatim excerpt for Protected content (DA-4 / #447).
+        snippet.regions.Should().BeNull();
+        snippet.charStart.Should().BeNull();
+        snippet.charEnd.Should().BeNull();
+        snippet.text.Should().BeEmpty();
+    }
+
+    private void SetupFusedResultWithRegion()
+    {
+        var fusedResult = new DomainSearchResult(
+            id: Guid.NewGuid(),
+            vectorDocumentId: Guid.NewGuid(),
+            textContent: "Sample rule text",
+            pageNumber: 2,
+            relevanceScore: new Confidence(0.9),
+            rank: 1,
+            searchMethod: "hybrid",
+            boundingBoxesJson: "[{\"page\":2,\"x\":0.1,\"y\":0.2,\"width\":0.3,\"height\":0.4}]",
+            charStart: 100,
+            charEnd: 250);
+
+        _rrfFusionServiceMock
+            .Setup(x => x.FuseResults(
+                It.IsAny<List<DomainSearchResult>>(),
+                It.IsAny<List<DomainSearchResult>>(),
+                It.IsAny<int>(),
+                It.IsAny<GameBookRole>(),
+                It.IsAny<IReadOnlyList<string>?>()))
+            .Returns(new List<DomainSearchResult> { fusedResult });
+    }
+
+    private async Task<List<RagStreamingEvent>> CollectEventsAsync(StreamQaQuery query)
+    {
+        var events = new List<RagStreamingEvent>();
+        await foreach (var evt in _handler.Handle(query, TestContext.Current.CancellationToken))
+        {
+            events.Add(evt);
+        }
+        return events;
+    }
+
+    private static Snippet FirstCitation(List<RagStreamingEvent> events)
+    {
+        var citationsEvent = events.First(e => e.Type == StreamingEventType.Citations);
+        var citations = citationsEvent.Data.Should().BeOfType<StreamingCitations>().Which;
+        citations.citations.Should().NotBeEmpty();
+        return citations.citations[0];
     }
 
     [Fact]
@@ -1367,6 +1468,7 @@ public class StreamQaQueryHandlerTests
             new InlineCitationMatcherService(),
             _intentClassifierMock.Object,
             ragAccessService,
+            _copyrightTierResolverMock.Object,
             _loggerMock.Object,
             _fakeTimeProvider);
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/StreamQaQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/StreamQaQueryHandlerTests.cs
@@ -296,7 +296,7 @@ public class StreamQaQueryHandlerTests
     }
 
     [Fact]
-    public async Task Handle_ProtectedTierCitation_NullsRegions_AndRedactsText()
+    public async Task Handle_ProtectedTierCitation_NullsRegions_ButKeepsVerbatimTextForGrounding()
     {
         // Arrange: same bbox-carrying result, but the resolver resolves to Protected.
         var gameId = Guid.NewGuid().ToString();
@@ -311,11 +311,50 @@ public class StreamQaQueryHandlerTests
         // Act
         var snippet = FirstCitation(await CollectEventsAsync(query));
 
-        // Assert: no verbatim region highlight nor verbatim excerpt for Protected content (DA-4 / #447).
+        // Assert: the verbatim region highlight is withheld for Protected content (DA-4)...
         snippet.regions.Should().BeNull();
         snippet.charStart.Should().BeNull();
         snippet.charEnd.Should().BeNull();
-        snippet.text.Should().BeEmpty();
+        // ...but the verbatim snippet text is PRESERVED — the same list grounds the LLM prompt, so
+        // redacting it would starve the model of retrieved context (SP-C review regression guard).
+        snippet.text.Should().Be("Sample rule text");
+    }
+
+    [Fact]
+    public async Task Handle_CachedResponseWithRegions_StripsRegionsOnReplay()
+    {
+        // SP-C review (DA-4): the QA cache key is (game, query) only — NOT user/tier. A Full-tier
+        // user's cached regions must NOT be replayed to a later Protected-tier user on a cache hit,
+        // so cache-served citations strip regions/char offsets (fallback to the text-quote highlight).
+        var gameId = Guid.NewGuid().ToString();
+        var query = new StreamQaQuery(gameId, "cached with regions?", null);
+        var cachedResponse = new QaResponse(
+            answer: "cached answer",
+            snippets: new List<Snippet>
+            {
+                new Snippet("verbatim rule text", "PDF:doc-1", 2, 0, 0.9f)
+                {
+                    regions = new[] { new CitationRegion(2, 0.1, 0.2, 0.3, 0.4) },
+                    charStart = 100,
+                    charEnd = 250,
+                },
+            },
+            promptTokens: 10, completionTokens: 5, totalTokens: 15, confidence: 0.85, metadata: null);
+
+        _cacheMock
+            .Setup(x => x.GenerateQaCacheKey(It.IsAny<string>(), It.IsAny<string>()))
+            .Returns("test-cache-key");
+        _cacheMock
+            .Setup(x => x.GetAsync<QaResponse>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(cachedResponse);
+
+        var snippet = FirstCitation(await CollectEventsAsync(query));
+
+        // Text is still served from cache (pre-existing behavior); regions are stripped (no cross-tier leak).
+        snippet.text.Should().Be("verbatim rule text");
+        snippet.regions.Should().BeNull();
+        snippet.charStart.Should().BeNull();
+        snippet.charEnd.Should().BeNull();
     }
 
     private void SetupFusedResultWithRegion()

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyServiceTests.cs
@@ -195,6 +195,43 @@ public class RagPromptAssemblyServiceTests
         result.SystemPrompt.Should().Contain("Pawns move forward");
     }
 
+    [Fact]
+    public async Task AssemblePrompt_VectorChunkWithBoundingBoxes_PropagatesToCitation()
+    {
+        // SP-C (#3407): bbox + char offsets on the vector-arm Embedding must survive BOTH the
+        // vector→SearchResultItem map AND the hybrid-fusion GroupBy rebuild (a drop site) into the
+        // ChunkCitation, so the handler boundary can parse + Full-gate them into regions[].
+        const string bbox = "[{\"page\":2,\"x\":0.1,\"y\":0.2,\"width\":0.3,\"height\":0.4}]";
+        SetupSuccessfulEmbedding();
+        var scored = new List<ScoredEmbedding>
+        {
+            new(new Embedding(
+                    Guid.NewGuid(), Guid.NewGuid(), "Pawns move forward one square.",
+                    new Vector(TestEmbedding), "test-model", chunkIndex: 0, pageNumber: 2,
+                    boundingBoxesJson: bbox, charStart: 100, charEnd: 250),
+                0.85)
+        };
+        _embeddingRepositoryMock
+            .Setup(r => r.SearchByVectorWithScoresAsync(
+                It.IsAny<Guid>(), It.IsAny<Vector>(), It.IsAny<int>(), It.IsAny<double>(),
+                It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(scored);
+        SetupTextSearchResults(); // no FTS — the vector chunk alone flows through hybrid fusion
+        SetupRerankerPassthrough();
+        var service = CreateService();
+
+        // Act
+        var result = await service.AssemblePromptAsync(
+            "tutor", "Chess", null, "How do pawns move?",
+            TestGameId, null, null, "it", CancellationToken.None);
+
+        // Assert — the (only) coordinate-bearing citation kept its bbox + char offsets end-to-end.
+        var cited = result.Citations.Should().ContainSingle(c => c.BoundingBoxesJson != null).Which;
+        cited.BoundingBoxesJson.Should().Be(bbox);
+        cited.CharStart.Should().Be(100);
+        cited.CharEnd.Should().Be(250);
+    }
+
     #endregion
 
     #region AssemblePromptAsync - With Chunks (FTS-only post pgvector migration)

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/RrfFusionDomainServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/RrfFusionDomainServiceTests.cs
@@ -172,6 +172,29 @@ public sealed class RrfFusionDomainServiceTests
     }
 
     [Fact]
+    public void FuseResults_CarriesBoundingBoxesAndCharOffsets_FromVectorArm()
+    {
+        // SP-C (#3407): the FuseResults rebuild (new SearchResult from `original`) is a known DROP
+        // SITE — region-grounding carriers must survive fusion. Vector arm carries bbox + char
+        // offsets; the fused result must keep them (preferring the vector-arm original).
+        const string bbox = "[{\"page\":2,\"x\":0.1,\"y\":0.2,\"width\":0.3,\"height\":0.4}]";
+        var pdf = Guid.NewGuid();
+        var vector = new List<SearchResult>
+        {
+            new(Guid.NewGuid(), Guid.NewGuid(), "cited chunk", 1, new Confidence(0.90), 1, "vector",
+                pdfDocumentId: pdf, chunkIndex: 0, roleTags: GameBookRole.None, heading: null,
+                boundingBoxesJson: bbox, charStart: 100, charEnd: 250)
+        };
+
+        var fused = _service.FuseResults(vector, new List<SearchResult>());
+
+        fused.Should().HaveCount(1);
+        fused[0].BoundingBoxesJson.Should().Be(bbox);
+        fused[0].CharStart.Should().Be(100);
+        fused[0].CharEnd.Should().Be(250);
+    }
+
+    [Fact]
     public void FuseResults_WithOverlappingDocuments_CombinesScores()
     {
         // Arrange

--- a/apps/api/tests/Api.Tests/Unit/Models/CitationRegionTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/Models/CitationRegionTests.cs
@@ -1,0 +1,81 @@
+using System.Text.Json;
+using Api.Infrastructure.Serialization;
+using Api.Models;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Unit.Models;
+
+/// <summary>
+/// SP-C (#3407): CitationRegion is the FE-facing, Full-gated region shape parsed from the
+/// persisted <c>text_chunks.bounding_boxes_json</c> (produced by
+/// <c>ChunkBoundingBoxJson.Serialize</c>). The stored JSON is an ARRAY of objects with
+/// LOWERCASE keys <c>[{page,x,y,width,height}]</c> and x/y/width/height normalized to
+/// [0,1] top-left. Parse must be case-insensitive and defensive (never throw).
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "KnowledgeBase")]
+public sealed class CitationRegionTests
+{
+    [Fact]
+    public void Parse_LowercaseJsonArray_ReturnsRegionWithNormalizedValues()
+    {
+        // Arrange: EXACT shape persisted by ChunkBoundingBoxJson.Serialize (lowercase keys, array)
+        const string json = "[{\"page\":2,\"x\":0.1,\"y\":0.2,\"width\":0.3,\"height\":0.4}]";
+
+        // Act
+        var regions = CitationRegion.Parse(json);
+
+        // Assert
+        regions.Should().NotBeNull();
+        regions!.Should().HaveCount(1);
+        var r = regions[0];
+        r.Page.Should().Be(2);
+        r.X.Should().BeApproximately(0.1, 1e-9);
+        r.Y.Should().BeApproximately(0.2, 1e-9);
+        r.Width.Should().BeApproximately(0.3, 1e-9);
+        r.Height.Should().BeApproximately(0.4, 1e-9);
+    }
+
+    [Fact]
+    public void Parse_MultipleBoxes_ReturnsAllRegionsInOrder()
+    {
+        const string json =
+            "[{\"page\":1,\"x\":0,\"y\":0,\"width\":0.5,\"height\":0.5}," +
+            "{\"page\":1,\"x\":0.5,\"y\":0.5,\"width\":0.4,\"height\":0.4}]";
+
+        var regions = CitationRegion.Parse(json);
+
+        regions.Should().NotBeNull();
+        regions!.Should().HaveCount(2);
+        regions[0].X.Should().BeApproximately(0, 1e-9);
+        regions[1].X.Should().BeApproximately(0.5, 1e-9);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("[]")]              // valid JSON but no boxes → treated as "no regions"
+    [InlineData("not json")]        // malformed → defensive null, no throw
+    [InlineData("{\"page\":1}")]    // object, not the expected array → null
+    public void Parse_NullEmptyOrInvalid_ReturnsNull(string? json)
+    {
+        CitationRegion.Parse(json).Should().BeNull();
+    }
+
+    [Fact]
+    public void CitationRegion_SerializesCamelCase_ViaSseOptions()
+    {
+        // The wire contract the FE (zod CitationSchema / mapSseCitation) expects.
+        var region = new CitationRegion(3, 0.11, 0.22, 0.33, 0.44);
+
+        var wire = JsonSerializer.Serialize(region, SseJsonOptions.Default);
+
+        wire.Should().Contain("\"page\":3");
+        wire.Should().Contain("\"x\":0.11");
+        wire.Should().Contain("\"y\":0.22");
+        wire.Should().Contain("\"width\":0.33");
+        wire.Should().Contain("\"height\":0.44");
+    }
+}

--- a/apps/api/tests/Api.Tests/Unit/Models/SnippetRegionSerializationTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/Models/SnippetRegionSerializationTests.cs
@@ -1,0 +1,52 @@
+using System.Text.Json;
+using Api.Infrastructure.Serialization;
+using Api.Models;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Unit.Models;
+
+/// <summary>
+/// SP-C (#3407): the per-game StreamQa Snippet gains additive, Full-gated region fields
+/// (regions/charStart/charEnd). Like chunkId/chunkPosition (#1702), they are
+/// <c>[JsonIgnore(WhenWritingNull)]</c> so the D-4 additive-only wire contract holds:
+/// legacy/Protected snippets (null fields) MUST NOT emit the new keys.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "KnowledgeBase")]
+public sealed class SnippetRegionSerializationTests
+{
+    [Fact]
+    public void Snippet_WithoutRegions_OmitsRegionKeys_ViaSseOptions()
+    {
+        var snippet = new Snippet("rules text", "PDF:abc-123", 14, 0, 0.85f);
+        var citations = new StreamingCitations(new[] { snippet });
+
+        var json = JsonSerializer.Serialize(citations, SseJsonOptions.Default);
+
+        json.Should().NotContain("regions");
+        json.Should().NotContain("charStart");
+        json.Should().NotContain("charEnd");
+    }
+
+    [Fact]
+    public void Snippet_WithRegions_EmitsCamelCaseRegionArray_ViaSseOptions()
+    {
+        var snippet = new Snippet("rules text", "PDF:abc-123", 14, 0, 0.85f)
+        {
+            regions = new[] { new CitationRegion(14, 0.1, 0.2, 0.3, 0.4) },
+            charStart = 100,
+            charEnd = 250,
+        };
+        var citations = new StreamingCitations(new[] { snippet });
+
+        var json = JsonSerializer.Serialize(citations, SseJsonOptions.Default);
+
+        json.Should().Contain("\"regions\":[");
+        json.Should().Contain("\"page\":14");
+        json.Should().Contain("\"x\":0.1");
+        json.Should().Contain("\"width\":0.3");
+        json.Should().Contain("\"charStart\":100");
+        json.Should().Contain("\"charEnd\":250");
+    }
+}

--- a/apps/web/src/__tests__/types/citation.test.ts
+++ b/apps/web/src/__tests__/types/citation.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import type { Citation } from '@/types/domain';
+import type { Citation, CitationRegion } from '@/types/domain';
 
 describe('Citation type', () => {
   it('accepts full tier citation', () => {
@@ -60,5 +60,37 @@ describe('Citation type', () => {
     };
     expect(citation.paraphrasedSnippet).toBeUndefined();
     expect(citation.isPublic).toBeUndefined();
+  });
+
+  // SP-C (#3407): Full-gated region grounding fields.
+  it('accepts full-tier citation carrying regions and char offsets', () => {
+    const regions: CitationRegion[] = [{ page: 2, x: 0.1, y: 0.2, width: 0.3, height: 0.4 }];
+    const citation: Citation = {
+      documentId: 'doc-4',
+      pageNumber: 2,
+      snippet: 'Original text',
+      relevanceScore: 0.9,
+      copyrightTier: 'full',
+      regions,
+      charStart: 100,
+      charEnd: 250,
+    };
+    expect(citation.regions).toHaveLength(1);
+    expect(citation.regions?.[0]).toEqual({ page: 2, x: 0.1, y: 0.2, width: 0.3, height: 0.4 });
+    expect(citation.charStart).toBe(100);
+    expect(citation.charEnd).toBe(250);
+  });
+
+  it('regions/charStart/charEnd are optional (backward compat)', () => {
+    const citation: Citation = {
+      documentId: 'doc-5',
+      pageNumber: 1,
+      snippet: 'text',
+      relevanceScore: 0.5,
+      copyrightTier: 'protected',
+    };
+    expect(citation.regions).toBeUndefined();
+    expect(citation.charStart).toBeUndefined();
+    expect(citation.charEnd).toBeUndefined();
   });
 });

--- a/apps/web/src/hooks/queries/__tests__/useGameChat.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useGameChat.test.tsx
@@ -170,6 +170,41 @@ describe('useGameChat', () => {
     expect(agent.outOfContext).toBe(false);
   });
 
+  it('surfaces SP-C region grounding fields (regions/charStart/charEnd) from the type-1 event (#3407)', async () => {
+    // The BE Snippet now Full-gates + emits regions[]/charStart/charEnd on the type-1 CITATIONS
+    // event; mapSseCitation must forward them to the FE Citation so SP-D can draw the overlay.
+    const sseEvents = [
+      { type: 7, data: { token: 'Answer.' } },
+      {
+        type: 1,
+        data: {
+          citations: [
+            {
+              text: 'verbatim rule text',
+              source: 'PDF:doc-1',
+              page: 2,
+              line: 0,
+              score: 0.9,
+              regions: [{ page: 2, x: 0.1, y: 0.2, width: 0.3, height: 0.4 }],
+              charStart: 100,
+              charEnd: 250,
+            },
+          ],
+        },
+      },
+      { type: 4, data: { confidence: 0.8, citations: null } },
+    ];
+    vi.mocked(qaStream).mockReturnValueOnce(mockStream(sseEvents) as any);
+    const { result } = renderHook(() => useGameChat('azul'));
+    await act(async () => {
+      await result.current.ask('come si calcolano i punti?');
+    });
+    const cite = result.current.messages[1].citations?.[0];
+    expect(cite?.regions).toEqual([{ page: 2, x: 0.1, y: 0.2, width: 0.3, height: 0.4 }]);
+    expect(cite?.charStart).toBe(100);
+    expect(cite?.charEnd).toBe(250);
+  });
+
   it('derives outOfContext=true when no citations + confidence < 0.30', async () => {
     const oocEvents = [
       { type: 7, data: 'Non ho informazioni.' },

--- a/apps/web/src/hooks/queries/useGameChat.ts
+++ b/apps/web/src/hooks/queries/useGameChat.ts
@@ -85,11 +85,23 @@ interface ErrorPayload {
 // page, score }, while the type-4 COMPLETE payload carries citations:null in
 // production. Map that shape to the FE Citation type so the chat renders
 // CitationChip and can open the source PDF at the cited page.
+interface SseRegion {
+  readonly page: number;
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+}
+
 interface SseCitation {
   readonly text?: string;
   readonly source?: string;
   readonly page?: number;
   readonly score?: number;
+  // SP-C (#3407): Full-gated region grounding emitted by the BE Snippet (camelCase wire).
+  readonly regions?: ReadonlyArray<SseRegion> | null;
+  readonly charStart?: number | null;
+  readonly charEnd?: number | null;
 }
 
 function mapSseCitation(c: SseCitation): Citation {
@@ -99,6 +111,12 @@ function mapSseCitation(c: SseCitation): Citation {
     snippet: c.text ?? '',
     relevanceScore: c.score ?? 0,
     copyrightTier: 'full',
+    // SP-C (#3407): surface the region overlay + char offsets (already Full-gated by the BE).
+    regions: c.regions
+      ? c.regions.map(r => ({ page: r.page, x: r.x, y: r.y, width: r.width, height: r.height }))
+      : null,
+    charStart: c.charStart ?? null,
+    charEnd: c.charEnd ?? null,
   };
 }
 

--- a/apps/web/src/lib/api/schemas/__tests__/streaming.schemas.test.ts
+++ b/apps/web/src/lib/api/schemas/__tests__/streaming.schemas.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { CitationSchema } from '@/lib/api/schemas/streaming.schemas';
+
+/**
+ * SP-C (#3407): the streaming CitationSchema (session-agent + live chains) must additively carry
+ * the Full-gated region-grounding fields (regions/charStart/charEnd) emitted by the BE CitationDto.
+ * zod strips unknown keys by default, so without the schema extension `data.regions` is dropped.
+ */
+describe('CitationSchema — SP-C region fields', () => {
+  it('parses and retains regions[] from the wire', () => {
+    const result = CitationSchema.safeParse({
+      documentId: 'doc-1',
+      pageNumber: 2,
+      snippetPreview: 'verbatim rule text',
+      copyrightTier: 'full',
+      regions: [{ page: 2, x: 0.1, y: 0.2, width: 0.3, height: 0.4 }],
+      charStart: 100,
+      charEnd: 250,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.regions).toEqual([{ page: 2, x: 0.1, y: 0.2, width: 0.3, height: 0.4 }]);
+    expect(result.data.charStart).toBe(100);
+    expect(result.data.charEnd).toBe(250);
+  });
+
+  it('accepts a citation without region fields (backward-compat)', () => {
+    const result = CitationSchema.safeParse({
+      documentId: 'doc-2',
+      pageNumber: 1,
+      snippetPreview: 'text',
+      copyrightTier: 'protected',
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    // Absent → nullish, never throws.
+    expect(result.data.regions ?? null).toBeNull();
+    expect(result.data.charStart ?? null).toBeNull();
+  });
+});

--- a/apps/web/src/lib/api/schemas/streaming.schemas.ts
+++ b/apps/web/src/lib/api/schemas/streaming.schemas.ts
@@ -66,6 +66,23 @@ export const CitationSchema = z.object({
   copyrightTier: z.enum(['full', 'protected']).default('full'), // Default 'full' for backward compat
   paraphrasedSnippet: z.string().optional().nullable(),
   isPublic: z.boolean().optional().default(false),
+  // SP-C (#3407): Full-gated region grounding. `regions` are normalized [0,1] top-left bounding
+  // boxes for the PDF overlay (SP-D); BE emits them only for Full-tier citations. Additive/nullable
+  // so the current wire (no region fields) keeps safeParse-ing.
+  regions: z
+    .array(
+      z.object({
+        page: z.number(),
+        x: z.number(),
+        y: z.number(),
+        width: z.number(),
+        height: z.number(),
+      })
+    )
+    .optional()
+    .nullable(),
+  charStart: z.number().optional().nullable(),
+  charEnd: z.number().optional().nullable(),
 });
 
 export type Citation = z.infer<typeof CitationSchema>;

--- a/apps/web/src/types/domain.ts
+++ b/apps/web/src/types/domain.ts
@@ -129,6 +129,19 @@ export interface Snippet {
 }
 
 /**
+ * SP-C (#3407): a normalized [0,1] top-left bounding box of a citation on its source PDF page.
+ * Page-relative coordinates enable a scale/DPR-independent %-based overlay (SP-D). Emitted by the
+ * BE only for Full-tier citations (DA-4 — drawing the verbatim region on a Protected doc would leak).
+ */
+export interface CitationRegion {
+  page: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/**
  * Citation from RAG response with relevance scoring (Issue #859, BGAI-074)
  */
 export interface Citation {
@@ -142,6 +155,15 @@ export interface Citation {
   paraphrasedSnippet?: string;
   /** Whether the game is publicly available (affects upsell CTA copy) */
   isPublic?: boolean;
+  /**
+   * SP-C (#3407): Full-gated PDF region overlay boxes (SP-D). Null/absent for the pre-coordinate
+   * corpus, the non-Unstructured branch, or Protected-tier citations.
+   */
+  regions?: CitationRegion[] | null;
+  /** SP-C (#3407): char offset (inclusive) of the chunk in the source PDF text. Full-gated. */
+  charStart?: number | null;
+  /** SP-C (#3407): char offset (exclusive) of the chunk in the source PDF text. Full-gated. */
+  charEnd?: number | null;
 }
 
 /**

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -24,6 +24,7 @@ export type {
   RuleSpecComment,
   Snippet,
   Citation,
+  CitationRegion,
   Message,
   QaResponse,
 } from './domain';


### PR DESCRIPTION
## SP-C (#3407) — Region DTO surfacing + copyright gate

Sub-progetto dell'epic [#3403](https://github.com/meepleAi-app/meepleai-monorepo/issues/3403) (RAG citation region grounding). Porta le **regioni citazione** (bounding box normalizzate `[0,1]` top-left) + char offset fino al FE su **entrambe le catene di retrieval**, con gate copyright: le regions sono emesse **solo per `CopyrightTier=Full`** (DA-4 — disegnare la regione verbatim su un doc Protected sarebbe un leak, #447).

Persistenza già a terra (SP-A `char_start/char_end`, SP-B `bounding_boxes_json`): **SP-C è read/surface only** — nessuna migration, `IndexerVersion` resta v1.1 (re-extract → SP-E).

### Cosa cambia

**Infra condivisa**
- `PgVectorStoreAdapter.SearchWithScoresAsync`: estende SELECT + reader a `tc.char_start/char_end/bounding_boxes_json` (col 10/11/12, snake_case NON quotate) riusando il `LEFT JOIN text_chunks` già presente per #3270.
- `Embedding`: 3 carrier primitivi (`BoundingBoxesJson`, `CharStart`, `CharEnd`).

**Catena 1 — StreamQa** (`POST /agents/qa/stream`, chat in-game)
- Propagazione `SearchResult`(dominio) → `RrfFusionDomainService` (copy da `original` vector-preferred) → `SearchResultDto` → `Snippet`.
- Iniettato `ICopyrightTierResolver` (prima StreamQa non aveva alcun gate) e gate `Snippet.regions/charStart/charEnd` a Full.
- `Snippet`: nuovi campi `[JsonIgnore(WhenWritingNull)]` (contratto wire additivo, D-4).

**Catena 2 — session-agent** (`POST /game-sessions/{id}/agent/chat`, sessione live)
- Propagazione `SearchResultItem` → `RagPromptAssemblyService` (map vettoriale + coalesce in fusione + build `ChunkCitation`) → `CitationDto` (7→10 arg).
- Gate `CitationDto.Regions` a Full al confine `ChatWithSessionAgentCommandHandler` (parallelo al gate `SnippetPreview` già esistente).
- Carrier `[JsonIgnore]` su `ChunkCitation` → **non persistono ungated** in `citationsJson` (no leak su reload; fallback Pattern A/SP0).

**API + FE**
- Nuovo record `CitationRegion(Page,X,Y,Width,Height)` + `Parse` case-insensitive/difensiva (JSON persistito è array lowercase `[{page,x,y,width,height}]`).
- FE: `Citation`/`CitationRegion` (domain) + zod `CitationSchema` + `mapSseCitation` — additivi/nullable.

### Fix da code review avversariale (3 finding confermati)

Una review multi-agente (find → verifica avversariale) ha trovato 3 difetti reali, tutti corretti nel commit `069863cc8`:

1. **[CRITICO]** Il gate del **testo verbatim** StreamQa svuotava la lista `snippets` condivisa — che alimenta anche il **prompt LLM** → risposte non-grounded per contenuti Protected. **Fix**: il testo verbatim resta per tutti i tier (comportamento pre-SP-C, LLM grounded); **solo** la superficie regions è gated. *(Il gap verbatim-testo-al-FE di StreamQa resta pre-esistente: chiuderlo richiede separare la sorgente prompt-LLM da quella FE — fuori scope SP-C.)*
2. **[HIGH]** La cache QA è keyed `(game,query)` — non user/tier → le regions di un utente Full trapelavano a un utente Protected su cache-hit. **Fix**: `StripRegions()` rimuove regions/char offset dalle citazioni servite da cache (DA-4).
3. **[MEDIUM]** Il merge CRAG requery (`RagPromptAssemblyService`, ramo Ambiguous) era un drop-site GroupBy. **Fix**: coalesce dei carrier come il merge hybrid-fusion.

### Test
- **Nuovi (backend)**: `CitationRegion.Parse` + wire camelCase, `Snippet` regions serialization, 2 gate StreamQa (Full/Protected), 2 gate session-agent broadcast (Full/Protected), propagazione chain-2 end-to-end (Embedding→fusione→ChunkCitation), RRF fusione preserva regions, cache-strip.
- **Nuovi (FE)**: `CitationSchema` parse regions, `Citation` type, `mapSseCitation` surface via hook.
- **RED→GREEN** verificato; i gate anti-leak + il cache-strip provati **load-bearing** (neuter check).
- **Regressione**: sweep mirato 196 test backend + 115 test FE consumer + typecheck + lint + **solution build 0 errori**. (Suite completa Testcontainers → CI.)

### Follow-up
- **SP-D** (#3408): `PdfBBoxOverlay` + wire `Citation.regions` nel viewer PDF chat.
- **SP-E** (#3409): re-extract corpus (bbox non backfillabile) + `IndexerVersion` v1.2 → attiva il grounding sui dati reali (oggi `regions=null` su tutto il corpus fino al re-extract).

Refs #3403 · Closes #3407

🤖 Generated with [Claude Code](https://claude.com/claude-code)
