### PR TITLE
feat(rag-citation): PDF region overlay (PdfBBoxOverlay) + wire chat (SP-D, #3408)

### DIFF
--- a/apps/web/src/components/chat-unified/PdfPageModal.tsx
+++ b/apps/web/src/components/chat-unified/PdfPageModal.tsx
@@ -7,6 +7,7 @@ import dynamic from 'next/dynamic';
 import 'react-pdf/dist/Page/TextLayer.css';
 
 import { makeQuoteTextRenderer } from '@/components/pdf/pdf-quote-highlight';
+import { PdfBBoxOverlay } from '@/components/pdf/PdfBBoxOverlay';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/overlays/dialog';
 import { Button } from '@/components/ui/primitives/button';
 import { api } from '@/lib/api';
@@ -65,9 +66,23 @@ export function PdfPageModal({ citation, open, onClose }: PdfPageModalProps) {
   const highlightQuote =
     citation.copyrightTier === 'protected' ? undefined : citation.snippet || undefined;
   const isCitedPage = currentPage === citation.pageNumber;
+
+  // SP-D (#3408): overlay bbox della regione (Pattern B), gated su copyright come l'highlight
+  // verbatim. Le regions sono già Full-gated dal BE; qui belt-and-suspenders per "protected".
+  const regions =
+    citation.copyrightTier === 'protected' ? undefined : (citation.regions ?? undefined);
+  const hasRects = (regions?.length ?? 0) > 0;
+  const pageRects = useMemo(
+    () => (regions ?? []).filter(r => r.page === currentPage),
+    [regions, currentPage]
+  );
+
+  // Pattern B (overlay) ha precedenza su Pattern A (quote text-layer): se ci sono regions,
+  // niente customTextRenderer.
   const quoteRenderer = useMemo(
-    () => (highlightQuote && isCitedPage ? makeQuoteTextRenderer(highlightQuote) : null),
-    [highlightQuote, isCitedPage]
+    () =>
+      highlightQuote && isCitedPage && !hasRects ? makeQuoteTextRenderer(highlightQuote) : null,
+    [highlightQuote, isCitedPage, hasRects]
   );
 
   const handleDocumentLoad = useCallback(({ numPages }: { numPages: number }) => {
@@ -141,7 +156,9 @@ export function PdfPageModal({ citation, open, onClose }: PdfPageModalProps) {
                   customTextRenderer={
                     quoteRenderer ? ({ str }) => quoteRenderer.render({ str }) : undefined
                   }
-                />
+                >
+                  {pageRects.length > 0 ? <PdfBBoxOverlay rects={pageRects} /> : null}
+                </PdfPage>
               </PdfDocument>
             </div>
           )}

--- a/apps/web/src/components/chat-unified/__tests__/PdfPageModal.test.tsx
+++ b/apps/web/src/components/chat-unified/__tests__/PdfPageModal.test.tsx
@@ -36,7 +36,7 @@ vi.mock('react-pdf', () => {
   return {
     Document: ({ children }: any) =>
       React.createElement('div', { 'data-testid': 'pdf-document' }, children),
-    Page: ({ pageNumber, renderTextLayer, customTextRenderer }: any) =>
+    Page: ({ pageNumber, renderTextLayer, customTextRenderer, children }: any) =>
       React.createElement(
         'div',
         {
@@ -45,7 +45,8 @@ vi.mock('react-pdf', () => {
           'data-render-text-layer': String(!!renderTextLayer),
           'data-has-custom-renderer': String(!!customTextRenderer),
         },
-        `Page ${pageNumber}`
+        `Page ${pageNumber}`,
+        children
       ),
     pdfjs: { GlobalWorkerOptions: { workerSrc: '' }, version: '4.0.0' },
   };
@@ -166,5 +167,54 @@ describe('PdfPageModal', () => {
     );
     const page = screen.getByTestId('pdf-page');
     expect(page).toHaveAttribute('data-has-custom-renderer', 'false');
+  });
+
+  // ── SP-D #3408: region overlay (Pattern B) on the cited page ──────────────────
+
+  it('draws the region overlay on the cited page for tier "full"', () => {
+    render(
+      <PdfPageModal
+        citation={makeCitation({
+          pageNumber: 5,
+          copyrightTier: 'full',
+          regions: [{ page: 5, x: 0.1, y: 0.2, width: 0.3, height: 0.05 }],
+        })}
+        open
+        onClose={onClose}
+      />
+    );
+    expect(screen.getByTestId('pdf-bbox-rect')).toBeInTheDocument();
+    // Pattern B suppresses the Pattern A quote text-layer.
+    expect(screen.getByTestId('pdf-page')).toHaveAttribute('data-has-custom-renderer', 'false');
+  });
+
+  it('does NOT draw the region overlay for tier "protected"', () => {
+    render(
+      <PdfPageModal
+        citation={makeCitation({
+          pageNumber: 5,
+          copyrightTier: 'protected',
+          regions: [{ page: 5, x: 0.1, y: 0.2, width: 0.3, height: 0.05 }],
+        })}
+        open
+        onClose={onClose}
+      />
+    );
+    expect(screen.queryByTestId('pdf-bbox-rect')).not.toBeInTheDocument();
+  });
+
+  it('does not draw overlay rects that belong to another page', () => {
+    render(
+      <PdfPageModal
+        citation={makeCitation({
+          pageNumber: 5,
+          copyrightTier: 'full',
+          regions: [{ page: 9, x: 0.1, y: 0.2, width: 0.3, height: 0.05 }],
+        })}
+        open
+        onClose={onClose}
+      />
+    );
+    expect(screen.queryByTestId('pdf-bbox-rect')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/features/game-chat/CitationModal.tsx
+++ b/apps/web/src/components/features/game-chat/CitationModal.tsx
@@ -75,6 +75,11 @@ export function CitationModal({
   // il tab PDF apre la pagina senza evidenziare il testo.
   const highlightQuote = citation.copyrightTier === 'protected' ? undefined : citation.snippet;
 
+  // SP-D (#3408): overlay bbox della regione (Pattern B). Gated su copyright come l'highlight
+  // verbatim: le regions sono già Full-gated dal BE, qui belt-and-suspenders per "protected".
+  const regions =
+    citation.copyrightTier === 'protected' ? undefined : (citation.regions ?? undefined);
+
   return (
     <div
       role="dialog"
@@ -147,6 +152,7 @@ export function CitationModal({
               initialPage={citation.pageNumber}
               isPublic={citation.isPublic}
               quote={highlightQuote}
+              regions={regions}
             />
           )}
         </div>

--- a/apps/web/src/components/features/game-chat/CitationPdfTab.tsx
+++ b/apps/web/src/components/features/game-chat/CitationPdfTab.tsx
@@ -23,6 +23,7 @@ import { CitationOwnershipUpsell } from '@/components/features/game-chat/Citatio
 import { PdfInlineViewer } from '@/components/pdf/PdfInlineViewer';
 import { PdfQuoteViewer } from '@/components/pdf/PdfQuoteViewer';
 import { useCanViewPdf } from '@/hooks/queries/useCanViewPdf';
+import type { CitationRegion } from '@/types';
 
 export interface CitationPdfTabProps {
   readonly documentId: string;
@@ -36,6 +37,12 @@ export interface CitationPdfTabProps {
    * Se assente/vuoto si ripiega sul viewer semplice (solo pagina).
    */
   readonly quote?: string;
+  /**
+   * SP-D (#3408): normalized [0,1] region boxes for a precise PDF overlay (Pattern B).
+   * When non-empty, the overlay takes precedence over the {@link quote} highlight (Pattern A).
+   * Already Full-gated by the BE and by {@link CitationModal} (never passed for Protected tier).
+   */
+  readonly regions?: readonly CitationRegion[] | null;
   readonly className?: string;
 }
 
@@ -45,6 +52,7 @@ export function CitationPdfTab({
   initialPage,
   isPublic = false,
   quote,
+  regions,
   className,
 }: CitationPdfTabProps): ReactElement {
   const ownership = useCanViewPdf({
@@ -79,6 +87,20 @@ export function CitationPdfTab({
 
   if (showUpsell) {
     return <CitationOwnershipUpsell gameId={gameId} className={className} />;
+  }
+
+  // SP-D (#3408): Pattern B (bbox overlay) takes precedence over Pattern A (quote highlight).
+  const hasRects = !!regions && regions.length > 0;
+  if (hasRects) {
+    return (
+      <PdfInlineViewer
+        documentId={documentId}
+        initialPage={initialPage}
+        highlightRects={regions}
+        features={{ antiLeak: true }}
+        className={className}
+      />
+    );
   }
 
   const trimmedQuote = quote?.trim();

--- a/apps/web/src/components/features/game-chat/__tests__/CitationModal.test.tsx
+++ b/apps/web/src/components/features/game-chat/__tests__/CitationModal.test.tsx
@@ -12,6 +12,7 @@ vi.mock('../CitationPdfTab', () => ({
       data-game-id={props.gameId}
       data-initial-page={props.initialPage}
       data-quote={props.quote ?? ''}
+      data-regions-count={props.regions?.length ?? 0}
     >
       PDF tab mock
     </div>
@@ -99,5 +100,39 @@ describe('CitationModal', () => {
     render(<CitationModal citation={protectedCitation} open onClose={vi.fn()} gameId="wingspan" />);
     fireEvent.click(screen.getByRole('tab', { name: /pdf originale/i }));
     expect(screen.getByTestId('citation-pdf-tab-mounted')).toHaveAttribute('data-quote', '');
+  });
+
+  // ── SP-D #3408: region overlay passed through, gated on copyright tier ────────
+
+  it('passes Full-tier regions to CitationPdfTab', () => {
+    const citationWithRegions: Citation = {
+      ...sampleCitation,
+      regions: [{ page: 12, x: 0.1, y: 0.2, width: 0.3, height: 0.05 }],
+    };
+    render(
+      <CitationModal citation={citationWithRegions} open onClose={vi.fn()} gameId="wingspan" />
+    );
+    fireEvent.click(screen.getByRole('tab', { name: /pdf originale/i }));
+    expect(screen.getByTestId('citation-pdf-tab-mounted')).toHaveAttribute(
+      'data-regions-count',
+      '1'
+    );
+  });
+
+  it('does NOT pass regions for tier "protected" (no verbatim region overlay)', () => {
+    const protectedWithRegions: Citation = {
+      ...sampleCitation,
+      copyrightTier: 'protected',
+      paraphrasedSnippet: 'parafrasi non verbatim',
+      regions: [{ page: 12, x: 0.1, y: 0.2, width: 0.3, height: 0.05 }],
+    };
+    render(
+      <CitationModal citation={protectedWithRegions} open onClose={vi.fn()} gameId="wingspan" />
+    );
+    fireEvent.click(screen.getByRole('tab', { name: /pdf originale/i }));
+    expect(screen.getByTestId('citation-pdf-tab-mounted')).toHaveAttribute(
+      'data-regions-count',
+      '0'
+    );
   });
 });

--- a/apps/web/src/components/features/game-chat/__tests__/CitationPdfTab.test.tsx
+++ b/apps/web/src/components/features/game-chat/__tests__/CitationPdfTab.test.tsx
@@ -13,9 +13,10 @@ vi.mock('react-pdf', () => ({
     setTimeout(() => onLoadSuccess?.({ numPages: 24 }), 0);
     return <div data-testid="pdf-document">{children}</div>;
   },
-  Page: ({ pageNumber }: { pageNumber: number }) => (
+  Page: ({ pageNumber, children }: { pageNumber: number; children?: unknown }) => (
     <div data-testid="pdf-page" data-page-number={pageNumber}>
       Page {pageNumber}
+      {children as never}
     </div>
   ),
   pdfjs: { GlobalWorkerOptions: { workerSrc: '' } },
@@ -144,5 +145,57 @@ describe('CitationPdfTab', () => {
     );
     await waitFor(() => expect(screen.getByTestId('pdf-page')).toBeInTheDocument());
     expect(container.querySelector('[data-slot="pdf-quote-viewer"]')).not.toBeInTheDocument();
+  });
+
+  // ── SP-D #3408: region overlay (Pattern B) via regions ──────────────────────
+
+  it('renders the region overlay (Pattern B) when regions are provided', async () => {
+    const { container } = render(
+      <CitationPdfTab
+        documentId="pdf-public-1"
+        gameId="game-1"
+        initialPage={12}
+        isPublic
+        regions={[{ page: 12, x: 0.1, y: 0.2, width: 0.3, height: 0.05 }]}
+      />,
+      { wrapper }
+    );
+    await waitFor(() => expect(screen.getByTestId('pdf-page')).toBeInTheDocument());
+    expect(screen.getByTestId('pdf-bbox-rect')).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="pdf-quote-viewer"]')).not.toBeInTheDocument();
+  });
+
+  it('prefers the region overlay over the quote highlight when both are present', async () => {
+    const { container } = render(
+      <CitationPdfTab
+        documentId="pdf-public-1"
+        gameId="game-1"
+        initialPage={12}
+        isPublic
+        quote="regola X"
+        regions={[{ page: 12, x: 0.1, y: 0.2, width: 0.3, height: 0.05 }]}
+      />,
+      { wrapper }
+    );
+    await waitFor(() => expect(screen.getByTestId('pdf-page')).toBeInTheDocument());
+    expect(screen.getByTestId('pdf-bbox-rect')).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="pdf-quote-viewer"]')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the quote viewer (Pattern A) when regions is empty', async () => {
+    const { container } = render(
+      <CitationPdfTab
+        documentId="pdf-public-1"
+        gameId="game-1"
+        initialPage={7}
+        isPublic
+        quote="regola X"
+        regions={[]}
+      />,
+      { wrapper }
+    );
+    await waitFor(() => expect(screen.getByTestId('pdf-page')).toBeInTheDocument());
+    expect(container.querySelector('[data-slot="pdf-quote-viewer"]')).toBeInTheDocument();
+    expect(screen.queryByTestId('pdf-bbox-rect')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/pdf/PdfBBoxOverlay.tsx
+++ b/apps/web/src/components/pdf/PdfBBoxOverlay.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+/**
+ * PdfBBoxOverlay — %-based region overlay for the RAG citation grounding (SP-D #3408).
+ *
+ * Draws one rectangle per {@link CitationRegion} as an absolutely-positioned child of the
+ * react-pdf `<Page>` wrapper (which is `position: relative`, react-pdf@10 Page.js:247). Because
+ * the rects are normalized [0,1] top-left and expressed in percentages, the overlay is
+ * scale/DPR-independent — no pixel math, no coupling to the current zoom.
+ *
+ * The caller is responsible for filtering `rects` to the visible page (regions carry a `page`,
+ * but this component is intentionally page-agnostic and purely presentational). Decorative only
+ * (`aria-hidden`) — the citation text is already conveyed by the snippet / page header.
+ *
+ * Spec: docs/superpowers/specs/2026-07-30-rag-citation-region-grounding-design.md §6.5 (DA-5)
+ */
+
+import type { ReactElement } from 'react';
+
+import type { CitationRegion } from '@/types';
+
+export interface PdfBBoxOverlayProps {
+  readonly rects: readonly CitationRegion[];
+}
+
+export function PdfBBoxOverlay({ rects }: PdfBBoxOverlayProps): ReactElement | null {
+  if (rects.length === 0) return null;
+
+  return (
+    <div
+      aria-hidden="true"
+      data-slot="pdf-bbox-overlay"
+      data-testid="pdf-bbox-overlay"
+      className="pointer-events-none absolute inset-0"
+    >
+      {rects.map((r, i) => (
+        <div
+          key={`${r.page}:${r.x},${r.y},${r.width},${r.height}:${i}`}
+          data-testid="pdf-bbox-rect"
+          className="pdf-bbox-highlight absolute"
+          style={{
+            left: `${r.x * 100}%`,
+            top: `${r.y * 100}%`,
+            width: `${r.width * 100}%`,
+            height: `${r.height * 100}%`,
+          }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/pdf/PdfInlineViewer.tsx
+++ b/apps/web/src/components/pdf/PdfInlineViewer.tsx
@@ -35,8 +35,10 @@ import 'react-pdf/dist/Page/AnnotationLayer.css';
 import 'react-pdf/dist/Page/TextLayer.css';
 
 import { api } from '@/lib/api';
+import type { CitationRegion } from '@/types';
 
 import { makeQuoteTextRenderer } from './pdf-quote-highlight';
+import { PdfBBoxOverlay } from './PdfBBoxOverlay';
 
 // Worker setup — T0 spike confirmed idempotent (multi-module assignment safe).
 pdfjs.GlobalWorkerOptions.workerSrc = new URL(
@@ -61,6 +63,12 @@ export interface PdfInlineViewerProps {
   readonly renderTextLayer?: boolean;
   readonly highlightQuote?: string;
   readonly onQuoteMatch?: (found: boolean) => void;
+  /**
+   * SP-D (#3408): normalized [0,1] top-left region boxes to draw as a precise overlay
+   * (Pattern B). When present (any page), the quote text-layer highlight (Pattern A) is
+   * suppressed — bbox grounding takes precedence. Rects are filtered to the visible page.
+   */
+  readonly highlightRects?: readonly CitationRegion[];
 }
 
 type ZoomState = 'fit-width' | number;
@@ -78,6 +86,7 @@ export function PdfInlineViewer({
   renderTextLayer = false,
   highlightQuote,
   onQuoteMatch,
+  highlightRects,
 }: PdfInlineViewerProps): ReactElement {
   const [numPages, setNumPages] = useState<number>(0);
   const [currentPage, setCurrentPage] = useState<number>(initialPage);
@@ -91,9 +100,17 @@ export function PdfInlineViewer({
 
   const downloadUrl = api.pdf.getPdfDownloadUrl(documentId);
 
+  // SP-D (#3408): Pattern B (bbox overlay) takes precedence over Pattern A (quote text-layer).
+  // Once any region exists for this citation we are in bbox mode → skip the quote renderer.
+  const hasRects = (highlightRects?.length ?? 0) > 0;
+  const pageRects = useMemo(
+    () => (highlightRects ?? []).filter(r => r.page === currentPage),
+    [highlightRects, currentPage]
+  );
+
   const quoteRenderer = useMemo(
-    () => (highlightQuote ? makeQuoteTextRenderer(highlightQuote) : null),
-    [highlightQuote]
+    () => (highlightQuote && !hasRects ? makeQuoteTextRenderer(highlightQuote) : null),
+    [highlightQuote, hasRects]
   );
 
   const onDocumentLoadSuccess = useCallback(({ numPages: n }: { numPages: number }) => {
@@ -305,7 +322,7 @@ export function PdfInlineViewer({
               pageNumber={currentPage}
               scale={scale}
               renderAnnotationLayer={false}
-              renderTextLayer={renderTextLayer || !!highlightQuote}
+              renderTextLayer={renderTextLayer || (!!highlightQuote && !hasRects)}
               customTextRenderer={
                 quoteRenderer ? ({ str }) => quoteRenderer.render({ str }) : undefined
               }
@@ -314,7 +331,9 @@ export function PdfInlineViewer({
                   ? () => onQuoteMatch(quoteRenderer.matched())
                   : undefined
               }
-            />
+            >
+              {pageRects.length > 0 ? <PdfBBoxOverlay rects={pageRects} /> : null}
+            </Page>
           </Document>
         )}
       </div>

--- a/apps/web/src/components/pdf/PdfInlineViewer.tsx
+++ b/apps/web/src/components/pdf/PdfInlineViewer.tsx
@@ -311,30 +311,36 @@ export function PdfInlineViewer({
           </div>
         )}
         {pdfBlob && !loadError && (
-          <Document
-            file={pdfBlob}
-            onLoadSuccess={onDocumentLoadSuccess}
-            onLoadError={onDocumentLoadError}
-            loading={null}
-            error={null}
-          >
-            <Page
-              pageNumber={currentPage}
-              scale={scale}
-              renderAnnotationLayer={false}
-              renderTextLayer={renderTextLayer || (!!highlightQuote && !hasRects)}
-              customTextRenderer={
-                quoteRenderer ? ({ str }) => quoteRenderer.render({ str }) : undefined
-              }
-              onRenderTextLayerSuccess={
-                quoteRenderer && onQuoteMatch
-                  ? () => onQuoteMatch(quoteRenderer.matched())
-                  : undefined
-              }
+          // SP-D (#3408): center + shrink-wrap the page so the react-pdf `.react-pdf__Page`
+          // ancestor hugs the canvas (not the full container width). Otherwise the block Page div
+          // fills the container and the %-based bbox overlay (its child) misaligns for pages
+          // narrower than A4. Mirrors the proven PdfPageModal `flex justify-center` layout.
+          <div className="flex justify-center">
+            <Document
+              file={pdfBlob}
+              onLoadSuccess={onDocumentLoadSuccess}
+              onLoadError={onDocumentLoadError}
+              loading={null}
+              error={null}
             >
-              {pageRects.length > 0 ? <PdfBBoxOverlay rects={pageRects} /> : null}
-            </Page>
-          </Document>
+              <Page
+                pageNumber={currentPage}
+                scale={scale}
+                renderAnnotationLayer={false}
+                renderTextLayer={renderTextLayer || (!!highlightQuote && !hasRects)}
+                customTextRenderer={
+                  quoteRenderer ? ({ str }) => quoteRenderer.render({ str }) : undefined
+                }
+                onRenderTextLayerSuccess={
+                  quoteRenderer && onQuoteMatch
+                    ? () => onQuoteMatch(quoteRenderer.matched())
+                    : undefined
+                }
+              >
+                {pageRects.length > 0 ? <PdfBBoxOverlay rects={pageRects} /> : null}
+              </Page>
+            </Document>
+          </div>
         )}
       </div>
     </div>

--- a/apps/web/src/components/pdf/__tests__/PdfBBoxOverlay.test.tsx
+++ b/apps/web/src/components/pdf/__tests__/PdfBBoxOverlay.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * PdfBBoxOverlay — presentational %-based region overlay (SP-D #3408).
+ *
+ * Pure component: given normalized [0,1] top-left CitationRegion rects (already
+ * filtered to the visible page by the caller), renders one absolutely-positioned
+ * rectangle per rect as a child of the react-pdf <Page> wrapper.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import type { CitationRegion } from '@/types';
+
+import { PdfBBoxOverlay } from '../PdfBBoxOverlay';
+
+function rect(overrides: Partial<CitationRegion> = {}): CitationRegion {
+  return { page: 5, x: 0.1, y: 0.2, width: 0.3, height: 0.05, ...overrides };
+}
+
+describe('PdfBBoxOverlay', () => {
+  it('renders one pdf-bbox-rect per region', () => {
+    render(<PdfBBoxOverlay rects={[rect(), rect({ y: 0.5 }), rect({ y: 0.8 })]} />);
+    expect(screen.getAllByTestId('pdf-bbox-rect')).toHaveLength(3);
+  });
+
+  it('maps normalized [0,1] coords to left/top/width/height percentages', () => {
+    render(<PdfBBoxOverlay rects={[rect({ x: 0.1, y: 0.2, width: 0.3, height: 0.05 })]} />);
+    const el = screen.getByTestId('pdf-bbox-rect');
+    expect(el.style.left).toBe('10%');
+    expect(el.style.top).toBe('20%');
+    expect(el.style.width).toBe('30%');
+    expect(el.style.height).toBe('5%');
+  });
+
+  it('uses top-left y-down convention: a rect near the top has a SMALL top% (no mirroring)', () => {
+    render(<PdfBBoxOverlay rects={[rect({ y: 0.02, height: 0.04 })]} />);
+    const el = screen.getByTestId('pdf-bbox-rect');
+    // top-left convention → top ≈ 2% (NOT 1 - 0.02 = 98%)
+    expect(el.style.top).toBe('2%');
+  });
+
+  it('renders nothing when rects is empty', () => {
+    const { container } = render(<PdfBBoxOverlay rects={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('is decorative (aria-hidden) and does not capture pointer events', () => {
+    render(<PdfBBoxOverlay rects={[rect()]} />);
+    const overlay = screen.getByTestId('pdf-bbox-overlay');
+    expect(overlay).toHaveAttribute('aria-hidden', 'true');
+    expect(overlay.className).toContain('pointer-events-none');
+  });
+});

--- a/apps/web/src/components/pdf/__tests__/PdfInlineViewer.test.tsx
+++ b/apps/web/src/components/pdf/__tests__/PdfInlineViewer.test.tsx
@@ -227,4 +227,16 @@ describe('PdfInlineViewer', () => {
     expect(screen.getByTestId('pdf-page')).toHaveAttribute('data-has-custom-renderer', 'true');
     expect(screen.queryByTestId('pdf-bbox-rect')).not.toBeInTheDocument();
   });
+
+  // Geometry contract (SP-D #3408): the bbox overlay is a child of <Page> and anchors to its
+  // box, so that box MUST shrink-wrap the canvas. The canvas renders at scale×pageWidth (A4
+  // denominator) and is left-aligned; if the Page div filled the full container width the
+  // %-based rects would misalign for pages narrower than A4. A `justify-center` flex wrapper
+  // shrinks the Page ancestor to the canvas (mirrors PdfPageModal). Guard against its removal.
+  it('renders the PDF page inside a centering wrapper so the overlay anchors to the canvas', async () => {
+    render(<PdfInlineViewer documentId="doc-1" initialPage={1} />);
+    await waitFor(() => expect(screen.getByTestId('pdf-document')).toBeInTheDocument());
+    const wrapper = screen.getByTestId('pdf-document').parentElement;
+    expect(wrapper?.className).toContain('justify-center');
+  });
 });

--- a/apps/web/src/components/pdf/__tests__/PdfInlineViewer.test.tsx
+++ b/apps/web/src/components/pdf/__tests__/PdfInlineViewer.test.tsx
@@ -14,9 +14,16 @@ vi.mock('react-pdf', () => ({
     setTimeout(() => onLoadSuccess?.({ numPages: 5 }), 0);
     return <div data-testid="pdf-document">{children}</div>;
   },
-  Page: ({ pageNumber, scale }: { pageNumber: number; scale?: number }) => (
-    <div data-testid="pdf-page" data-page-number={pageNumber} data-scale={scale ?? 1}>
+  Page: ({ pageNumber, scale, renderTextLayer, customTextRenderer, children }: any) => (
+    <div
+      data-testid="pdf-page"
+      data-page-number={pageNumber}
+      data-scale={scale ?? 1}
+      data-render-text-layer={String(!!renderTextLayer)}
+      data-has-custom-renderer={String(!!customTextRenderer)}
+    >
       Page {pageNumber}
+      {children}
     </div>
   ),
   pdfjs: { GlobalWorkerOptions: { workerSrc: '' } },
@@ -170,5 +177,54 @@ describe('PdfInlineViewer', () => {
     render(<PdfInlineViewer documentId="doc-1" />);
     await waitFor(() => expect(screen.getByTestId('pdf-page')).toBeInTheDocument());
     expect(screen.queryByRole('combobox', { name: /zoom/i })).not.toBeInTheDocument();
+  });
+
+  // ── SP-D #3408: region overlay (Pattern B) via highlightRects ────────────────
+
+  it('renders the bbox overlay for highlightRects on the current page', async () => {
+    render(
+      <PdfInlineViewer
+        documentId="doc-1"
+        initialPage={3}
+        highlightRects={[{ page: 3, x: 0.1, y: 0.2, width: 0.3, height: 0.05 }]}
+      />
+    );
+    await waitFor(() => expect(screen.getByTestId('pdf-page')).toBeInTheDocument());
+    expect(screen.getByTestId('pdf-bbox-rect')).toBeInTheDocument();
+  });
+
+  it('does not render overlay rects that belong to another page', async () => {
+    render(
+      <PdfInlineViewer
+        documentId="doc-1"
+        initialPage={3}
+        highlightRects={[{ page: 7, x: 0.1, y: 0.2, width: 0.3, height: 0.05 }]}
+      />
+    );
+    await waitFor(() => expect(screen.getByTestId('pdf-page')).toBeInTheDocument());
+    expect(screen.queryByTestId('pdf-bbox-rect')).not.toBeInTheDocument();
+  });
+
+  it('suppresses the quote text layer when highlightRects are present (Pattern B over A)', async () => {
+    render(
+      <PdfInlineViewer
+        documentId="doc-1"
+        initialPage={3}
+        highlightQuote="regola X"
+        highlightRects={[{ page: 3, x: 0.1, y: 0.2, width: 0.3, height: 0.05 }]}
+      />
+    );
+    await waitFor(() => expect(screen.getByTestId('pdf-page')).toBeInTheDocument());
+    expect(screen.getByTestId('pdf-page')).toHaveAttribute('data-render-text-layer', 'false');
+    expect(screen.getByTestId('pdf-page')).toHaveAttribute('data-has-custom-renderer', 'false');
+    expect(screen.getByTestId('pdf-bbox-rect')).toBeInTheDocument();
+  });
+
+  it('keeps the quote text layer active when only highlightQuote is provided (Pattern A)', async () => {
+    render(<PdfInlineViewer documentId="doc-1" initialPage={3} highlightQuote="regola X" />);
+    await waitFor(() => expect(screen.getByTestId('pdf-page')).toBeInTheDocument());
+    expect(screen.getByTestId('pdf-page')).toHaveAttribute('data-render-text-layer', 'true');
+    expect(screen.getByTestId('pdf-page')).toHaveAttribute('data-has-custom-renderer', 'true');
+    expect(screen.queryByTestId('pdf-bbox-rect')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -866,3 +866,18 @@
 .pdf-quote-highlight {
   background-color: rgba(255, 235, 59, 0.4);
 }
+
+/* ============================================================================
+ * PdfBBoxOverlay — region grounding overlay (SP-D #3408)
+ * Precise %-based rectangle drawn over the react-pdf <Page> for a citation's
+ * source region (Pattern B). Semantic --c-warning token (decorative fill +
+ * border), static (no animation) → no motion concern. Full-gated at the wire.
+ * ============================================================================ */
+
+.pdf-bbox-highlight {
+  position: absolute;
+  background-color: hsl(var(--c-warning) / 0.2);
+  border: 1px solid hsl(var(--c-warning));
+  border-radius: 2px;
+  pointer-events: none;
+}


### PR DESCRIPTION
## SP-D — FE region overlay + wire chat (epic #3403)

Disegna la **regione PDF sorgente** della citazione come overlay preciso (Pattern B), con fallback graceful al quote-highlight testuale di SP0 (Pattern A) quando le `regions` sono assenti.

Chiude **#3408** (sub-issue dell'epic **#3403** "RAG citation region grounding"). Si innesta su SP-C (#3407, già merged): le `regions[]` arrivano già Full-gated fino al tipo FE `Citation`.

### Cosa
- **`PdfBBoxOverlay`** (nuovo): rettangoli **%-based** figli del `<Page>` react-pdf (`position:relative`), coordinate normalizzate `[0,1]` top-left → scale/DPR-independent, zero pixel-math. Decorativo (`aria-hidden`).
- **`PdfInlineViewer.highlightRects`**: filtra per pagina corrente, monta l'overlay, e **sopprime il quote-layer** quando ci sono regions (Pattern B ha precedenza su A).
- **`CitationPdfTab.regions`** + **`CitationModal`** wire (game-chat, Chain-1).
- **`PdfPageModal`** (chat-unified): overlay sulla pagina citata.
- **`.pdf-bbox-highlight`** in `globals.css` via token `--c-warning` (fill+bordo, statico → nessun concern motion).

### Copyright gate (DA-4)
Le regions sono già Full-gated dal BE (SP-C). Qui **re-gate difensivo** in `CitationModal`/`PdfPageModal`: mai renderizzate per tier `protected` (coerenza ADR-059/#447), con test dedicati.

### Scope (deciso in discovery)
Solo le **due superfici PDF** che ricevono il tipo ricco `Citation`: `CitationModal` (Chain-1 game-chat) e `PdfPageModal` (chat-unified). La **Chain-2 live** (`ChatCitationCard`) è text-only senza viewer PDF → fuori scope (dare un viewer PDF alla sessione live = feature separata).

### Nota sui dati reali
Il corpus attuale ha `regions=null` ovunque finché **SP-E (#3409)** non ri-estrae le bbox. Fino ad allora si vede il fallback Pattern A (SP0). Questo PR è testato con fixture.

### Fix da review avversariale (multi-agent find→verify)
Trovato e corretto un **disallineamento orizzontale** dell'overlay in `PdfInlineViewer` per PDF più stretti di A4 (A5/digest): il div `.react-pdf__Page` (`width:auto`) riempiva il container mentre il canvas (scale su denominatore A4 595pt) è più stretto e a sinistra. Fix: wrapper `flex justify-center` che restringe il Page al canvas (stesso pattern già corretto di `PdfPageModal`).

### Test / verifica
- TDD RED→GREEN per ogni slice. Nuovi/estesi: `PdfBBoxOverlay` (5), `PdfInlineViewer` (+5, incl. guard geometrico), `CitationPdfTab` (+3), `CitationModal` (+2), `PdfPageModal` (+3).
- Regressione area toccata + consumer: **560/560** vitest verdi · `pnpm typecheck` 0 err · ESLint 0 err (token/`no-hardcoded-color-utility` ok).

🤖 Generated with [Claude Code](https://claude.com/claude-code)