### PR TITLE
feat(rag-citation): IndexerVersion v1.2 coordinate-aware for region grounding (SP-E, #3409)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/Queue/BulkReindexReadyCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/Queue/BulkReindexReadyCommand.cs
@@ -4,8 +4,8 @@ namespace Api.BoundedContexts.DocumentProcessing.Application.Commands.Queue;
 
 /// <summary>
 /// Bulk-triggers re-index of ALL <c>Ready</c> PDFs whose <c>IndexerVersion</c> differs from the
-/// target (heading-aware v1.1), by fanning out the existing <see cref="ReindexDocumentCommand"/>.
-/// SP3 RAG bulk re-index (issue #3269, epic #3266).
+/// target (coordinate-aware v1.2), by fanning out the existing <see cref="ReindexDocumentCommand"/>.
+/// SP3 RAG bulk re-index (issue #3269, epic #3266); target bumped by #3409 (SP-E, epic #3403).
 /// </summary>
 /// <param name="RequestedBy">The admin user id that triggered the bulk re-index.</param>
 /// <param name="TargetVersion">

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
@@ -444,8 +444,9 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
             pdfDoc.ProcessingState = nameof(PdfProcessingState.Ready);
             pdfDoc.ProcessedAt = _timeProvider.GetUtcNow().UtcDateTime;
             // Issue #3269 (SP3): stamp the current indexer version so a completed fresh ingest is
-            // v1.1 (heading-aware) and `IndexerVersion == null` means only true pre-versioning
-            // legacy — keeps the bulk re-index selector from redundantly re-processing fresh docs.
+            // the current pipeline version (v1.2 coordinate-aware after #3409/SP-E) and
+            // `IndexerVersion == null` means only true pre-versioning legacy — keeps the bulk
+            // re-index selector from redundantly re-processing fresh docs.
             // Null-coalescing (not overwrite): a reindex path already stamped its chosen version at
             // reset (ReindexDocumentCommandHandler), so we preserve that explicit choice here.
             pdfDoc.IndexerVersion ??= IndexerVersionRegistry.Current.Version;

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/ValueObjects/IndexerVersionRegistry.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/ValueObjects/IndexerVersionRegistry.cs
@@ -36,14 +36,24 @@ internal static class IndexerVersionRegistry
         new("v1.0", "v1.0 — flat chunking pipeline", IsSelectable: true);
 
     /// <summary>
-    /// Versione corrente della pipeline. Equivale al comportamento di default quando
-    /// `reindexDocument` viene chiamato senza `IndexerVersion` esplicito.
-    /// SP3 #3269 (epic #3266): pipeline heading-aware (SP1/SP2 già deployati).
+    /// Pipeline heading-aware (pre coordinate-aware). Non più <see cref="Current"/> dopo l'epic
+    /// #3403 SP-E, ma resta nel registry per la deprecation policy (≥18 mesi) e selezionabile da `/reindex`.
+    /// SP3 #3269 (epic #3266): SP1/SP2 heading-aware.
     /// </summary>
-    public static readonly IndexerVersion Current =
+    public static readonly IndexerVersion V1_1 =
         new("v1.1", "v1.1 — heading-aware chunking", IsSelectable: true);
 
-    public static IReadOnlyList<IndexerVersion> All { get; } = [Legacy, V1_0, Current];
+    /// <summary>
+    /// Versione corrente della pipeline. Equivale al comportamento di default quando
+    /// `reindexDocument` viene chiamato senza `IndexerVersion` esplicito.
+    /// SP-E #3409 (epic #3403): pipeline coordinate-aware — l'estrazione Unstructured emette le bbox
+    /// normalizzate (SP-B) persistite in <c>bounding_boxes_json</c> per il region grounding. Un
+    /// re-extract del corpus a questa versione ri-popola le coordinate (le regions oggi sono null).
+    /// </summary>
+    public static readonly IndexerVersion Current =
+        new("v1.2", "v1.2 — coordinate-aware (region grounding)", IsSelectable: true);
+
+    public static IReadOnlyList<IndexerVersion> All { get; } = [Legacy, V1_0, V1_1, Current];
 
     /// <summary>
     /// Restituisce la lista delle versioni effettivamente invocabili da `/reindex`.

--- a/apps/api/src/Api/Routing/AdminQueueEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminQueueEndpoints.cs
@@ -105,12 +105,13 @@ internal static class AdminQueueEndpoints
             .Produces<BulkReindexResult>(200)
             .WithSummary("Re-queue all failed documents as Low priority");
 
-        // Issue #3269 (SP3 RAG bulk re-index): re-index all Ready documents whose indexer
-        // version differs from the target (heading-aware v1.1).
+        // Issue #3269 (SP3 RAG bulk re-index) → target bumped to coordinate-aware v1.2 by
+        // #3409 (SP-E, epic #3403): re-index all Ready documents whose indexer version differs
+        // from the current target.
         group.MapPost("/reindex-ready", HandleBulkReindexReady)
             .WithName("BulkReindexReady")
             .Produces<BulkReindexResult>(200)
-            .WithSummary("Re-index all Ready documents whose indexer version differs from the target (heading-aware v1.1)");
+            .WithSummary("Re-index all Ready documents whose indexer version differs from the target (coordinate-aware v1.2)");
 
         // Issue #5456: Extracted text preview
         group.MapGet("/documents/{pdfDocumentId:guid}/extracted-text", HandleGetExtractedText)

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/Queue/BulkReindexReadyCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/Queue/BulkReindexReadyCommandHandlerTests.cs
@@ -108,8 +108,8 @@ public sealed class BulkReindexReadyCommandHandlerTests : IAsyncLifetime
                     c.PdfId == pdf.Id && c.IndexerVersion == IndexerVersionRegistry.Current.Version),
                 It.IsAny<CancellationToken>()),
             Times.Once);
-        // The current pipeline version is v1.1 (SP3 #3269). Assert the literal explicitly.
-        IndexerVersionRegistry.Current.Version.Should().Be("v1.1");
+        // The current pipeline version is v1.2 (SP-E #3409, coordinate-aware). Assert the literal explicitly.
+        IndexerVersionRegistry.Current.Version.Should().Be("v1.2");
         result.EnqueuedCount.Should().Be(1);
         result.SkippedCount.Should().Be(0);
         result.Errors.Should().BeEmpty();

--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/BulkReindexReadySelectorIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/BulkReindexReadySelectorIntegrationTests.cs
@@ -22,7 +22,7 @@ namespace Api.Tests.Integration.DocumentProcessing;
 /// real PostgreSQL instance (Testcontainers). Issue #3269 (SP3 RAG bulk re-index).
 /// <para>
 /// Proves the mandatory Postgres null-comparison guard on the selector: a plain
-/// <c>indexer_version &lt;&gt; 'v1.1'</c> predicate silently drops rows where
+/// <c>indexer_version &lt;&gt; 'v1.2'</c> predicate silently drops rows where
 /// <c>indexer_version IS NULL</c> (three-valued logic), so the handler MUST use
 /// <c>IndexerVersion == null || IndexerVersion != target</c>. This test seeds a NULL-version
 /// Ready row and asserts it IS selected — it fails against Npgsql SQL semantics if the
@@ -130,7 +130,7 @@ public sealed class BulkReindexReadySelectorIntegrationTests : IAsyncLifetime
     {
         // PDF-A: Ready + IndexerVersion = NULL  → MUST be selected (null-comparison guard).
         var pdfA = await SeedPdfAsync("Ready", indexerVersion: null);
-        // PDF-B: Ready + already at target v1.1 → excluded (idempotent).
+        // PDF-B: Ready + already at the current target (v1.2) → excluded (idempotent).
         await SeedPdfAsync("Ready", indexerVersion: IndexerVersionRegistry.Current.Version);
         // PDF-C: Failed + NULL                 → excluded (non-Ready).
         await SeedPdfAsync("Failed", indexerVersion: null);

--- a/apps/api/tests/Api.Tests/Unit/DocumentProcessing/IndexerVersionRegistryTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/DocumentProcessing/IndexerVersionRegistryTests.cs
@@ -14,10 +14,11 @@ public sealed class IndexerVersionRegistryTests
     [Fact]
     public void Current_ReturnsLatestSelectableVersion()
     {
-        // SP3 #3269 D2: Current bumped to the heading-aware pipeline version.
-        IndexerVersionRegistry.Current.Version.Should().Be("v1.1");
+        // SP-E #3409 (epic #3403): Current bumped to the coordinate-aware pipeline version so a
+        // corpus re-extract re-populates bounding_boxes_json for region grounding.
+        IndexerVersionRegistry.Current.Version.Should().Be("v1.2");
         IndexerVersionRegistry.Current.IsSelectable.Should().BeTrue();
-        IndexerVersionRegistry.Current.DisplayName.Should().Contain("heading-aware");
+        IndexerVersionRegistry.Current.DisplayName.Should().Contain("coordinate-aware");
     }
 
     [Fact]
@@ -28,20 +29,22 @@ public sealed class IndexerVersionRegistryTests
     }
 
     [Fact]
-    public void All_ContainsLegacyV0AndV1_0AndV1_1()
+    public void All_ContainsLegacyV0AndV1_0AndV1_1AndV1_2()
     {
         var versions = IndexerVersionRegistry.All;
-        versions.Should().HaveCountGreaterThanOrEqualTo(3);
+        versions.Should().HaveCountGreaterThanOrEqualTo(4);
         versions.Should().Contain(v => v.Version == "v0");
-        // v1.0 retained per the ≥18mo deprecation policy even though it is no longer Current.
+        // v1.0 / v1.1 retained per the ≥18mo deprecation policy even though they are no longer Current.
         versions.Should().Contain(v => v.Version == "v1.0");
         versions.Should().Contain(v => v.Version == "v1.1");
+        versions.Should().Contain(v => v.Version == "v1.2");
     }
 
     [Theory]
     [InlineData("v0")]
     [InlineData("v1.0")]
     [InlineData("v1.1")]
+    [InlineData("v1.2")]
     public void TryGet_KnownVersion_ReturnsTrue(string input)
     {
         IndexerVersionRegistry.TryGet(input, out var version).Should().BeTrue();
@@ -67,9 +70,10 @@ public sealed class IndexerVersionRegistryTests
     [Fact]
     public void IsSelectable_Current_ReturnsTrue()
     {
-        // Both the retained v1.0 and the new heading-aware v1.1 remain selectable from /reindex.
+        // The retained v1.0/v1.1 and the new coordinate-aware v1.2 all remain selectable from /reindex.
         IndexerVersionRegistry.IsSelectable("v1.0").Should().BeTrue();
         IndexerVersionRegistry.IsSelectable("v1.1").Should().BeTrue();
+        IndexerVersionRegistry.IsSelectable("v1.2").Should().BeTrue();
     }
 
     [Fact]

--- a/docs/for-developers/operations/2026-07-26-corpus-reindex-runbook.md
+++ b/docs/for-developers/operations/2026-07-26-corpus-reindex-runbook.md
@@ -10,6 +10,39 @@ corpus**. Sub-project 3/4 of epic [#3266](https://github.com/meepleAi-app/meeple
 - **Slice 3 (this runbook)**: `make reindex-corpus ENV=…` — loops the Slice 1 endpoint until
   the corpus is drained + ADR [adr-086](../../for-claude/architecture/adr/adr-086-corpus-reindex-orchestration.md).
 
+> ### 🎯 SP-E addendum — coordinate-aware v1.2 (region grounding, #3409 / epic #3403)
+>
+> The same orchestration now also activates **PDF region grounding** (epic
+> [#3403](https://github.com/meepleAi-app/meepleai-monorepo/issues/3403)). The server's current
+> `IndexerVersion` was bumped **v1.1 → v1.2 (coordinate-aware)** in #3409, so `make reindex-corpus
+> ENV=…` re-extracts every Ready PDF and repopulates the normalized bounding boxes (SP-B #3406)
+> into `text_chunks.bounding_boxes_json`. The FE overlay (SP-D #3408) then renders the cited region
+> on real documents. Deltas vs the v1.1 procedure below:
+>
+> - **Target version** is now `v1.2` (not `v1.1`). The selector, drain loop, and idempotency are
+>   unchanged — `reindex-ready` picks every Ready PDF whose `IndexerVersion != v1.2`.
+> - **§1 precondition** is stronger: the `unstructured` container must be the **coordinate-aware
+>   (SP-B #3406) build**, not merely SP1. A stale (pre-SP-B) container extracts **without**
+>   coordinates → `bounding_boxes_json` stays NULL silently (the run still stamps v1.2, so it looks
+>   done but grounds nothing). Rebuild + verify the container emits a `bbox` field per element
+>   before running. Region grounding is **Unstructured-only** — SmolDocling/Docnet branches leave
+>   `bounding_boxes_json` NULL (expected; FE falls back to Pattern A).
+> - **§4 post-reindex assertion** additionally checks bbox coverage:
+>   ```sql
+>   -- Unstructured-branch Ready PDFs should have non-null bbox after the v1.2 reindex.
+>   SELECT COUNT(*) FILTER (WHERE bounding_boxes_json IS NOT NULL) AS with_bbox,
+>          COUNT(*) AS total
+>   FROM text_chunks tc
+>   JOIN pdf_documents pd ON pd.id = tc.pdf_document_id
+>   WHERE pd.processing_state = 'Ready' AND pd.indexer_version = 'v1.2';
+>   ```
+> - **§5 baseline**: re-capture the `rag-smoke` golden baseline after the reindex (the snapshot id +
+>   `indexer_version` change), per the [rag-smoke runbook](./rag-smoke-runbook.md).
+> - **Scope (DC-3)**: validate on **staging first**; the prod decision is taken separately after the
+>   staging FE-overlay check. **Extraction strategy (DC-2)** stays `fast` for this rollout — `fast`
+>   already emits coordinates; `hi_res` for table-heavy PDFs is a tracked follow-up
+>   ([#3419](https://github.com/meepleAi-app/meepleai-monorepo/issues/3419)), not required for the AC.
+
 ## Why a big-bang is needed
 
 The heading-aware pipeline is **latent**: it only runs on fresh ingests. The already-indexed

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -427,7 +427,10 @@ game-reset-rollback-rehearse: ## Run disposable docker rollback rehearsal
 
 # === Corpus re-index orchestration (issue #3269 SP3 Slice 3 / D4) ===
 # Script lives in infra/scripts/reindex-corpus/. Wraps POST /admin/queue/reindex-ready
-# in a drain loop until the whole Ready corpus is re-indexed to heading-aware v1.1.
+# in a drain loop until the whole Ready corpus is re-indexed to the server's current
+# IndexerVersion — now coordinate-aware v1.2 (region grounding, #3409 SP-E / epic #3403).
+# 🔴 Precondition: the `unstructured` container MUST be the SP-B coordinate-aware build,
+# else the re-extract silently produces bbox-less chunks (regions stay null).
 
 reindex-corpus-help: ## Show corpus re-index (SP3 #3269) workflow help
 	@echo "Corpus big-bang re-index (SP3 #3269 D4) — usage:"
@@ -441,7 +444,7 @@ reindex-corpus-help: ## Show corpus re-index (SP3 #3269) workflow help
 	@echo "Per env, create infra/scripts/reindex-corpus/.env.<ENV> from .env.example (NEVER commit filled files)."
 	@echo "Full runbook: docs/for-developers/operations/2026-07-26-corpus-reindex-runbook.md"
 
-reindex-corpus: ## Big-bang re-index Ready PDFs to heading-aware v1.1 (ENV=staging|prod|dev; EXTRA=--dry-run for preview; prod needs IMEANIT=--i-mean-it)
+reindex-corpus: ## Big-bang re-index Ready PDFs to coordinate-aware v1.2 (ENV=staging|prod|dev; EXTRA=--dry-run for preview; prod needs IMEANIT=--i-mean-it)
 	@test -n "$(ENV)" || (echo "ENV required: make reindex-corpus ENV=staging" && exit 64)
 	@test -f scripts/reindex-corpus/.env.$(ENV) || (echo "Missing scripts/reindex-corpus/.env.$(ENV) — copy from .env.example" && exit 66)
 	./scripts/reindex-corpus/reindex-corpus.sh scripts/reindex-corpus/.env.$(ENV) $(EXTRA) $(IMEANIT)

--- a/infra/scripts/reindex-corpus/.env.example
+++ b/infra/scripts/reindex-corpus/.env.example
@@ -20,7 +20,7 @@ ADMIN_EMAIL="admin@example.com"
 ADMIN_PASSWORD="change-me"
 
 # OPTIONAL — target indexer version to re-index toward. Leave empty/unset to let the
-# server resolve its Current version (heading-aware v1.1). Set explicitly only to pin
+# server resolve its Current version (coordinate-aware v1.2). Set explicitly only to pin
 # a specific version during a controlled migration.
 TARGET_VERSION=""
 

--- a/infra/scripts/reindex-corpus/reindex-corpus.sh
+++ b/infra/scripts/reindex-corpus/reindex-corpus.sh
@@ -4,12 +4,12 @@
 #
 # Wraps the admin endpoint `POST /api/v1/admin/queue/reindex-ready` (Slice 1, #3269)
 # in a drain loop. That endpoint enqueues Ready PDFs whose IndexerVersion differs from
-# the target (heading-aware v1.1) but is capped by the processing queue (MaxQueueSize),
+# the target (coordinate-aware v1.2) but is capped by the processing queue (MaxQueueSize),
 # so a large corpus needs REPEATED calls. This script loops until EnqueuedCount == 0
 # (corpus drained), pacing between iterations so the Quartz rail can process the queue
 # before the next batch is enqueued.
 #
-# The selector skips already-v1.1 docs (IndexerVersion == target), so the loop is
+# The selector skips already-current docs (IndexerVersion == target), so the loop is
 # idempotent / resumable — a crash mid-run is safe to re-run: already-re-indexed PDFs
 # are not touched again.
 #
@@ -67,7 +67,7 @@ fi
 : "${API_BASE_URL:?API_BASE_URL must be set in $ENV_FILE}"
 : "${ADMIN_EMAIL:?ADMIN_EMAIL must be set in $ENV_FILE}"
 : "${ADMIN_PASSWORD:?ADMIN_PASSWORD must be set in $ENV_FILE}"
-TARGET_VERSION="${TARGET_VERSION:-}"      # empty → server resolves Current (v1.1)
+TARGET_VERSION="${TARGET_VERSION:-}"      # empty → server resolves Current (v1.2)
 PACING_SECONDS="${PACING_SECONDS:-5}"
 MAX_ITERATIONS="${MAX_ITERATIONS:-200}"
 
@@ -94,7 +94,7 @@ LOGIN_ENDPOINT="$API_BASE_URL/api/v1/auth/login"
 if [ -n "$TARGET_VERSION" ]; then
   BODY=$(jq -n --arg v "$TARGET_VERSION" '{targetVersion:$v}')
 else
-  BODY='{}'   # omit targetVersion → server uses Current (heading-aware v1.1)
+  BODY='{}'   # omit targetVersion → server uses Current (coordinate-aware v1.2)
 fi
 
 COOKIE=$(mktemp)
@@ -119,7 +119,7 @@ if [ "$DRY_RUN" = true ]; then
   log_info "DRY-RUN plan:"
   log_info "  Environment : $ENV_NAME"
   log_info "  Endpoint    : POST $REINDEX_ENDPOINT"
-  log_info "  Target ver  : ${TARGET_VERSION:-<server Current — heading-aware v1.1>}"
+  log_info "  Target ver  : ${TARGET_VERSION:-<server Current — coordinate-aware v1.2>}"
   log_info "  Pacing      : ${PACING_SECONDS}s between iterations"
   log_info "  Max iters   : $MAX_ITERATIONS (safety cap)"
   log_info "  Plan        : loop POST reindex-ready until EnqueuedCount==0 (corpus drained)."
@@ -131,7 +131,7 @@ fi
 # --- real run: login then drain-loop ---
 login
 
-log_info "Starting big-bang corpus re-index for ENV=$ENV_NAME (target=${TARGET_VERSION:-<server Current v1.1>})"
+log_info "Starting big-bang corpus re-index for ENV=$ENV_NAME (target=${TARGET_VERSION:-<server Current v1.2>})"
 total_enqueued=0
 iteration=0
 
@@ -179,7 +179,7 @@ while [ "$iteration" -lt "$MAX_ITERATIONS" ]; do
 done
 
 log_error "MAX_ITERATIONS ($MAX_ITERATIONS) exceeded without draining (EnqueuedCount never reached 0)."
-log_error "This signals a STUCK queue: PDFs are re-enqueued but not progressing to $([ -n "$TARGET_VERSION" ] && echo "$TARGET_VERSION" || echo 'v1.1'). Check:"
+log_error "This signals a STUCK queue: PDFs are re-enqueued but not progressing to $([ -n "$TARGET_VERSION" ] && echo "$TARGET_VERSION" || echo 'v1.2'). Check:"
 log_error "  - the 'unstructured' Docker container is rebuilt with SP1 code (stale → 0 elements → no version bump)"
 log_error "  - the Quartz processing rail is running and the queue is not paused"
 log_error "  - raise MAX_ITERATIONS only after confirming the queue is actually progressing"


### PR DESCRIPTION
## SP-E — Re-extract/re-index corpus + rollout (epic #3403, chiude l'epic)

Attiva il **region grounding sui dati reali** bumpando la pipeline a **v1.2 coordinate-aware**. Chiude **#3409** e completa l'epic **#3403** (SP0/SP-A/SP-B/SP-C/SP-D già merged).

### Scoperta chiave: SP-E era quasi tutto già costruito (SP3 #3269)
Il re-extract big-bang **esiste già**: `BulkReindexReadyCommand → ReindexDocumentCommand` cancella i chunk, resetta il PDF a `Pending` e **ri-estrae l'intera pipeline dal PDF sorgente** (non solo re-chunk). Null-trap selector (`IndexerVersion == null || != target`), pacing coda, `ConflictException` per-PDF → skip: tutti già presenti. `make reindex-corpus ENV=`, rag-smoke EN+IT (11 query), runbook e precondizione container-rebuild: già esistenti.

**Quindi D1 si riduce al bump `IndexerVersion` v1.1 → v1.2**: il selector ripesca tutti i v1.1/null e li ri-estrae col container coordinate-aware → `text_chunks.bounding_boxes_json` popolato (SP-B) → overlay FE (SP-D) sui documenti reali.

### Cosa (code)
- **`IndexerVersionRegistry`**: `Current` v1.1 → **v1.2 (coordinate-aware)**; v1.1 mantenuto come `V1_1` storico selezionabile (deprecation ≥18 mesi); `All` aggiornato.
- Aggiornato l'unico assert letterale (`.Should().Be("v1.1")` → `"v1.2"`) + commenti/log-string stale (endpoint summary, `reindex-corpus.sh`, `.env.example`, stamp pipeline, integration-test comments).
- **Runbook** (`2026-07-26-corpus-reindex-runbook.md`): addendum SP-E — precondizione container **coordinate-aware** (SP-B, non solo SP1), SQL assert `bounding_boxes_json IS NOT NULL`, re-baseline rag-smoke, staging-first (DC-3), strategy `fast` (DC-2). `Makefile` reindex-corpus help → v1.2.

### DoD
- [x] **D1** re-extract big-bang + null-trap test → esistono (SP3 #3269); enabler = bump v1.2 (TDD registry 24→verde, 61 test versione/reindex verdi).
- [x] **D2** non-regression EN+IT → suite `rag-smoke` esiste (11 query bilingue); re-baseline documentato nel runbook §5.
- [x] **D3** runbook + rebuild container documentato + `make reindex-corpus ENV=`.
- [x] PR → main-dev (chiude #3409 + epic #3403 alla merge).

### Decisioni utente
- **DC-2** = hi_res-per-tabelle → scorporato in follow-up **#3419** (plumbing cross-cutting grande, non necessario per l'AC: `fast` emette già le coordinate).
- **DC-3** = big-bang **solo staging**, poi decisione prod separata.

### ⚠️ Handoff ops (richiede accesso infra, non eseguibile da qui)
L'overlay sui dati reali appare dopo che **tu** esegui su staging:
1. `cd infra && docker compose build unstructured && docker compose up -d unstructured` (container coordinate-aware SP-B).
2. `make reindex-corpus ENV=staging EXTRA=--dry-run` poi `make reindex-corpus ENV=staging`.
3. Verifica SQL `bounding_boxes_json IS NOT NULL` (runbook §4/SP-E addendum) + check overlay FE.
4. Re-baseline rag-smoke, poi decidi prod.

### Verifica
Solution build verde (pre-push backend gate); 61/61 test unit versione/reindex verdi; 24/24 registry+handler. Commit-msg ≤90 char.

🤖 Generated with [Claude Code](https://claude.com/claude-code)