### PR TITLE
feat(rag): MechanicCard claim injection into RAG agent (R1)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/AskQuestionQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/AskQuestionQueryHandler.cs
@@ -4,6 +4,7 @@ using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
 using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries;
 using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Application.Services.MechanicClaimInjection;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services.Reranking;
@@ -56,6 +57,8 @@ internal class AskQuestionQueryHandler : IQueryHandler<AskQuestionQuery, QaRespo
     private readonly IGenericTranslationService _genericTranslationService;
     private readonly IIntentClassifierService _intentClassifier;
     private readonly IOptionsMonitor<LlmQueryComplexityRoutingOptions> _routingOptions;
+    private readonly IMechanicCardProvider _mechanicCardProvider;
+    private readonly IFeatureFlagService _featureFlags;
     private readonly ILogger<AskQuestionQueryHandler> _logger;
 
     // Issue #2708: retrieve a wider candidate pool, then let the cross-encoder narrow it to the
@@ -83,6 +86,8 @@ internal class AskQuestionQueryHandler : IQueryHandler<AskQuestionQuery, QaRespo
         IGenericTranslationService genericTranslationService,
         IIntentClassifierService intentClassifier,
         IOptionsMonitor<LlmQueryComplexityRoutingOptions> routingOptions,
+        IMechanicCardProvider mechanicCardProvider,
+        IFeatureFlagService featureFlags,
         ILogger<AskQuestionQueryHandler> logger)
     {
         _searchQueryHandler = searchQueryHandler ?? throw new ArgumentNullException(nameof(searchQueryHandler));
@@ -104,6 +109,8 @@ internal class AskQuestionQueryHandler : IQueryHandler<AskQuestionQuery, QaRespo
         _genericTranslationService = genericTranslationService ?? throw new ArgumentNullException(nameof(genericTranslationService));
         _intentClassifier = intentClassifier ?? throw new ArgumentNullException(nameof(intentClassifier));
         _routingOptions = routingOptions ?? throw new ArgumentNullException(nameof(routingOptions));
+        _mechanicCardProvider = mechanicCardProvider ?? throw new ArgumentNullException(nameof(mechanicCardProvider));
+        _featureFlags = featureFlags ?? throw new ArgumentNullException(nameof(featureFlags));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -177,11 +184,38 @@ internal class AskQuestionQueryHandler : IQueryHandler<AskQuestionQuery, QaRespo
         if (!quotaAllowed)
             throw new ForbiddenException("Quota giornaliera esaurita. Acquista crediti per continuare.");
 
+        // R1 (issue #3416, ADR-088): fetch approved mechanic-card claims to inject as authoritative
+        // context. Feature-flag gated (default off), best-effort, and computed HERE — above the semantic
+        // cache and the no-results early-exit — so the claim block still fires when retrieval is empty
+        // (spec §6.1). The card read runs AFTER CanAccessRag (§9) and adds no LLM call (quota-neutral).
+        var verifiedBlock = VerifiedRulesBlock.Empty;
+        var flagRole = Enum.TryParse<UserRole>(query.UserRole, ignoreCase: true, out var parsedFlagRole)
+            ? parsedFlagRole : (UserRole?)null;
+        if (await _featureFlags.IsEnabledAsync(FeatureFlagConstants.MechanicCardInjectionKey, flagRole)
+                .ConfigureAwait(false))
+        {
+            var claimSections = MechanicSectionRouter.Route(_intentClassifier.ClassifyIntent(query.Question));
+            if (claimSections.Count > 0)
+            {
+                var card = await _mechanicCardProvider.GetActiveCardAsync(query.GameId, cancellationToken)
+                    .ConfigureAwait(false);
+                if (card is not null)
+                {
+                    verifiedBlock = VerifiedRulesRenderer.Render(card, claimSections);
+                }
+            }
+        }
+        var injectClaims = !verifiedBlock.IsEmpty;
+
         // P1-5: Semantic cache lookup — generate query vector and check for a cached response.
         // Issue #563: The vector produced here is now also forwarded to SearchQueryHandler via
         // SearchQuery.QueryVector to eliminate the duplicate embedding call (~50-200ms saved per cache miss).
         float[]? queryVector = null;
-        if (!query.BypassCache)
+        // R1: when claims are injected, bypass the semantic response cache entirely (both read and write).
+        // The cache is keyed on (GameId, queryVector) with no card fingerprint, so a cached no-card answer
+        // must not shadow a claim-injected one, and a claim answer must not be replayed after suppression
+        // (spec §6.2). Claim-injected answers are simply not cached in v1 (bounded, documented trade-off).
+        if (!query.BypassCache && !injectClaims)
         {
             try
             {
@@ -267,8 +301,11 @@ internal class AskQuestionQueryHandler : IQueryHandler<AskQuestionQuery, QaRespo
         _logger.LogInformation("[AskQuestionHandler] Step 1 DONE: Vector search completed in {ElapsedMs}ms - {ResultCount} results, confidence: {Confidence}",
             sw1.ElapsedMilliseconds, searchResults.Count, searchConfidence.Value);
 
-        // No-context early exit: skip LLM call when vector search returned no results
-        if (searchResults.Count == 0)
+        // No-context early exit: skip LLM call when vector search returned no results.
+        // R1 (spec §6.1): but NOT when an approved-claim block is present — the claims are the answer
+        // source in the retrieval-miss case (e.g. TM "Setup per N"), so proceed to the LLM with a
+        // claims-only prompt instead of the "not available" sentinel.
+        if (searchResults.Count == 0 && verifiedBlock.IsEmpty)
         {
             _logger.LogInformation("[AskQuestionHandler] No search results found, returning early without LLM call");
             var noContextMetrics = new RagQueryMetrics(
@@ -308,6 +345,14 @@ internal class AskQuestionQueryHandler : IQueryHandler<AskQuestionQuery, QaRespo
         _logger.LogDebug("[AskQuestionHandler] Step 3: Building LLM prompts...");
         var systemPrompt = await _promptTemplateService.GetActivePromptAsync("rag-system-prompt")
             .ConfigureAwait(false) ?? DefaultSystemPrompt;
+        if (injectClaims)
+        {
+            // Grounding (spec §7.1): authorize the [Verified Rules] block as valid provided context so the
+            // "answer ONLY from context" constraint does not reject it when the RAG context is empty.
+            systemPrompt += " A section titled '[Verified Rules — human-approved]' may precede the Context; "
+                + "it is human-approved rulebook content and counts as provided context — you MAY answer "
+                + "from it and cite its [Page N].";
+        }
         var context = string.Join("\n\n", searchResults.Select(sr =>
             $"[Page {sr.PageNumber}] {sr.TextContent}"));
 
@@ -318,7 +363,10 @@ internal class AskQuestionQueryHandler : IQueryHandler<AskQuestionQuery, QaRespo
             ? $"[House Rule for this group]\n{houseRuleMatch}\n\n"
             : string.Empty;
 
-        var baseQuestion = $"{houseRulePrefix}Question: {query.Question}\n\nContext:\n{context}";
+        // R1 (spec §7.1/D8): approved claims rank between house rules and raw RAG context.
+        var verifiedPrefix = injectClaims ? $"{verifiedBlock.PromptText}\n\n" : string.Empty;
+
+        var baseQuestion = $"{houseRulePrefix}{verifiedPrefix}Question: {query.Question}\n\nContext:\n{context}";
         var userPrompt = !string.IsNullOrWhiteSpace(chatHistoryContext)
             ? _chatContextService.EnrichPromptWithHistory(baseQuestion, chatHistoryContext)
             : baseQuestion;
@@ -344,13 +392,28 @@ internal class AskQuestionQueryHandler : IQueryHandler<AskQuestionQuery, QaRespo
         _logger.LogInformation("[AskQuestionHandler] Step 5 DONE: Response validation completed in {ElapsedMs}ms",
             sw5.ElapsedMilliseconds);
 
+        // R1 (spec §7.4): emit claim-derived citations (PdfId/PdfPage + verbatim Quote) alongside the RAG
+        // citations. Provenance is carried by the inline [Vk] marker in the answer, not a DTO field —
+        // the shared CitationDto is left unchanged (coordination with the citation epic, spec §7.5).
+        if (injectClaims && verifiedBlock.Citations.Count > 0)
+        {
+            var claimCitations = verifiedBlock.Citations.Select(vc => new CitationDto(
+                DocumentId: vc.PdfId.ToString(),
+                PageNumber: vc.PdfPage,
+                Snippet: vc.Quote,
+                RelevanceScore: 1.0)).ToList();
+            var existingCitations = response.Citations ?? (IReadOnlyList<CitationDto>)Array.Empty<CitationDto>();
+            response = response with { Citations = [.. existingCitations, .. claimCitations] };
+        }
+
         _logger.LogInformation(
             "[AskQuestionHandler] COMPLETE - AskQuestionQuery completed: OverallConfidence={Confidence}, IsLowQuality={IsLowQuality}",
             response.OverallConfidence, response.IsLowQuality);
 
         // P1-5: Store successful response in semantic cache for future queries
-        // Don't cache low-quality or no-context responses to avoid polluting the cache
-        if (!query.BypassCache && queryVector != null && !IsLowQualityResponse(response))
+        // Don't cache low-quality or no-context responses to avoid polluting the cache.
+        // R1: never cache a claim-injected answer (no card fingerprint in the key — spec §6.2).
+        if (!query.BypassCache && queryVector != null && !injectClaims && !IsLowQualityResponse(response))
         {
             var citationTexts = response.Citations?
                 .Select(c => c.Snippet)
@@ -373,7 +436,7 @@ internal class AskQuestionQueryHandler : IQueryHandler<AskQuestionQuery, QaRespo
             ChunksRetrieved: searchResults.Count,
             ChunksUsed: searchResults.Count, // currently equal to ChunksRetrieved — all retrieved chunks are passed to LLM context
             CitationsCount: response.Citations?.Count ?? 0,
-            Strategy: $"{query.SearchMode ?? "hybrid"}|tier:{queryRoutingTier}",
+            Strategy: $"{query.SearchMode ?? "hybrid"}|tier:{queryRoutingTier}|claims:{(injectClaims ? "injected" : "none")}",
             ModelUsed: llmResult.Cost.ModelId ?? "unknown",
             LatencyMs: (int)(DateTime.UtcNow - startTime).TotalMilliseconds,
             CacheHit: false,

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamQaQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamQaQueryHandler.cs
@@ -4,6 +4,7 @@ using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 using Api.BoundedContexts.KnowledgeBase.Application.Models;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries;
 using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Application.Services.MechanicClaimInjection;
 using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services;
@@ -53,6 +54,8 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
     private readonly IIntentClassifierService _intentClassifier;
     private readonly IRagAccessService _ragAccessService;
     private readonly ICopyrightTierResolver _copyrightTierResolver;
+    private readonly IMechanicCardProvider _mechanicCardProvider;
+    private readonly IFeatureFlagService _featureFlags;
     private readonly ILogger<StreamQaQueryHandler> _logger;
     private readonly TimeProvider _timeProvider;
 
@@ -71,6 +74,8 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
         IIntentClassifierService intentClassifier,
         IRagAccessService ragAccessService,
         ICopyrightTierResolver copyrightTierResolver,
+        IMechanicCardProvider mechanicCardProvider,
+        IFeatureFlagService featureFlags,
         ILogger<StreamQaQueryHandler> logger,
         TimeProvider? timeProvider = null)
     {
@@ -88,6 +93,8 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
         _intentClassifier = intentClassifier ?? throw new ArgumentNullException(nameof(intentClassifier));
         _ragAccessService = ragAccessService ?? throw new ArgumentNullException(nameof(ragAccessService));
         _copyrightTierResolver = copyrightTierResolver ?? throw new ArgumentNullException(nameof(copyrightTierResolver));
+        _mechanicCardProvider = mechanicCardProvider ?? throw new ArgumentNullException(nameof(mechanicCardProvider));
+        _featureFlags = featureFlags ?? throw new ArgumentNullException(nameof(featureFlags));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _timeProvider = timeProvider ?? TimeProvider.System;
     }
@@ -126,9 +133,19 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
         _logger.LogInformation("Starting streaming QA for game {GameId}, query: {Query}",
             query.GameId, query.Query);
 
-        // Check cache first - if cached, return it as streaming events
+        // R1 (issue #3416, ADR-088): resolve approved mechanic-card claims to inject as authoritative
+        // context. Feature-flag gated (default off), best-effort. Computed here — above the cache and
+        // the NO_RESULTS exit — so the claim block still answers when retrieval is empty (spec §6.1).
+        var verifiedBlock = await ResolveVerifiedRulesBlockAsync(query, cancellationToken).ConfigureAwait(false);
+        var injectClaims = !verifiedBlock.IsEmpty;
+
+        // Check cache first - if cached, return it as streaming events.
+        // R1: skip the semantic cache when injecting (the (game,query) key carries no card fingerprint,
+        // so a cached no-card answer must not shadow, nor a claim answer replay after suppression — §6.2).
         var cacheKey = _cache.GenerateQaCacheKey(query.GameId, query.Query);
-        var cachedResponse = await _cache.GetAsync<QaResponse>(cacheKey, cancellationToken).ConfigureAwait(false);
+        var cachedResponse = injectClaims
+            ? null
+            : await _cache.GetAsync<QaResponse>(cacheKey, cancellationToken).ConfigureAwait(false);
 
         if (cachedResponse != null)
         {
@@ -174,7 +191,7 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
         }
 
         // Stream fresh QA response
-        await foreach (var evt in AskStreamInternalAsync(query, cancellationToken).ConfigureAwait(false))
+        await foreach (var evt in AskStreamInternalAsync(query, verifiedBlock, cancellationToken).ConfigureAwait(false))
         {
             yield return evt;
         }
@@ -182,8 +199,10 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
 
     private async IAsyncEnumerable<RagStreamingEvent> AskStreamInternalAsync(
         StreamQaQuery query,
+        VerifiedRulesBlock verifiedBlock,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
+        var injectClaims = !verifiedBlock.IsEmpty;
         var startTime = _timeProvider.GetUtcNow();
         var cacheKey = _cache.GenerateQaCacheKey(query.GameId, query.Query);
 
@@ -211,15 +230,28 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
         var (searchSuccess, snippets, domainSearchResults, searchConfidence) = await PerformSearchAndBuildCitationsAsync(
             query.GameId, query.Query, query.DocumentIds, query.UserId ?? Guid.Empty, cancellationToken).ConfigureAwait(false);
 
-        if (!searchSuccess)
+        // R1 (spec §6.1): the NO_RESULTS exit is skipped when an approved-claim block is present — the
+        // claims become the answer source in the retrieval-miss case (e.g. Catan/TM "Setup per N").
+        if (!searchSuccess && !injectClaims)
         {
             yield return CreateEvent(StreamingEventType.Error,
                 new StreamingError("No relevant information found in the rulebook.", "NO_RESULTS"));
             yield break;
         }
 
+        // Normalize retrieval outputs for the claims-only path (empty search but claims present).
+        var ragSnippets = snippets ?? new List<Snippet>();
+        var confidence = searchConfidence ?? Confidence.Zero;
+        var domainResults = domainSearchResults ?? new List<Domain.Entities.SearchResult>();
+
+        // R1 (spec §7.4): claim citations (PdfId/PdfPage + verbatim Quote) ride the same citation channel,
+        // emitted for display but NOT fed to the LLM context (the prompt uses the reformulated Claim via
+        // verifiedBlock, never the Quote — §7.2 copyright). Claim snippets carry no regions (not Full-gated).
+        var claimSnippets = injectClaims ? BuildClaimSnippets(verifiedBlock) : new List<Snippet>();
+        var allSnippets = claimSnippets.Count == 0 ? ragSnippets : ragSnippets.Concat(claimSnippets).ToList();
+
         yield return CreateEvent(StreamingEventType.Citations,
-            new StreamingCitations(snippets!));
+            new StreamingCitations(allSnippets));
 
         // Step 2: Load chat thread context if ThreadId provided
         var chatHistoryContext = await LoadChatThreadContextAsync(
@@ -230,8 +262,8 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
             new StreamingStateUpdate("Generating answer..."));
 
         var (systemPrompt, userPrompt) = await BuildLlmPromptsAsync(
-            query.GameId, query.Query, snippets!, chatHistoryContext,
-            query.ResponseStyle, query.ContinuationContext).ConfigureAwait(false);
+            query.GameId, query.Query, ragSnippets, chatHistoryContext,
+            query.ResponseStyle, query.ContinuationContext, verifiedBlock).ConfigureAwait(false);
 
         // Step 4: Stream tokens from LLM
         var answerBuilder = new StringBuilder();
@@ -272,16 +304,17 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
 
         var answer = answerBuilder.ToString().Trim();
 
-        // Step 5: Calculate quality metrics, cache response, emit completion
+        // Step 5: Calculate quality metrics, cache response, emit completion.
+        // R1: never cache a claim-injected answer (the (game,query) key carries no card fingerprint, §6.2).
         var overallConfidence = await CalculateAndCacheResponseAsync(
-            answer, snippets!, domainSearchResults!, searchConfidence ?? Confidence.Parse(0.5),
-            tokenCount, cacheKey, llmUsage, llmCost, cancellationToken).ConfigureAwait(false);
+            answer, ragSnippets, domainResults, confidence,
+            tokenCount, cacheKey, llmUsage, llmCost, injectClaims, cancellationToken).ConfigureAwait(false);
 
         yield return CreateEvent(StreamingEventType.Complete,
             new StreamingComplete(0, 0, tokenCount, tokenCount, overallConfidence.Value));
 
-        // Emit inline citation matches
-        var inlineCitations = _citationMatcher.Match(answerBuilder.ToString(), snippets!);
+        // Emit inline citation matches (over RAG + claim citations, so [Vk] claim markers can match too)
+        var inlineCitations = _citationMatcher.Match(answerBuilder.ToString(), allSnippets);
         if (inlineCitations.Count > 0)
             yield return CreateEvent(StreamingEventType.InlineCitation, new StreamingInlineCitations(inlineCitations));
 
@@ -476,10 +509,19 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
         List<Snippet> snippets,
         string chatHistoryContext,
         string? responseStyle = null,
-        string? continuationContext = null)
+        string? continuationContext = null,
+        VerifiedRulesBlock? verifiedBlock = null)
     {
         var context = string.Join("\n\n", snippets.Select(s =>
             $"[Page {s.page}] {s.text}"));
+
+        // R1 (spec §7.1/D8): approved claims rank above raw RAG context (the stream path has no house rules).
+        if (verifiedBlock is { IsEmpty: false })
+        {
+            context = context.Length > 0
+                ? $"{verifiedBlock.PromptText}\n\n{context}"
+                : verifiedBlock.PromptText;
+        }
 
         // Use PromptTemplateService for advanced prompt engineering
         var questionType = _promptTemplateService.ClassifyQuestion(queryText);
@@ -490,6 +532,15 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
 
         // Append response style instruction
         systemPrompt += PromptTemplateService.GetResponseStyleInstruction(responseStyle ?? "concise");
+
+        // R1 (spec §7.1): authorize the [Verified Rules] block as valid provided context so the grounding
+        // constraint does not reject it when the RAG context is empty.
+        if (verifiedBlock is { IsEmpty: false })
+        {
+            systemPrompt += " A section titled '[Verified Rules — human-approved]' may precede the Context; "
+                + "it is human-approved rulebook content and counts as provided context — you MAY answer "
+                + "from it and cite its [Page N].";
+        }
 
         var baseUserPrompt = _promptTemplateService.RenderUserPrompt(template, context, queryText);
 
@@ -523,6 +574,7 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
         string cacheKey,
         LlmUsage? llmUsage,
         LlmCost? llmCost,
+        bool skipCache,
         CancellationToken cancellationToken)
     {
         // ISSUE-1725: Record LLM token usage with OpenTelemetry GenAI semantic conventions
@@ -558,10 +610,46 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
             overallConfidence.Value,
             null);
 
-        await _cache.SetAsync(cacheKey, response, 86400, cancellationToken).ConfigureAwait(false);
+        // R1 (spec §6.2): claim-injected answers are never cached ((game,query) key has no card fingerprint).
+        if (!skipCache)
+        {
+            await _cache.SetAsync(cacheKey, response, 86400, cancellationToken).ConfigureAwait(false);
+        }
 
         return overallConfidence;
     }
+
+    /// <summary>
+    /// R1 (spec §6.1/§8): resolves the approved-claim block to inject for this query, gated by the
+    /// feature flag (default off) and best-effort. Returns Empty when disabled, no section matches the
+    /// intent, the game id is malformed, or no active card exists (fail-open to raw RAG).
+    /// </summary>
+    private async Task<VerifiedRulesBlock> ResolveVerifiedRulesBlockAsync(
+        StreamQaQuery query, CancellationToken cancellationToken)
+    {
+        var flagRole = Enum.TryParse<UserRole>(query.UserRole, ignoreCase: true, out var parsedRole)
+            ? parsedRole : (UserRole?)null;
+        if (!await _featureFlags.IsEnabledAsync(FeatureFlagConstants.MechanicCardInjectionKey, flagRole)
+                .ConfigureAwait(false))
+        {
+            return VerifiedRulesBlock.Empty;
+        }
+
+        var sections = MechanicSectionRouter.Route(_intentClassifier.ClassifyIntent(query.Query));
+        if (sections.Count == 0 || !Guid.TryParse(query.GameId, out var gameGuid))
+        {
+            return VerifiedRulesBlock.Empty;
+        }
+
+        var card = await _mechanicCardProvider.GetActiveCardAsync(gameGuid, cancellationToken).ConfigureAwait(false);
+        return card is null ? VerifiedRulesBlock.Empty : VerifiedRulesRenderer.Render(card, sections);
+    }
+
+    /// <summary>R1 (spec §7.4): claim citations as Snippets — verbatim Quote text, no region overlay.</summary>
+    private static List<Snippet> BuildClaimSnippets(VerifiedRulesBlock verifiedBlock) =>
+        verifiedBlock.Citations
+            .Select(vc => new Snippet(vc.Quote, $"PDF:{vc.PdfId}", vc.PdfPage, 0, 1.0f))
+            .ToList();
 
     private async Task<(bool allReady, int processing, int total)> CheckDocumentsReadyAsync(
         Guid gameId, List<Guid>? documentIds, CancellationToken ct)

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/MechanicClaimInjection/IMechanicCardProvider.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/MechanicClaimInjection/IMechanicCardProvider.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Services.MechanicClaimInjection;
+
+/// <summary>
+/// Best-effort read of the active (Published, non-suppressed) mechanic card for a game, consumed by the
+/// RAG agent to inject approved claims into the prompt (spec §6.2). Consumes ONLY the SharedGameCatalog
+/// published contract (<c>GetPublishedMechanicCardByGameQuery</c> / <see cref="PublishedMechanicCardDto"/>),
+/// never the MechanicAnalysis aggregate. Returns null on absence, suppression, or any failure — the caller
+/// falls open to raw RAG.
+/// </summary>
+internal interface IMechanicCardProvider
+{
+    Task<PublishedMechanicCardDto?> GetActiveCardAsync(Guid sharedGameId, CancellationToken cancellationToken);
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/MechanicClaimInjection/MechanicCardProvider.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/MechanicClaimInjection/MechanicCardProvider.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.MechanicExtractor;
+using Api.Services;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Services.MechanicClaimInjection;
+
+/// <summary>Cache wrapper so a "no card" result is cacheable too (<c>where T : class</c> on the cache API).</summary>
+internal sealed record MechanicCardCacheEntry(PublishedMechanicCardDto? Card);
+
+/// <summary>
+/// Read-time + cache provider for the published mechanic card (spec §6.2, D2). Wraps the SharedGameCatalog
+/// published query behind <see cref="IHybridCacheService"/> (stampede-safe) and swallows any failure so the
+/// RAG path never aborts on a cross-BC fault (fail-open, mirror of IHouseRuleMatcher).
+/// </summary>
+internal sealed class MechanicCardProvider : IMechanicCardProvider
+{
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(10);
+
+    private readonly IMediator _mediator;
+    private readonly IHybridCacheService _cache;
+    private readonly ILogger<MechanicCardProvider> _logger;
+
+    public MechanicCardProvider(IMediator mediator, IHybridCacheService cache, ILogger<MechanicCardProvider> logger)
+    {
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<PublishedMechanicCardDto?> GetActiveCardAsync(Guid sharedGameId, CancellationToken cancellationToken)
+    {
+        if (sharedGameId == Guid.Empty)
+        {
+            return null;
+        }
+
+        _logger.LogDebug("[MechanicCardProvider] Fetching active card for game {GameId}", sharedGameId);
+
+        try
+        {
+            var entry = await _cache.GetOrCreateAsync(
+                $"mechanic-card:{sharedGameId}",
+                async ct => new MechanicCardCacheEntry(
+                    await _mediator.Send(new GetPublishedMechanicCardByGameQuery(sharedGameId), ct).ConfigureAwait(false)),
+                tags: new[] { "mechanic-card", $"game:{sharedGameId}" },
+                expiration: CacheTtl,
+                ct: cancellationToken).ConfigureAwait(false);
+
+            return entry.Card;
+        }
+        catch (Exception ex)
+        {
+            // Best-effort / fail-open (spec §9, D7): a cross-BC read fault must never abort the RAG path.
+            _logger.LogWarning(ex, "[MechanicCardProvider] Best-effort read failed for game {GameId}", sharedGameId);
+            return null;
+        }
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/MechanicClaimInjection/MechanicCardProvider.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/MechanicClaimInjection/MechanicCardProvider.cs
@@ -55,7 +55,9 @@ internal sealed class MechanicCardProvider : IMechanicCardProvider
         }
         catch (Exception ex)
         {
-            // Best-effort / fail-open (spec §9, D7): a cross-BC read fault must never abort the RAG path.
+            // A genuine caller cancellation must propagate, not be swallowed as a fail-open "no card"
+            // (repo rule for best-effort catches). Only real read faults fall open below (spec §9, D7).
+            cancellationToken.ThrowIfCancellationRequested();
             _logger.LogWarning(ex, "[MechanicCardProvider] Best-effort read failed for game {GameId}", sharedGameId);
             return null;
         }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/MechanicClaimInjection/MechanicSectionRouter.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/MechanicClaimInjection/MechanicSectionRouter.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Services.MechanicClaimInjection;
+
+/// <summary>
+/// Maps a query's <see cref="GameBookRole"/> intent hint to the set of
+/// <see cref="MechanicSection"/> whose approved claims should be injected into the
+/// RAG prompt. Pure, stateless. See spec §8 (2026-07-30-mechanic-card-rag-integration).
+/// </summary>
+internal static class MechanicSectionRouter
+{
+    // Canonical read/display order — mirrors GetPublishedMechanicCardByGameQueryHandler
+    // so injected claim sections read in a stable, card-consistent sequence.
+    private static readonly MechanicSection[] CanonicalOrder =
+    {
+        MechanicSection.Summary,
+        MechanicSection.Setup,
+        MechanicSection.Components,
+        MechanicSection.Mechanics,
+        MechanicSection.Resources,
+        MechanicSection.Phases,
+        MechanicSection.Victory,
+        MechanicSection.EndgameScoring,
+        MechanicSection.Faq,
+    };
+
+    public static IReadOnlyList<MechanicSection> Route(GameBookRole role)
+    {
+        var set = new HashSet<MechanicSection>();
+
+        if (role.HasFlag(GameBookRole.Setup))
+        {
+            set.Add(MechanicSection.Setup);
+            set.Add(MechanicSection.Components);
+        }
+
+        if (role.HasFlag(GameBookRole.Tutorial))
+        {
+            set.Add(MechanicSection.Summary);
+            set.Add(MechanicSection.Setup);
+        }
+
+        if (role.HasFlag(GameBookRole.RulesReference))
+        {
+            set.Add(MechanicSection.Mechanics);
+            set.Add(MechanicSection.Phases);
+            set.Add(MechanicSection.Resources);
+        }
+
+        if (role.HasFlag(GameBookRole.Encounter))
+        {
+            set.Add(MechanicSection.Phases);
+            set.Add(MechanicSection.Mechanics);
+        }
+
+        // Narrative / Lore / None → no mechanic-section coverage (RAG-only).
+
+        if (set.Count == 0)
+        {
+            return Array.Empty<MechanicSection>();
+        }
+
+        var result = new List<MechanicSection>(set.Count);
+        foreach (var section in CanonicalOrder)
+        {
+            if (set.Contains(section))
+            {
+                result.Add(section);
+            }
+        }
+
+        return result;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/MechanicClaimInjection/VerifiedRulesRenderer.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/MechanicClaimInjection/VerifiedRulesRenderer.cs
@@ -15,6 +15,8 @@ internal sealed record VerifiedRuleCitation(int Marker, Guid PdfId, int PdfPage,
 internal sealed record VerifiedRulesBlock(string PromptText, IReadOnlyList<VerifiedRuleCitation> Citations)
 {
     public bool IsEmpty => PromptText.Length == 0;
+
+    public static VerifiedRulesBlock Empty { get; } = new(string.Empty, Array.Empty<VerifiedRuleCitation>());
 }
 
 /// <summary>
@@ -27,9 +29,6 @@ internal static class VerifiedRulesRenderer
 {
     public const string Header = "[Verified Rules — human-approved]";
 
-    private static readonly VerifiedRulesBlock Empty =
-        new(string.Empty, Array.Empty<VerifiedRuleCitation>());
-
     public static VerifiedRulesBlock Render(
         PublishedMechanicCardDto card,
         IReadOnlyList<MechanicSection> sections,
@@ -37,7 +36,7 @@ internal static class VerifiedRulesRenderer
     {
         if (card?.Sections is null || sections is null || sections.Count == 0 || maxClaimsPerSection <= 0)
         {
-            return Empty;
+            return VerifiedRulesBlock.Empty;
         }
 
         var sb = new StringBuilder();
@@ -79,6 +78,6 @@ internal static class VerifiedRulesRenderer
             }
         }
 
-        return sb.Length == 0 ? Empty : new VerifiedRulesBlock(sb.ToString(), citations);
+        return sb.Length == 0 ? VerifiedRulesBlock.Empty : new VerifiedRulesBlock(sb.ToString(), citations);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/MechanicClaimInjection/VerifiedRulesRenderer.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/MechanicClaimInjection/VerifiedRulesRenderer.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Services.MechanicClaimInjection;
+
+/// <summary>A claim-derived citation to emit on the RAG citation channel (source=claim), keyed to its
+/// inline <c>[Vk]</c> marker in the rendered block.</summary>
+internal sealed record VerifiedRuleCitation(int Marker, Guid PdfId, int PdfPage, string Quote);
+
+/// <summary>The assembled <c>[Verified Rules …]</c> prompt block plus the ordered claim citations.</summary>
+internal sealed record VerifiedRulesBlock(string PromptText, IReadOnlyList<VerifiedRuleCitation> Citations)
+{
+    public bool IsEmpty => PromptText.Length == 0;
+}
+
+/// <summary>
+/// Renders approved claims of a <see cref="PublishedMechanicCardDto"/> into the authoritative
+/// <c>[Verified Rules — human-approved]</c> prompt block (spec §7.2). Pure, stateless.
+/// Uses the reformulated <c>Claim</c> text in the body (never the verbatim <c>Quote</c>, §16 copyright);
+/// the verbatim <c>Quote</c> travels only in the structured <see cref="VerifiedRuleCitation"/>.
+/// </summary>
+internal static class VerifiedRulesRenderer
+{
+    public const string Header = "[Verified Rules — human-approved]";
+
+    private static readonly VerifiedRulesBlock Empty =
+        new(string.Empty, Array.Empty<VerifiedRuleCitation>());
+
+    public static VerifiedRulesBlock Render(
+        PublishedMechanicCardDto card,
+        IReadOnlyList<MechanicSection> sections,
+        int maxClaimsPerSection = 8)
+    {
+        if (card?.Sections is null || sections is null || sections.Count == 0 || maxClaimsPerSection <= 0)
+        {
+            return Empty;
+        }
+
+        var sb = new StringBuilder();
+        var citations = new List<VerifiedRuleCitation>();
+        var marker = 0;
+
+        foreach (var section in sections)
+        {
+            var name = section.ToString();
+            var dto = card.Sections.FirstOrDefault(s =>
+                string.Equals(s.Section, name, StringComparison.OrdinalIgnoreCase));
+            if (dto?.Claims is not { Count: > 0 })
+            {
+                continue;
+            }
+
+            if (sb.Length == 0)
+            {
+                sb.Append(Header);
+            }
+
+            sb.Append('\n').Append("## ").Append(name);
+
+            var take = Math.Min(maxClaimsPerSection, dto.Claims.Count);
+            for (var i = 0; i < take; i++)
+            {
+                var claim = dto.Claims[i];
+                marker++;
+
+                sb.Append("\n[V").Append(marker).Append("] ").Append(claim.Claim);
+                if (claim.Citations is { Count: > 0 })
+                {
+                    sb.Append(" [Page ").Append(claim.Citations[0].PdfPage).Append(']');
+                    foreach (var cite in claim.Citations)
+                    {
+                        citations.Add(new VerifiedRuleCitation(marker, cite.PdfId, cite.PdfPage, cite.Quote));
+                    }
+                }
+            }
+        }
+
+        return sb.Length == 0 ? Empty : new VerifiedRulesBlock(sb.ToString(), citations);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/DependencyInjection/KnowledgeBaseServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/DependencyInjection/KnowledgeBaseServiceExtensions.cs
@@ -507,6 +507,11 @@ internal static class KnowledgeBaseServiceExtensions
         // Agent Memory context builder — injects house rules, group preferences into RAG prompts
         services.AddScoped<IAgentMemoryContextBuilder, AgentMemoryContextBuilder>();
 
+        // R1 (issue #3416, ADR-088): read-time provider for approved mechanic-card claim injection into RAG.
+        services.AddScoped<
+            Application.Services.MechanicClaimInjection.IMechanicCardProvider,
+            Application.Services.MechanicClaimInjection.MechanicCardProvider>();
+
         // RAG Copyright KB Cards: per-chunk copyright tier resolution
         services.AddScoped<ICopyrightTierResolver, CopyrightTierResolver>();
 

--- a/apps/api/src/Api/Infrastructure/Seeders/Core/FeatureFlagSeeder.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Core/FeatureFlagSeeder.cs
@@ -44,6 +44,9 @@ internal static class FeatureFlagSeeder
         // Admin tools
         new("Features.DatabaseSync", "Enable Database Sync admin tool", false, false, false, false),
 
+        // R1 (issue #3416, ADR-088): approved mechanic-card claim injection into RAG. Default OFF (all tiers).
+        new("rag.mechanic-card-injection", "Inject approved mechanic-card claims into RAG answers", false, false, false, false),
+
         // RAG Enhancement flags
         new("rag.enhancement.adaptive-routing", "Adaptive RAG: skip retrieval for simple queries", true, false, true, true),
         new("rag.enhancement.crag-evaluation", "CRAG: evaluate retrieval quality before generation", true, false, false, true),

--- a/apps/api/src/Api/Services/FeatureFlagService.cs
+++ b/apps/api/src/Api/Services/FeatureFlagService.cs
@@ -16,6 +16,9 @@ public static class FeatureFlagConstants
 {
     public const string RagAuxModelKey = "rag.enhancement.aux-model";
 
+    // R1 (issue #3416, ADR-088): gate approved mechanic-card claim injection into RAG answers. Default off.
+    public const string MechanicCardInjectionKey = "rag.mechanic-card-injection";
+
     public static readonly string[] RagEnhancements =
     [
         "rag.enhancement.adaptive-routing",

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AskQuestionQueryHandlerSecurityTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AskQuestionQueryHandlerSecurityTests.cs
@@ -245,6 +245,8 @@ public class AskQuestionQueryHandlerSecurityTests
             // D7: use the real classifier (pure, stateless, no dependencies).
             new IntentClassifierService(),
             routingOptionsMonitor.Object,
+            Mock.Of<Api.BoundedContexts.KnowledgeBase.Application.Services.MechanicClaimInjection.IMechanicCardProvider>(),
+            Mock.Of<Api.Services.IFeatureFlagService>(),
             _mockLogger.Object);
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/StreamQaQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/StreamQaQueryHandlerTests.cs
@@ -2,8 +2,10 @@ using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
 using Api.Infrastructure.Entities;
 using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Application.Services.MechanicClaimInjection;
 using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 using Api.BoundedContexts.KnowledgeBase.Application.Commands;
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries;
 using Api.BoundedContexts.KnowledgeBase.Application.Models;
 using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
@@ -134,6 +136,8 @@ public class StreamQaQueryHandlerTests
             _intentClassifierMock.Object,
             CreatePermissiveRagAccessServiceMock(),
             _copyrightTierResolverMock.Object,
+            Mock.Of<Api.BoundedContexts.KnowledgeBase.Application.Services.MechanicClaimInjection.IMechanicCardProvider>(),
+            Mock.Of<Api.Services.IFeatureFlagService>(),
             _loggerMock.Object,
             _fakeTimeProvider
         );
@@ -1274,6 +1278,109 @@ public class StreamQaQueryHandlerTests
             "Cache should not store partial responses after errors"
         );
     }
+    // ─── R1 (issue #3416, ADR-088): MechanicCard claim injection into the streaming path ───
+
+    private static PublishedMechanicCardDto CardWithSetupClaim(Guid gameId, Guid pdfId) =>
+        new(
+            CardId: Guid.NewGuid(), SharedGameId: gameId, Title: "T", Version: 1, PublishedAt: DateTime.UtcNow,
+            GameName: "Terraforming Mars", Publisher: null, Language: "it",
+            Sections: new[]
+            {
+                new PublishedMechanicCardSectionDto("Setup", new[]
+                {
+                    new PublishedMechanicCardClaimDto(
+                        Guid.NewGuid(),
+                        "In una partita a 3 giocatori si usa la plancia standard.",
+                        new[] { new PublishedMechanicCardCitationDto(pdfId, 3, "3-player uses the standard board") }),
+                }),
+            },
+            SourceAnalysisId: Guid.NewGuid(), PublicationYear: null, DocumentName: null);
+
+    private void ForceEmptyRetrieval() =>
+        _rrfFusionServiceMock
+            .Setup(x => x.FuseResults(
+                It.IsAny<List<DomainSearchResult>>(), It.IsAny<List<DomainSearchResult>>(),
+                It.IsAny<int>(), It.IsAny<GameBookRole>(), It.IsAny<IReadOnlyList<string>?>()))
+            .Returns(new List<DomainSearchResult>());
+
+    [Fact]
+    public async Task Handle_FlagOnWithCard_InjectsVerifiedRules_WhenRetrievalEmpty()
+    {
+        var gameId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var query = new StreamQaQuery(gameId.ToString(), "Setup per 3 giocatori", ThreadId: null,
+            DocumentIds: null, ResponseStyle: null, ContinuationContext: null, UserId: userId, UserRole: "User");
+
+        SetupHappyPathMocks(gameId.ToString(), query.Query);
+        ForceEmptyRetrieval(); // the retrieval-miss case R1 targets (e.g. Catan/TM "Setup per N")
+        // This class uses a MOCKED intent classifier (unlike Phase2Tests' real one) → configure it.
+        _intentClassifierMock.Setup(x => x.ClassifyIntent(It.IsAny<string>()))
+            .Returns(GameBookRole.Tutorial | GameBookRole.Setup);
+        // SetupPromptMocks stubs RenderUserPrompt to a fixed string that DISCARDS the context; echo the
+        // context instead so the injected [Verified Rules] block (prepended to context) is observable.
+        _promptTemplateServiceMock
+            .Setup(x => x.RenderUserPrompt(It.IsAny<PromptTemplate>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Returns((PromptTemplate _, string context, string q) => $"Question: {q}\n\nContext:\n{context}");
+
+        string? capturedUserPrompt = null;
+        _llmServiceMock
+            .Setup(x => x.GenerateCompletionStreamAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, RequestSource, CancellationToken>((_, user, _, _) => capturedUserPrompt = user)
+            .Returns(StreamTokensAsync(new[] { "In", " una", " partita", " a", " 3." }));
+
+        var provider = new Mock<IMechanicCardProvider>();
+        provider.Setup(p => p.GetActiveCardAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CardWithSetupClaim(gameId, Guid.NewGuid()));
+        var flag = new Mock<IFeatureFlagService>();
+        flag.Setup(f => f.IsEnabledAsync(FeatureFlagConstants.MechanicCardInjectionKey, It.IsAny<UserRole?>()))
+            .ReturnsAsync(true);
+
+        var handler = CreateHandlerWith(CreatePermissiveRagAccessServiceMock(), provider.Object, flag.Object);
+
+        var events = new List<RagStreamingEvent>();
+        await foreach (var e in handler.Handle(query, TestContext.Current.CancellationToken))
+            events.Add(e);
+
+        // The NO_RESULTS exit was bypassed → the LLM ran, with the injected block in its prompt.
+        _llmServiceMock.Verify(
+            x => x.GenerateCompletionStreamAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        capturedUserPrompt.Should().NotBeNull();
+        capturedUserPrompt.Should().Contain("[Verified Rules — human-approved]");
+        capturedUserPrompt.Should().Contain("## Setup");
+        // Verbatim Quote must NOT be in the prompt body (copyright §7.2).
+        capturedUserPrompt.Should().NotContain("3-player uses the standard board");
+    }
+
+    [Fact]
+    public async Task Handle_FlagOff_EmitsNoResults_WhenRetrievalEmpty()
+    {
+        var gameId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var query = new StreamQaQuery(gameId.ToString(), "Setup per 3 giocatori", ThreadId: null,
+            DocumentIds: null, ResponseStyle: null, ContinuationContext: null, UserId: userId, UserRole: "User");
+
+        SetupHappyPathMocks(gameId.ToString(), query.Query);
+        ForceEmptyRetrieval();
+        _intentClassifierMock.Setup(x => x.ClassifyIntent(It.IsAny<string>()))
+            .Returns(GameBookRole.Tutorial | GameBookRole.Setup);
+
+        // A card IS available and the intent DOES map to Setup — the ONLY thing withholding injection is
+        // the disabled flag (CreateHandlerWith's default feature-flag mock returns false). Proves the gate.
+        var provider = new Mock<IMechanicCardProvider>();
+        provider.Setup(p => p.GetActiveCardAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CardWithSetupClaim(gameId, Guid.NewGuid()));
+        var handler = CreateHandlerWith(CreatePermissiveRagAccessServiceMock(), provider.Object);
+
+        var events = new List<RagStreamingEvent>();
+        await foreach (var e in handler.Handle(query, TestContext.Current.CancellationToken))
+            events.Add(e);
+
+        _llmServiceMock.Verify(
+            x => x.GenerateCompletionStreamAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
     private void SetupHappyPathMocks(string gameId, string userQuery)
     {
         _cacheMock
@@ -1491,7 +1598,10 @@ public class StreamQaQueryHandlerTests
     /// Builds a StreamQaQueryHandler reusing the shared field mocks but with a caller-supplied
     /// IRagAccessService — used by the Bug B5 access-enforcement tests.
     /// </summary>
-    private StreamQaQueryHandler CreateHandlerWith(IRagAccessService ragAccessService)
+    private StreamQaQueryHandler CreateHandlerWith(
+        IRagAccessService ragAccessService,
+        Api.BoundedContexts.KnowledgeBase.Application.Services.MechanicClaimInjection.IMechanicCardProvider? mechanicCardProvider = null,
+        Api.Services.IFeatureFlagService? featureFlags = null)
     {
         return new StreamQaQueryHandler(
             _searchQueryHandler,
@@ -1508,6 +1618,8 @@ public class StreamQaQueryHandlerTests
             _intentClassifierMock.Object,
             ragAccessService,
             _copyrightTierResolverMock.Object,
+            mechanicCardProvider ?? Mock.Of<Api.BoundedContexts.KnowledgeBase.Application.Services.MechanicClaimInjection.IMechanicCardProvider>(),
+            featureFlags ?? Mock.Of<Api.Services.IFeatureFlagService>(),
             _loggerMock.Object,
             _fakeTimeProvider);
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/AskQuestionQueryHandlerIntentRoutingTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/AskQuestionQueryHandlerIntentRoutingTests.cs
@@ -209,6 +209,8 @@ public sealed class AskQuestionQueryHandlerIntentRoutingTests
             new Mock<IGenericTranslationService>().Object,
             intentClassifier,
             routingMonitorMock.Object,
+            Mock.Of<Api.BoundedContexts.KnowledgeBase.Application.Services.MechanicClaimInjection.IMechanicCardProvider>(),
+            Mock.Of<Api.Services.IFeatureFlagService>(),
             new Mock<ILogger<AskQuestionQueryHandler>>().Object);
 
         return (handler, () => capturedRoleHint);

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/AskQuestionQueryHandlerPhase2Tests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/AskQuestionQueryHandlerPhase2Tests.cs
@@ -3,7 +3,9 @@ using Api.Infrastructure.Entities;
 using Api.Infrastructure.Translation;
 using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Application.Services.MechanicClaimInjection;
 using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries;
 using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
@@ -490,9 +492,120 @@ public class AskQuestionQueryHandlerPhase2Tests
     // Helpers
     // ─────────────────────────────────────────────────────────────────────────
 
+    // ── R1 (issue #3416, ADR-088): MechanicCard claim injection ─────────────────────────────────
+    // This class's _searchHandler is wired to always return EMPTY results, so it exercises the exact
+    // retrieval-miss case R1 targets (e.g. TM "Setup per N"): flag off → sentinel; flag on + card →
+    // the claim block is injected above the no-results early-exit and the LLM is invoked.
+
+    private const string NoContextSentinel = "This information is not available in the provided rulebook.";
+
+    private static PublishedMechanicCardDto CardWithSetupClaim(Guid gameId, Guid pdfId) => new(
+        CardId: Guid.NewGuid(),
+        SharedGameId: gameId,
+        Title: "T",
+        Version: 1,
+        PublishedAt: DateTime.UtcNow,
+        GameName: "Terraforming Mars",
+        Publisher: null,
+        Language: "it",
+        Sections: new[]
+        {
+            new PublishedMechanicCardSectionDto("Setup", new[]
+            {
+                new PublishedMechanicCardClaimDto(
+                    Guid.NewGuid(),
+                    "In una partita a 3 giocatori si usa la plancia standard.",
+                    new[] { new PublishedMechanicCardCitationDto(pdfId, 3, "3-player uses the standard board") }),
+            }),
+        },
+        SourceAnalysisId: Guid.NewGuid(),
+        PublicationYear: null,
+        DocumentName: null);
+
+    private void SetupSuccessfulLlm(out System.Collections.Generic.List<string> capturedUserPrompts)
+    {
+        var captured = new System.Collections.Generic.List<string>();
+        capturedUserPrompts = captured;
+        _mockLlmService
+            .Setup(s => s.GenerateCompletionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, RequestSource, CancellationToken>((_, user, _, _) => captured.Add(user))
+            .ReturnsAsync(LlmCompletionResult.CreateSuccess(
+                response: "In una partita a 3 si usa la plancia standard. [Page 3]",
+                usage: new LlmUsage(1, 1, 2),
+                cost: new LlmCost { InputCost = 0m, OutputCost = 0m, ModelId = "test", Provider = "test" }));
+        _mockPricingEngine
+            .Setup(p => p.ConsumeQuotaAsync(It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        // QualityTrackingDomainService is mocked in this class → its virtual confidence methods return
+        // null by default; the handler dereferences .Value on each. Return Zero for the full LLM path.
+        _mockQualityService
+            .Setup(q => q.CalculateSearchConfidence(It.IsAny<System.Collections.Generic.List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>()))
+            .Returns(Confidence.Zero);
+        _mockQualityService
+            .Setup(q => q.CalculateLlmConfidence(It.IsAny<string>(), It.IsAny<System.Collections.Generic.List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>()))
+            .Returns(Confidence.Zero);
+        _mockQualityService
+            .Setup(q => q.CalculateOverallConfidence(It.IsAny<Confidence>(), It.IsAny<Confidence>()))
+            .Returns(Confidence.Zero);
+    }
+
+    [Fact]
+    public async Task Handle_FlagOnWithCard_InjectsVerifiedRulesBlock_WhenRetrievalEmpty()
+    {
+        var gameId = Guid.NewGuid();
+        var pdfId = Guid.NewGuid();
+        SetupSuccessfulLlm(out var capturedPrompts);
+
+        var providerMock = new Mock<IMechanicCardProvider>();
+        providerMock
+            .Setup(p => p.GetActiveCardAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CardWithSetupClaim(gameId, pdfId));
+
+        var flagMock = new Mock<IFeatureFlagService>();
+        flagMock
+            .Setup(f => f.IsEnabledAsync(FeatureFlagConstants.MechanicCardInjectionKey, It.IsAny<UserRole?>()))
+            .ReturnsAsync(true);
+
+        var handler = BuildHandler(mechanicCardProvider: providerMock.Object, featureFlags: flagMock.Object);
+        var query = new AskQuestionQuery(GameId: gameId, Question: "Setup per 3 giocatori", UserId: Guid.NewGuid(), UserRole: "User");
+
+        var result = await handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Bypassed the no-results early-exit — the LLM ran and received the authoritative block.
+        result.Answer.Should().NotBe(NoContextSentinel);
+        capturedPrompts.Should().ContainSingle();
+        capturedPrompts[0].Should().Contain("[Verified Rules — human-approved]");
+        capturedPrompts[0].Should().Contain("## Setup");
+        capturedPrompts[0].Should().Contain("In una partita a 3 giocatori si usa la plancia standard.");
+        // Verbatim quote must NOT be in the prompt body (copyright rule §7.2).
+        capturedPrompts[0].Should().NotContain("3-player uses the standard board");
+        // Claim citation surfaced (PdfPage + verbatim Quote).
+        result.Citations.Should().Contain(c => c.PageNumber == 3 && c.Snippet == "3-player uses the standard board");
+    }
+
+    [Fact]
+    public async Task Handle_FlagOff_ReturnsSentinel_WhenRetrievalEmpty()
+    {
+        var gameId = Guid.NewGuid();
+        SetupSuccessfulLlm(out _);
+
+        // BuildHandler's default feature-flag mock returns false → no injection.
+        var handler = BuildHandler();
+        var query = new AskQuestionQuery(GameId: gameId, Question: "Setup per 3 giocatori", UserId: Guid.NewGuid(), UserRole: "User");
+
+        var result = await handler.Handle(query, TestContext.Current.CancellationToken);
+
+        result.Answer.Should().Be(NoContextSentinel);
+        _mockLlmService.Verify(
+            s => s.GenerateCompletionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
     private AskQuestionQueryHandler BuildHandler(
         Api.Configuration.LlmQueryComplexityRoutingOptions? routingOverrides = null,
-        IRagAccessService? ragAccessService = null) =>
+        IRagAccessService? ragAccessService = null,
+        Api.BoundedContexts.KnowledgeBase.Application.Services.MechanicClaimInjection.IMechanicCardProvider? mechanicCardProvider = null,
+        Api.Services.IFeatureFlagService? featureFlags = null) =>
         new(
             _searchHandler,
             CreatePassthroughReranker(),
@@ -514,6 +627,8 @@ public class AskQuestionQueryHandlerPhase2Tests
             // D7: use the real classifier (pure, stateless, no dependencies).
             new IntentClassifierService(),
             BuildRoutingMonitor(routingOverrides ?? new Api.Configuration.LlmQueryComplexityRoutingOptions()),
+            mechanicCardProvider ?? Mock.Of<Api.BoundedContexts.KnowledgeBase.Application.Services.MechanicClaimInjection.IMechanicCardProvider>(),
+            featureFlags ?? Mock.Of<Api.Services.IFeatureFlagService>(),
             _mockLogger.Object);
 
     private static Api.BoundedContexts.KnowledgeBase.Domain.Services.Reranking.ICrossEncoderReranker CreatePassthroughReranker()

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/MechanicClaimInjection/MechanicCardProviderTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/MechanicClaimInjection/MechanicCardProviderTests.cs
@@ -85,6 +85,21 @@ public class MechanicCardProviderTests
     }
 
     [Fact]
+    public async Task GetActiveCardAsync_PropagatesCancellation_NotSwallowedAsFailOpen()
+    {
+        // Best-effort catch must still honour caller cancellation (repo rule): a genuine cancel must
+        // NOT be logged as a failed read and converted into a fail-open "no card" result.
+        _mediator.Setup(m => m.Send(It.IsAny<GetPublishedMechanicCardByGameQuery>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        Func<Task> act = () => Build().GetActiveCardAsync(Guid.NewGuid(), cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
     public async Task GetActiveCardAsync_ReturnsNull_ForEmptyGuid_WithoutQuerying()
     {
         var result = await Build().GetActiveCardAsync(Guid.Empty, CancellationToken.None);

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/MechanicClaimInjection/MechanicCardProviderTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/MechanicClaimInjection/MechanicCardProviderTests.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Api.BoundedContexts.KnowledgeBase.Application.Services.MechanicClaimInjection;
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.MechanicExtractor;
+using Api.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Services.MechanicClaimInjection;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public class MechanicCardProviderTests
+{
+    private readonly Mock<IMediator> _mediator = new();
+    private readonly Mock<IHybridCacheService> _cache = new();
+
+    private MechanicCardProvider Build()
+    {
+        // Fake cache: always invoke the factory (no real caching) so provider logic is exercised.
+        _cache.Setup(c => c.GetOrCreateAsync(
+                It.IsAny<string>(),
+                It.IsAny<Func<CancellationToken, Task<MechanicCardCacheEntry>>>(),
+                It.IsAny<string[]?>(),
+                It.IsAny<TimeSpan?>(),
+                It.IsAny<CancellationToken>()))
+            .Returns((string _, Func<CancellationToken, Task<MechanicCardCacheEntry>> factory, string[]? _, TimeSpan? _, CancellationToken ct)
+                => factory(ct));
+        return new MechanicCardProvider(_mediator.Object, _cache.Object, NullLogger<MechanicCardProvider>.Instance);
+    }
+
+    private static PublishedMechanicCardDto SampleCard(Guid gameId) => new(
+        CardId: Guid.NewGuid(),
+        SharedGameId: gameId,
+        Title: "T",
+        Version: 1,
+        PublishedAt: DateTime.UtcNow,
+        GameName: "G",
+        Publisher: null,
+        Language: "it",
+        Sections: Array.Empty<PublishedMechanicCardSectionDto>(),
+        SourceAnalysisId: Guid.NewGuid(),
+        PublicationYear: null,
+        DocumentName: null);
+
+    [Fact]
+    public async Task GetActiveCardAsync_ReturnsCard_WhenQueryReturnsOne()
+    {
+        var gameId = Guid.NewGuid();
+        var card = SampleCard(gameId);
+        _mediator.Setup(m => m.Send(It.IsAny<GetPublishedMechanicCardByGameQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(card);
+
+        var result = await Build().GetActiveCardAsync(gameId, CancellationToken.None);
+
+        result.Should().BeSameAs(card);
+    }
+
+    [Fact]
+    public async Task GetActiveCardAsync_ReturnsNull_WhenQueryReturnsNull()
+    {
+        _mediator.Setup(m => m.Send(It.IsAny<GetPublishedMechanicCardByGameQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PublishedMechanicCardDto?)null);
+
+        var result = await Build().GetActiveCardAsync(Guid.NewGuid(), CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetActiveCardAsync_ReturnsNull_WhenMediatorThrows_BestEffort()
+    {
+        _mediator.Setup(m => m.Send(It.IsAny<GetPublishedMechanicCardByGameQuery>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("cross-BC boom"));
+
+        var result = await Build().GetActiveCardAsync(Guid.NewGuid(), CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetActiveCardAsync_ReturnsNull_ForEmptyGuid_WithoutQuerying()
+    {
+        var result = await Build().GetActiveCardAsync(Guid.Empty, CancellationToken.None);
+
+        result.Should().BeNull();
+        _mediator.Verify(
+            m => m.Send(It.IsAny<GetPublishedMechanicCardByGameQuery>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/MechanicClaimInjection/MechanicSectionRouterTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/MechanicClaimInjection/MechanicSectionRouterTests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.BoundedContexts.KnowledgeBase.Application.Services.MechanicClaimInjection;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Services.MechanicClaimInjection;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public class MechanicSectionRouterTests
+{
+    public static IEnumerable<object[]> MappingCases() => new[]
+    {
+        // single-flag mappings (spec §8)
+        new object[] { GameBookRole.Setup, new[] { MechanicSection.Setup, MechanicSection.Components } },
+        new object[] { GameBookRole.Tutorial, new[] { MechanicSection.Summary, MechanicSection.Setup } },
+        new object[] { GameBookRole.RulesReference, new[] { MechanicSection.Mechanics, MechanicSection.Phases, MechanicSection.Resources } },
+        new object[] { GameBookRole.Encounter, new[] { MechanicSection.Phases, MechanicSection.Mechanics } },
+        // roles with no mechanic-section coverage → empty (RAG-only)
+        new object[] { GameBookRole.Narrative, Array.Empty<MechanicSection>() },
+        new object[] { GameBookRole.Lore, Array.Empty<MechanicSection>() },
+        new object[] { GameBookRole.None, Array.Empty<MechanicSection>() },
+    };
+
+    [Theory]
+    [MemberData(nameof(MappingCases))]
+    public void Route_MapsRoleToExpectedSections(GameBookRole role, MechanicSection[] expected)
+    {
+        MechanicSectionRouter.Route(role).Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void Route_UnionsMultipleFlags_AndDeduplicates()
+    {
+        // Tutorial (Summary, Setup) | Setup (Setup, Components) → union deduped
+        var result = MechanicSectionRouter.Route(GameBookRole.Tutorial | GameBookRole.Setup);
+
+        result.Should().BeEquivalentTo(new[]
+        {
+            MechanicSection.Summary,
+            MechanicSection.Setup,
+            MechanicSection.Components,
+        });
+        result.Should().OnlyHaveUniqueItems();
+    }
+
+    [Fact]
+    public void Route_ReturnsSectionsInCanonicalCardDisplayOrder()
+    {
+        // Canonical order (GetPublishedMechanicCardByGameQueryHandler display order):
+        // Summary, Setup, Components, Mechanics, Resources, Phases, Victory, EndgameScoring, Faq
+        var result = MechanicSectionRouter.Route(
+            GameBookRole.Tutorial | GameBookRole.Setup | GameBookRole.RulesReference);
+
+        result.Should().ContainInOrder(
+            MechanicSection.Summary,
+            MechanicSection.Setup,
+            MechanicSection.Components,
+            MechanicSection.Mechanics,
+            MechanicSection.Resources,
+            MechanicSection.Phases);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/MechanicClaimInjection/VerifiedRulesRendererTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/MechanicClaimInjection/VerifiedRulesRendererTests.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Api.BoundedContexts.KnowledgeBase.Application.Services.MechanicClaimInjection;
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Services.MechanicClaimInjection;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public class VerifiedRulesRendererTests
+{
+    private static readonly Guid Pdf = Guid.NewGuid();
+
+    private static PublishedMechanicCardCitationDto Cite(int page, string quote) => new(Pdf, page, quote);
+
+    private static PublishedMechanicCardClaimDto Claim(string text, params PublishedMechanicCardCitationDto[] cites)
+        => new(Guid.NewGuid(), text, cites);
+
+    private static PublishedMechanicCardDto Card(params PublishedMechanicCardSectionDto[] sections)
+        => new(
+            CardId: Guid.NewGuid(),
+            SharedGameId: Guid.NewGuid(),
+            Title: "Test Card",
+            Version: 1,
+            PublishedAt: DateTime.UtcNow,
+            GameName: "Test Game",
+            Publisher: "Pub",
+            Language: "it",
+            Sections: sections,
+            SourceAnalysisId: Guid.NewGuid(),
+            PublicationYear: 2020,
+            DocumentName: "rulebook.pdf");
+
+    private static PublishedMechanicCardDto SampleCard() => Card(
+        new PublishedMechanicCardSectionDto(nameof(MechanicSection.Setup), new[]
+        {
+            Claim("I giocatori ricevono 2 carte progetto.", Cite(3, "each player draws two project cards")),
+            Claim("In una partita a 3 si usa la plancia standard.", Cite(3, "3-player uses the standard board")),
+        }),
+        new PublishedMechanicCardSectionDto(nameof(MechanicSection.Components), new[]
+        {
+            Claim("Ogni giocatore prende 40 cubi.", Cite(2, "forty cubes per player")),
+        }),
+        new PublishedMechanicCardSectionDto(nameof(MechanicSection.Victory), new[]
+        {
+            Claim("Vince chi ha piu' punti.", Cite(9, "most points wins")),
+        }));
+
+    [Fact]
+    public void Render_IncludesHeaderSectionHeadersAndNumberedClaimsForRequestedSectionsOnly()
+    {
+        var block = VerifiedRulesRenderer.Render(
+            SampleCard(),
+            new[] { MechanicSection.Setup, MechanicSection.Components });
+
+        block.PromptText.Should().StartWith(VerifiedRulesRenderer.Header);
+        block.PromptText.Should().Contain("## Setup");
+        block.PromptText.Should().Contain("## Components");
+        block.PromptText.Should().Contain("[V1]");
+        block.PromptText.Should().Contain("[V2]");
+        block.PromptText.Should().Contain("[V3]");
+        block.PromptText.Should().Contain("[Page 3]");
+        block.PromptText.Should().Contain("[Page 2]");
+        // Victory was NOT requested → excluded
+        block.PromptText.Should().NotContain("## Victory");
+    }
+
+    [Fact]
+    public void Render_UsesReformulatedClaimText_NotVerbatimQuote()
+    {
+        var block = VerifiedRulesRenderer.Render(SampleCard(), new[] { MechanicSection.Setup });
+
+        block.PromptText.Should().Contain("I giocatori ricevono 2 carte progetto.");
+        // Copyright rule (§7.2/§16): verbatim Quote must NOT appear in the prompt body.
+        block.PromptText.Should().NotContain("each player draws two project cards");
+    }
+
+    [Fact]
+    public void Render_EmitsStructuredCitationsMappedToMarkers()
+    {
+        var block = VerifiedRulesRenderer.Render(
+            SampleCard(),
+            new[] { MechanicSection.Setup, MechanicSection.Components });
+
+        block.Citations.Should().HaveCount(3); // 2 Setup + 1 Components claims, one cite each
+        block.Citations.Select(c => c.Marker).Should().Equal(1, 2, 3);
+        block.Citations.Should().OnlyContain(c => c.PdfId == Pdf);
+        block.Citations[0].Quote.Should().Be("each player draws two project cards");
+        block.Citations[0].PdfPage.Should().Be(3);
+        block.Citations[2].PdfPage.Should().Be(2);
+    }
+
+    [Fact]
+    public void Render_RespectsPerSectionCap()
+    {
+        var block = VerifiedRulesRenderer.Render(
+            SampleCard(),
+            new[] { MechanicSection.Setup },
+            maxClaimsPerSection: 1);
+
+        block.PromptText.Should().Contain("[V1]");
+        block.PromptText.Should().NotContain("[V2]");
+        block.Citations.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void Render_ReturnsEmpty_WhenNoRequestedSectionPresentInCard()
+    {
+        var block = VerifiedRulesRenderer.Render(SampleCard(), new[] { MechanicSection.Faq });
+
+        block.PromptText.Should().BeEmpty();
+        block.Citations.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Render_UsesGlobalContiguousMarkerNumberingAcrossSections()
+    {
+        var block = VerifiedRulesRenderer.Render(
+            SampleCard(),
+            new[] { MechanicSection.Setup, MechanicSection.Components });
+
+        // Setup claims → [V1],[V2]; Components claim → [V3] (contiguous across the section boundary)
+        var idxV2 = block.PromptText.IndexOf("[V2]", StringComparison.Ordinal);
+        var idxComponents = block.PromptText.IndexOf("## Components", StringComparison.Ordinal);
+        var idxV3 = block.PromptText.IndexOf("[V3]", StringComparison.Ordinal);
+        idxV2.Should().BeLessThan(idxComponents);
+        idxComponents.Should().BeLessThan(idxV3);
+    }
+}


### PR DESCRIPTION
## Cosa

Implementa **R1** dello spec di integrazione MechanicCard → agente RAG (docs PR 3415, ADR-088): i **claim approvati e pubblicati** del Mechanic Extractor vengono iniettati come contesto autorevole nelle risposte dell'agente RAG player-facing, dietro un feature flag **default off**.

Risolve il caso reale del retrieval-miss (es. "Setup per N giocatori" su Terraforming Mars / Catan): il RAG grezzo fallisce, R1 risponde dai claim Setup approvati.

## Slice (TDD)

- `MechanicSectionRouter` — mapping `GameBookRole → MechanicSection`
- `VerifiedRulesRenderer` — blocco `[Verified Rules]` + citazioni claim (usa il `Claim` riformulato, mai la `Quote` verbatim → copyright)
- `IMechanicCardProvider` — read cross-BC del contratto pubblicato + `IHybridCacheService` (stampede-safe) + fail-open
- Wiring **`AskQuestionQueryHandler`** (`/agents/qa`) e **`StreamQaQueryHandler`** (`/agents/qa/stream`, la chat player usa lo streaming): card-fetch **sopra** gli early-exit no-results/cache · blocco nel prompt (precedenza `house-rule > claim > RAG`, grounding system-prompt) · bypass response-cache quando iniettato · citazioni `source=claim` · metrica `claims:injected`
- Feature flag `rag.mechanic-card-injection` (seeder + constant, default OFF)

## Decisioni chiave

- Gate su `Published` (trust-flag `certified` deferito). Provenienza claim via marker `[Vk]` + metrica → **CitationDto condivisa intatta** (coordinamento con l'epic citation region grounding / SP-C, che possiede la shape DTO).
- Cache bypass quando iniettato (la chiave semantic/AiResponseCache non ha fingerprint card).

## Testing

~35 test (unit + handler-driven, entrambi i path). **Api.Tests KB: 2522/2523, 0 regressione.**

## Validazione E2E (dev locale, dato reale Catan)

Query "Setup per 3 giocatori" su Catan (card Published, 59 claim):
- **flag OFF**: `"This information is not available in the provided rulebook."`
- **flag ON**: setup 3-giocatori reale e citato `[Page 4]`; metrica `Hybrid|tier:Medium|claims:injected`.

## Scope

Backend only, dietro flag default-off → nessun impatto finché non abilitato. Deferito: trust-flag `certified` (producer-side), integration test Testcontainers HTTP.

Closes #3416

🤖 Generated with [Claude Code](https://claude.com/claude-code)
