### PR TITLE
release: main-dev → main-staging (RAG citation region grounding epic #3403 + catalog/docs)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs
@@ -920,7 +920,10 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
                 Heading = chunk.Heading,
                 Level = chunk.Level,
                 ParentChunkId = chunk.ParentChunkId,
-                ElementType = chunk.ElementType
+                ElementType = chunk.ElementType,
+                // SP-A (#3405): persist char offsets for citation grounding
+                CharStart = chunk.CharStart,
+                CharEnd = chunk.CharEnd
             })
             .ToList();
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs
@@ -923,7 +923,9 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
                 ElementType = chunk.ElementType,
                 // SP-A (#3405): persist char offsets for citation grounding
                 CharStart = chunk.CharStart,
-                CharEnd = chunk.CharEnd
+                CharEnd = chunk.CharEnd,
+                // SP-B (#3406): persist the normalized region for citation grounding
+                BoundingBoxesJson = ChunkBoundingBoxJson.Serialize(chunk.BBox, chunk.Page)
             })
             .ToList();
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/IndexPdfCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/IndexPdfCommandHandler.cs
@@ -579,7 +579,9 @@ internal class IndexPdfCommandHandler : ICommandHandler<IndexPdfCommand, Indexin
                 ElementType = chunk.ElementType,
                 // SP-A (#3405): persist char offsets for citation grounding
                 CharStart = chunk.CharStart,
-                CharEnd = chunk.CharEnd
+                CharEnd = chunk.CharEnd,
+                // SP-B (#3406): persist the normalized region for citation grounding
+                BoundingBoxesJson = ChunkBoundingBoxJson.Serialize(chunk.BBox, chunk.Page)
             })
             .ToList();
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/IndexPdfCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/IndexPdfCommandHandler.cs
@@ -576,7 +576,10 @@ internal class IndexPdfCommandHandler : ICommandHandler<IndexPdfCommand, Indexin
                 Heading = chunk.Heading,
                 Level = chunk.Level,
                 ParentChunkId = chunk.ParentChunkId,
-                ElementType = chunk.ElementType
+                ElementType = chunk.ElementType,
+                // SP-A (#3405): persist char offsets for citation grounding
+                CharStart = chunk.CharStart,
+                CharEnd = chunk.CharEnd
             })
             .ToList();
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/Queue/BulkReindexReadyCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/Queue/BulkReindexReadyCommand.cs
@@ -4,8 +4,8 @@ namespace Api.BoundedContexts.DocumentProcessing.Application.Commands.Queue;
 
 /// <summary>
 /// Bulk-triggers re-index of ALL <c>Ready</c> PDFs whose <c>IndexerVersion</c> differs from the
-/// target (heading-aware v1.1), by fanning out the existing <see cref="ReindexDocumentCommand"/>.
-/// SP3 RAG bulk re-index (issue #3269, epic #3266).
+/// target (coordinate-aware v1.2), by fanning out the existing <see cref="ReindexDocumentCommand"/>.
+/// SP3 RAG bulk re-index (issue #3269, epic #3266); target bumped by #3409 (SP-E, epic #3403).
 /// </summary>
 /// <param name="RequestedBy">The admin user id that triggered the bulk re-index.</param>
 /// <param name="TargetVersion">

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
@@ -665,7 +665,10 @@ internal partial class UploadPdfCommandHandler
                 Heading = chunk.Heading,
                 Level = chunk.Level,
                 ParentChunkId = chunk.ParentChunkId,
-                ElementType = chunk.ElementType
+                ElementType = chunk.ElementType,
+                // SP-A (#3405): persist char offsets for citation grounding
+                CharStart = chunk.CharStart,
+                CharEnd = chunk.CharEnd
             })
             .ToList();
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
@@ -668,7 +668,9 @@ internal partial class UploadPdfCommandHandler
                 ElementType = chunk.ElementType,
                 // SP-A (#3405): persist char offsets for citation grounding
                 CharStart = chunk.CharStart,
-                CharEnd = chunk.CharEnd
+                CharEnd = chunk.CharEnd,
+                // SP-B (#3406): persist the normalized region for citation grounding
+                BoundingBoxesJson = ChunkBoundingBoxJson.Serialize(chunk.BBox, chunk.Page)
             })
             .ToList();
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/EventHandlers/PdfDeletedEventHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/EventHandlers/PdfDeletedEventHandler.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.DocumentProcessing.Domain.Events;
 using Api.Services.Pdf;
+using Api.SharedKernel.Domain.Covers;
 using MediatR;
 using Microsoft.Extensions.Logging;
 
@@ -44,7 +45,7 @@ internal sealed class PdfDeletedEventHandler : INotificationHandler<PdfDeletedDo
         // The categorized DeleteAsync cannot be used because it runs
         // PathSecurity.ValidateIdentifier, which rejects '/' and '.'; delete via
         // the raw-key primitive instead (mirrors CoverUrlResolver's raw-key reads).
-        var rawKey = $"{notification.CoverR2Key}-preview.webp";
+        var rawKey = CoverKeyBuilder.PhysicalKeyFor(CoverKind.Pdf, notification.CoverR2Key);
         await TryDeleteRawKeyAsync(rawKey, notification.PdfDocumentId, cancellationToken).ConfigureAwait(false);
     }
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/BackfillPdfCoversJob.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/BackfillPdfCoversJob.cs
@@ -6,6 +6,7 @@ using Api.Infrastructure.Entities;
 using Api.Observability;
 using Api.Services.Pdf;
 using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Domain.Covers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -169,7 +170,8 @@ public sealed class BackfillPdfCoversJob : IJob
                         // physical R2 object "{dbKey}-preview.webp" that the resolver
                         // reconstructs. Only the preview size is uploaded (the
                         // resolver never reads the thumbnail size).
-                        var dbKey = $"covers/pdf/{pdf.Id:D}/cover";
+                        // #3384 D5-A: DB key comes from the single CoverKeyBuilder.
+                        var dbKey = CoverKeyBuilder.ForPdf(pdf.Id).DbKey;
 
                         var persistedKey = await coverUploadPipeline
                             .UploadAsync(dbKey, result.PreviewWebp!, ct)
@@ -233,7 +235,7 @@ public sealed class BackfillPdfCoversJob : IJob
             // R2 will contain an orphan preview under the deterministic key. The
             // entity ends up Failed without a CoverR2Key so cleanup can't reach it.
             // Embed the prospective physical key so operators can grep the bucket.
-            var orphanPhysicalKey = $"covers/pdf/{pdf.Id:D}/cover-preview.webp";
+            var orphanPhysicalKey = CoverKeyBuilder.ForPdf(pdf.Id).PhysicalKey;
             _logger.LogWarning(ex,
                 "BackfillPdfCoversJob: unexpected error processing PDF {PdfId}; marking Failed. " +
                 "Inspect R2 key {OrphanKey} for an orphan preview blob and clean up manually if present.",

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/PdfCoverOrphanRecoveryJob.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/PdfCoverOrphanRecoveryJob.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.Infrastructure;
 using Api.Services.Pdf;
+using Api.SharedKernel.Domain.Covers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -113,7 +114,7 @@ public sealed class PdfCoverOrphanRecoveryJob : IJob
                 // via the RAW-KEY primitive (mirrors CoverUrlResolver): CoverR2Key
                 // is a deterministic key containing '/' (e.g. "covers/pdf/{id:D}/cover"),
                 // which the categorized ExistsAsync cannot validate/resolve.
-                var previewRawKey = $"{pdf.CoverR2Key}-preview.webp";
+                var previewRawKey = CoverKeyBuilder.PhysicalKeyFor(CoverKind.Pdf, pdf.CoverR2Key!);
                 var exists = await blob.GetPresignedUrlForRawKeyAsync(previewRawKey)
                     .ConfigureAwait(false) is not null;
 
@@ -207,7 +208,7 @@ public sealed class PdfCoverOrphanRecoveryJob : IJob
             var pdf = batch[i];
             try
             {
-                var previewRawKey = $"covers/pdf/{pdf.Id:D}/cover-preview.webp";
+                var previewRawKey = CoverKeyBuilder.ForPdf(pdf.Id).PhysicalKey;
                 var orphanExists = await blob.GetPresignedUrlForRawKeyAsync(previewRawKey).ConfigureAwait(false) is not null;
                 if (orphanExists)
                 {

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/Chunking/HeadingAwareChunkAdapter.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/Chunking/HeadingAwareChunkAdapter.cs
@@ -27,6 +27,7 @@ internal static class HeadingAwareChunkAdapter
                 Level = c.Level,
                 ParentChunkId = c.ParentChunkId,
                 ElementType = c.ElementType,
+                BBox = c.BBox,  // SP-B (#3406): propagate the region to persistence
             })
             .ToList();
     }

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
@@ -444,8 +444,9 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
             pdfDoc.ProcessingState = nameof(PdfProcessingState.Ready);
             pdfDoc.ProcessedAt = _timeProvider.GetUtcNow().UtcDateTime;
             // Issue #3269 (SP3): stamp the current indexer version so a completed fresh ingest is
-            // v1.1 (heading-aware) and `IndexerVersion == null` means only true pre-versioning
-            // legacy — keeps the bulk re-index selector from redundantly re-processing fresh docs.
+            // the current pipeline version (v1.2 coordinate-aware after #3409/SP-E) and
+            // `IndexerVersion == null` means only true pre-versioning legacy — keeps the bulk
+            // re-index selector from redundantly re-processing fresh docs.
             // Null-coalescing (not overwrite): a reindex path already stamped its chosen version at
             // reset (ReindexDocumentCommandHandler), so we preserve that explicit choice here.
             pdfDoc.IndexerVersion ??= IndexerVersionRegistry.Current.Version;

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
@@ -970,7 +970,9 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
                 ElementType = chunk.ElementType,
                 // SP-A (#3405): persist char offsets for citation grounding
                 CharStart = chunk.CharStart,
-                CharEnd = chunk.CharEnd
+                CharEnd = chunk.CharEnd,
+                // SP-B (#3406): persist the normalized region for citation grounding
+                BoundingBoxesJson = ChunkBoundingBoxJson.Serialize(chunk.BBox, chunk.Page)
             })
             .ToList();
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
@@ -967,7 +967,10 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
                 Heading = chunk.Heading,
                 Level = chunk.Level,
                 ParentChunkId = chunk.ParentChunkId,
-                ElementType = chunk.ElementType
+                ElementType = chunk.ElementType,
+                // SP-A (#3405): persist char offsets for citation grounding
+                CharStart = chunk.CharStart,
+                CharEnd = chunk.CharEnd
             })
             .ToList();
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
@@ -15,6 +15,7 @@ using Api.Observability;
 using Api.Services;
 using Api.Services.Pdf;
 using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Domain.Covers;
 using Microsoft.EntityFrameworkCore;
 using System.Text.Json;
 using KbEntities = Api.BoundedContexts.KnowledgeBase.Domain.Entities;
@@ -583,7 +584,8 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
                         // physical R2 object "{dbKey}-preview.webp" that the resolver
                         // reconstructs. Only the preview size is uploaded (the
                         // resolver never reads the thumbnail size).
-                        var dbKey = $"covers/pdf/{pdfDoc.Id:D}/cover";
+                        // #3384 D5-A: DB key comes from the single CoverKeyBuilder.
+                        var dbKey = CoverKeyBuilder.ForPdf(pdfDoc.Id).DbKey;
 
                         var persistedKey = await _pdfCoverUploadPipeline
                             .UploadAsync(dbKey, result.PreviewWebp!, cancellationToken)

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Entities/PdfDocument.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Entities/PdfDocument.cs
@@ -102,6 +102,15 @@ internal sealed class PdfDocument : AggregateRoot<Guid>
     public int? CoverPageIndex { get; private set; }
     public string? CoverGenerationError { get; private set; }
 
+    /// <summary>
+    /// #3373 D1 / #3401: transient-failure retry budget counter, mirrored from
+    /// <c>PdfDocumentEntity.CoverGenerationAttempts</c>. Managed by the cover jobs
+    /// directly on the entity; carried on the aggregate purely so the repository
+    /// round-trip (<c>UpdateAsync</c> rebuilds + <c>DbSet.Update</c> the whole row)
+    /// does not silently zero it.
+    /// </summary>
+    public int CoverGenerationAttempts { get; private set; }
+
     // Issue #4219: Per-state timing tracking for metrics and ETA
     public DateTime? UploadingStartedAt { get; private set; }
     public DateTime? ExtractingStartedAt { get; private set; }
@@ -220,7 +229,8 @@ internal sealed class PdfDocument : AggregateRoot<Guid>
         string? coverR2Key = null,
         string? coverGenerationStatus = null,
         int? coverPageIndex = null,
-        string? coverGenerationError = null)
+        string? coverGenerationError = null,
+        int coverGenerationAttempts = 0)
     {
         var document = new PdfDocument
         {
@@ -294,7 +304,8 @@ internal sealed class PdfDocument : AggregateRoot<Guid>
                 ? PdfCoverGenerationStatus.Pending
                 : Enum.Parse<PdfCoverGenerationStatus>(coverGenerationStatus, ignoreCase: true),
             CoverPageIndex = coverPageIndex,
-            CoverGenerationError = coverGenerationError
+            CoverGenerationError = coverGenerationError,
+            CoverGenerationAttempts = coverGenerationAttempts
         };
 
         if (tags is { Count: > 0 })

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Services/ExtractedElement.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Services/ExtractedElement.cs
@@ -9,4 +9,16 @@ namespace Api.BoundedContexts.DocumentProcessing.Domain.Services;
 public record ExtractedElement(
     string Text,
     int PageNumber,
-    string ElementType);
+    string ElementType,
+    ElementBoundingBox? BoundingBox = null);
+
+/// <summary>
+/// Normalized bounding box of a PDF element (SP-B #3406): [0,1] fractions of the page
+/// layout, top-left origin (y grows downward), independent of strategy/DPI/zoom. Null when
+/// the extractor emitted no coordinates. Defined here in DocumentProcessing (the published
+/// extraction contract); KnowledgeBase maps it to its own BoundingBox VO — the dependency
+/// arrow is KB → DocumentProcessing, never the reverse. Optional trailing param keeps the
+/// record backward-compatible with StructuredElementsJson already persisted (member absent
+/// deserializes to null).
+/// </summary>
+public sealed record ElementBoundingBox(float X, float Y, float Width, float Height);

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/ValueObjects/IndexerVersionRegistry.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/ValueObjects/IndexerVersionRegistry.cs
@@ -36,14 +36,24 @@ internal static class IndexerVersionRegistry
         new("v1.0", "v1.0 — flat chunking pipeline", IsSelectable: true);
 
     /// <summary>
-    /// Versione corrente della pipeline. Equivale al comportamento di default quando
-    /// `reindexDocument` viene chiamato senza `IndexerVersion` esplicito.
-    /// SP3 #3269 (epic #3266): pipeline heading-aware (SP1/SP2 già deployati).
+    /// Pipeline heading-aware (pre coordinate-aware). Non più <see cref="Current"/> dopo l'epic
+    /// #3403 SP-E, ma resta nel registry per la deprecation policy (≥18 mesi) e selezionabile da `/reindex`.
+    /// SP3 #3269 (epic #3266): SP1/SP2 heading-aware.
     /// </summary>
-    public static readonly IndexerVersion Current =
+    public static readonly IndexerVersion V1_1 =
         new("v1.1", "v1.1 — heading-aware chunking", IsSelectable: true);
 
-    public static IReadOnlyList<IndexerVersion> All { get; } = [Legacy, V1_0, Current];
+    /// <summary>
+    /// Versione corrente della pipeline. Equivale al comportamento di default quando
+    /// `reindexDocument` viene chiamato senza `IndexerVersion` esplicito.
+    /// SP-E #3409 (epic #3403): pipeline coordinate-aware — l'estrazione Unstructured emette le bbox
+    /// normalizzate (SP-B) persistite in <c>bounding_boxes_json</c> per il region grounding. Un
+    /// re-extract del corpus a questa versione ri-popola le coordinate (le regions oggi sono null).
+    /// </summary>
+    public static readonly IndexerVersion Current =
+        new("v1.2", "v1.2 — coordinate-aware (region grounding)", IsSelectable: true);
+
+    public static IReadOnlyList<IndexerVersion> All { get; } = [Legacy, V1_0, V1_1, Current];
 
     /// <summary>
     /// Restituisce la lista delle versioni effettivamente invocabili da `/reindex`.

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/External/UnstructuredPdfTextExtractor.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/External/UnstructuredPdfTextExtractor.cs
@@ -292,7 +292,10 @@ internal class UnstructuredPdfTextExtractor : IPdfTextExtractor
             .Select(e => new ExtractedElement(
                 Text: e.Text!,
                 PageNumber: e.PageNumber > 0 ? e.PageNumber : 1,
-                ElementType: string.IsNullOrWhiteSpace(e.Category) ? "NarrativeText" : e.Category!))
+                ElementType: string.IsNullOrWhiteSpace(e.Category) ? "NarrativeText" : e.Category!,
+                BoundingBox: e.Bbox is null
+                    ? null
+                    : new ElementBoundingBox(e.Bbox.X, e.Bbox.Y, e.Bbox.Width, e.Bbox.Height)))
             .ToList();
 
         return mapped.Count > 0 ? mapped : null;
@@ -369,7 +372,15 @@ internal record UnstructuredChunk(
 internal record UnstructuredElement(
     [property: JsonPropertyName("text")] string? Text,
     [property: JsonPropertyName("page_number")] int PageNumber,
-    [property: JsonPropertyName("category")] string? Category);
+    [property: JsonPropertyName("category")] string? Category,
+    [property: JsonPropertyName("bbox")] UnstructuredBbox? Bbox = null);
+
+/// <summary>SP-B (#3406): normalized [0,1] bounding box emitted by the Python service.</summary>
+internal record UnstructuredBbox(
+    [property: JsonPropertyName("x")] float X,
+    [property: JsonPropertyName("y")] float Y,
+    [property: JsonPropertyName("width")] float Width,
+    [property: JsonPropertyName("height")] float Height);
 
 internal record UnstructuredMetadata(
     [property: JsonPropertyName("extraction_duration_ms")] int? ExtractionDurationMs,

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Persistence/PdfDocumentRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Persistence/PdfDocumentRepository.cs
@@ -259,7 +259,14 @@ internal class PdfDocumentRepository : RepositoryBase, IPdfDocumentRepository
             title: entity.Title, // Issue #1687
             tags: entity.Tags, // Issue #1687
             updatedAt: entity.UpdatedAt, // Issue #1687
-            updatedBy: entity.UpdatedBy // Issue #1687
+            updatedBy: entity.UpdatedBy, // Issue #1687
+            // Issue #3401: cover state round-trip — without these the read path defaults
+            // cover fields (null / Pending) and UpdateAsync then zeroes the DB row.
+            coverR2Key: entity.CoverR2Key,
+            coverGenerationStatus: entity.CoverGenerationStatus,
+            coverPageIndex: entity.CoverPageIndex,
+            coverGenerationError: entity.CoverGenerationError,
+            coverGenerationAttempts: entity.CoverGenerationAttempts
         );
     }
 
@@ -307,7 +314,15 @@ internal class PdfDocumentRepository : RepositoryBase, IPdfDocumentRepository
             Title = domain.Title, // Issue #1687
             Tags = domain.Tags.ToList(), // Issue #1687
             UpdatedAt = domain.UpdatedAt, // Issue #1687
-            UpdatedBy = domain.UpdatedBy // Issue #1687
+            UpdatedBy = domain.UpdatedBy, // Issue #1687
+            // Issue #3401: cover state round-trip. UpdateAsync rebuilds the entity and
+            // calls DbSet.Update (all columns modified), so omitting these silently
+            // zeroed the persisted cover key/status/attempts (broke MaterializePdfCover).
+            CoverR2Key = domain.CoverR2Key,
+            CoverGenerationStatus = domain.CoverGenerationStatus.ToString(),
+            CoverPageIndex = domain.CoverPageIndex,
+            CoverGenerationError = domain.CoverGenerationError,
+            CoverGenerationAttempts = domain.CoverGenerationAttempts
         };
     }
 }

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/PdfCoverUploadPipeline.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/PdfCoverUploadPipeline.cs
@@ -2,6 +2,7 @@ using Amazon.S3;
 using Amazon.S3.Model;
 using Api.BoundedContexts.DocumentProcessing.Application.Services;
 using Api.Services.Pdf;
+using Api.SharedKernel.Domain.Covers;
 using Microsoft.Extensions.Logging;
 
 namespace Api.BoundedContexts.DocumentProcessing.Infrastructure.Services;
@@ -45,10 +46,9 @@ internal sealed class PdfCoverUploadPipeline : IPdfCoverUploadPipeline
             throw new ArgumentException("WebP bytes must be non-null and non-empty.", nameof(webpBytes));
         }
 
-        // The resolver (CoverUrlResolver.ResolvePublicAsync) appends -preview.webp
-        // to the DB-stored key to derive the physical R2 object — this is the
-        // write side of that convention.
-        var objectKey = $"{dbKey}-preview.webp";
+        // #3384 D5-A: the single CoverKeyBuilder owns the "-preview.webp" suffix, so
+        // this write key and CoverUrlResolver's read key coincide by construction.
+        var objectKey = CoverKeyBuilder.PhysicalKeyFor(CoverKind.Pdf, dbKey);
 
         using var stream = new MemoryStream(webpBytes, writable: false);
         var request = new PutObjectRequest

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentCommandHandler.cs
@@ -650,7 +650,12 @@ internal sealed class ChatWithSessionAgentCommandHandler : IStreamingQueryHandle
             c.CopyrightTier == CopyrightTier.Full ? c.SnippetPreview : null,
             c.CopyrightTier.ToString().ToLowerInvariant(),
             c.ParaphrasedSnippet,
-            c.IsPublic)).ToList();
+            c.IsPublic,
+            // SP-C (#3407): region overlay + char offsets are Full-gated (same rule as SnippetPreview) —
+            // parsed from the raw bbox JSON only for Full-tier citations (DA-4: no verbatim highlight leak).
+            Regions: c.CopyrightTier == CopyrightTier.Full ? CitationRegion.Parse(c.BoundingBoxesJson) : null,
+            CharStart: c.CopyrightTier == CopyrightTier.Full ? c.CharStart : null,
+            CharEnd: c.CopyrightTier == CopyrightTier.Full ? c.CharEnd : null)).ToList();
 
         // SP5-b T2: record citations-per-answer ONCE, post-stream, using citationDtos.Count
         // (the broadcast-authoritative list — NOT the earlier assembled.Citations or resolvedCitations).

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/SearchResultDto.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/SearchResultDto.cs
@@ -12,7 +12,12 @@ internal record SearchResultDto(
     int PageNumber,
     double RelevanceScore,
     int Rank,
-    string? SearchMethod
+    string? SearchMethod,
+    // SP-C (#3407): region-grounding carriers (primitives, no layer dep). Null for the keyword arm /
+    // pre-coordinate corpus. Parsed to CitationRegion + Full-gated at the StreamQa handler boundary.
+    string? BoundingBoxesJson = null,
+    int? CharStart = null,
+    int? CharEnd = null
 )
 {
     /// <summary>
@@ -28,7 +33,10 @@ internal record SearchResultDto(
             PageNumber: searchResult.PageNumber,
             RelevanceScore: searchResult.RelevanceScore.Value,
             Rank: searchResult.Rank,
-            SearchMethod: searchResult.SearchMethod
+            SearchMethod: searchResult.SearchMethod,
+            BoundingBoxesJson: searchResult.BoundingBoxesJson,
+            CharStart: searchResult.CharStart,
+            CharEnd: searchResult.CharEnd
         );
     }
 };

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Models/AssembledPrompt.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Models/AssembledPrompt.cs
@@ -51,4 +51,23 @@ internal sealed record ChunkCitation(
     /// best-effort no-op.
     /// </summary>
     public int? ChunkIndex { get; init; }
+
+    /// <summary>
+    /// SP-C (#3407): raw bounding-box JSON of the cited chunk (<c>text_chunks.bounding_boxes_json</c>),
+    /// carried from the vector arm. <see cref="JsonIgnoreAttribute"/> like <see cref="FullText"/>:
+    /// transient per-request retrieval metadata that MUST NOT persist in <c>CitationsJson</c>. Raw bbox
+    /// is verbatim-equivalent (highlights the exact cited text), so persisting it ungated would leak on
+    /// history reload for Protected content (DA-4). The live path parses + Full-gates it into
+    /// <c>CitationDto.Regions</c> at the handler boundary; reloaded citations fall back to the text-quote
+    /// highlight (SP0 Pattern A).
+    /// </summary>
+    [JsonIgnore]
+    public string? BoundingBoxesJson { get; init; }
+
+    /// <summary>SP-C (#3407): chunk char offsets in the source PDF text. Transient ([JsonIgnore]) — see <see cref="BoundingBoxesJson"/>.</summary>
+    [JsonIgnore]
+    public int? CharStart { get; init; }
+
+    [JsonIgnore]
+    public int? CharEnd { get; init; }
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchQueryHandler.cs
@@ -120,7 +120,10 @@ internal class SearchQueryHandler : IQueryHandler<SearchQuery, List<SearchResult
             PageNumber: sr.PageNumber,
             RelevanceScore: sr.RelevanceScore.Value,
             Rank: sr.Rank,
-            SearchMethod: sr.SearchMethod
+            SearchMethod: sr.SearchMethod,
+            BoundingBoxesJson: sr.BoundingBoxesJson,   // SP-C (#3407)
+            CharStart: sr.CharStart,
+            CharEnd: sr.CharEnd
         )).ToList();
 
         _logger.LogInformation(
@@ -167,7 +170,10 @@ internal class SearchQueryHandler : IQueryHandler<SearchQuery, List<SearchResult
                 pdfDocumentId: scored.Embedding.PdfDocumentId,                       // real (JOIN-resolved)
                 chunkIndex: scored.Embedding.ChunkIndex,
                 roleTags: (GameBookRole)scored.Embedding.RoleTags,                   // int → enum
-                heading: scored.Embedding.Heading                                     // #3270
+                heading: scored.Embedding.Heading,                                    // #3270
+                boundingBoxesJson: scored.Embedding.BoundingBoxesJson,               // SP-C (#3407)
+                charStart: scored.Embedding.CharStart,
+                charEnd: scored.Embedding.CharEnd
             );
         }).ToList();
 

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamQaQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamQaQueryHandler.cs
@@ -1,8 +1,10 @@
 using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.BoundedContexts.KnowledgeBase.Application.Models;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries;
 using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services.Reranking;
@@ -50,6 +52,7 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
     private readonly InlineCitationMatcherService _citationMatcher;
     private readonly IIntentClassifierService _intentClassifier;
     private readonly IRagAccessService _ragAccessService;
+    private readonly ICopyrightTierResolver _copyrightTierResolver;
     private readonly ILogger<StreamQaQueryHandler> _logger;
     private readonly TimeProvider _timeProvider;
 
@@ -67,6 +70,7 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
         InlineCitationMatcherService citationMatcher,
         IIntentClassifierService intentClassifier,
         IRagAccessService ragAccessService,
+        ICopyrightTierResolver copyrightTierResolver,
         ILogger<StreamQaQueryHandler> logger,
         TimeProvider? timeProvider = null)
     {
@@ -83,6 +87,7 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
         _citationMatcher = citationMatcher ?? throw new ArgumentNullException(nameof(citationMatcher));
         _intentClassifier = intentClassifier ?? throw new ArgumentNullException(nameof(intentClassifier));
         _ragAccessService = ragAccessService ?? throw new ArgumentNullException(nameof(ragAccessService));
+        _copyrightTierResolver = copyrightTierResolver ?? throw new ArgumentNullException(nameof(copyrightTierResolver));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _timeProvider = timeProvider ?? TimeProvider.System;
     }
@@ -133,9 +138,13 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
             yield return CreateEvent(StreamingEventType.StateUpdate,
                 new StreamingStateUpdate("Retrieved from cache"));
 
-            // Emit citations
+            // Emit citations — SP-C (#3407): STRIP regions/char offsets from cache-served snippets.
+            // The QA cache key is (game, query) only, NOT user/tier (AiResponseCacheService), so a
+            // Full-tier user's cached Full-gated regions must NOT be replayed to a later Protected-tier
+            // user (DA-4). Regions are transient per-request data; fresh, correctly-gated regions are
+            // emitted only on a cache MISS. Cache hits gracefully fall back to the text-quote highlight.
             yield return CreateEvent(StreamingEventType.Citations,
-                new StreamingCitations(cachedResponse.snippets));
+                new StreamingCitations(StripRegions(cachedResponse.snippets)));
 
             // Emit answer as tokens (simulate streaming for consistency)
             var words = cachedResponse.answer.Split(' ', StringSplitOptions.RemoveEmptyEntries);
@@ -200,7 +209,7 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
             new StreamingStateUpdate("Searching knowledge base..."));
 
         var (searchSuccess, snippets, domainSearchResults, searchConfidence) = await PerformSearchAndBuildCitationsAsync(
-            query.GameId, query.Query, query.DocumentIds, cancellationToken).ConfigureAwait(false);
+            query.GameId, query.Query, query.DocumentIds, query.UserId ?? Guid.Empty, cancellationToken).ConfigureAwait(false);
 
         if (!searchSuccess)
         {
@@ -301,6 +310,7 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
         string gameId,
         string queryText,
         IReadOnlyList<Guid>? documentIds,
+        Guid userId,
         CancellationToken cancellationToken)
     {
         // Issue #3270 (Task 7): classify user intent into GameBookRole tag(s) so the hybrid
@@ -358,7 +368,11 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
             .GetByGameIdAsync(Guid.Parse(gameId), cancellationToken).ConfigureAwait(false);
         var pdfIdByVectorId = vectorDocs.ToDictionary(v => v.Id, v => v.PdfDocumentId);
 
-        var snippets = searchResults.Select(r =>
+        // SP-C (#3407): resolve the copyright tier per citation and gate BOTH the verbatim excerpt and
+        // the region overlay to Full — StreamQa previously emitted verbatim text with NO gate (a leak,
+        // #447/DA-4). The resolver keys on ChunkCitation.DocumentId = the resolved pdf id string (NOT
+        // the vector id, NOT the "PDF:"-prefixed source), matching the session-agent chain.
+        var rawCitations = searchResults.Select(r =>
         {
             // Fall back to the vector id if resolution fails (keeps a stable source string).
             var citationDocId =
@@ -366,16 +380,56 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
                 && pdfIdByVectorId.TryGetValue(vecId, out var pdfId)
                     ? pdfId.ToString()
                     : r.VectorDocumentId;
+            return new ChunkCitation(
+                DocumentId: citationDocId,
+                PageNumber: r.PageNumber,
+                RelevanceScore: (float)r.RelevanceScore,
+                SnippetPreview: r.TextContent)
+            {
+                BoundingBoxesJson = r.BoundingBoxesJson,
+                CharStart = r.CharStart,
+                CharEnd = r.CharEnd,
+            };
+        }).ToList();
+
+        var resolvedCitations = await _copyrightTierResolver
+            .ResolveAsync(rawCitations, userId, cancellationToken).ConfigureAwait(false);
+
+        var snippets = resolvedCitations.Select(c =>
+        {
+            var isFull = c.CopyrightTier == CopyrightTier.Full;
             return new Snippet(
-                r.TextContent,
-                $"PDF:{citationDocId}",
-                r.PageNumber,
+                // Verbatim text is preserved for ALL tiers on purpose: this SAME snippets list grounds
+                // the LLM prompt (BuildLlmPromptsAsync) and feeds the inline-citation matcher, so
+                // redacting it here would starve the model of retrieved context. Only the NEW SP-C
+                // region-grounding surface is Full-gated. (The pre-existing verbatim-text-to-FE
+                // behavior is intentionally unchanged; closing that #447 gap needs a separate
+                // LLM-prompt/FE-citation source split — out of SP-C scope.)
+                c.SnippetPreview,
+                $"PDF:{c.DocumentId}",
+                c.PageNumber,
                 0,
-                (float)r.RelevanceScore);
+                c.RelevanceScore)
+            {
+                // Region overlay + char offsets are Full-gated: drawing the verbatim region on a
+                // Protected doc would leak (DA-4). Null → key omitted (additive-only wire, D-4).
+                regions = isFull ? CitationRegion.Parse(c.BoundingBoxesJson) : null,
+                charStart = isFull ? c.CharStart : null,
+                charEnd = isFull ? c.CharEnd : null,
+            };
         }).ToList();
 
         return (true, snippets, domainSearchResults, searchConfidence);
     }
+
+    /// <summary>
+    /// SP-C (#3407): returns a copy of <paramref name="snippets"/> with the Full-gated region-grounding
+    /// fields (regions/charStart/charEnd) removed. Used on the cache-hit path because the QA cache is
+    /// keyed only by (game, query) — not by user/tier — so cached regions must never be replayed across
+    /// tiers (DA-4). Verbatim text is left intact (its cross-tier caching is pre-existing behavior).
+    /// </summary>
+    private static IReadOnlyList<Snippet> StripRegions(IReadOnlyList<Snippet> snippets) =>
+        snippets.Select(s => s with { regions = null, charStart = null, charEnd = null }).ToList();
 
     /// <summary>
     /// Loads chat thread context if ThreadId provided.
@@ -490,10 +544,14 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
             searchConfidence,
             llmConfidence);
 
-        // Build and cache response
+        // Build and cache response — SP-C (#3407): NEVER cache the Full-gated regions/char offsets.
+        // The cache key is (game, query) only (not user/tier), so caching gated data risks a
+        // cross-tier replay leak (DA-4). Fresh, correctly-gated regions are emitted per-request on a
+        // cache MISS; cache hits fall back to the text-quote highlight. (StripRegions on the read path
+        // stays as defense-in-depth for any entry cached before this line shipped.)
         var response = new QaResponse(
             answer,
-            snippets,
+            StripRegions(snippets),
             0,
             tokenCount,
             tokenCount,

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/AdvancedChunkingService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/AdvancedChunkingService.cs
@@ -121,6 +121,7 @@ internal sealed class AdvancedChunkingService : IAdvancedChunkingService
                 section.Page,
                 section.Heading,
                 section.CharStart,
+                section.BBox,
                 config);
 
             // Link children to parent
@@ -199,7 +200,8 @@ internal sealed class AdvancedChunkingService : IAdvancedChunkingService
                     parentMetadata.Page,
                     heading: null,
                     parentMetadata.CharStart,
-                    config);
+                    baseBBox: null,
+                    config: config);
 
                 foreach (var child in childChunks)
                 {
@@ -226,6 +228,7 @@ internal sealed class AdvancedChunkingService : IAdvancedChunkingService
         int basePage,
         string? heading,
         int baseCharStart,
+        BoundingBox? baseBBox,
         ChunkingConfiguration config)
     {
         var childChunks = new List<HierarchicalChunk>();
@@ -246,7 +249,8 @@ internal sealed class AdvancedChunkingService : IAdvancedChunkingService
                 GameId = gameId,
                 DocumentId = documentId,
                 CharStart = baseCharStart + textChunk.CharStart,
-                CharEnd = baseCharStart + textChunk.CharEnd
+                CharEnd = baseCharStart + textChunk.CharEnd,
+                BBox = baseBBox  // SP-B (#3406): children inherit the parent section's region
             };
 
             var childChunk = HierarchicalChunk.CreateChild(

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/EmbeddedTitleSplitter.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/EmbeddedTitleSplitter.cs
@@ -72,7 +72,7 @@ internal static class EmbeddedTitleSplitter
                 {
                     result.Add(el with { Text = head });
                 }
-                result.Add(new ExtractedElement(token, el.PageNumber, TitleCategory));
+                result.Add(new ExtractedElement(token, el.PageNumber, TitleCategory, el.BoundingBox));
                 if (tail.Length > 0)
                 {
                     result.Add(el with { Text = tail });

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/ExtractedDocumentFactory.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/ExtractedDocumentFactory.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.DocumentProcessing.Domain.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.Chunking;
 
 namespace Api.BoundedContexts.KnowledgeBase.Application.Services.Chunking;
 
@@ -48,6 +49,7 @@ internal static class ExtractedDocumentFactory
                 ElementType = NormalizeElementType(group.Elements[0].ElementType),
                 CharStart = sectionStart,
                 CharEnd = sectionEnd,
+                BBox = ComputeSectionBBox(group.Elements),
             });
 
             // Inter-section separator: lands in the GAP between this section's CharEnd and the
@@ -127,4 +129,33 @@ internal static class ExtractedDocumentFactory
         "ListItem" => "list",
         _ => "text",
     };
+
+    /// <summary>
+    /// SP-B (#3406): the section's region = union (min/max) of its elements' normalized boxes on the
+    /// section start page. Elements without coordinates — or on later pages of a multi-page section —
+    /// are skipped; returns null when none carry a box. Single box per section (MVP): multi-page
+    /// sections are anchored to the start page. Maps the DocumentProcessing ElementBoundingBox to the
+    /// KnowledgeBase BoundingBox VO (dependency arrow KB → DocumentProcessing).
+    /// </summary>
+    private static BoundingBox? ComputeSectionBBox(IReadOnlyList<ExtractedElement> elements)
+    {
+        var startPage = elements[0].PageNumber;
+        float minX = float.MaxValue, minY = float.MaxValue, maxX = float.MinValue, maxY = float.MinValue;
+        var found = false;
+        foreach (var el in elements)
+        {
+            if (el.PageNumber != startPage || el.BoundingBox is null)
+            {
+                continue;
+            }
+            var b = el.BoundingBox;
+            found = true;
+            if (b.X < minX) minX = b.X;
+            if (b.Y < minY) minY = b.Y;
+            if (b.X + b.Width > maxX) maxX = b.X + b.Width;
+            if (b.Y + b.Height > maxY) maxY = b.Y + b.Height;
+        }
+
+        return found ? BoundingBox.FromCoordinates(minX, minY, maxX - minX, maxY - minY) : null;
+    }
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/HierarchicalChunkMapper.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/HierarchicalChunkMapper.cs
@@ -40,6 +40,7 @@ internal static class HierarchicalChunkMapper
                 Page = chunk.Metadata.Page,
                 CharStart = chunk.Metadata.CharStart,
                 CharEnd = chunk.Metadata.CharEnd,
+                BBox = chunk.Metadata.BBox,  // SP-B (#3406): carry the region to the sink
                 Embedding = Array.Empty<float>()
             });
         }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyService.cs
@@ -285,7 +285,11 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
                         Text = scored.Embedding.TextContent,
                         PdfId = scored.Embedding.VectorDocumentId.ToString(),
                         Page = scored.Embedding.PageNumber,
-                        ChunkIndex = scored.Embedding.ChunkIndex
+                        ChunkIndex = scored.Embedding.ChunkIndex,
+                        // SP-C (#3407): carry region-grounding primitives from the vector arm.
+                        BoundingBoxesJson = scored.Embedding.BoundingBoxesJson,
+                        CharStart = scored.Embedding.CharStart,
+                        CharEnd = scored.Embedding.CharEnd,
                     });
                 }
             }
@@ -354,7 +358,19 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
                         filteredChunks = filteredChunks
                             .Concat(expandedChunks)
                             .GroupBy(c => $"{c.PdfId}:{c.ChunkIndex}", StringComparer.Ordinal)
-                            .Select(g => g.OrderByDescending(c => c.Score).First())
+                            .Select(g =>
+                            {
+                                var best = g.OrderByDescending(c => c.Score).First();
+                                // SP-C (#3407): this GroupBy is a DROP SITE (mirrors the hybrid-fusion
+                                // merge). The expanded arm is FTS-only (no bbox); coalesce the region
+                                // carriers across the group so the original vector chunk's bbox survives.
+                                return best with
+                                {
+                                    BoundingBoxesJson = g.Select(c => c.BoundingBoxesJson).FirstOrDefault(b => b != null),
+                                    CharStart = g.Select(c => c.CharStart).FirstOrDefault(v => v != null),
+                                    CharEnd = g.Select(c => c.CharEnd).FirstOrDefault(v => v != null),
+                                };
+                            })
                             .OrderByDescending(c => c.Score)
                             .Take(profile.TopK * 2)
                             .ToList();
@@ -444,6 +460,11 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
                 {
                     FullText = chunk.Text,  // #447: preserve full text for copyright leak guard
                     ChunkIndex = chunk.ChunkIndex,
+                    // SP-C (#3407): raw region carriers (transient, [JsonIgnore]) — parsed + Full-gated
+                    // into CitationDto.Regions at the handler boundary.
+                    BoundingBoxesJson = chunk.BoundingBoxesJson,
+                    CharStart = chunk.CharStart,
+                    CharEnd = chunk.CharEnd,
                 };
 
                 citations.Add(citation);
@@ -610,7 +631,13 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
                         Text = best.Text,
                         PdfId = best.PdfId,
                         Page = best.Page,
-                        ChunkIndex = best.ChunkIndex
+                        ChunkIndex = best.ChunkIndex,
+                        // SP-C (#3407): this GroupBy rebuild is a DROP SITE. Coalesce the region
+                        // carriers across the group (the vector arm has them; the FTS arm never
+                        // does) so bbox survives even when the FTS copy wins `best` on score.
+                        BoundingBoxesJson = g.Select(c => c.BoundingBoxesJson).FirstOrDefault(b => b != null),
+                        CharStart = g.Select(c => c.CharStart).FirstOrDefault(v => v != null),
+                        CharEnd = g.Select(c => c.CharEnd).FirstOrDefault(v => v != null),
                     };
                 })
                 .ToList();

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/Embedding.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/Embedding.cs
@@ -46,6 +46,20 @@ internal sealed class Embedding : Entity<Guid>
     public string? Heading { get; private set; }
 
     /// <summary>
+    /// SP-C (#3407): raw bounding-box JSON (<c>text_chunks.bounding_boxes_json</c>) resolved via the
+    /// same <c>source_chunk_id</c> JOIN as <see cref="Heading"/>. Carried as a primitive string (no
+    /// layer dep) — parsed to <c>CitationRegion</c> and Full-gated only at the API handler boundary.
+    /// Null for the pre-coordinate corpus / non-Unstructured branch / reads that don't project it.
+    /// </summary>
+    public string? BoundingBoxesJson { get; private set; }
+
+    /// <summary>SP-C (#3407): char offset (inclusive) of the chunk in the source PDF text (<c>text_chunks.char_start</c>). Null when unavailable.</summary>
+    public int? CharStart { get; private set; }
+
+    /// <summary>SP-C (#3407): char offset (exclusive) of the chunk in the source PDF text (<c>text_chunks.char_end</c>). Null when unavailable.</summary>
+    public int? CharEnd { get; private set; }
+
+    /// <summary>
     /// Private constructor for EF Core.
     /// </summary>
 #pragma warning disable CS8618
@@ -70,7 +84,10 @@ internal sealed class Embedding : Entity<Guid>
         bool isTranslation = false,
         int roleTags = 0,
         Guid pdfDocumentId = default,
-        string? heading = null) : base(id)
+        string? heading = null,
+        string? boundingBoxesJson = null,
+        int? charStart = null,
+        int? charEnd = null) : base(id)
     {
         if (string.IsNullOrWhiteSpace(textContent))
             throw new ArgumentException("Text content cannot be empty", nameof(textContent));
@@ -97,6 +114,9 @@ internal sealed class Embedding : Entity<Guid>
         RoleTags = roleTags;
         PdfDocumentId = pdfDocumentId;
         Heading = heading;
+        BoundingBoxesJson = boundingBoxesJson;
+        CharStart = charStart;
+        CharEnd = charEnd;
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/SearchResult.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/SearchResult.cs
@@ -24,6 +24,14 @@ internal sealed class SearchResult : Entity<Guid>
     public string? Heading { get; private set; }
 
     /// <summary>
+    /// SP-C (#3407): raw bounding-box JSON + char offsets carried from the vector arm to the citation
+    /// surface (parsed + Full-gated at the API boundary). Null for the keyword arm / pre-coordinate corpus.
+    /// </summary>
+    public string? BoundingBoxesJson { get; private set; }
+    public int? CharStart { get; private set; }
+    public int? CharEnd { get; private set; }
+
+    /// <summary>
     /// Private constructor for EF Core.
     /// </summary>
 #pragma warning disable CS8618
@@ -46,7 +54,10 @@ internal sealed class SearchResult : Entity<Guid>
         Guid pdfDocumentId = default,
         int chunkIndex = 0,
         GameBookRole roleTags = GameBookRole.None,
-        string? heading = null) : base(id)
+        string? heading = null,
+        string? boundingBoxesJson = null,
+        int? charStart = null,
+        int? charEnd = null) : base(id)
     {
         if (string.IsNullOrWhiteSpace(textContent))
             throw new ArgumentException("Text content cannot be empty", nameof(textContent));
@@ -67,6 +78,9 @@ internal sealed class SearchResult : Entity<Guid>
         ChunkIndex = chunkIndex;
         RoleTags = roleTags;
         Heading = heading;
+        BoundingBoxesJson = boundingBoxesJson;
+        CharStart = charStart;
+        CharEnd = charEnd;
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/RrfFusionDomainService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/RrfFusionDomainService.cs
@@ -69,7 +69,12 @@ internal class RrfFusionDomainService
                     pdfDocumentId: original.PdfDocumentId,
                     chunkIndex: original.ChunkIndex,
                     roleTags: f.RoleTags,
-                    heading: f.Heading);
+                    heading: f.Heading,
+                    // SP-C (#3407): carry the region-grounding primitives from the (vector-preferred)
+                    // original, else the fused result drops the bbox/char offsets before the citation.
+                    boundingBoxesJson: original.BoundingBoxesJson,
+                    charStart: original.CharStart,
+                    charEnd: original.CharEnd);
             })
             .ToList();
     }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/PgVectorStoreAdapter.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/PgVectorStoreAdapter.cs
@@ -142,11 +142,15 @@ internal sealed class PgVectorStoreAdapter : IVectorStoreAdapter
         // heading-match boost — LEFT (not INNER) so a pre-SP2 embedding with a null source_chunk_id
         // still returns its row with heading=null instead of being dropped. text_chunks."Id" is the
         // PK, so the join is 1:0-or-1 (no row fan-out).
+        // SP-C (#3407): reuse the SAME LEFT JOIN to carry the chunk's char offsets and normalized
+        // bounding boxes (columns 10/11/12) for citation region grounding. NOTE these are snake_case
+        // columns (HasColumnName) → UNQUOTED, unlike the default-PascalCase tc."Heading".
         var sql = $"""
             SELECT e.id, e.vector_document_id, e.text_content, e.model, e.chunk_index, e.page_number, e.role_tags,
                    vd."PdfDocumentId",
                    1 - (e.vector <=> @queryVector) AS similarity,
-                   tc."Heading"
+                   tc."Heading",
+                   tc.char_start, tc.char_end, tc.bounding_boxes_json
             FROM {TableName} e
             JOIN vector_documents vd ON vd."Id" = e.vector_document_id
             LEFT JOIN text_chunks tc ON tc."Id" = e.source_chunk_id
@@ -202,6 +206,18 @@ internal sealed class PgVectorStoreAdapter : IVectorStoreAdapter
                     var heading = await reader.IsDBNullAsync(9, cancellationToken).ConfigureAwait(false)
                         ? null
                         : reader.GetString(9);
+                    // SP-C (#3407) Columns 10/11/12: chunk char offsets + normalized bounding boxes
+                    // via the same LEFT JOIN (all nullable — null for the pre-coordinate corpus or a
+                    // null source_chunk_id). bounding_boxes_json is jsonb → read as string.
+                    var charStart = await reader.IsDBNullAsync(10, cancellationToken).ConfigureAwait(false)
+                        ? (int?)null
+                        : reader.GetInt32(10);
+                    var charEnd = await reader.IsDBNullAsync(11, cancellationToken).ConfigureAwait(false)
+                        ? (int?)null
+                        : reader.GetInt32(11);
+                    var boundingBoxesJson = await reader.IsDBNullAsync(12, cancellationToken).ConfigureAwait(false)
+                        ? null
+                        : reader.GetString(12);
 
                     var placeholderVector = DomainVector.CreatePlaceholder(queryVector.Dimensions);
                     var embedding = new Embedding(
@@ -214,7 +230,10 @@ internal sealed class PgVectorStoreAdapter : IVectorStoreAdapter
                         pageNumber: Math.Max(1, pageNumber),
                         roleTags: roleTags,
                         pdfDocumentId: pdfDocumentId,
-                        heading: heading);
+                        heading: heading,
+                        boundingBoxesJson: boundingBoxesJson,
+                        charStart: charStart,
+                        charEnd: charEnd);
 
                     results.Add(new ScoredEmbedding(embedding, score));
                 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolver.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolver.cs
@@ -2,6 +2,7 @@ using Api.Infrastructure.Entities.SharedGameCatalog;
 using Api.Infrastructure.Entities.UserLibrary;
 using Api.Observability;
 using Api.Services.Pdf;
+using Api.SharedKernel.Domain.Covers;
 
 namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
 
@@ -50,7 +51,8 @@ internal static class CoverUrlResolver
         if (!string.IsNullOrWhiteSpace(userEntry?.CustomCoverR2Key))
         {
             var url = await blobStorage
-                .GetPresignedUrlForRawKeyAsync($"{userEntry.CustomCoverR2Key}.webp")
+                .GetPresignedUrlForRawKeyAsync(
+                    CoverKeyBuilder.PhysicalKeyFor(CoverKind.User, userEntry.CustomCoverR2Key))
                 .ConfigureAwait(false);
             if (url is not null)
             {
@@ -80,7 +82,8 @@ internal static class CoverUrlResolver
         if (!string.IsNullOrWhiteSpace(sharedGame.PdfCoverR2Key))
         {
             var url = await blobStorage
-                .GetPresignedUrlForRawKeyAsync($"{sharedGame.PdfCoverR2Key}-preview.webp")
+                .GetPresignedUrlForRawKeyAsync(
+                    CoverKeyBuilder.PhysicalKeyFor(CoverKind.Pdf, sharedGame.PdfCoverR2Key))
                 .ConfigureAwait(false);
             if (url is not null)
             {
@@ -99,7 +102,8 @@ internal static class CoverUrlResolver
         if (!string.IsNullOrWhiteSpace(sharedGame.BggCoverR2Key))
         {
             var url = await blobStorage
-                .GetPresignedUrlForRawKeyAsync(sharedGame.BggCoverR2Key)
+                .GetPresignedUrlForRawKeyAsync(
+                    CoverKeyBuilder.PhysicalKeyFor(CoverKind.Bgg, sharedGame.BggCoverR2Key))
                 .ConfigureAwait(false);
             if (url is not null)
             {
@@ -112,7 +116,8 @@ internal static class CoverUrlResolver
         if (!string.IsNullOrWhiteSpace(sharedGame.WikidataCoverR2Key))
         {
             var url = await blobStorage
-                .GetPresignedUrlForRawKeyAsync($"{sharedGame.WikidataCoverR2Key}.webp")
+                .GetPresignedUrlForRawKeyAsync(
+                    CoverKeyBuilder.PhysicalKeyFor(CoverKind.Wikidata, sharedGame.WikidataCoverR2Key))
                 .ConfigureAwait(false);
             if (url is not null)
             {

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/BggCoverUploadPipeline.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/BggCoverUploadPipeline.cs
@@ -2,8 +2,8 @@ using Amazon.S3;
 using Amazon.S3.Model;
 using Api.BoundedContexts.SharedGameCatalog.Application.Services;
 using Api.Services.Pdf;
+using Api.SharedKernel.Domain.Covers;
 using Microsoft.Extensions.Logging;
-using System.Globalization;
 
 namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 
@@ -19,7 +19,6 @@ internal sealed class BggCoverUploadPipeline : IBggCoverUploadPipeline
     // Cover assets are immutable for 1 year; re-uploads reuse the same key so
     // Cloudflare CDN cache stays warm (mirrors CoverR2UploadPipeline).
     private const string ImmutableCacheControl = "public, max-age=31536000, immutable";
-    private const string DefaultExtension = ".jpg";
 
     private readonly IAmazonS3 _s3Client;
     private readonly S3StorageOptions _options;
@@ -42,10 +41,13 @@ internal sealed class BggCoverUploadPipeline : IBggCoverUploadPipeline
             throw new ArgumentException("imageBytes must be non-null and non-empty.", nameof(imageBytes));
         }
 
-        var ext = NormalizeExtension(extension);
+        // #3384 D5-A: the single CoverKeyBuilder owns the key shape + extension
+        // normalization; ContentType is derived from the SAME normalized extension.
+        // For BGG the physical key == DB key (the extension is embedded, no suffix).
+        var ext = CoverKeyBuilder.NormalizeBggExtension(extension);
         var contentType = ContentTypeFor(ext);
-        // Deterministic physical key = DB key (resolver appends NO suffix for L2.5).
-        var objectKey = $"bgg-covers/{bggId.ToString(CultureInfo.InvariantCulture)}/cover{ext}";
+        var coverKey = CoverKeyBuilder.ForBgg(bggId, ext);
+        var objectKey = coverKey.PhysicalKey;
 
         using var stream = new MemoryStream(imageBytes, writable: false);
         var request = new PutObjectRequest
@@ -68,7 +70,7 @@ internal sealed class BggCoverUploadPipeline : IBggCoverUploadPipeline
             _logger.LogInformation(
                 "Uploaded BGG cover to R2: BggId={BggId}, Key={Key}, Size={Size} bytes, ETag={ETag}",
                 bggId, objectKey, imageBytes.Length, response.ETag);
-            return objectKey;
+            return coverKey.DbKey;
         }
         catch (AmazonS3Exception ex)
         {
@@ -78,22 +80,6 @@ internal sealed class BggCoverUploadPipeline : IBggCoverUploadPipeline
                 bggId, objectKey, ex.StatusCode, ex.ErrorCode);
             throw;
         }
-    }
-
-    private static string NormalizeExtension(string extension)
-    {
-        if (string.IsNullOrWhiteSpace(extension))
-        {
-            return DefaultExtension;
-        }
-
-        var ext = extension.StartsWith('.') ? extension : "." + extension;
-        ext = ext.ToLowerInvariant();
-        return ext switch
-        {
-            ".jpg" or ".jpeg" or ".png" or ".gif" or ".webp" => ext,
-            _ => DefaultExtension,
-        };
     }
 
     private static string ContentTypeFor(string normalizedExtension) => normalizedExtension switch

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/CoverR2UploadPipeline.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/CoverR2UploadPipeline.cs
@@ -1,8 +1,8 @@
 using Amazon.S3;
 using Amazon.S3.Model;
 using Api.Services.Pdf;
+using Api.SharedKernel.Domain.Covers;
 using Microsoft.Extensions.Logging;
-using System.Globalization;
 
 namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 
@@ -41,13 +41,12 @@ internal sealed class CoverR2UploadPipeline : ICoverR2UploadPipeline
                 nameof(webpBytes));
         }
 
-        var gameIdSegment = gameId.ToString("D", CultureInfo.InvariantCulture);
-        // Physical R2 object key — INCLUDES .webp suffix (matches Content-Type).
-        var objectKey = $"covers/{gameIdSegment}/cover.webp";
-        // DB-safe key — EXCLUDES .webp suffix. CoverUrlResolver.cs:73-79 will
-        // append ".webp" when minting presigned URLs; storing the suffix here
-        // would yield "covers/.../cover.webp.webp" → 404.
-        var dbKey = $"covers/{gameIdSegment}/cover";
+        // #3384 D5-A: the single CoverKeyBuilder owns the suffix convention, so the
+        // physical key here and CoverUrlResolver's read key coincide by construction
+        // (no more "covers/.../cover.webp.webp" → 404 drift).
+        var coverKey = CoverKeyBuilder.ForWikidata(gameId);
+        var objectKey = coverKey.PhysicalKey;
+        var dbKey = coverKey.DbKey;
 
         using var stream = new MemoryStream(webpBytes, writable: false);
         var request = new PutObjectRequest

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/CustomCover/RemoveCustomCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/CustomCover/RemoveCustomCoverCommandHandler.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.UserLibrary.Domain.Repositories;
 using Api.Middleware.Exceptions;
 using Api.Services.Pdf;
 using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Domain.Covers;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Microsoft.Extensions.Logging;
 
@@ -31,11 +32,6 @@ internal sealed class RemoveCustomCoverCommandHandler : ICommandHandler<RemoveCu
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    /// <summary>
-    /// Centralizes the .webp extension to prevent hardcoding it in multiple places.
-    /// </summary>
-    private static string ToObjectKey(string resourceKey) => $"{resourceKey}.webp";
-
     public async Task Handle(RemoveCustomCoverCommand command, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(command);
@@ -53,13 +49,12 @@ internal sealed class RemoveCustomCoverCommandHandler : ICommandHandler<RemoveCu
 
         var keyToDelete = entry.CustomCoverR2Key;
 
-        // Best-effort R2 cleanup
+        // Best-effort R2 cleanup via the RAW-KEY delete (#3384): the categorized
+        // DeleteAsync rejects the slash-containing deterministic key.
         try
         {
-            await _blobStorage.DeleteAsync(
-                ToObjectKey(keyToDelete),
-                BlobCategory.GameImage,
-                keyToDelete,
+            await _blobStorage.DeleteRawKeyAsync(
+                CoverKeyBuilder.PhysicalKeyFor(CoverKind.User, keyToDelete),
                 cancellationToken
             ).ConfigureAwait(false);
         }

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/CustomCover/UploadCustomCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/CustomCover/UploadCustomCoverCommandHandler.cs
@@ -3,6 +3,7 @@ using Api.BoundedContexts.UserLibrary.Domain.Repositories;
 using Api.Middleware.Exceptions;
 using Api.Services.Pdf;
 using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Domain.Covers;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Microsoft.Extensions.Logging;
 
@@ -15,6 +16,10 @@ namespace Api.BoundedContexts.UserLibrary.Application.Commands.CustomCover;
 /// </summary>
 internal sealed class UploadCustomCoverCommandHandler : ICommandHandler<UploadCustomCoverCommand, CustomCoverUploadResult>
 {
+    // Custom cover physical keys end in ".webp" (CoverKind.User suffix); the stored
+    // object's Content-Type must match so the CDN serves it correctly.
+    private const string WebpContentType = "image/webp";
+
     private readonly IUserLibraryRepository _libraryRepository;
     private readonly IBlobStorageService _blobStorage;
     private readonly IUnitOfWork _unitOfWork;
@@ -32,11 +37,6 @@ internal sealed class UploadCustomCoverCommandHandler : ICommandHandler<UploadCu
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    /// <summary>
-    /// Centralizes the .webp extension to prevent hardcoding it in multiple places.
-    /// </summary>
-    private static string ToObjectKey(string resourceKey) => $"{resourceKey}.webp";
-
     public async Task<CustomCoverUploadResult> Handle(UploadCustomCoverCommand command, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(command);
@@ -47,18 +47,21 @@ internal sealed class UploadCustomCoverCommandHandler : ICommandHandler<UploadCu
             .ConfigureAwait(false)
             ?? throw new ForbiddenException($"Game {command.GameId} is not in user library");
 
-        var resourceKey = $"user-covers/{command.UserId}/{command.GameId}/cover";
-        var objectKey = ToObjectKey(resourceKey);
+        // #3384 D5-A: the single CoverKeyBuilder owns the ".webp" suffix convention
+        // (suffix-free DbKey persisted, PhysicalKey written) so writer and resolver
+        // never drift.
+        var coverKey = CoverKeyBuilder.ForUser(command.UserId, command.GameId);
 
-        // Best-effort delete old cover so stale R2 objects don't accumulate
+        // Best-effort delete old cover so stale R2 objects don't accumulate. Uses the
+        // RAW-KEY delete (mirrors CoverUrlResolver's raw-key reads): the categorized
+        // DeleteAsync runs PathSecurity.ValidateIdentifier which rejects the '/' in the
+        // deterministic key.
         if (entry.HasCustomCover)
         {
             try
             {
-                await _blobStorage.DeleteAsync(
-                    ToObjectKey(entry.CustomCoverR2Key!),
-                    BlobCategory.GameImage,
-                    entry.CustomCoverR2Key!,
+                await _blobStorage.DeleteRawKeyAsync(
+                    CoverKeyBuilder.PhysicalKeyFor(CoverKind.User, entry.CustomCoverR2Key!),
                     cancellationToken
                 ).ConfigureAwait(false);
             }
@@ -70,32 +73,39 @@ internal sealed class UploadCustomCoverCommandHandler : ICommandHandler<UploadCu
             }
         }
 
-        // Upload new cover (StoreAsync derives the final path internally)
-        await _blobStorage.StoreAsync(
+        // #3384: write to the EXACT deterministic physical key via the RAW-KEY path.
+        // The categorized StoreAsync rejects the slash-containing key via
+        // PathSecurity.ValidateIdentifier AND generates a random-id key the resolver
+        // cannot reconstruct — either way the cover would never resolve. StoreRawKeyAsync
+        // returns false on a write failure (or in local-storage mode, which does not host
+        // raw keys); surface it instead of persisting an unresolvable key.
+        var stored = await _blobStorage.StoreRawKeyAsync(
+            coverKey.PhysicalKey,
             command.FileStream,
-            objectKey,
-            BlobCategory.GameImage,
-            resourceKey,
+            WebpContentType,
             cancellationToken
         ).ConfigureAwait(false);
 
-        // Persist updated R2 key on domain aggregate
-        entry.SetCustomCoverR2Key(resourceKey);
+        if (!stored)
+        {
+            throw new ExternalServiceException(
+                "Impossibile salvare la cover personalizzata: storage oggetti non disponibile.");
+        }
+
+        // Persist the suffix-free DB key ONLY after the object is confirmed written.
+        entry.SetCustomCoverR2Key(coverKey.DbKey);
         await _libraryRepository.UpdateAsync(entry, cancellationToken).ConfigureAwait(false);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
         _logger.LogInformation(
             "Custom cover uploaded for game {GameId}, user {UserId}, key {Key}",
-            command.GameId, command.UserId, resourceKey);
+            command.GameId, command.UserId, coverKey.DbKey);
 
-        // Return presigned URL valid for 1 hour (3600 seconds)
-        var presignedUrl = await _blobStorage.GetPresignedDownloadUrlAsync(
-            ToObjectKey(resourceKey),
-            BlobCategory.GameImage,
-            resourceKey,
-            expirySeconds: 3600
-        ).ConfigureAwait(false) ?? string.Empty;
+        // Return presigned URL valid for 1 hour (3600 seconds) for the exact object just written.
+        var presignedUrl = await _blobStorage
+            .GetPresignedUrlForRawKeyAsync(coverKey.PhysicalKey, expirySeconds: 3600)
+            .ConfigureAwait(false) ?? string.Empty;
 
-        return new CustomCoverUploadResult(resourceKey, presignedUrl);
+        return new CustomCoverUploadResult(coverKey.DbKey, presignedUrl);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/EventHandlers/GameRemovedFromLibraryCustomCoverHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/EventHandlers/GameRemovedFromLibraryCustomCoverHandler.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.UserLibrary.Domain.Events;
 using Api.Services.Pdf;
+using Api.SharedKernel.Domain.Covers;
 using MediatR;
 
 namespace Api.BoundedContexts.UserLibrary.Application.EventHandlers;
@@ -37,10 +38,10 @@ internal sealed class GameRemovedFromLibraryCustomCoverHandler : INotificationHa
 
         try
         {
-            await _blobStorage.DeleteAsync(
-                ToObjectKey(resourceKey),
-                BlobCategory.GameImage,
-                resourceKey,
+            // #3384: raw-key delete (the categorized DeleteAsync rejects the '/' in the
+            // deterministic key). Mirrors CoverUrlResolver's raw-key reads.
+            await _blobStorage.DeleteRawKeyAsync(
+                CoverKeyBuilder.PhysicalKeyFor(CoverKind.User, resourceKey),
                 cancellationToken
             ).ConfigureAwait(false);
         }
@@ -65,10 +66,4 @@ internal sealed class GameRemovedFromLibraryCustomCoverHandler : INotificationHa
                 notification.GameId);
         }
     }
-
-    /// <summary>
-    /// Derives the R2 object key from the resource key.
-    /// Mirrors the upload convention in <c>UploadCustomCoverCommandHandler</c>.
-    /// </summary>
-    private static string ToObjectKey(string resourceKey) => $"{resourceKey}.webp";
 }

--- a/apps/api/src/Api/DevTools/MockImpls/MockBlobStorageService.cs
+++ b/apps/api/src/Api/DevTools/MockImpls/MockBlobStorageService.cs
@@ -116,4 +116,15 @@ internal sealed class MockBlobStorageService : IBlobStorageService
         // Return true for the same "everything is present" mock semantics as DeleteAsync.
         return Task.FromResult(true);
     }
+
+    /// <inheritdoc />
+    public async Task<bool> StoreRawKeyAsync(string rawKey, Stream stream, string contentType, CancellationToken ct = default)
+    {
+        _ = (contentType);
+        using var ms = new MemoryStream();
+        await stream.CopyToAsync(ms, ct).ConfigureAwait(false);
+        _store[rawKey] = ms.ToArray();
+        // "Everything succeeds" mock semantics (mirrors StoreAsync).
+        return true;
+    }
 }

--- a/apps/api/src/Api/Infrastructure/Entities/KnowledgeBase/ChunkBoundingBoxJson.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/KnowledgeBase/ChunkBoundingBoxJson.cs
@@ -1,0 +1,30 @@
+using System.Text.Json;
+using Api.BoundedContexts.KnowledgeBase.Domain.Chunking;
+
+// Namespace matches TextChunkEntity (Api.Infrastructure.Entities, not the folder) so the helper is
+// in scope wherever the entity is constructed, without an extra using at the 4 insert sites.
+namespace Api.Infrastructure.Entities;
+
+/// <summary>
+/// SP-B (#3406, epic #3403): serializes a chunk's normalized region to the
+/// <c>text_chunks.bounding_boxes_json</c> column. Format is a JSON array of page-aware boxes
+/// <c>[{page,x,y,width,height}]</c> — MVP emits 0 or 1 box per chunk (the union computed upstream by
+/// <c>ExtractedDocumentFactory</c>); the array shape leaves room for future multi-region chunks.
+/// Returns <c>null</c> when the chunk carries no region, so the column stays NULL for the
+/// pre-coordinate corpus (backfilled by SP-E re-extraction).
+/// </summary>
+internal static class ChunkBoundingBoxJson
+{
+    public static string? Serialize(BoundingBox? bbox, int page)
+    {
+        if (bbox is null)
+        {
+            return null;
+        }
+
+        return JsonSerializer.Serialize(new[]
+        {
+            new { page, x = bbox.X, y = bbox.Y, width = bbox.Width, height = bbox.Height },
+        });
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Entities/KnowledgeBase/TextChunkEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/KnowledgeBase/TextChunkEntity.cs
@@ -36,6 +36,11 @@ public class TextChunkEntity
     public int? CharStart { get; set; }
     public int? CharEnd { get; set; }
 
+    // SP-B (#3406): normalized region(s) of the chunk as JSON array [{page,x,y,width,height}]
+    // ([0,1] top-left). Nullable — NULL for chunks without coordinates (SmolDocling/Docnet path,
+    // or pre-coordinate corpus backfilled by SP-E re-extraction).
+    public string? BoundingBoxesJson { get; set; }
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
     // Issue #730: Chunk hierarchy fields (heading_path derivation)

--- a/apps/api/src/Api/Infrastructure/Entities/KnowledgeBase/TextChunkEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/KnowledgeBase/TextChunkEntity.cs
@@ -27,6 +27,15 @@ public class TextChunkEntity
     public int ChunkIndex { get; set; }
     public int? PageNumber { get; set; }
     public int CharacterCount { get; set; }
+
+    // SP-A (#3405, epic #3403): char offsets del chunk nel testo ricostruito dal chunker,
+    // per il grounding/highlight della citazione. Nullable: le righe indicizzate prima di
+    // questa feature non hanno il dato (backfill via re-index — il valore è derivabile da
+    // StructuredElementsJson/ExtractedText). Reference frame: content ricostruito della
+    // sezione (non l'ExtractedText grezzo né il PDF originale).
+    public int? CharStart { get; set; }
+    public int? CharEnd { get; set; }
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
     // Issue #730: Chunk hierarchy fields (heading_path derivation)

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/KnowledgeBase/TextChunkEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/KnowledgeBase/TextChunkEntityConfiguration.cs
@@ -25,6 +25,12 @@ internal class TextChunkEntityConfiguration : IEntityTypeConfiguration<TextChunk
         builder.Property(e => e.CharStart).HasColumnName("char_start").IsRequired(false);
         builder.Property(e => e.CharEnd).HasColumnName("char_end").IsRequired(false);
 
+        // SP-B (#3406): normalized region(s) as jsonb (nullable; NULL when no coordinates)
+        builder.Property(e => e.BoundingBoxesJson)
+               .HasColumnName("bounding_boxes_json")
+               .HasColumnType("jsonb")
+               .IsRequired(false);
+
         builder.Property(e => e.CreatedAt).IsRequired();
 
         // Issue #730: Chunk hierarchy fields

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/KnowledgeBase/TextChunkEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/KnowledgeBase/TextChunkEntityConfiguration.cs
@@ -20,6 +20,11 @@ internal class TextChunkEntityConfiguration : IEntityTypeConfiguration<TextChunk
         builder.Property(e => e.ChunkIndex).IsRequired();
         builder.Property(e => e.PageNumber);
         builder.Property(e => e.CharacterCount).IsRequired();
+
+        // SP-A (#3405): char offsets nullable (backfill via re-index; NULL per righe pre-esistenti)
+        builder.Property(e => e.CharStart).HasColumnName("char_start").IsRequired(false);
+        builder.Property(e => e.CharEnd).HasColumnName("char_end").IsRequired(false);
+
         builder.Property(e => e.CreatedAt).IsRequired();
 
         // Issue #730: Chunk hierarchy fields

--- a/apps/api/src/Api/Infrastructure/Migrations/20260730092605_AddChunkCharOffsets.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260730092605_AddChunkCharOffsets.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260730092605_AddChunkCharOffsets")]
+    partial class AddChunkCharOffsets
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260730092605_AddChunkCharOffsets.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260730092605_AddChunkCharOffsets.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddChunkCharOffsets : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "char_end",
+                table: "text_chunks",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "char_start",
+                table: "text_chunks",
+                type: "integer",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "char_end",
+                table: "text_chunks");
+
+            migrationBuilder.DropColumn(
+                name: "char_start",
+                table: "text_chunks");
+        }
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Migrations/20260730125719_AddChunkBoundingBoxes.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260730125719_AddChunkBoundingBoxes.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260730125719_AddChunkBoundingBoxes")]
+    partial class AddChunkBoundingBoxes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260730125719_AddChunkBoundingBoxes.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260730125719_AddChunkBoundingBoxes.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddChunkBoundingBoxes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "bounding_boxes_json",
+                table: "text_chunks",
+                type: "jsonb",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "bounding_boxes_json",
+                table: "text_chunks");
+        }
+    }
+}

--- a/apps/api/src/Api/Models/Contracts.cs
+++ b/apps/api/src/Api/Models/Contracts.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -42,6 +43,30 @@ internal record Snippet(string text, string source, int page, int line, float sc
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public int? chunkPosition { get; init; }
+
+    /// <summary>
+    /// SP-C (#3407): normalized [0,1] top-left bounding boxes of the cited chunk, for the
+    /// FE PDF region overlay. Full-gated: populated ONLY when CopyrightTier=Full (drawing
+    /// the verbatim region on a Protected doc would leak, DA-4). Null for the pre-coordinate
+    /// corpus / non-Unstructured branch / Protected tier → key omitted (additive-only, D-4).
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<CitationRegion>? regions { get; init; }
+
+    /// <summary>
+    /// SP-C (#3407): char offset (inclusive) of the chunk within the source PDF text.
+    /// Full-gated; null when unavailable. NOT to be confused with InlineCitationMatch
+    /// offsets, which index into the ANSWER text.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? charStart { get; init; }
+
+    /// <summary>
+    /// SP-C (#3407): char offset (exclusive) of the chunk within the source PDF text.
+    /// Full-gated; null when unavailable.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? charEnd { get; init; }
 }
 
 /// <summary>
@@ -139,7 +164,51 @@ internal record CitationDto(
     string? SnippetPreview,
     string CopyrightTier,
     string? ParaphrasedSnippet = null,
-    bool IsPublic = false);
+    bool IsPublic = false,
+    IReadOnlyList<CitationRegion>? Regions = null,
+    int? CharStart = null,
+    int? CharEnd = null);
+
+/// <summary>
+/// SP-C (#3407): FE-facing, Full-gated region of a citation on the source PDF.
+/// Coordinates are normalized to [0,1] top-left (page-relative), enabling a
+/// scale/DPR-independent %-based overlay (SP-D). Parsed at the handler boundary from
+/// the persisted <c>text_chunks.bounding_boxes_json</c> array; never carried through the
+/// domain/application layers (those hold the raw JSON string only — no layer deps).
+/// </summary>
+internal record CitationRegion(int Page, double X, double Y, double Width, double Height)
+{
+    /// <summary>
+    /// Parses the persisted bounding-box JSON (<c>[{page,x,y,width,height}]</c>, lowercase
+    /// keys) into regions. Returns null for null/blank/empty/malformed input — never throws,
+    /// so a corrupt column can never break a citation response.
+    /// </summary>
+    public static IReadOnlyList<CitationRegion>? Parse(string? boundingBoxesJson)
+    {
+        if (string.IsNullOrWhiteSpace(boundingBoxesJson))
+        {
+            return null;
+        }
+
+        try
+        {
+            var regions = JsonSerializer.Deserialize<List<CitationRegion>>(
+                boundingBoxesJson, RegionParseOptions);
+            return regions is { Count: > 0 } ? regions : null;
+        }
+        catch (JsonException)
+        {
+            // Defensive: a corrupt/unexpected column must never break a citation response.
+            return null;
+        }
+    }
+
+    private static readonly JsonSerializerOptions RegionParseOptions = new()
+    {
+        // Persisted keys are lowercase (page/x/y/width/height) — the record members are PascalCase.
+        PropertyNameCaseInsensitive = true,
+    };
+}
 internal record StreamingError(string errorMessage, string? errorCode = null);
 internal record StreamingToken(string token); // CHAT-01: Individual LLM token
 internal record StreamingSetupStep(SetupGuideStep step); // AI-03: Individual setup step

--- a/apps/api/src/Api/Routing/AdminQueueEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminQueueEndpoints.cs
@@ -105,12 +105,13 @@ internal static class AdminQueueEndpoints
             .Produces<BulkReindexResult>(200)
             .WithSummary("Re-queue all failed documents as Low priority");
 
-        // Issue #3269 (SP3 RAG bulk re-index): re-index all Ready documents whose indexer
-        // version differs from the target (heading-aware v1.1).
+        // Issue #3269 (SP3 RAG bulk re-index) → target bumped to coordinate-aware v1.2 by
+        // #3409 (SP-E, epic #3403): re-index all Ready documents whose indexer version differs
+        // from the current target.
         group.MapPost("/reindex-ready", HandleBulkReindexReady)
             .WithName("BulkReindexReady")
             .Produces<BulkReindexResult>(200)
-            .WithSummary("Re-index all Ready documents whose indexer version differs from the target (heading-aware v1.1)");
+            .WithSummary("Re-index all Ready documents whose indexer version differs from the target (coordinate-aware v1.2)");
 
         // Issue #5456: Extracted text preview
         group.MapGet("/documents/{pdfDocumentId:guid}/extracted-text", HandleGetExtractedText)

--- a/apps/api/src/Api/Services/Pdf/BlobStorageService.cs
+++ b/apps/api/src/Api/Services/Pdf/BlobStorageService.cs
@@ -258,6 +258,18 @@ internal class BlobStorageService : IBlobStorageService
         return Task.FromResult(false);
     }
 
+    /// <summary>
+    /// Local storage does not host objects under raw R2-style keys (mirrors
+    /// <see cref="DeleteRawKeyAsync"/>/<see cref="GetPresignedUrlForRawKeyAsync"/>).
+    /// No-op returning false so cover-write callers (#3384) surface a clear failure in
+    /// local mode rather than persisting an unresolvable deterministic key.
+    /// </summary>
+    public Task<bool> StoreRawKeyAsync(string rawKey, Stream stream, string contentType, CancellationToken ct = default)
+    {
+        _ = (rawKey, stream, contentType, ct); // Local storage: raw keys are not supported
+        return Task.FromResult(false);
+    }
+
     private static string SanitizeFileName(string fileName)
     {
         return StringHelper.SanitizeFilename(fileName, maxLength: 200, fallbackName: "file");

--- a/apps/api/src/Api/Services/Pdf/IBlobStorageService.cs
+++ b/apps/api/src/Api/Services/Pdf/IBlobStorageService.cs
@@ -169,6 +169,25 @@ internal interface IBlobStorageService
     /// <param name="ct">Cancellation token.</param>
     /// <returns>True if the delete request was issued successfully (best-effort; local storage returns false as it does not host raw keys).</returns>
     Task<bool> DeleteRawKeyAsync(string rawKey, CancellationToken ct = default);
+
+    /// <summary>
+    /// Stores an object at an EXACT physical storage key — the write-side counterpart
+    /// of <see cref="GetPresignedUrlForRawKeyAsync"/> / <see cref="DeleteRawKeyAsync"/>.
+    /// Unlike <see cref="StoreAsync"/>, this does NOT run
+    /// <c>PathSecurity.ValidateIdentifier</c> and does NOT prepend a category folder
+    /// or a random file-id segment — the object is written verbatim to
+    /// <paramref name="rawKey"/> (slashes and dots allowed). Required by the
+    /// deterministic cover keys (#3384) so the write key and the resolver's raw-key
+    /// read coincide by construction; the categorized <see cref="StoreAsync"/> would
+    /// reject the slash-containing cover key AND generate a random-id key the resolver
+    /// cannot reconstruct.
+    /// </summary>
+    /// <param name="rawKey">The exact physical storage object key to write.</param>
+    /// <param name="stream">The content to store.</param>
+    /// <param name="contentType">MIME content type of the stored object.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>True if the object was written successfully; false on failure or when the backend does not host raw keys (local storage).</returns>
+    Task<bool> StoreRawKeyAsync(string rawKey, Stream stream, string contentType, CancellationToken ct = default);
 }
 
 /// <summary>

--- a/apps/api/src/Api/Services/Pdf/S3BlobStorageService.cs
+++ b/apps/api/src/Api/Services/Pdf/S3BlobStorageService.cs
@@ -465,6 +465,77 @@ internal sealed class S3BlobStorageService : IBlobStorageService
 #pragma warning restore CA1031 // Do not catch general exception types
     }
 
+    /// <summary>
+    /// #3384 — writes an object to an EXACT physical key (write-side counterpart of
+    /// <see cref="GetPresignedUrlForRawKeyAsync"/>). No <c>ValidateIdentifier</c>, no
+    /// category folder, no random file-id segment: the key is written verbatim so the
+    /// resolver's raw-key read reconstructs it deterministically. Mirrors the cover
+    /// upload pipelines' <c>DisablePayloadSigning</c> requirement for S3-compatible
+    /// providers (R2/MinIO) that don't support the streaming payload trailer.
+    /// </summary>
+    public async Task<bool> StoreRawKeyAsync(string rawKey, Stream stream, string contentType, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(rawKey) || stream is null)
+        {
+            return false;
+        }
+
+        MemoryStream? buffered = null;
+        try
+        {
+            // Pre-buffer non-seekable streams so PutObject can declare a length (#2271).
+            Stream uploadStream;
+            if (stream.CanSeek)
+            {
+                uploadStream = stream;
+            }
+            else
+            {
+                buffered = new MemoryStream();
+                await stream.CopyToAsync(buffered, ct).ConfigureAwait(false);
+                buffered.Position = 0;
+                uploadStream = buffered;
+            }
+
+            var request = new PutObjectRequest
+            {
+                BucketName = _options.BucketName,
+                Key = rawKey,
+                InputStream = uploadStream,
+                ContentType = contentType,
+                AutoCloseStream = false,
+                DisablePayloadSigning = true,
+            };
+
+            await _s3Client.PutObjectAsync(request, ct).ConfigureAwait(false);
+            _logger.LogInformation("Stored file in S3 (raw key): {Key}", rawKey);
+            return true;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (AmazonS3Exception ex)
+        {
+            _logger.LogWarning(ex, "S3 error storing raw key {Key}: {ErrorCode}", rawKey, ex.ErrorCode);
+            return false;
+        }
+#pragma warning disable CA1031 // Do not catch general exception types
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Unexpected error storing raw key {Key}", rawKey);
+            return false;
+        }
+#pragma warning restore CA1031 // Do not catch general exception types
+        finally
+        {
+            if (buffered is not null)
+            {
+                await buffered.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+    }
+
     private static string SanitizeFileName(string fileName)
     {
         return StringHelper.SanitizeFilename(fileName, maxLength: 200, fallbackName: "file");

--- a/apps/api/src/Api/Services/TextChunkingService.cs
+++ b/apps/api/src/Api/Services/TextChunkingService.cs
@@ -1,4 +1,5 @@
 using Api.Constants;
+using Api.BoundedContexts.KnowledgeBase.Domain.Chunking;
 
 #pragma warning disable MA0048 // File name must match type name - Contains Service with Configuration classes
 namespace Api.Services;
@@ -403,4 +404,6 @@ internal record DocumentChunkInput
     public short Level { get; init; } = 1;
     public Guid? ParentChunkId { get; init; }
     public string ElementType { get; init; } = "NarrativeText";
+    // SP-B (#3406): normalized region [0,1] top-left; null when unavailable.
+    public BoundingBox? BBox { get; init; }
 }

--- a/apps/api/src/Api/Services/VectorSearchModels.cs
+++ b/apps/api/src/Api/Services/VectorSearchModels.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.BoundedContexts.KnowledgeBase.Domain.Chunking;
 
 namespace Api.Services;
 
@@ -22,6 +23,9 @@ internal record DocumentChunk
     public short Level { get; init; } = 1;
     public Guid? ParentChunkId { get; init; }
     public string ElementType { get; init; } = "NarrativeText";
+    // SP-B (#3406): normalized region [0,1] top-left (union of the section's element boxes on
+    // the start page); null when the extractor emitted no coordinates.
+    public BoundingBox? BBox { get; init; }
 }
 
 /// <summary>

--- a/apps/api/src/Api/Services/VectorSearchModels.cs
+++ b/apps/api/src/Api/Services/VectorSearchModels.cs
@@ -76,6 +76,17 @@ internal record SearchResultItem
 
     /// <summary>#3270: chunk heading-path label for the heading-match boost (nullable).</summary>
     public string? Heading { get; init; }
+
+    /// <summary>
+    /// SP-C (#3407): raw bounding-box JSON carried from the vector arm (<c>Embedding.BoundingBoxesJson</c>).
+    /// Primitive string (no layer dep); parsed + Full-gated at the API handler boundary. Null for the
+    /// keyword/FTS/RAPTOR arms and the pre-coordinate corpus.
+    /// </summary>
+    public string? BoundingBoxesJson { get; init; }
+
+    /// <summary>SP-C (#3407): chunk char offsets in the source PDF text (nullable).</summary>
+    public int? CharStart { get; init; }
+    public int? CharEnd { get; init; }
 }
 
 /// <summary>

--- a/apps/api/src/Api/SharedKernel/Domain/Covers/CoverKeyBuilder.cs
+++ b/apps/api/src/Api/SharedKernel/Domain/Covers/CoverKeyBuilder.cs
@@ -1,0 +1,112 @@
+using System.Globalization;
+
+namespace Api.SharedKernel.Domain.Covers;
+
+/// <summary>
+/// The four cover sources resolved by <c>CoverUrlResolver</c>, in precedence
+/// order User (L3) → Pdf (L4) → Bgg (L2.5) → Wikidata (L2). Each source uses a
+/// distinct R2 physical-key suffix convention (ADR-087 D5-A, issue #3384).
+/// </summary>
+internal enum CoverKind
+{
+    /// <summary>User-uploaded custom cover — physical key adds <c>.webp</c>.</summary>
+    User,
+
+    /// <summary>PDF-derived cover (rulebook page) — physical key adds <c>-preview.webp</c>.</summary>
+    Pdf,
+
+    /// <summary>BGG re-uploaded cover — physical key IS the DB key (extension already embedded).</summary>
+    Bgg,
+
+    /// <summary>Wikidata/Commons cover — physical key adds <c>.webp</c>.</summary>
+    Wikidata,
+}
+
+/// <summary>
+/// A cover's storage identity: the suffix-free <see cref="DbKey"/> persisted in
+/// the DB column, and the <see cref="PhysicalKey"/> actually PUT to / GET from R2.
+/// </summary>
+internal readonly record struct CoverKey(CoverKind Kind, string DbKey, string PhysicalKey);
+
+/// <summary>
+/// Issue #3384 (ADR-087 D5-A) — the SINGLE source of truth for the cover R2 key
+/// convention. Every writer (<c>CoverR2UploadPipeline</c>,
+/// <c>BggCoverUploadPipeline</c>, <c>PdfCoverUploadPipeline</c>,
+/// <c>UploadCustomCoverCommandHandler</c>) and the read side
+/// (<c>CoverUrlResolver</c> + the PDF orphan / delete / materialize sites)
+/// derive keys through here, so the write-key and the read-key coincide by
+/// construction. This makes the <c>.webp.webp</c> double-suffix drift — the bug
+/// whose root cause (<c>PathSecurity.ValidateIdentifier</c> rejecting the
+/// suffix/slash) recurred three times — structurally impossible.
+/// </summary>
+internal static class CoverKeyBuilder
+{
+    private const string DefaultBggExtension = ".jpg";
+
+    /// <summary>User custom cover (L3): <c>user-covers/{userId:D}/{gameId:D}/cover</c>.</summary>
+    public static CoverKey ForUser(Guid userId, Guid gameId) =>
+        Build(CoverKind.User, $"user-covers/{userId:D}/{gameId:D}/cover");
+
+    /// <summary>PDF-derived cover (L4): <c>covers/pdf/{pdfDocumentId:D}/cover</c>.</summary>
+    public static CoverKey ForPdf(Guid pdfDocumentId) =>
+        Build(CoverKind.Pdf, $"covers/pdf/{pdfDocumentId:D}/cover");
+
+    /// <summary>Wikidata/Commons cover (L2): <c>covers/{gameId:D}/cover</c>.</summary>
+    public static CoverKey ForWikidata(Guid gameId) =>
+        Build(CoverKind.Wikidata, $"covers/{gameId:D}/cover");
+
+    /// <summary>
+    /// BGG re-uploaded cover (L2.5): <c>bgg-covers/{bggId}/cover{ext}</c>. The
+    /// extension is embedded in the key (BGG keeps its original image format), so
+    /// the physical key equals the DB key — no suffix is appended at read time.
+    /// </summary>
+    public static CoverKey ForBgg(int bggId, string sourceExtension) =>
+        Build(
+            CoverKind.Bgg,
+            $"bgg-covers/{bggId.ToString(CultureInfo.InvariantCulture)}/cover{NormalizeBggExtension(sourceExtension)}");
+
+    /// <summary>
+    /// Reconstructs the physical R2 object key from a DB-stored key. This is the
+    /// ONE place the per-kind suffix rule lives — the resolver calls this instead
+    /// of hardcoding <c>+ ".webp"</c> / <c>+ "-preview.webp"</c> / nothing.
+    /// </summary>
+    public static string PhysicalKeyFor(CoverKind kind, string dbKey)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(dbKey);
+        return dbKey + SuffixFor(kind);
+    }
+
+    /// <summary>
+    /// Normalizes a BGG source image extension to a supported, dot-prefixed,
+    /// lowercase form; unsupported or empty extensions fall back to <c>.jpg</c>.
+    /// Exposed so <c>BggCoverUploadPipeline</c> can derive the matching
+    /// Content-Type from the SAME normalized extension that shapes the key.
+    /// </summary>
+    public static string NormalizeBggExtension(string? extension)
+    {
+        if (string.IsNullOrWhiteSpace(extension))
+        {
+            return DefaultBggExtension;
+        }
+
+        var ext = extension.StartsWith('.') ? extension : "." + extension;
+        ext = ext.ToLowerInvariant();
+        return ext switch
+        {
+            ".jpg" or ".jpeg" or ".png" or ".gif" or ".webp" => ext,
+            _ => DefaultBggExtension,
+        };
+    }
+
+    private static string SuffixFor(CoverKind kind) => kind switch
+    {
+        CoverKind.User => ".webp",
+        CoverKind.Pdf => "-preview.webp",
+        CoverKind.Bgg => string.Empty,
+        CoverKind.Wikidata => ".webp",
+        _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, "Unknown cover kind."),
+    };
+
+    private static CoverKey Build(CoverKind kind, string dbKey) =>
+        new(kind, dbKey, dbKey + SuffixFor(kind));
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/Queue/BulkReindexReadyCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/Queue/BulkReindexReadyCommandHandlerTests.cs
@@ -108,8 +108,8 @@ public sealed class BulkReindexReadyCommandHandlerTests : IAsyncLifetime
                     c.PdfId == pdf.Id && c.IndexerVersion == IndexerVersionRegistry.Current.Version),
                 It.IsAny<CancellationToken>()),
             Times.Once);
-        // The current pipeline version is v1.1 (SP3 #3269). Assert the literal explicitly.
-        IndexerVersionRegistry.Current.Version.Should().Be("v1.1");
+        // The current pipeline version is v1.2 (SP-E #3409, coordinate-aware). Assert the literal explicitly.
+        IndexerVersionRegistry.Current.Version.Should().Be("v1.2");
         result.EnqueuedCount.Should().Be(1);
         result.SkippedCount.Should().Be(0);
         result.Errors.Should().BeEmpty();

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/Persistence/PdfDocumentRepositoryCoverMappingTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/Persistence/PdfDocumentRepositoryCoverMappingTests.cs
@@ -1,0 +1,148 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.SharedKernel.Application.Services;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Infrastructure.Persistence;
+
+/// <summary>
+/// Issue #3401 — <see cref="PdfDocumentRepository"/> must round-trip the L4 PDF
+/// cover fields (CoverR2Key, CoverGenerationStatus, CoverPageIndex,
+/// CoverGenerationError, CoverGenerationAttempts) through both MapToDomain and
+/// MapToPersistence. Before the fix, both mappers silently dropped these columns,
+/// so <c>UpdateAsync</c> (which rebuilds the entity and calls DbSet.Update, marking
+/// every column modified) zeroed the persisted cover state — a data-loss bug that
+/// broke <c>MaterializePdfCoverCommandHandler</c>.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "DocumentProcessing")]
+public sealed class PdfDocumentRepositoryCoverMappingTests : IDisposable
+{
+    private readonly MeepleAiDbContext _db;
+
+    public PdfDocumentRepositoryCoverMappingTests()
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase($"PdfDocRepoCover_{Guid.NewGuid()}")
+            .Options;
+        _db = new MeepleAiDbContext(
+            options,
+            new Mock<IMediator>().Object,
+            new Mock<IDomainEventCollector>().Object);
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private PdfDocumentRepository CreateRepository() =>
+        new(_db, new Mock<IDomainEventCollector>().Object);
+
+    private PdfDocumentEntity SeedEntity(
+        string? coverR2Key,
+        string coverStatus,
+        int? coverPageIndex,
+        string? coverError,
+        int coverAttempts)
+    {
+        var pdf = new PdfDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            FileName = "rules.pdf",
+            FilePath = "/tmp/rules.pdf",
+            FileSizeBytes = 2048,
+            ContentType = "application/pdf",
+            UploadedByUserId = Guid.NewGuid(),
+            UploadedAt = DateTime.UtcNow,
+            ProcessingState = "Ready",
+            CoverR2Key = coverR2Key,
+            CoverGenerationStatus = coverStatus,
+            CoverPageIndex = coverPageIndex,
+            CoverGenerationError = coverError,
+            CoverGenerationAttempts = coverAttempts,
+        };
+        _db.PdfDocuments.Add(pdf);
+        _db.SaveChanges();
+        _db.ChangeTracker.Clear();
+        return pdf;
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_MapsAllCoverFieldsToDomain()
+    {
+        var seeded = SeedEntity(
+            coverR2Key: "covers/pdf/00000000-0000-0000-0000-000000000001/cover",
+            coverStatus: nameof(PdfCoverGenerationStatus.Generated),
+            coverPageIndex: 2,
+            coverError: null,
+            coverAttempts: 1);
+
+        var domain = await CreateRepository().GetByIdAsync(seeded.Id);
+
+        domain.Should().NotBeNull();
+        domain!.CoverR2Key.Should().Be(seeded.CoverR2Key);
+        domain.CoverGenerationStatus.Should().Be(PdfCoverGenerationStatus.Generated);
+        domain.CoverPageIndex.Should().Be(2);
+        domain.CoverGenerationError.Should().BeNull();
+        domain.CoverGenerationAttempts.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_PreservesAllCoverFields_RoundTrip()
+    {
+        // A Failed cover mid-retry: attempts must NOT be zeroed by the round-trip.
+        var seeded = SeedEntity(
+            coverR2Key: null,
+            coverStatus: nameof(PdfCoverGenerationStatus.Failed),
+            coverPageIndex: 4,
+            coverError: "boom",
+            coverAttempts: 2);
+
+        var repo = CreateRepository();
+        var domain = await repo.GetByIdAsync(seeded.Id);
+        domain.Should().NotBeNull();
+
+        // Simulate a metadata edit that goes through the repository's UpdateAsync
+        // (the exact path MaterializePdfCoverCommandHandler uses).
+        await repo.UpdateAsync(domain!);
+        await _db.SaveChangesAsync();
+        _db.ChangeTracker.Clear();
+
+        var reloaded = await _db.PdfDocuments.AsNoTracking().SingleAsync(p => p.Id == seeded.Id);
+        reloaded.CoverGenerationStatus.Should().Be(nameof(PdfCoverGenerationStatus.Failed),
+            "the persisted cover status must survive an UpdateAsync round-trip");
+        reloaded.CoverPageIndex.Should().Be(4);
+        reloaded.CoverGenerationError.Should().Be("boom");
+        reloaded.CoverGenerationAttempts.Should().Be(2,
+            "the retry budget must not be silently zeroed by MapToPersistence");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_AfterMarkCoverGenerated_PersistsGeneratedState()
+    {
+        // The concrete MaterializePdfCoverCommandHandler flow: MarkCoverGenerated then UpdateAsync.
+        var seeded = SeedEntity(
+            coverR2Key: null,
+            coverStatus: nameof(PdfCoverGenerationStatus.Pending),
+            coverPageIndex: null,
+            coverError: null,
+            coverAttempts: 0);
+
+        var repo = CreateRepository();
+        var domain = await repo.GetByIdAsync(seeded.Id);
+        domain!.MarkCoverGenerated("covers/pdf/aaaa/cover", pageIndex: 0);
+
+        await repo.UpdateAsync(domain);
+        await _db.SaveChangesAsync();
+        _db.ChangeTracker.Clear();
+
+        var reloaded = await _db.PdfDocuments.AsNoTracking().SingleAsync(p => p.Id == seeded.Id);
+        reloaded.CoverGenerationStatus.Should().Be(nameof(PdfCoverGenerationStatus.Generated));
+        reloaded.CoverR2Key.Should().Be("covers/pdf/aaaa/cover");
+        reloaded.CoverPageIndex.Should().Be(0);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatSessionAgentBroadcastTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatSessionAgentBroadcastTests.cs
@@ -127,6 +127,93 @@ public class ChatSessionAgentBroadcastTests
     }
 
     // -----------------------------------------------------------------------
+    // SP-C (#3407): region overlay is Full-gated (same as SnippetPreview)
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task Chat_WithLiveSession_FullTierCitation_BroadcastsRegions()
+    {
+        // Arrange — Full-tier citation carrying a bounding box.
+        var liveSessionId = Guid.NewGuid();
+        var liveSession = BuildLiveSession(liveSessionId);
+
+        var citation = new ChunkCitation(
+            DocumentId: "doc-1",
+            PageNumber: 2,
+            RelevanceScore: 0.95f,
+            SnippetPreview: "verbatim rule text",
+            CopyrightTier: CopyrightTier.Full,
+            IsPublic: true)
+        {
+            BoundingBoxesJson = "[{\"page\":2,\"x\":0.1,\"y\":0.2,\"width\":0.3,\"height\":0.4}]",
+            CharStart = 100,
+            CharEnd = 250,
+        };
+
+        var gateway = new Mock<ILiveSessionStreamGateway>();
+        var handler = BuildHandler(
+            liveSession: liveSession,
+            resolvedCitations: new List<ChunkCitation> { citation },
+            gateway: gateway.Object);
+        var command = BuildCommand();
+
+        // Act
+        await foreach (var _ in handler.Handle(command, CancellationToken.None)) { }
+
+        // Assert — the region overlay is surfaced for Full-tier content.
+        gateway.Verify(
+            g => g.BroadcastAsync(
+                liveSessionId,
+                It.Is<LiveSessionStreamEvent>(e =>
+                    e.Type == "session:chat" &&
+                    HasRegions(e.Data)),
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "Full tier: broadcast citation must carry parsed regions[]");
+    }
+
+    [Fact]
+    public async Task Chat_WithLiveSession_ProtectedTierCitation_BroadcastsWithNullRegions()
+    {
+        // Arrange — same bounding box, but Protected tier → regions MUST be withheld (DA-4).
+        var liveSessionId = Guid.NewGuid();
+        var liveSession = BuildLiveSession(liveSessionId);
+
+        var citation = new ChunkCitation(
+            DocumentId: "doc-2",
+            PageNumber: 1,
+            RelevanceScore: 0.80f,
+            SnippetPreview: "this should be suppressed",
+            CopyrightTier: CopyrightTier.Protected)
+        {
+            BoundingBoxesJson = "[{\"page\":1,\"x\":0.1,\"y\":0.2,\"width\":0.3,\"height\":0.4}]",
+            CharStart = 100,
+            CharEnd = 250,
+        };
+
+        var gateway = new Mock<ILiveSessionStreamGateway>();
+        var handler = BuildHandler(
+            liveSession: liveSession,
+            resolvedCitations: new List<ChunkCitation> { citation },
+            gateway: gateway.Object);
+        var command = BuildCommand();
+
+        // Act
+        await foreach (var _ in handler.Handle(command, CancellationToken.None)) { }
+
+        // Assert — no verbatim region highlight for Protected content.
+        gateway.Verify(
+            g => g.BroadcastAsync(
+                liveSessionId,
+                It.Is<LiveSessionStreamEvent>(e =>
+                    e.Type == "session:chat" &&
+                    NoRegions(e.Data)),
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "Protected tier: regions must be null on the broadcast payload (no verbatim highlight leak)");
+    }
+
+    // -----------------------------------------------------------------------
     // AC-CHAT-3: Non-grounded / no citations → still broadcasts with citations == []
     // -----------------------------------------------------------------------
 
@@ -458,6 +545,33 @@ public class ChatSessionAgentBroadcastTests
         var doc = ToJsonDocument(data);
         if (!doc.RootElement.TryGetProperty("citations", out var citations)) return true;
         return citations.GetArrayLength() == 0;
+    }
+
+    private static bool HasRegions(object data)
+    {
+        var doc = ToJsonDocument(data);
+        if (!doc.RootElement.TryGetProperty("citations", out var citations)) return false;
+        if (citations.GetArrayLength() == 0) return false;
+        var first = citations[0];
+        return first.TryGetProperty("regions", out var regions) &&
+               regions.ValueKind == JsonValueKind.Array &&
+               regions.GetArrayLength() > 0;
+    }
+
+    private static bool NoRegions(object data)
+    {
+        var doc = ToJsonDocument(data);
+        if (!doc.RootElement.TryGetProperty("citations", out var citations)) return true;
+        foreach (var item in citations.EnumerateArray())
+        {
+            if (item.TryGetProperty("regions", out var regions) &&
+                regions.ValueKind == JsonValueKind.Array &&
+                regions.GetArrayLength() > 0)
+            {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static JsonDocument ToJsonDocument(object data)

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/StreamQaQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/StreamQaQueryHandlerTests.cs
@@ -5,7 +5,9 @@ using Api.BoundedContexts.KnowledgeBase.Application.Services;
 using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 using Api.BoundedContexts.KnowledgeBase.Application.Commands;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries;
+using Api.BoundedContexts.KnowledgeBase.Application.Models;
 using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services.Reranking;
@@ -48,6 +50,7 @@ public class StreamQaQueryHandlerTests
     private readonly Mock<IAiResponseCacheService> _cacheMock;
     private readonly Mock<IPromptTemplateService> _promptTemplateServiceMock;
     private readonly Mock<IIntentClassifierService> _intentClassifierMock;
+    private readonly Mock<ICopyrightTierResolver> _copyrightTierResolverMock;
     private readonly Mock<ILogger<StreamQaQueryHandler>> _loggerMock;
     private readonly FakeTimeProvider _fakeTimeProvider;
     private readonly StreamQaQueryHandler _handler;
@@ -96,6 +99,14 @@ public class StreamQaQueryHandlerTests
         _intentClassifierMock
             .Setup(x => x.ClassifyIntent(It.IsAny<string>()))
             .Returns(GameBookRole.None);
+        // SP-C (#3407): default permissive resolver — echoes citations resolved to Full so existing
+        // tests keep their verbatim snippet text (pre-SP-C behavior = no gate = everything verbatim).
+        // Gate tests override this with a Protected-tier resolver.
+        _copyrightTierResolverMock = new Mock<ICopyrightTierResolver>();
+        _copyrightTierResolverMock
+            .Setup(x => x.ResolveAsync(It.IsAny<IReadOnlyList<ChunkCitation>>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<ChunkCitation> cits, Guid _, CancellationToken _) =>
+                cits.Select(c => c with { CopyrightTier = CopyrightTier.Full }).ToList());
         _loggerMock = new Mock<ILogger<StreamQaQueryHandler>>();
         _fakeTimeProvider = new FakeTimeProvider();
         _fakeTimeProvider.SetUtcNow(new DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero));
@@ -122,6 +133,7 @@ public class StreamQaQueryHandlerTests
             new InlineCitationMatcherService(),
             _intentClassifierMock.Object,
             CreatePermissiveRagAccessServiceMock(),
+            _copyrightTierResolverMock.Object,
             _loggerMock.Object,
             _fakeTimeProvider
         );
@@ -257,6 +269,134 @@ public class StreamQaQueryHandlerTests
         var complete = completeEvent.Data.Should().BeOfType<StreamingComplete>().Which;
         (complete.totalTokens > 0).Should().BeTrue();
         complete.confidence.HasValue.Should().BeTrue();
+    }
+
+    // ─── SP-C (#3407): citation region grounding + copyright gate ───
+
+    [Fact]
+    public async Task Handle_FullTierCitation_EmitsRegions_AndVerbatimText()
+    {
+        // Arrange: fused result carries a bbox + char offsets; default resolver resolves to Full.
+        var gameId = Guid.NewGuid().ToString();
+        var query = new StreamQaQuery(gameId, "how do I score?", null);
+        SetupHappyPathMocks(gameId, query.Query);
+        SetupFusedResultWithRegion();
+
+        // Act
+        var snippet = FirstCitation(await CollectEventsAsync(query));
+
+        // Assert: region overlay + verbatim snippet are surfaced for Full-tier content.
+        snippet.regions.Should().NotBeNull();
+        snippet.regions!.Should().ContainSingle();
+        snippet.regions![0].Page.Should().Be(2);
+        snippet.regions![0].X.Should().BeApproximately(0.1, 1e-9);
+        snippet.charStart.Should().Be(100);
+        snippet.charEnd.Should().Be(250);
+        snippet.text.Should().Be("Sample rule text");
+    }
+
+    [Fact]
+    public async Task Handle_ProtectedTierCitation_NullsRegions_ButKeepsVerbatimTextForGrounding()
+    {
+        // Arrange: same bbox-carrying result, but the resolver resolves to Protected.
+        var gameId = Guid.NewGuid().ToString();
+        var query = new StreamQaQuery(gameId, "how do I score?", null);
+        SetupHappyPathMocks(gameId, query.Query);
+        SetupFusedResultWithRegion();
+        _copyrightTierResolverMock
+            .Setup(x => x.ResolveAsync(It.IsAny<IReadOnlyList<ChunkCitation>>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<ChunkCitation> cits, Guid _, CancellationToken _) =>
+                cits.Select(c => c with { CopyrightTier = CopyrightTier.Protected }).ToList());
+
+        // Act
+        var snippet = FirstCitation(await CollectEventsAsync(query));
+
+        // Assert: the verbatim region highlight is withheld for Protected content (DA-4)...
+        snippet.regions.Should().BeNull();
+        snippet.charStart.Should().BeNull();
+        snippet.charEnd.Should().BeNull();
+        // ...but the verbatim snippet text is PRESERVED — the same list grounds the LLM prompt, so
+        // redacting it would starve the model of retrieved context (SP-C review regression guard).
+        snippet.text.Should().Be("Sample rule text");
+    }
+
+    [Fact]
+    public async Task Handle_CachedResponseWithRegions_StripsRegionsOnReplay()
+    {
+        // SP-C review (DA-4): the QA cache key is (game, query) only — NOT user/tier. A Full-tier
+        // user's cached regions must NOT be replayed to a later Protected-tier user on a cache hit,
+        // so cache-served citations strip regions/char offsets (fallback to the text-quote highlight).
+        var gameId = Guid.NewGuid().ToString();
+        var query = new StreamQaQuery(gameId, "cached with regions?", null);
+        var cachedResponse = new QaResponse(
+            answer: "cached answer",
+            snippets: new List<Snippet>
+            {
+                new Snippet("verbatim rule text", "PDF:doc-1", 2, 0, 0.9f)
+                {
+                    regions = new[] { new CitationRegion(2, 0.1, 0.2, 0.3, 0.4) },
+                    charStart = 100,
+                    charEnd = 250,
+                },
+            },
+            promptTokens: 10, completionTokens: 5, totalTokens: 15, confidence: 0.85, metadata: null);
+
+        _cacheMock
+            .Setup(x => x.GenerateQaCacheKey(It.IsAny<string>(), It.IsAny<string>()))
+            .Returns("test-cache-key");
+        _cacheMock
+            .Setup(x => x.GetAsync<QaResponse>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(cachedResponse);
+
+        var snippet = FirstCitation(await CollectEventsAsync(query));
+
+        // Text is still served from cache (pre-existing behavior); regions are stripped (no cross-tier leak).
+        snippet.text.Should().Be("verbatim rule text");
+        snippet.regions.Should().BeNull();
+        snippet.charStart.Should().BeNull();
+        snippet.charEnd.Should().BeNull();
+    }
+
+    private void SetupFusedResultWithRegion()
+    {
+        var fusedResult = new DomainSearchResult(
+            id: Guid.NewGuid(),
+            vectorDocumentId: Guid.NewGuid(),
+            textContent: "Sample rule text",
+            pageNumber: 2,
+            relevanceScore: new Confidence(0.9),
+            rank: 1,
+            searchMethod: "hybrid",
+            boundingBoxesJson: "[{\"page\":2,\"x\":0.1,\"y\":0.2,\"width\":0.3,\"height\":0.4}]",
+            charStart: 100,
+            charEnd: 250);
+
+        _rrfFusionServiceMock
+            .Setup(x => x.FuseResults(
+                It.IsAny<List<DomainSearchResult>>(),
+                It.IsAny<List<DomainSearchResult>>(),
+                It.IsAny<int>(),
+                It.IsAny<GameBookRole>(),
+                It.IsAny<IReadOnlyList<string>?>()))
+            .Returns(new List<DomainSearchResult> { fusedResult });
+    }
+
+    private async Task<List<RagStreamingEvent>> CollectEventsAsync(StreamQaQuery query)
+    {
+        var events = new List<RagStreamingEvent>();
+        await foreach (var evt in _handler.Handle(query, TestContext.Current.CancellationToken))
+        {
+            events.Add(evt);
+        }
+        return events;
+    }
+
+    private static Snippet FirstCitation(List<RagStreamingEvent> events)
+    {
+        var citationsEvent = events.First(e => e.Type == StreamingEventType.Citations);
+        var citations = citationsEvent.Data.Should().BeOfType<StreamingCitations>().Which;
+        citations.citations.Should().NotBeEmpty();
+        return citations.citations[0];
     }
 
     [Fact]
@@ -1367,6 +1507,7 @@ public class StreamQaQueryHandlerTests
             new InlineCitationMatcherService(),
             _intentClassifierMock.Object,
             ragAccessService,
+            _copyrightTierResolverMock.Object,
             _loggerMock.Object,
             _fakeTimeProvider);
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/Chunking/ExtractedDocumentFactoryTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/Chunking/ExtractedDocumentFactoryTests.cs
@@ -10,6 +10,8 @@ namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Services.Chunking;
 public class ExtractedDocumentFactoryTests
 {
     private static ExtractedElement El(string text, string type, int page = 1) => new(text, page, type);
+    private static ExtractedElement ElBox(string text, string type, int page, float x, float y, float w, float h) =>
+        new(text, page, type, new ElementBoundingBox(x, y, w, h));
     private static readonly Guid Doc = Guid.NewGuid();
 
     [Fact]
@@ -22,6 +24,49 @@ public class ExtractedDocumentFactoryTests
         doc.Sections[0].Heading.Should().Be("Preparazione");
         doc.Sections[0].ElementType.Should().Be("heading");
         doc.Sections[0].Content.Should().Be("Preparazione\n\nDisponi le tessere.");
+    }
+
+    // ── SP-B #3406: section bounding-box union ─────────────────────────────────
+
+    [Fact]
+    public void SectionBBox_IsUnionOfElementBoxesOnStartPage()
+    {
+        var doc = ExtractedDocumentFactory.FromExtraction(Doc, null, new[]
+        {
+            ElBox("Setup", "Title", 1, 0.1f, 0.1f, 0.2f, 0.05f),
+            ElBox("body", "NarrativeText", 1, 0.1f, 0.2f, 0.6f, 0.1f),
+        }, "x");
+
+        var bbox = doc.Sections[0].BBox;
+        bbox.Should().NotBeNull();
+        bbox!.X.Should().BeApproximately(0.1f, 1e-4f);
+        bbox.Y.Should().BeApproximately(0.1f, 1e-4f);
+        bbox.Width.Should().BeApproximately(0.6f, 1e-4f); // maxX=max(0.3,0.7)=0.7 → 0.7-0.1
+        bbox.Height.Should().BeApproximately(0.2f, 1e-4f); // maxY=max(0.15,0.3)=0.3 → 0.3-0.1
+    }
+
+    [Fact]
+    public void SectionBBox_IsNullWhenNoElementHasCoordinates()
+    {
+        var doc = ExtractedDocumentFactory.FromExtraction(Doc, null,
+            new[] { El("Setup", "Title"), El("body", "NarrativeText") }, "x");
+
+        doc.Sections[0].BBox.Should().BeNull();
+    }
+
+    [Fact]
+    public void SectionBBox_SkipsElementsNotOnStartPage()
+    {
+        var doc = ExtractedDocumentFactory.FromExtraction(Doc, null, new[]
+        {
+            ElBox("Setup", "Title", 1, 0.1f, 0.1f, 0.2f, 0.05f),
+            ElBox("later", "NarrativeText", 2, 0.9f, 0.9f, 0.1f, 0.1f), // page 2 → ignored
+        }, "x");
+
+        var bbox = doc.Sections[0].BBox;
+        bbox.Should().NotBeNull();
+        bbox!.X.Should().BeApproximately(0.1f, 1e-4f);
+        bbox.Width.Should().BeApproximately(0.2f, 1e-4f); // only the start-page box counts
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyServiceTests.cs
@@ -195,6 +195,43 @@ public class RagPromptAssemblyServiceTests
         result.SystemPrompt.Should().Contain("Pawns move forward");
     }
 
+    [Fact]
+    public async Task AssemblePrompt_VectorChunkWithBoundingBoxes_PropagatesToCitation()
+    {
+        // SP-C (#3407): bbox + char offsets on the vector-arm Embedding must survive BOTH the
+        // vector→SearchResultItem map AND the hybrid-fusion GroupBy rebuild (a drop site) into the
+        // ChunkCitation, so the handler boundary can parse + Full-gate them into regions[].
+        const string bbox = "[{\"page\":2,\"x\":0.1,\"y\":0.2,\"width\":0.3,\"height\":0.4}]";
+        SetupSuccessfulEmbedding();
+        var scored = new List<ScoredEmbedding>
+        {
+            new(new Embedding(
+                    Guid.NewGuid(), Guid.NewGuid(), "Pawns move forward one square.",
+                    new Vector(TestEmbedding), "test-model", chunkIndex: 0, pageNumber: 2,
+                    boundingBoxesJson: bbox, charStart: 100, charEnd: 250),
+                0.85)
+        };
+        _embeddingRepositoryMock
+            .Setup(r => r.SearchByVectorWithScoresAsync(
+                It.IsAny<Guid>(), It.IsAny<Vector>(), It.IsAny<int>(), It.IsAny<double>(),
+                It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(scored);
+        SetupTextSearchResults(); // no FTS — the vector chunk alone flows through hybrid fusion
+        SetupRerankerPassthrough();
+        var service = CreateService();
+
+        // Act
+        var result = await service.AssemblePromptAsync(
+            "tutor", "Chess", null, "How do pawns move?",
+            TestGameId, null, null, "it", CancellationToken.None);
+
+        // Assert — the (only) coordinate-bearing citation kept its bbox + char offsets end-to-end.
+        var cited = result.Citations.Should().ContainSingle(c => c.BoundingBoxesJson != null).Which;
+        cited.BoundingBoxesJson.Should().Be(bbox);
+        cited.CharStart.Should().Be(100);
+        cited.CharEnd.Should().Be(250);
+    }
+
     #endregion
 
     #region AssemblePromptAsync - With Chunks (FTS-only post pgvector migration)

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/RrfFusionDomainServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/RrfFusionDomainServiceTests.cs
@@ -172,6 +172,29 @@ public sealed class RrfFusionDomainServiceTests
     }
 
     [Fact]
+    public void FuseResults_CarriesBoundingBoxesAndCharOffsets_FromVectorArm()
+    {
+        // SP-C (#3407): the FuseResults rebuild (new SearchResult from `original`) is a known DROP
+        // SITE — region-grounding carriers must survive fusion. Vector arm carries bbox + char
+        // offsets; the fused result must keep them (preferring the vector-arm original).
+        const string bbox = "[{\"page\":2,\"x\":0.1,\"y\":0.2,\"width\":0.3,\"height\":0.4}]";
+        var pdf = Guid.NewGuid();
+        var vector = new List<SearchResult>
+        {
+            new(Guid.NewGuid(), Guid.NewGuid(), "cited chunk", 1, new Confidence(0.90), 1, "vector",
+                pdfDocumentId: pdf, chunkIndex: 0, roleTags: GameBookRole.None, heading: null,
+                boundingBoxesJson: bbox, charStart: 100, charEnd: 250)
+        };
+
+        var fused = _service.FuseResults(vector, new List<SearchResult>());
+
+        fused.Should().HaveCount(1);
+        fused[0].BoundingBoxesJson.Should().Be(bbox);
+        fused[0].CharStart.Should().Be(100);
+        fused[0].CharEnd.Should().Be(250);
+    }
+
+    [Fact]
     public void FuseResults_WithOverlappingDocuments_CombinesScores()
     {
         // Arrange

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Infrastructure/Services/GamebookPhotoStorageServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Infrastructure/Services/GamebookPhotoStorageServiceTests.cs
@@ -72,6 +72,12 @@ public sealed class GamebookPhotoStorageServiceTests
             return Task.FromResult(true);
         }
 
+        public Task<bool> StoreRawKeyAsync(string rawKey, Stream stream, string contentType, CancellationToken ct = default)
+        {
+            _ = (rawKey, stream, contentType, ct);
+            return Task.FromResult(true);
+        }
+
         public Task<string?> GetPresignedUrlForRawKeyAsync(string rawKey, int? expirySeconds = null)
         {
             _ = (rawKey, expirySeconds);

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserLibrary/Application/EventHandlers/GameRemovedFromLibraryCustomCoverHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserLibrary/Application/EventHandlers/GameRemovedFromLibraryCustomCoverHandlerTests.cs
@@ -32,17 +32,15 @@ public sealed class GameRemovedFromLibraryCustomCoverHandlerTests
         var expectedObjectKey = $"{resourceKey}.webp";
 
         var evt = new GameRemovedFromLibraryEvent(Guid.NewGuid(), userId, gameId, resourceKey);
-        _blob.Setup(b => b.DeleteAsync(expectedObjectKey, BlobCategory.GameImage, resourceKey, It.IsAny<CancellationToken>()))
+        _blob.Setup(b => b.DeleteRawKeyAsync(expectedObjectKey, It.IsAny<CancellationToken>()))
              .ReturnsAsync(true);
 
         // Act
         await Handler().Handle(evt, default);
 
-        // Assert — DeleteAsync called exactly once with ToObjectKey(resourceKey), GameImage, resourceKey
-        _blob.Verify(b => b.DeleteAsync(
+        // Assert — raw-key delete of the exact physical object (#3384)
+        _blob.Verify(b => b.DeleteRawKeyAsync(
             expectedObjectKey,
-            BlobCategory.GameImage,
-            resourceKey,
             It.IsAny<CancellationToken>()), Times.Once);
     }
 
@@ -58,7 +56,7 @@ public sealed class GameRemovedFromLibraryCustomCoverHandlerTests
 
         // Assert — DeleteAsync must never be called
         _blob.Verify(
-            b => b.DeleteAsync(It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            b => b.DeleteRawKeyAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -73,7 +71,7 @@ public sealed class GameRemovedFromLibraryCustomCoverHandlerTests
 
         // Assert
         _blob.Verify(
-            b => b.DeleteAsync(It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            b => b.DeleteRawKeyAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -84,7 +82,7 @@ public sealed class GameRemovedFromLibraryCustomCoverHandlerTests
         // Arrange
         var resourceKey = $"user-covers/{Guid.NewGuid()}/{Guid.NewGuid()}/cover";
         var evt = MakeEvent(resourceKey);
-        _blob.Setup(b => b.DeleteAsync(It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _blob.Setup(b => b.DeleteRawKeyAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
              .ThrowsAsync(new InvalidOperationException("S3 endpoint unreachable"));
 
         // Act
@@ -114,7 +112,7 @@ public sealed class GameRemovedFromLibraryCustomCoverHandlerTests
         using var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        _blob.Setup(b => b.DeleteAsync(It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), cts.Token))
+        _blob.Setup(b => b.DeleteRawKeyAsync(It.IsAny<string>(), cts.Token))
              .ThrowsAsync(new OperationCanceledException(cts.Token));
 
         // Act

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserLibrary/Application/Handlers/CustomCover/RemoveCustomCoverCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserLibrary/Application/Handlers/CustomCover/RemoveCustomCoverCommandHandlerTests.cs
@@ -116,7 +116,7 @@ public sealed class RemoveCustomCoverCommandHandlerTests
             .ReturnsAsync(entry);
 
         _mockBlobStorage
-            .Setup(b => b.DeleteAsync(It.IsAny<string>(), BlobCategory.GameImage, coverKey, It.IsAny<CancellationToken>()))
+            .Setup(b => b.DeleteRawKeyAsync($"{coverKey}.webp", It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
         var command = CreateCommand(userId, gameId);
@@ -124,13 +124,9 @@ public sealed class RemoveCustomCoverCommandHandlerTests
         // Act
         await _handler.Handle(command, TestContext.Current.CancellationToken);
 
-        // Assert
+        // Assert — raw-key delete of the exact physical object (#3384)
         _mockBlobStorage.Verify(
-            b => b.DeleteAsync(
-                $"{coverKey}.webp",
-                BlobCategory.GameImage,
-                coverKey,
-                It.IsAny<CancellationToken>()),
+            b => b.DeleteRawKeyAsync($"{coverKey}.webp", It.IsAny<CancellationToken>()),
             Times.Once);
 
         // Verify SetCustomCoverR2Key was called with null
@@ -162,7 +158,7 @@ public sealed class RemoveCustomCoverCommandHandlerTests
 
         var deleteException = new InvalidOperationException("R2 service unavailable");
         _mockBlobStorage
-            .Setup(b => b.DeleteAsync(It.IsAny<string>(), BlobCategory.GameImage, coverKey, It.IsAny<CancellationToken>()))
+            .Setup(b => b.DeleteRawKeyAsync($"{coverKey}.webp", It.IsAny<CancellationToken>()))
             .ThrowsAsync(deleteException);
 
         var command = CreateCommand(userId, gameId);
@@ -172,11 +168,7 @@ public sealed class RemoveCustomCoverCommandHandlerTests
 
         // Assert: handler should NOT propagate exception
         _mockBlobStorage.Verify(
-            b => b.DeleteAsync(
-                $"{coverKey}.webp",
-                BlobCategory.GameImage,
-                coverKey,
-                It.IsAny<CancellationToken>()),
+            b => b.DeleteRawKeyAsync($"{coverKey}.webp", It.IsAny<CancellationToken>()),
             Times.Once);
 
         // DB should still be updated despite R2 failure

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserLibrary/Application/Handlers/CustomCover/UploadCustomCoverCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserLibrary/Application/Handlers/CustomCover/UploadCustomCoverCommandHandlerTests.cs
@@ -67,7 +67,8 @@ public sealed class UploadCustomCoverCommandHandlerTests
     }
 
     // -------------------------------------------------------
-    // T2-2: happy path — uploads to R2, saves DB, returns URL
+    // T2-2: happy path — writes to R2 via the RAW-KEY deterministic path (#3384),
+    // saves DB, returns presigned URL for the exact physical key.
     // -------------------------------------------------------
 
     [Fact]
@@ -79,17 +80,18 @@ public sealed class UploadCustomCoverCommandHandlerTests
         var entry = CreateEntry(userId, gameId);
         var expectedUrl = "https://r2.example.com/presigned-url";
         var expectedKey = $"user-covers/{userId}/{gameId}/cover";
+        var physicalKey = $"{expectedKey}.webp";
 
         _mockLibraryRepo
             .Setup(r => r.GetByUserAndGameAsync(userId, gameId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(entry);
 
         _mockBlobStorage
-            .Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), BlobCategory.GameImage, expectedKey, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BlobStorageResult(true, "file-id", "/path", 1024));
+            .Setup(b => b.StoreRawKeyAsync(physicalKey, It.IsAny<Stream>(), "image/webp", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
 
         _mockBlobStorage
-            .Setup(b => b.GetPresignedDownloadUrlAsync(It.IsAny<string>(), BlobCategory.GameImage, expectedKey, 3600))
+            .Setup(b => b.GetPresignedUrlForRawKeyAsync(physicalKey, 3600))
             .ReturnsAsync(expectedUrl);
 
         var command = CreateCommand(userId, gameId);
@@ -101,21 +103,22 @@ public sealed class UploadCustomCoverCommandHandlerTests
         result.CoverR2Key.Should().Be(expectedKey);
         result.PresignedUrl.Should().Be(expectedUrl);
 
+        // The deterministic physical key is written verbatim — NOT the categorized
+        // StoreAsync (which would reject the '/' and mint a random-id key the resolver
+        // cannot reconstruct).
         _mockBlobStorage.Verify(
-            b => b.StoreAsync(
-                It.IsAny<Stream>(),
-                $"{expectedKey}.webp",
-                BlobCategory.GameImage,
-                expectedKey,
-                It.IsAny<CancellationToken>()),
+            b => b.StoreRawKeyAsync(physicalKey, It.IsAny<Stream>(), "image/webp", It.IsAny<CancellationToken>()),
             Times.Once);
+        _mockBlobStorage.Verify(
+            b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
 
         _mockLibraryRepo.Verify(r => r.UpdateAsync(entry, It.IsAny<CancellationToken>()), Times.Once);
         _mockUnitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 
     // -------------------------------------------------------
-    // T2-3: replace flow — DeleteAsync called before StoreAsync
+    // T2-3: replace flow — raw-key delete of the old cover before the raw-key write.
     // -------------------------------------------------------
 
     [Fact]
@@ -125,27 +128,26 @@ public sealed class UploadCustomCoverCommandHandlerTests
         var userId = Guid.NewGuid();
         var gameId = Guid.NewGuid();
         var entry = CreateEntry(userId, gameId);
-        var oldKey = $"user-covers/{userId}/{gameId}/cover";
+        var key = $"user-covers/{userId}/{gameId}/cover";
+        var physicalKey = $"{key}.webp";
 
         // Seed an existing custom cover on the entry
-        entry.SetCustomCoverR2Key(oldKey);
-
-        var newKey = $"user-covers/{userId}/{gameId}/cover";
+        entry.SetCustomCoverR2Key(key);
 
         _mockLibraryRepo
             .Setup(r => r.GetByUserAndGameAsync(userId, gameId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(entry);
 
         _mockBlobStorage
-            .Setup(b => b.DeleteAsync(It.IsAny<string>(), BlobCategory.GameImage, oldKey, It.IsAny<CancellationToken>()))
+            .Setup(b => b.DeleteRawKeyAsync(physicalKey, It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
         _mockBlobStorage
-            .Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), BlobCategory.GameImage, newKey, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BlobStorageResult(true, "file-id", "/path", 1024));
+            .Setup(b => b.StoreRawKeyAsync(physicalKey, It.IsAny<Stream>(), "image/webp", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
 
         _mockBlobStorage
-            .Setup(b => b.GetPresignedDownloadUrlAsync(It.IsAny<string>(), BlobCategory.GameImage, newKey, 3600))
+            .Setup(b => b.GetPresignedUrlForRawKeyAsync(physicalKey, 3600))
             .ReturnsAsync("https://r2.example.com/new-url");
 
         var command = CreateCommand(userId, gameId);
@@ -153,22 +155,48 @@ public sealed class UploadCustomCoverCommandHandlerTests
         // Act
         await _handler.Handle(command, TestContext.Current.CancellationToken);
 
-        // Assert: delete called before store (verify both were called; ordering guaranteed by sequential await)
+        // Assert: delete before store (both via the raw-key path; ordering guaranteed by sequential await)
         _mockBlobStorage.Verify(
-            b => b.DeleteAsync(
-                $"{oldKey}.webp",
-                BlobCategory.GameImage,
-                oldKey,
-                It.IsAny<CancellationToken>()),
+            b => b.DeleteRawKeyAsync(physicalKey, It.IsAny<CancellationToken>()),
             Times.Once);
+        _mockBlobStorage.Verify(
+            b => b.StoreRawKeyAsync(physicalKey, It.IsAny<Stream>(), "image/webp", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
 
-        _mockBlobStorage.Verify(
-            b => b.StoreAsync(
-                It.IsAny<Stream>(),
-                $"{newKey}.webp",
-                BlobCategory.GameImage,
-                newKey,
-                It.IsAny<CancellationToken>()),
-            Times.Once);
+    // -------------------------------------------------------
+    // T2-4 (#3384): a failed raw-key write (false — S3 error or local-storage mode)
+    // must NOT persist an unresolvable key. Throw ExternalServiceException and leave
+    // the DB untouched.
+    // -------------------------------------------------------
+
+    [Fact]
+    public async Task Handle_RawKeyWriteFails_ThrowsAndDoesNotPersist()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+        var entry = CreateEntry(userId, gameId);
+        var physicalKey = $"user-covers/{userId}/{gameId}/cover.webp";
+
+        _mockLibraryRepo
+            .Setup(r => r.GetByUserAndGameAsync(userId, gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(entry);
+
+        _mockBlobStorage
+            .Setup(b => b.StoreRawKeyAsync(physicalKey, It.IsAny<Stream>(), "image/webp", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var command = CreateCommand(userId, gameId);
+
+        // Act
+        var act = () => _handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        await act.Should().ThrowAsync<ExternalServiceException>();
+
+        entry.CustomCoverR2Key.Should().BeNull("no key is persisted when the object write failed");
+        _mockLibraryRepo.Verify(r => r.UpdateAsync(It.IsAny<UserLibraryEntry>(), It.IsAny<CancellationToken>()), Times.Never);
+        _mockUnitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/BulkReindexReadySelectorIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/BulkReindexReadySelectorIntegrationTests.cs
@@ -22,7 +22,7 @@ namespace Api.Tests.Integration.DocumentProcessing;
 /// real PostgreSQL instance (Testcontainers). Issue #3269 (SP3 RAG bulk re-index).
 /// <para>
 /// Proves the mandatory Postgres null-comparison guard on the selector: a plain
-/// <c>indexer_version &lt;&gt; 'v1.1'</c> predicate silently drops rows where
+/// <c>indexer_version &lt;&gt; 'v1.2'</c> predicate silently drops rows where
 /// <c>indexer_version IS NULL</c> (three-valued logic), so the handler MUST use
 /// <c>IndexerVersion == null || IndexerVersion != target</c>. This test seeds a NULL-version
 /// Ready row and asserts it IS selected — it fails against Npgsql SQL semantics if the
@@ -130,7 +130,7 @@ public sealed class BulkReindexReadySelectorIntegrationTests : IAsyncLifetime
     {
         // PDF-A: Ready + IndexerVersion = NULL  → MUST be selected (null-comparison guard).
         var pdfA = await SeedPdfAsync("Ready", indexerVersion: null);
-        // PDF-B: Ready + already at target v1.1 → excluded (idempotent).
+        // PDF-B: Ready + already at the current target (v1.2) → excluded (idempotent).
         await SeedPdfAsync("Ready", indexerVersion: IndexerVersionRegistry.Current.Version);
         // PDF-C: Failed + NULL                 → excluded (non-Ready).
         await SeedPdfAsync("Failed", indexerVersion: null);

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/GameNightPhotoUploadTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/GameNightPhotoUploadTests.cs
@@ -72,6 +72,9 @@ public sealed class GameNightPhotoUploadTests : IAsyncLifetime
             => Task.FromResult<string?>(null);
         public Task<bool> DeleteRawKeyAsync(string rawKey, CancellationToken ct = default)
             => Task.FromResult(true);
+
+        public Task<bool> StoreRawKeyAsync(string rawKey, Stream stream, string contentType, CancellationToken ct = default)
+            => Task.FromResult(true);
     }
 
     public async ValueTask InitializeAsync()

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/PlayRecordPhotoUploadTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/PlayRecordPhotoUploadTests.cs
@@ -98,6 +98,9 @@ public sealed class PlayRecordPhotoUploadTests : IAsyncLifetime
             => Task.FromResult<string?>(null);
         public Task<bool> DeleteRawKeyAsync(string rawKey, CancellationToken ct = default)
             => Task.FromResult(true);
+
+        public Task<bool> StoreRawKeyAsync(string rawKey, Stream stream, string contentType, CancellationToken ct = default)
+            => Task.FromResult(true);
     }
 
     // ---------------------------------------------------------------------------

--- a/apps/api/tests/Api.Tests/SharedKernel/Domain/Covers/CoverKeyContractTests.cs
+++ b/apps/api/tests/Api.Tests/SharedKernel/Domain/Covers/CoverKeyContractTests.cs
@@ -1,0 +1,112 @@
+using Api.SharedKernel.Domain.Covers;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.SharedKernel.Domain.Covers;
+
+/// <summary>
+/// Issue #3384 (ADR-087 D5-A) — the Docker-free contract test the issue asks for.
+/// Asserts that the SINGLE key-builder makes write-key and read-key coincide
+/// by construction for every <see cref="CoverKind"/>, so the recurring
+/// <c>.webp.webp</c> double-suffix / writer↔resolver drift bug is structurally
+/// impossible. Replaces the value of <c>CoverR2ConventionIntegrationTests</c>
+/// (which needs MinIO and skips locally) with a pure, always-runnable check.
+///
+/// The golden keys also pin the EXACT production convention — this refactor must
+/// remain byte-compatible with keys already stored in R2/DB (no data migration).
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedKernel")]
+public sealed class CoverKeyContractTests
+{
+    private static readonly Guid UserId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly Guid GameId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static readonly Guid PdfId = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+    private const int BggId = 13;
+
+    [Fact]
+    public void ForUser_MatchesProductionConvention()
+    {
+        var key = CoverKeyBuilder.ForUser(UserId, GameId);
+
+        key.Kind.Should().Be(CoverKind.User);
+        key.DbKey.Should().Be($"user-covers/{UserId:D}/{GameId:D}/cover");
+        key.PhysicalKey.Should().Be($"user-covers/{UserId:D}/{GameId:D}/cover.webp");
+    }
+
+    [Fact]
+    public void ForPdf_MatchesProductionConvention()
+    {
+        var key = CoverKeyBuilder.ForPdf(PdfId);
+
+        key.Kind.Should().Be(CoverKind.Pdf);
+        key.DbKey.Should().Be($"covers/pdf/{PdfId:D}/cover");
+        key.PhysicalKey.Should().Be($"covers/pdf/{PdfId:D}/cover-preview.webp");
+    }
+
+    [Fact]
+    public void ForWikidata_MatchesProductionConvention()
+    {
+        var key = CoverKeyBuilder.ForWikidata(GameId);
+
+        key.Kind.Should().Be(CoverKind.Wikidata);
+        key.DbKey.Should().Be($"covers/{GameId:D}/cover");
+        key.PhysicalKey.Should().Be($"covers/{GameId:D}/cover.webp");
+    }
+
+    [Theory]
+    [InlineData(".jpg", "bgg-covers/13/cover.jpg")]
+    [InlineData("jpg", "bgg-covers/13/cover.jpg")]    // normalizes a missing leading dot
+    [InlineData(".JPG", "bgg-covers/13/cover.jpg")]   // normalizes case
+    [InlineData(".jpeg", "bgg-covers/13/cover.jpeg")]
+    [InlineData(".png", "bgg-covers/13/cover.png")]
+    [InlineData(".webp", "bgg-covers/13/cover.webp")]
+    [InlineData("", "bgg-covers/13/cover.jpg")]        // empty → default extension
+    [InlineData(".bmp", "bgg-covers/13/cover.jpg")]    // unsupported → default extension
+    public void ForBgg_MatchesProductionConventionAndNormalizesExtension(string ext, string expected)
+    {
+        var key = CoverKeyBuilder.ForBgg(BggId, ext);
+
+        key.Kind.Should().Be(CoverKind.Bgg);
+        // BGG stores its source extension IN the key → physical == db (no suffix appended).
+        key.DbKey.Should().Be(expected);
+        key.PhysicalKey.Should().Be(expected);
+    }
+
+    /// <summary>
+    /// THE core contract: a key stored in the DB (the suffix-free <c>DbKey</c>),
+    /// re-read and passed to <see cref="CoverKeyBuilder.PhysicalKeyFor"/>, must
+    /// reconstruct EXACTLY the physical key the writer PUT — for every kind,
+    /// including the BGG-with-.webp-source edge case where the ext equals the
+    /// suffix (must NOT produce <c>cover.webp.webp</c>).
+    /// </summary>
+    [Fact]
+    public void PhysicalKeyFor_FromStoredDbKey_ReconstructsWriterPhysicalKey_ForEveryKind()
+    {
+        var keys = new[]
+        {
+            CoverKeyBuilder.ForUser(UserId, GameId),
+            CoverKeyBuilder.ForPdf(PdfId),
+            CoverKeyBuilder.ForWikidata(GameId),
+            CoverKeyBuilder.ForBgg(BggId, ".jpg"),
+            CoverKeyBuilder.ForBgg(BggId, ".webp"),
+        };
+
+        foreach (var k in keys)
+        {
+            CoverKeyBuilder.PhysicalKeyFor(k.Kind, k.DbKey).Should().Be(
+                k.PhysicalKey,
+                $"the resolver must reconstruct the writer's physical key for {k.Kind}");
+            k.PhysicalKey.Should().NotContain(".webp.webp");
+            k.PhysicalKey.Should().NotContain("-preview.webp-preview.webp");
+        }
+    }
+
+    [Fact]
+    public void PhysicalKeyFor_RejectsBlankDbKey()
+    {
+        var act = () => CoverKeyBuilder.PhysicalKeyFor(CoverKind.Pdf, "  ");
+
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/apps/api/tests/Api.Tests/Unit/DocumentProcessing/IndexerVersionRegistryTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/DocumentProcessing/IndexerVersionRegistryTests.cs
@@ -14,10 +14,11 @@ public sealed class IndexerVersionRegistryTests
     [Fact]
     public void Current_ReturnsLatestSelectableVersion()
     {
-        // SP3 #3269 D2: Current bumped to the heading-aware pipeline version.
-        IndexerVersionRegistry.Current.Version.Should().Be("v1.1");
+        // SP-E #3409 (epic #3403): Current bumped to the coordinate-aware pipeline version so a
+        // corpus re-extract re-populates bounding_boxes_json for region grounding.
+        IndexerVersionRegistry.Current.Version.Should().Be("v1.2");
         IndexerVersionRegistry.Current.IsSelectable.Should().BeTrue();
-        IndexerVersionRegistry.Current.DisplayName.Should().Contain("heading-aware");
+        IndexerVersionRegistry.Current.DisplayName.Should().Contain("coordinate-aware");
     }
 
     [Fact]
@@ -28,20 +29,22 @@ public sealed class IndexerVersionRegistryTests
     }
 
     [Fact]
-    public void All_ContainsLegacyV0AndV1_0AndV1_1()
+    public void All_ContainsLegacyV0AndV1_0AndV1_1AndV1_2()
     {
         var versions = IndexerVersionRegistry.All;
-        versions.Should().HaveCountGreaterThanOrEqualTo(3);
+        versions.Should().HaveCountGreaterThanOrEqualTo(4);
         versions.Should().Contain(v => v.Version == "v0");
-        // v1.0 retained per the ≥18mo deprecation policy even though it is no longer Current.
+        // v1.0 / v1.1 retained per the ≥18mo deprecation policy even though they are no longer Current.
         versions.Should().Contain(v => v.Version == "v1.0");
         versions.Should().Contain(v => v.Version == "v1.1");
+        versions.Should().Contain(v => v.Version == "v1.2");
     }
 
     [Theory]
     [InlineData("v0")]
     [InlineData("v1.0")]
     [InlineData("v1.1")]
+    [InlineData("v1.2")]
     public void TryGet_KnownVersion_ReturnsTrue(string input)
     {
         IndexerVersionRegistry.TryGet(input, out var version).Should().BeTrue();
@@ -67,9 +70,10 @@ public sealed class IndexerVersionRegistryTests
     [Fact]
     public void IsSelectable_Current_ReturnsTrue()
     {
-        // Both the retained v1.0 and the new heading-aware v1.1 remain selectable from /reindex.
+        // The retained v1.0/v1.1 and the new coordinate-aware v1.2 all remain selectable from /reindex.
         IndexerVersionRegistry.IsSelectable("v1.0").Should().BeTrue();
         IndexerVersionRegistry.IsSelectable("v1.1").Should().BeTrue();
+        IndexerVersionRegistry.IsSelectable("v1.2").Should().BeTrue();
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/Unit/Models/CitationRegionTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/Models/CitationRegionTests.cs
@@ -1,0 +1,81 @@
+using System.Text.Json;
+using Api.Infrastructure.Serialization;
+using Api.Models;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Unit.Models;
+
+/// <summary>
+/// SP-C (#3407): CitationRegion is the FE-facing, Full-gated region shape parsed from the
+/// persisted <c>text_chunks.bounding_boxes_json</c> (produced by
+/// <c>ChunkBoundingBoxJson.Serialize</c>). The stored JSON is an ARRAY of objects with
+/// LOWERCASE keys <c>[{page,x,y,width,height}]</c> and x/y/width/height normalized to
+/// [0,1] top-left. Parse must be case-insensitive and defensive (never throw).
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "KnowledgeBase")]
+public sealed class CitationRegionTests
+{
+    [Fact]
+    public void Parse_LowercaseJsonArray_ReturnsRegionWithNormalizedValues()
+    {
+        // Arrange: EXACT shape persisted by ChunkBoundingBoxJson.Serialize (lowercase keys, array)
+        const string json = "[{\"page\":2,\"x\":0.1,\"y\":0.2,\"width\":0.3,\"height\":0.4}]";
+
+        // Act
+        var regions = CitationRegion.Parse(json);
+
+        // Assert
+        regions.Should().NotBeNull();
+        regions!.Should().HaveCount(1);
+        var r = regions[0];
+        r.Page.Should().Be(2);
+        r.X.Should().BeApproximately(0.1, 1e-9);
+        r.Y.Should().BeApproximately(0.2, 1e-9);
+        r.Width.Should().BeApproximately(0.3, 1e-9);
+        r.Height.Should().BeApproximately(0.4, 1e-9);
+    }
+
+    [Fact]
+    public void Parse_MultipleBoxes_ReturnsAllRegionsInOrder()
+    {
+        const string json =
+            "[{\"page\":1,\"x\":0,\"y\":0,\"width\":0.5,\"height\":0.5}," +
+            "{\"page\":1,\"x\":0.5,\"y\":0.5,\"width\":0.4,\"height\":0.4}]";
+
+        var regions = CitationRegion.Parse(json);
+
+        regions.Should().NotBeNull();
+        regions!.Should().HaveCount(2);
+        regions[0].X.Should().BeApproximately(0, 1e-9);
+        regions[1].X.Should().BeApproximately(0.5, 1e-9);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("[]")]              // valid JSON but no boxes → treated as "no regions"
+    [InlineData("not json")]        // malformed → defensive null, no throw
+    [InlineData("{\"page\":1}")]    // object, not the expected array → null
+    public void Parse_NullEmptyOrInvalid_ReturnsNull(string? json)
+    {
+        CitationRegion.Parse(json).Should().BeNull();
+    }
+
+    [Fact]
+    public void CitationRegion_SerializesCamelCase_ViaSseOptions()
+    {
+        // The wire contract the FE (zod CitationSchema / mapSseCitation) expects.
+        var region = new CitationRegion(3, 0.11, 0.22, 0.33, 0.44);
+
+        var wire = JsonSerializer.Serialize(region, SseJsonOptions.Default);
+
+        wire.Should().Contain("\"page\":3");
+        wire.Should().Contain("\"x\":0.11");
+        wire.Should().Contain("\"y\":0.22");
+        wire.Should().Contain("\"width\":0.33");
+        wire.Should().Contain("\"height\":0.44");
+    }
+}

--- a/apps/api/tests/Api.Tests/Unit/Models/SnippetRegionSerializationTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/Models/SnippetRegionSerializationTests.cs
@@ -1,0 +1,52 @@
+using System.Text.Json;
+using Api.Infrastructure.Serialization;
+using Api.Models;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Unit.Models;
+
+/// <summary>
+/// SP-C (#3407): the per-game StreamQa Snippet gains additive, Full-gated region fields
+/// (regions/charStart/charEnd). Like chunkId/chunkPosition (#1702), they are
+/// <c>[JsonIgnore(WhenWritingNull)]</c> so the D-4 additive-only wire contract holds:
+/// legacy/Protected snippets (null fields) MUST NOT emit the new keys.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "KnowledgeBase")]
+public sealed class SnippetRegionSerializationTests
+{
+    [Fact]
+    public void Snippet_WithoutRegions_OmitsRegionKeys_ViaSseOptions()
+    {
+        var snippet = new Snippet("rules text", "PDF:abc-123", 14, 0, 0.85f);
+        var citations = new StreamingCitations(new[] { snippet });
+
+        var json = JsonSerializer.Serialize(citations, SseJsonOptions.Default);
+
+        json.Should().NotContain("regions");
+        json.Should().NotContain("charStart");
+        json.Should().NotContain("charEnd");
+    }
+
+    [Fact]
+    public void Snippet_WithRegions_EmitsCamelCaseRegionArray_ViaSseOptions()
+    {
+        var snippet = new Snippet("rules text", "PDF:abc-123", 14, 0, 0.85f)
+        {
+            regions = new[] { new CitationRegion(14, 0.1, 0.2, 0.3, 0.4) },
+            charStart = 100,
+            charEnd = 250,
+        };
+        var citations = new StreamingCitations(new[] { snippet });
+
+        var json = JsonSerializer.Serialize(citations, SseJsonOptions.Default);
+
+        json.Should().Contain("\"regions\":[");
+        json.Should().Contain("\"page\":14");
+        json.Should().Contain("\"x\":0.1");
+        json.Should().Contain("\"width\":0.3");
+        json.Should().Contain("\"charStart\":100");
+        json.Should().Contain("\"charEnd\":250");
+    }
+}

--- a/apps/unstructured-service/src/api/coordinates.py
+++ b/apps/unstructured-service/src/api/coordinates.py
@@ -1,0 +1,48 @@
+"""Coordinate normalization for PDF elements (SP-B #3406, epic #3403).
+
+unstructured `partition_pdf` attaches `element.metadata.coordinates` — a
+CoordinatesMetadata carrying `.points` (list of (x, y)) and `.system`
+(CoordinateSystem with `.width`/`.height`). PixelSpace uses a top-left origin
+(y grows downward), so no Y flip is needed. We normalize to [0,1] fractions of the
+page layout so the value is independent of strategy (fast vs hi_res), DPI, and the
+viewer zoom — the C# side receives an already-normalized box and the FE overlay is
+zero-math.
+"""
+from typing import Any, Optional
+
+from .schemas import BBoxSchema
+
+
+def _clamp_unit(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
+def normalized_bbox(element: Any) -> Optional[BBoxSchema]:
+    """Return the element's bounding box normalized to [0,1] (top-left origin),
+    or None when the element carries no usable coordinates (e.g. PageBreak, or an
+    OCR element without a layout box)."""
+    coordinates = getattr(getattr(element, "metadata", None), "coordinates", None)
+    if coordinates is None:
+        return None
+
+    points = getattr(coordinates, "points", None)
+    system = getattr(coordinates, "system", None)
+    if not points or system is None:
+        return None
+
+    width = getattr(system, "width", None)
+    height = getattr(system, "height", None)
+    if not width or not height:
+        return None
+
+    xs = [point[0] for point in points]
+    ys = [point[1] for point in points]
+    x_min, x_max = min(xs), max(xs)
+    y_min, y_max = min(ys), max(ys)
+
+    return BBoxSchema(
+        x=_clamp_unit(x_min / width),
+        y=_clamp_unit(y_min / height),
+        width=_clamp_unit((x_max - x_min) / width),
+        height=_clamp_unit((y_max - y_min) / height),
+    )

--- a/apps/unstructured-service/src/api/schemas.py
+++ b/apps/unstructured-service/src/api/schemas.py
@@ -26,6 +26,19 @@ class TextChunkSchema(BaseModel):
     metadata: Dict[str, Any] = Field(default_factory=dict, description="Additional metadata")
 
 
+class BBoxSchema(BaseModel):
+    """Normalized bounding box of an element (SP-B #3406, epic #3403).
+
+    Fractions in [0,1] of the page layout, top-left origin (y grows downward), so
+    the value is independent of strategy (fast vs hi_res), DPI, and viewer zoom.
+    """
+
+    x: float = Field(description="Left edge, normalized 0..1")
+    y: float = Field(description="Top edge, normalized 0..1 (top-left origin)")
+    width: float = Field(description="Width, normalized 0..1")
+    height: float = Field(description="Height, normalized 0..1")
+
+
 class ElementSchema(BaseModel):
     """Raw partition element (pre-chunking), preserving its structural category."""
 
@@ -33,6 +46,10 @@ class ElementSchema(BaseModel):
     page_number: int = Field(description="Page number (1-indexed)", ge=1)
     category: Optional[str] = Field(
         default=None, description="Raw Unstructured category (Title, NarrativeText, Table, …)"
+    )
+    bbox: Optional[BBoxSchema] = Field(
+        default=None,
+        description="Normalized bounding box [0,1] top-left; None if the extractor emitted no coordinates",
     )
 
 

--- a/apps/unstructured-service/src/main.py
+++ b/apps/unstructured-service/src/main.py
@@ -20,6 +20,7 @@ from .api.schemas import (
     ErrorResponse,
     HealthCheckResponse,
 )
+from .api.coordinates import normalized_bbox
 
 # Configure logging
 logging.basicConfig(
@@ -219,6 +220,7 @@ async def extract_pdf(
                     text=el.text,
                     page_number=getattr(getattr(el, "metadata", None), "page_number", 1) or 1,
                     category=getattr(el, "category", None),
+                    bbox=normalized_bbox(el),  # SP-B (#3406): normalized [0,1] bbox, None if absent
                 )
                 for el in result.elements
                 if getattr(el, "text", None)

--- a/apps/unstructured-service/tests/test_coordinates.py
+++ b/apps/unstructured-service/tests/test_coordinates.py
@@ -1,0 +1,66 @@
+"""Unit tests for coordinate normalization (SP-B #3406, epic #3403).
+
+The unstructured `partition_pdf` output carries `element.metadata.coordinates`
+(points + system with width/height, PixelSpace = top-left origin). We normalize
+each element's bounding box to [0,1] fractions of the page layout so the value is
+independent of strategy (fast vs hi_res), DPI, and the viewer zoom.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from src.api.coordinates import normalized_bbox
+
+
+def _element(points, width, height):
+    """Build a mock unstructured element carrying metadata.coordinates."""
+    system = SimpleNamespace(width=width, height=height)
+    coordinates = SimpleNamespace(points=points, system=system)
+    return SimpleNamespace(metadata=SimpleNamespace(coordinates=coordinates))
+
+
+class TestNormalizedBbox:
+    def test_pixelspace_points_are_normalized_top_left(self):
+        # 4 points TL->BL->BR->TR in a 1000x2000 PixelSpace layout
+        el = _element([(100, 200), (100, 400), (500, 400), (500, 200)], 1000, 2000)
+        bbox = normalized_bbox(el)
+        assert bbox is not None
+        assert bbox.x == pytest.approx(0.1)  # 100/1000
+        assert bbox.y == pytest.approx(0.1)  # 200/2000, top-left origin (no Y flip)
+        assert bbox.width == pytest.approx(0.4)  # (500-100)/1000
+        assert bbox.height == pytest.approx(0.1)  # (400-200)/2000
+
+    def test_returns_none_when_coordinates_absent(self):
+        el = SimpleNamespace(metadata=SimpleNamespace(coordinates=None))
+        assert normalized_bbox(el) is None
+
+    def test_returns_none_when_metadata_absent(self):
+        el = SimpleNamespace()
+        assert normalized_bbox(el) is None
+
+    def test_returns_none_when_points_empty(self):
+        el = _element([], 1000, 2000)
+        assert normalized_bbox(el) is None
+
+    def test_returns_none_when_layout_dims_missing(self):
+        el = _element([(100, 200), (500, 400)], 0, 0)
+        assert normalized_bbox(el) is None
+
+    def test_layout_dimension_independent(self):
+        # Same relative box at two different layout scales → identical normalized result.
+        # min/max makes it robust to point ordering and count (2 or 4 points).
+        el_small = _element([(100, 200), (500, 400)], 1000, 2000)
+        el_large = _element([(200, 400), (1000, 800)], 2000, 4000)
+        b1 = normalized_bbox(el_small)
+        b2 = normalized_bbox(el_large)
+        assert b1.x == pytest.approx(b2.x)
+        assert b1.y == pytest.approx(b2.y)
+        assert b1.width == pytest.approx(b2.width)
+        assert b1.height == pytest.approx(b2.height)
+
+    def test_clamps_components_to_unit_interval(self):
+        # Points beyond layout bounds get clamped into [0,1].
+        el = _element([(-10, -20), (1100, 2100)], 1000, 2000)
+        bbox = normalized_bbox(el)
+        for value in (bbox.x, bbox.y, bbox.width, bbox.height):
+            assert 0.0 <= value <= 1.0

--- a/apps/web/src/__tests__/types/citation.test.ts
+++ b/apps/web/src/__tests__/types/citation.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import type { Citation } from '@/types/domain';
+import type { Citation, CitationRegion } from '@/types/domain';
 
 describe('Citation type', () => {
   it('accepts full tier citation', () => {
@@ -60,5 +60,37 @@ describe('Citation type', () => {
     };
     expect(citation.paraphrasedSnippet).toBeUndefined();
     expect(citation.isPublic).toBeUndefined();
+  });
+
+  // SP-C (#3407): Full-gated region grounding fields.
+  it('accepts full-tier citation carrying regions and char offsets', () => {
+    const regions: CitationRegion[] = [{ page: 2, x: 0.1, y: 0.2, width: 0.3, height: 0.4 }];
+    const citation: Citation = {
+      documentId: 'doc-4',
+      pageNumber: 2,
+      snippet: 'Original text',
+      relevanceScore: 0.9,
+      copyrightTier: 'full',
+      regions,
+      charStart: 100,
+      charEnd: 250,
+    };
+    expect(citation.regions).toHaveLength(1);
+    expect(citation.regions?.[0]).toEqual({ page: 2, x: 0.1, y: 0.2, width: 0.3, height: 0.4 });
+    expect(citation.charStart).toBe(100);
+    expect(citation.charEnd).toBe(250);
+  });
+
+  it('regions/charStart/charEnd are optional (backward compat)', () => {
+    const citation: Citation = {
+      documentId: 'doc-5',
+      pageNumber: 1,
+      snippet: 'text',
+      relevanceScore: 0.5,
+      copyrightTier: 'protected',
+    };
+    expect(citation.regions).toBeUndefined();
+    expect(citation.charStart).toBeUndefined();
+    expect(citation.charEnd).toBeUndefined();
   });
 });

--- a/apps/web/src/components/chat-unified/PdfPageModal.tsx
+++ b/apps/web/src/components/chat-unified/PdfPageModal.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { ChevronLeft, ChevronRight, Loader2 } from 'lucide-react';
 import dynamic from 'next/dynamic';
+import 'react-pdf/dist/Page/TextLayer.css';
 
+import { makeQuoteTextRenderer } from '@/components/pdf/pdf-quote-highlight';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/overlays/dialog';
 import { Button } from '@/components/ui/primitives/button';
 import { api } from '@/lib/api';
@@ -56,6 +58,17 @@ export function PdfPageModal({ citation, open, onClose }: PdfPageModalProps) {
 
   // Reset state when citation changes (different document/page)
   const pdfUrl = api.pdf.getPdfDownloadUrl(citation.documentId);
+
+  // SP0 (#3404) follow-up: highlight della regione citata sulla PAGINA citata.
+  // Gating copyright: highlight verbatim SOLO per tier "full" (ADR-059/#447);
+  // per "protected" nessun highlight (lo snippet parafrasato non è verbatim).
+  const highlightQuote =
+    citation.copyrightTier === 'protected' ? undefined : citation.snippet || undefined;
+  const isCitedPage = currentPage === citation.pageNumber;
+  const quoteRenderer = useMemo(
+    () => (highlightQuote && isCitedPage ? makeQuoteTextRenderer(highlightQuote) : null),
+    [highlightQuote, isCitedPage]
+  );
 
   const handleDocumentLoad = useCallback(({ numPages }: { numPages: number }) => {
     setNumPages(numPages);
@@ -123,8 +136,11 @@ export function PdfPageModal({ citation, open, onClose }: PdfPageModalProps) {
                     620,
                     typeof window !== 'undefined' ? window.innerWidth - 80 : 620
                   )}
-                  renderTextLayer={false}
+                  renderTextLayer={!!quoteRenderer}
                   renderAnnotationLayer={false}
+                  customTextRenderer={
+                    quoteRenderer ? ({ str }) => quoteRenderer.render({ str }) : undefined
+                  }
                 />
               </PdfDocument>
             </div>

--- a/apps/web/src/components/chat-unified/PdfPageModal.tsx
+++ b/apps/web/src/components/chat-unified/PdfPageModal.tsx
@@ -7,6 +7,7 @@ import dynamic from 'next/dynamic';
 import 'react-pdf/dist/Page/TextLayer.css';
 
 import { makeQuoteTextRenderer } from '@/components/pdf/pdf-quote-highlight';
+import { PdfBBoxOverlay } from '@/components/pdf/PdfBBoxOverlay';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/overlays/dialog';
 import { Button } from '@/components/ui/primitives/button';
 import { api } from '@/lib/api';
@@ -65,9 +66,23 @@ export function PdfPageModal({ citation, open, onClose }: PdfPageModalProps) {
   const highlightQuote =
     citation.copyrightTier === 'protected' ? undefined : citation.snippet || undefined;
   const isCitedPage = currentPage === citation.pageNumber;
+
+  // SP-D (#3408): overlay bbox della regione (Pattern B), gated su copyright come l'highlight
+  // verbatim. Le regions sono già Full-gated dal BE; qui belt-and-suspenders per "protected".
+  const regions =
+    citation.copyrightTier === 'protected' ? undefined : (citation.regions ?? undefined);
+  const hasRects = (regions?.length ?? 0) > 0;
+  const pageRects = useMemo(
+    () => (regions ?? []).filter(r => r.page === currentPage),
+    [regions, currentPage]
+  );
+
+  // Pattern B (overlay) ha precedenza su Pattern A (quote text-layer): se ci sono regions,
+  // niente customTextRenderer.
   const quoteRenderer = useMemo(
-    () => (highlightQuote && isCitedPage ? makeQuoteTextRenderer(highlightQuote) : null),
-    [highlightQuote, isCitedPage]
+    () =>
+      highlightQuote && isCitedPage && !hasRects ? makeQuoteTextRenderer(highlightQuote) : null,
+    [highlightQuote, isCitedPage, hasRects]
   );
 
   const handleDocumentLoad = useCallback(({ numPages }: { numPages: number }) => {
@@ -141,7 +156,9 @@ export function PdfPageModal({ citation, open, onClose }: PdfPageModalProps) {
                   customTextRenderer={
                     quoteRenderer ? ({ str }) => quoteRenderer.render({ str }) : undefined
                   }
-                />
+                >
+                  {pageRects.length > 0 ? <PdfBBoxOverlay rects={pageRects} /> : null}
+                </PdfPage>
               </PdfDocument>
             </div>
           )}

--- a/apps/web/src/components/chat-unified/__tests__/PdfPageModal.test.tsx
+++ b/apps/web/src/components/chat-unified/__tests__/PdfPageModal.test.tsx
@@ -28,8 +28,28 @@ vi.mock('@/lib/api', () => ({
   },
 }));
 
-// react-pdf is already mocked in vitest.setup.tsx
-// (Document renders data-testid="pdf-document", Page renders data-testid="pdf-page")
+// Local react-pdf mock (overrides vitest.setup.tsx for this file) so the Page can
+// expose renderTextLayer / customTextRenderer as data-attributes — required to
+// assert the SP0 quote-highlight wiring. Mirrors the global mock otherwise.
+vi.mock('react-pdf', () => {
+  const React = require('react');
+  return {
+    Document: ({ children }: any) =>
+      React.createElement('div', { 'data-testid': 'pdf-document' }, children),
+    Page: ({ pageNumber, renderTextLayer, customTextRenderer }: any) =>
+      React.createElement(
+        'div',
+        {
+          'data-testid': 'pdf-page',
+          'data-page': pageNumber,
+          'data-render-text-layer': String(!!renderTextLayer),
+          'data-has-custom-renderer': String(!!customTextRenderer),
+        },
+        `Page ${pageNumber}`
+      ),
+    pdfjs: { GlobalWorkerOptions: { workerSrc: '' }, version: '4.0.0' },
+  };
+});
 
 import { PdfPageModal } from '../PdfPageModal';
 import type { Citation } from '@/types';
@@ -115,5 +135,36 @@ describe('PdfPageModal', () => {
     );
     const prevBtn = screen.getByRole('button', { name: /pagina precedente/i });
     expect(prevBtn).toBeDisabled();
+  });
+
+  // ── SP0 #3404 follow-up: highlight della regione citata (chat-unified) ────────
+
+  it('highlights the verbatim quote on the cited page for tier "full"', () => {
+    render(
+      <PdfPageModal
+        citation={makeCitation({
+          pageNumber: 5,
+          snippet: 'most points wins',
+          copyrightTier: 'full',
+        })}
+        open
+        onClose={onClose}
+      />
+    );
+    const page = screen.getByTestId('pdf-page');
+    expect(page).toHaveAttribute('data-render-text-layer', 'true');
+    expect(page).toHaveAttribute('data-has-custom-renderer', 'true');
+  });
+
+  it('does NOT highlight for tier "protected" (no verbatim highlight)', () => {
+    render(
+      <PdfPageModal
+        citation={makeCitation({ copyrightTier: 'protected', snippet: 'segreto verbatim' })}
+        open
+        onClose={onClose}
+      />
+    );
+    const page = screen.getByTestId('pdf-page');
+    expect(page).toHaveAttribute('data-has-custom-renderer', 'false');
   });
 });

--- a/apps/web/src/components/chat-unified/__tests__/PdfPageModal.test.tsx
+++ b/apps/web/src/components/chat-unified/__tests__/PdfPageModal.test.tsx
@@ -36,7 +36,7 @@ vi.mock('react-pdf', () => {
   return {
     Document: ({ children }: any) =>
       React.createElement('div', { 'data-testid': 'pdf-document' }, children),
-    Page: ({ pageNumber, renderTextLayer, customTextRenderer }: any) =>
+    Page: ({ pageNumber, renderTextLayer, customTextRenderer, children }: any) =>
       React.createElement(
         'div',
         {
@@ -45,7 +45,8 @@ vi.mock('react-pdf', () => {
           'data-render-text-layer': String(!!renderTextLayer),
           'data-has-custom-renderer': String(!!customTextRenderer),
         },
-        `Page ${pageNumber}`
+        `Page ${pageNumber}`,
+        children
       ),
     pdfjs: { GlobalWorkerOptions: { workerSrc: '' }, version: '4.0.0' },
   };
@@ -166,5 +167,54 @@ describe('PdfPageModal', () => {
     );
     const page = screen.getByTestId('pdf-page');
     expect(page).toHaveAttribute('data-has-custom-renderer', 'false');
+  });
+
+  // ── SP-D #3408: region overlay (Pattern B) on the cited page ──────────────────
+
+  it('draws the region overlay on the cited page for tier "full"', () => {
+    render(
+      <PdfPageModal
+        citation={makeCitation({
+          pageNumber: 5,
+          copyrightTier: 'full',
+          regions: [{ page: 5, x: 0.1, y: 0.2, width: 0.3, height: 0.05 }],
+        })}
+        open
+        onClose={onClose}
+      />
+    );
+    expect(screen.getByTestId('pdf-bbox-rect')).toBeInTheDocument();
+    // Pattern B suppresses the Pattern A quote text-layer.
+    expect(screen.getByTestId('pdf-page')).toHaveAttribute('data-has-custom-renderer', 'false');
+  });
+
+  it('does NOT draw the region overlay for tier "protected"', () => {
+    render(
+      <PdfPageModal
+        citation={makeCitation({
+          pageNumber: 5,
+          copyrightTier: 'protected',
+          regions: [{ page: 5, x: 0.1, y: 0.2, width: 0.3, height: 0.05 }],
+        })}
+        open
+        onClose={onClose}
+      />
+    );
+    expect(screen.queryByTestId('pdf-bbox-rect')).not.toBeInTheDocument();
+  });
+
+  it('does not draw overlay rects that belong to another page', () => {
+    render(
+      <PdfPageModal
+        citation={makeCitation({
+          pageNumber: 5,
+          copyrightTier: 'full',
+          regions: [{ page: 9, x: 0.1, y: 0.2, width: 0.3, height: 0.05 }],
+        })}
+        open
+        onClose={onClose}
+      />
+    );
+    expect(screen.queryByTestId('pdf-bbox-rect')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/features/game-chat/CitationModal.tsx
+++ b/apps/web/src/components/features/game-chat/CitationModal.tsx
@@ -75,6 +75,11 @@ export function CitationModal({
   // il tab PDF apre la pagina senza evidenziare il testo.
   const highlightQuote = citation.copyrightTier === 'protected' ? undefined : citation.snippet;
 
+  // SP-D (#3408): overlay bbox della regione (Pattern B). Gated su copyright come l'highlight
+  // verbatim: le regions sono già Full-gated dal BE, qui belt-and-suspenders per "protected".
+  const regions =
+    citation.copyrightTier === 'protected' ? undefined : (citation.regions ?? undefined);
+
   return (
     <div
       role="dialog"
@@ -147,6 +152,7 @@ export function CitationModal({
               initialPage={citation.pageNumber}
               isPublic={citation.isPublic}
               quote={highlightQuote}
+              regions={regions}
             />
           )}
         </div>

--- a/apps/web/src/components/features/game-chat/CitationModal.tsx
+++ b/apps/web/src/components/features/game-chat/CitationModal.tsx
@@ -70,6 +70,11 @@ export function CitationModal({
       ? citation.paraphrasedSnippet
       : citation.snippet;
 
+  // SP0 (#3404): highlight della regione citata SOLO per tier "full" (verbatim).
+  // Per "protected" nessun highlight verbatim (coerenza copyright ADR-059/#447):
+  // il tab PDF apre la pagina senza evidenziare il testo.
+  const highlightQuote = citation.copyrightTier === 'protected' ? undefined : citation.snippet;
+
   return (
     <div
       role="dialog"
@@ -141,6 +146,7 @@ export function CitationModal({
               gameId={gameId}
               initialPage={citation.pageNumber}
               isPublic={citation.isPublic}
+              quote={highlightQuote}
             />
           )}
         </div>

--- a/apps/web/src/components/features/game-chat/CitationPdfTab.tsx
+++ b/apps/web/src/components/features/game-chat/CitationPdfTab.tsx
@@ -23,6 +23,7 @@ import { CitationOwnershipUpsell } from '@/components/features/game-chat/Citatio
 import { PdfInlineViewer } from '@/components/pdf/PdfInlineViewer';
 import { PdfQuoteViewer } from '@/components/pdf/PdfQuoteViewer';
 import { useCanViewPdf } from '@/hooks/queries/useCanViewPdf';
+import type { CitationRegion } from '@/types';
 
 export interface CitationPdfTabProps {
   readonly documentId: string;
@@ -36,6 +37,12 @@ export interface CitationPdfTabProps {
    * Se assente/vuoto si ripiega sul viewer semplice (solo pagina).
    */
   readonly quote?: string;
+  /**
+   * SP-D (#3408): normalized [0,1] region boxes for a precise PDF overlay (Pattern B).
+   * When non-empty, the overlay takes precedence over the {@link quote} highlight (Pattern A).
+   * Already Full-gated by the BE and by {@link CitationModal} (never passed for Protected tier).
+   */
+  readonly regions?: readonly CitationRegion[] | null;
   readonly className?: string;
 }
 
@@ -45,6 +52,7 @@ export function CitationPdfTab({
   initialPage,
   isPublic = false,
   quote,
+  regions,
   className,
 }: CitationPdfTabProps): ReactElement {
   const ownership = useCanViewPdf({
@@ -79,6 +87,20 @@ export function CitationPdfTab({
 
   if (showUpsell) {
     return <CitationOwnershipUpsell gameId={gameId} className={className} />;
+  }
+
+  // SP-D (#3408): Pattern B (bbox overlay) takes precedence over Pattern A (quote highlight).
+  const hasRects = !!regions && regions.length > 0;
+  if (hasRects) {
+    return (
+      <PdfInlineViewer
+        documentId={documentId}
+        initialPage={initialPage}
+        highlightRects={regions}
+        features={{ antiLeak: true }}
+        className={className}
+      />
+    );
   }
 
   const trimmedQuote = quote?.trim();

--- a/apps/web/src/components/features/game-chat/CitationPdfTab.tsx
+++ b/apps/web/src/components/features/game-chat/CitationPdfTab.tsx
@@ -21,6 +21,7 @@ import clsx from 'clsx';
 
 import { CitationOwnershipUpsell } from '@/components/features/game-chat/CitationOwnershipUpsell';
 import { PdfInlineViewer } from '@/components/pdf/PdfInlineViewer';
+import { PdfQuoteViewer } from '@/components/pdf/PdfQuoteViewer';
 import { useCanViewPdf } from '@/hooks/queries/useCanViewPdf';
 
 export interface CitationPdfTabProps {
@@ -28,6 +29,13 @@ export interface CitationPdfTabProps {
   readonly gameId?: string;
   readonly initialPage: number;
   readonly isPublic?: boolean;
+  /**
+   * SP0 (#3404): quote verbatim da evidenziare nel PDF (highlight della regione
+   * citata + banner fallback via {@link PdfQuoteViewer}). Deve essere passato SOLO
+   * per citazioni tier "full" — il chiamante (CitationModal) fa il gating copyright.
+   * Se assente/vuoto si ripiega sul viewer semplice (solo pagina).
+   */
+  readonly quote?: string;
   readonly className?: string;
 }
 
@@ -36,6 +44,7 @@ export function CitationPdfTab({
   gameId,
   initialPage,
   isPublic = false,
+  quote,
   className,
 }: CitationPdfTabProps): ReactElement {
   const ownership = useCanViewPdf({
@@ -70,6 +79,19 @@ export function CitationPdfTab({
 
   if (showUpsell) {
     return <CitationOwnershipUpsell gameId={gameId} className={className} />;
+  }
+
+  const trimmedQuote = quote?.trim();
+  if (trimmedQuote) {
+    return (
+      <PdfQuoteViewer
+        documentId={documentId}
+        page={initialPage}
+        quote={trimmedQuote}
+        features={{ antiLeak: true }}
+        className={className}
+      />
+    );
   }
 
   return (

--- a/apps/web/src/components/features/game-chat/__tests__/CitationModal.test.tsx
+++ b/apps/web/src/components/features/game-chat/__tests__/CitationModal.test.tsx
@@ -11,6 +11,7 @@ vi.mock('../CitationPdfTab', () => ({
       data-document-id={props.documentId}
       data-game-id={props.gameId}
       data-initial-page={props.initialPage}
+      data-quote={props.quote ?? ''}
     >
       PDF tab mock
     </div>
@@ -76,5 +77,27 @@ describe('CitationModal', () => {
     expect(tab).toHaveAttribute('data-document-id', sampleCitation.documentId);
     expect(tab).toHaveAttribute('data-game-id', 'wingspan');
     expect(tab).toHaveAttribute('data-initial-page', String(sampleCitation.pageNumber));
+  });
+
+  // ── SP0 #3404: quote per l'highlight, gated su copyright ─────────────────────
+
+  it('passes the verbatim snippet as quote for tier "full"', () => {
+    render(<CitationModal citation={sampleCitation} open onClose={vi.fn()} gameId="wingspan" />);
+    fireEvent.click(screen.getByRole('tab', { name: /pdf originale/i }));
+    expect(screen.getByTestId('citation-pdf-tab-mounted')).toHaveAttribute(
+      'data-quote',
+      sampleCitation.snippet
+    );
+  });
+
+  it('does NOT pass a verbatim quote for tier "protected" (no verbatim highlight)', () => {
+    const protectedCitation: Citation = {
+      ...sampleCitation,
+      copyrightTier: 'protected',
+      paraphrasedSnippet: 'parafrasi non verbatim',
+    };
+    render(<CitationModal citation={protectedCitation} open onClose={vi.fn()} gameId="wingspan" />);
+    fireEvent.click(screen.getByRole('tab', { name: /pdf originale/i }));
+    expect(screen.getByTestId('citation-pdf-tab-mounted')).toHaveAttribute('data-quote', '');
   });
 });

--- a/apps/web/src/components/features/game-chat/__tests__/CitationModal.test.tsx
+++ b/apps/web/src/components/features/game-chat/__tests__/CitationModal.test.tsx
@@ -12,6 +12,7 @@ vi.mock('../CitationPdfTab', () => ({
       data-game-id={props.gameId}
       data-initial-page={props.initialPage}
       data-quote={props.quote ?? ''}
+      data-regions-count={props.regions?.length ?? 0}
     >
       PDF tab mock
     </div>
@@ -99,5 +100,39 @@ describe('CitationModal', () => {
     render(<CitationModal citation={protectedCitation} open onClose={vi.fn()} gameId="wingspan" />);
     fireEvent.click(screen.getByRole('tab', { name: /pdf originale/i }));
     expect(screen.getByTestId('citation-pdf-tab-mounted')).toHaveAttribute('data-quote', '');
+  });
+
+  // ── SP-D #3408: region overlay passed through, gated on copyright tier ────────
+
+  it('passes Full-tier regions to CitationPdfTab', () => {
+    const citationWithRegions: Citation = {
+      ...sampleCitation,
+      regions: [{ page: 12, x: 0.1, y: 0.2, width: 0.3, height: 0.05 }],
+    };
+    render(
+      <CitationModal citation={citationWithRegions} open onClose={vi.fn()} gameId="wingspan" />
+    );
+    fireEvent.click(screen.getByRole('tab', { name: /pdf originale/i }));
+    expect(screen.getByTestId('citation-pdf-tab-mounted')).toHaveAttribute(
+      'data-regions-count',
+      '1'
+    );
+  });
+
+  it('does NOT pass regions for tier "protected" (no verbatim region overlay)', () => {
+    const protectedWithRegions: Citation = {
+      ...sampleCitation,
+      copyrightTier: 'protected',
+      paraphrasedSnippet: 'parafrasi non verbatim',
+      regions: [{ page: 12, x: 0.1, y: 0.2, width: 0.3, height: 0.05 }],
+    };
+    render(
+      <CitationModal citation={protectedWithRegions} open onClose={vi.fn()} gameId="wingspan" />
+    );
+    fireEvent.click(screen.getByRole('tab', { name: /pdf originale/i }));
+    expect(screen.getByTestId('citation-pdf-tab-mounted')).toHaveAttribute(
+      'data-regions-count',
+      '0'
+    );
   });
 });

--- a/apps/web/src/components/features/game-chat/__tests__/CitationPdfTab.test.tsx
+++ b/apps/web/src/components/features/game-chat/__tests__/CitationPdfTab.test.tsx
@@ -13,9 +13,10 @@ vi.mock('react-pdf', () => ({
     setTimeout(() => onLoadSuccess?.({ numPages: 24 }), 0);
     return <div data-testid="pdf-document">{children}</div>;
   },
-  Page: ({ pageNumber }: { pageNumber: number }) => (
+  Page: ({ pageNumber, children }: { pageNumber: number; children?: unknown }) => (
     <div data-testid="pdf-page" data-page-number={pageNumber}>
       Page {pageNumber}
+      {children as never}
     </div>
   ),
   pdfjs: { GlobalWorkerOptions: { workerSrc: '' } },
@@ -144,5 +145,57 @@ describe('CitationPdfTab', () => {
     );
     await waitFor(() => expect(screen.getByTestId('pdf-page')).toBeInTheDocument());
     expect(container.querySelector('[data-slot="pdf-quote-viewer"]')).not.toBeInTheDocument();
+  });
+
+  // ── SP-D #3408: region overlay (Pattern B) via regions ──────────────────────
+
+  it('renders the region overlay (Pattern B) when regions are provided', async () => {
+    const { container } = render(
+      <CitationPdfTab
+        documentId="pdf-public-1"
+        gameId="game-1"
+        initialPage={12}
+        isPublic
+        regions={[{ page: 12, x: 0.1, y: 0.2, width: 0.3, height: 0.05 }]}
+      />,
+      { wrapper }
+    );
+    await waitFor(() => expect(screen.getByTestId('pdf-page')).toBeInTheDocument());
+    expect(screen.getByTestId('pdf-bbox-rect')).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="pdf-quote-viewer"]')).not.toBeInTheDocument();
+  });
+
+  it('prefers the region overlay over the quote highlight when both are present', async () => {
+    const { container } = render(
+      <CitationPdfTab
+        documentId="pdf-public-1"
+        gameId="game-1"
+        initialPage={12}
+        isPublic
+        quote="regola X"
+        regions={[{ page: 12, x: 0.1, y: 0.2, width: 0.3, height: 0.05 }]}
+      />,
+      { wrapper }
+    );
+    await waitFor(() => expect(screen.getByTestId('pdf-page')).toBeInTheDocument());
+    expect(screen.getByTestId('pdf-bbox-rect')).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="pdf-quote-viewer"]')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the quote viewer (Pattern A) when regions is empty', async () => {
+    const { container } = render(
+      <CitationPdfTab
+        documentId="pdf-public-1"
+        gameId="game-1"
+        initialPage={7}
+        isPublic
+        quote="regola X"
+        regions={[]}
+      />,
+      { wrapper }
+    );
+    await waitFor(() => expect(screen.getByTestId('pdf-page')).toBeInTheDocument());
+    expect(container.querySelector('[data-slot="pdf-quote-viewer"]')).toBeInTheDocument();
+    expect(screen.queryByTestId('pdf-bbox-rect')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/features/game-chat/__tests__/CitationPdfTab.test.tsx
+++ b/apps/web/src/components/features/game-chat/__tests__/CitationPdfTab.test.tsx
@@ -118,4 +118,31 @@ describe('CitationPdfTab', () => {
       expect(screen.getByText(/PDF originale protetto da copyright/i)).toBeInTheDocument()
     );
   });
+
+  // ── SP0 #3404: highlight della regione citata nel percorso chat ──────────────
+
+  it('mounts the quote viewer (highlight + fallback) when a quote is provided', async () => {
+    const { container } = render(
+      <CitationPdfTab
+        documentId="pdf-public-1"
+        gameId="game-1"
+        initialPage={7}
+        isPublic
+        quote="regola X"
+      />,
+      { wrapper }
+    );
+    await waitFor(() => expect(screen.getByTestId('pdf-page')).toBeInTheDocument());
+    expect(container.querySelector('[data-slot="pdf-quote-viewer"]')).toBeInTheDocument();
+    expect(screen.getByTestId('pdf-page')).toHaveAttribute('data-page-number', '7');
+  });
+
+  it('mounts the plain viewer (no quote viewer) when no quote is provided', async () => {
+    const { container } = render(
+      <CitationPdfTab documentId="pdf-public-1" gameId="game-1" initialPage={7} isPublic />,
+      { wrapper }
+    );
+    await waitFor(() => expect(screen.getByTestId('pdf-page')).toBeInTheDocument());
+    expect(container.querySelector('[data-slot="pdf-quote-viewer"]')).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/pdf/PdfBBoxOverlay.tsx
+++ b/apps/web/src/components/pdf/PdfBBoxOverlay.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+/**
+ * PdfBBoxOverlay — %-based region overlay for the RAG citation grounding (SP-D #3408).
+ *
+ * Draws one rectangle per {@link CitationRegion} as an absolutely-positioned child of the
+ * react-pdf `<Page>` wrapper (which is `position: relative`, react-pdf@10 Page.js:247). Because
+ * the rects are normalized [0,1] top-left and expressed in percentages, the overlay is
+ * scale/DPR-independent — no pixel math, no coupling to the current zoom.
+ *
+ * The caller is responsible for filtering `rects` to the visible page (regions carry a `page`,
+ * but this component is intentionally page-agnostic and purely presentational). Decorative only
+ * (`aria-hidden`) — the citation text is already conveyed by the snippet / page header.
+ *
+ * Spec: docs/superpowers/specs/2026-07-30-rag-citation-region-grounding-design.md §6.5 (DA-5)
+ */
+
+import type { ReactElement } from 'react';
+
+import type { CitationRegion } from '@/types';
+
+export interface PdfBBoxOverlayProps {
+  readonly rects: readonly CitationRegion[];
+}
+
+export function PdfBBoxOverlay({ rects }: PdfBBoxOverlayProps): ReactElement | null {
+  if (rects.length === 0) return null;
+
+  return (
+    <div
+      aria-hidden="true"
+      data-slot="pdf-bbox-overlay"
+      data-testid="pdf-bbox-overlay"
+      className="pointer-events-none absolute inset-0"
+    >
+      {rects.map((r, i) => (
+        <div
+          key={`${r.page}:${r.x},${r.y},${r.width},${r.height}:${i}`}
+          data-testid="pdf-bbox-rect"
+          className="pdf-bbox-highlight absolute"
+          style={{
+            left: `${r.x * 100}%`,
+            top: `${r.y * 100}%`,
+            width: `${r.width * 100}%`,
+            height: `${r.height * 100}%`,
+          }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/pdf/PdfInlineViewer.tsx
+++ b/apps/web/src/components/pdf/PdfInlineViewer.tsx
@@ -35,8 +35,10 @@ import 'react-pdf/dist/Page/AnnotationLayer.css';
 import 'react-pdf/dist/Page/TextLayer.css';
 
 import { api } from '@/lib/api';
+import type { CitationRegion } from '@/types';
 
 import { makeQuoteTextRenderer } from './pdf-quote-highlight';
+import { PdfBBoxOverlay } from './PdfBBoxOverlay';
 
 // Worker setup — T0 spike confirmed idempotent (multi-module assignment safe).
 pdfjs.GlobalWorkerOptions.workerSrc = new URL(
@@ -61,6 +63,12 @@ export interface PdfInlineViewerProps {
   readonly renderTextLayer?: boolean;
   readonly highlightQuote?: string;
   readonly onQuoteMatch?: (found: boolean) => void;
+  /**
+   * SP-D (#3408): normalized [0,1] top-left region boxes to draw as a precise overlay
+   * (Pattern B). When present (any page), the quote text-layer highlight (Pattern A) is
+   * suppressed — bbox grounding takes precedence. Rects are filtered to the visible page.
+   */
+  readonly highlightRects?: readonly CitationRegion[];
 }
 
 type ZoomState = 'fit-width' | number;
@@ -78,6 +86,7 @@ export function PdfInlineViewer({
   renderTextLayer = false,
   highlightQuote,
   onQuoteMatch,
+  highlightRects,
 }: PdfInlineViewerProps): ReactElement {
   const [numPages, setNumPages] = useState<number>(0);
   const [currentPage, setCurrentPage] = useState<number>(initialPage);
@@ -91,9 +100,17 @@ export function PdfInlineViewer({
 
   const downloadUrl = api.pdf.getPdfDownloadUrl(documentId);
 
+  // SP-D (#3408): Pattern B (bbox overlay) takes precedence over Pattern A (quote text-layer).
+  // Once any region exists for this citation we are in bbox mode → skip the quote renderer.
+  const hasRects = (highlightRects?.length ?? 0) > 0;
+  const pageRects = useMemo(
+    () => (highlightRects ?? []).filter(r => r.page === currentPage),
+    [highlightRects, currentPage]
+  );
+
   const quoteRenderer = useMemo(
-    () => (highlightQuote ? makeQuoteTextRenderer(highlightQuote) : null),
-    [highlightQuote]
+    () => (highlightQuote && !hasRects ? makeQuoteTextRenderer(highlightQuote) : null),
+    [highlightQuote, hasRects]
   );
 
   const onDocumentLoadSuccess = useCallback(({ numPages: n }: { numPages: number }) => {
@@ -294,28 +311,36 @@ export function PdfInlineViewer({
           </div>
         )}
         {pdfBlob && !loadError && (
-          <Document
-            file={pdfBlob}
-            onLoadSuccess={onDocumentLoadSuccess}
-            onLoadError={onDocumentLoadError}
-            loading={null}
-            error={null}
-          >
-            <Page
-              pageNumber={currentPage}
-              scale={scale}
-              renderAnnotationLayer={false}
-              renderTextLayer={renderTextLayer || !!highlightQuote}
-              customTextRenderer={
-                quoteRenderer ? ({ str }) => quoteRenderer.render({ str }) : undefined
-              }
-              onRenderTextLayerSuccess={
-                quoteRenderer && onQuoteMatch
-                  ? () => onQuoteMatch(quoteRenderer.matched())
-                  : undefined
-              }
-            />
-          </Document>
+          // SP-D (#3408): center + shrink-wrap the page so the react-pdf `.react-pdf__Page`
+          // ancestor hugs the canvas (not the full container width). Otherwise the block Page div
+          // fills the container and the %-based bbox overlay (its child) misaligns for pages
+          // narrower than A4. Mirrors the proven PdfPageModal `flex justify-center` layout.
+          <div className="flex justify-center">
+            <Document
+              file={pdfBlob}
+              onLoadSuccess={onDocumentLoadSuccess}
+              onLoadError={onDocumentLoadError}
+              loading={null}
+              error={null}
+            >
+              <Page
+                pageNumber={currentPage}
+                scale={scale}
+                renderAnnotationLayer={false}
+                renderTextLayer={renderTextLayer || (!!highlightQuote && !hasRects)}
+                customTextRenderer={
+                  quoteRenderer ? ({ str }) => quoteRenderer.render({ str }) : undefined
+                }
+                onRenderTextLayerSuccess={
+                  quoteRenderer && onQuoteMatch
+                    ? () => onQuoteMatch(quoteRenderer.matched())
+                    : undefined
+                }
+              >
+                {pageRects.length > 0 ? <PdfBBoxOverlay rects={pageRects} /> : null}
+              </Page>
+            </Document>
+          </div>
         )}
       </div>
     </div>

--- a/apps/web/src/components/pdf/PdfQuoteViewer.tsx
+++ b/apps/web/src/components/pdf/PdfQuoteViewer.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 
-import { PdfInlineViewer } from './PdfInlineViewer';
+import { PdfInlineViewer, type PdfInlineViewerFeatures } from './PdfInlineViewer';
 
 export interface PdfQuoteViewerProps {
   readonly documentId: string;
@@ -14,6 +14,12 @@ export interface PdfQuoteViewerProps {
    * same citation re-arms the fallback banner.
    */
   readonly resetKey?: unknown;
+  /**
+   * Toolbar/behaviour surface forwarded to {@link PdfInlineViewer}. Defaults to
+   * `{ jumpToPage: true, zoom: true }` (mechanic-card / admin usage). The chat
+   * citation path (CitationPdfTab) passes `{ antiLeak: true }` instead.
+   */
+  readonly features?: PdfInlineViewerFeatures;
   readonly className?: string;
 }
 
@@ -35,6 +41,7 @@ export function PdfQuoteViewer({
   page,
   quote,
   resetKey,
+  features = { jumpToPage: true, zoom: true },
   className,
 }: PdfQuoteViewerProps): React.JSX.Element {
   const [matched, setMatched] = useState<boolean | null>(null);
@@ -68,7 +75,7 @@ export function PdfQuoteViewer({
         initialPage={page}
         highlightQuote={quote}
         onQuoteMatch={setMatched}
-        features={{ jumpToPage: true, zoom: true }}
+        features={features}
       />
     </div>
   );

--- a/apps/web/src/components/pdf/__tests__/PdfBBoxOverlay.test.tsx
+++ b/apps/web/src/components/pdf/__tests__/PdfBBoxOverlay.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * PdfBBoxOverlay — presentational %-based region overlay (SP-D #3408).
+ *
+ * Pure component: given normalized [0,1] top-left CitationRegion rects (already
+ * filtered to the visible page by the caller), renders one absolutely-positioned
+ * rectangle per rect as a child of the react-pdf <Page> wrapper.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import type { CitationRegion } from '@/types';
+
+import { PdfBBoxOverlay } from '../PdfBBoxOverlay';
+
+function rect(overrides: Partial<CitationRegion> = {}): CitationRegion {
+  return { page: 5, x: 0.1, y: 0.2, width: 0.3, height: 0.05, ...overrides };
+}
+
+describe('PdfBBoxOverlay', () => {
+  it('renders one pdf-bbox-rect per region', () => {
+    render(<PdfBBoxOverlay rects={[rect(), rect({ y: 0.5 }), rect({ y: 0.8 })]} />);
+    expect(screen.getAllByTestId('pdf-bbox-rect')).toHaveLength(3);
+  });
+
+  it('maps normalized [0,1] coords to left/top/width/height percentages', () => {
+    render(<PdfBBoxOverlay rects={[rect({ x: 0.1, y: 0.2, width: 0.3, height: 0.05 })]} />);
+    const el = screen.getByTestId('pdf-bbox-rect');
+    expect(el.style.left).toBe('10%');
+    expect(el.style.top).toBe('20%');
+    expect(el.style.width).toBe('30%');
+    expect(el.style.height).toBe('5%');
+  });
+
+  it('uses top-left y-down convention: a rect near the top has a SMALL top% (no mirroring)', () => {
+    render(<PdfBBoxOverlay rects={[rect({ y: 0.02, height: 0.04 })]} />);
+    const el = screen.getByTestId('pdf-bbox-rect');
+    // top-left convention → top ≈ 2% (NOT 1 - 0.02 = 98%)
+    expect(el.style.top).toBe('2%');
+  });
+
+  it('renders nothing when rects is empty', () => {
+    const { container } = render(<PdfBBoxOverlay rects={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('is decorative (aria-hidden) and does not capture pointer events', () => {
+    render(<PdfBBoxOverlay rects={[rect()]} />);
+    const overlay = screen.getByTestId('pdf-bbox-overlay');
+    expect(overlay).toHaveAttribute('aria-hidden', 'true');
+    expect(overlay.className).toContain('pointer-events-none');
+  });
+});

--- a/apps/web/src/components/pdf/__tests__/PdfInlineViewer.test.tsx
+++ b/apps/web/src/components/pdf/__tests__/PdfInlineViewer.test.tsx
@@ -14,9 +14,16 @@ vi.mock('react-pdf', () => ({
     setTimeout(() => onLoadSuccess?.({ numPages: 5 }), 0);
     return <div data-testid="pdf-document">{children}</div>;
   },
-  Page: ({ pageNumber, scale }: { pageNumber: number; scale?: number }) => (
-    <div data-testid="pdf-page" data-page-number={pageNumber} data-scale={scale ?? 1}>
+  Page: ({ pageNumber, scale, renderTextLayer, customTextRenderer, children }: any) => (
+    <div
+      data-testid="pdf-page"
+      data-page-number={pageNumber}
+      data-scale={scale ?? 1}
+      data-render-text-layer={String(!!renderTextLayer)}
+      data-has-custom-renderer={String(!!customTextRenderer)}
+    >
       Page {pageNumber}
+      {children}
     </div>
   ),
   pdfjs: { GlobalWorkerOptions: { workerSrc: '' } },
@@ -170,5 +177,66 @@ describe('PdfInlineViewer', () => {
     render(<PdfInlineViewer documentId="doc-1" />);
     await waitFor(() => expect(screen.getByTestId('pdf-page')).toBeInTheDocument());
     expect(screen.queryByRole('combobox', { name: /zoom/i })).not.toBeInTheDocument();
+  });
+
+  // ── SP-D #3408: region overlay (Pattern B) via highlightRects ────────────────
+
+  it('renders the bbox overlay for highlightRects on the current page', async () => {
+    render(
+      <PdfInlineViewer
+        documentId="doc-1"
+        initialPage={3}
+        highlightRects={[{ page: 3, x: 0.1, y: 0.2, width: 0.3, height: 0.05 }]}
+      />
+    );
+    await waitFor(() => expect(screen.getByTestId('pdf-page')).toBeInTheDocument());
+    expect(screen.getByTestId('pdf-bbox-rect')).toBeInTheDocument();
+  });
+
+  it('does not render overlay rects that belong to another page', async () => {
+    render(
+      <PdfInlineViewer
+        documentId="doc-1"
+        initialPage={3}
+        highlightRects={[{ page: 7, x: 0.1, y: 0.2, width: 0.3, height: 0.05 }]}
+      />
+    );
+    await waitFor(() => expect(screen.getByTestId('pdf-page')).toBeInTheDocument());
+    expect(screen.queryByTestId('pdf-bbox-rect')).not.toBeInTheDocument();
+  });
+
+  it('suppresses the quote text layer when highlightRects are present (Pattern B over A)', async () => {
+    render(
+      <PdfInlineViewer
+        documentId="doc-1"
+        initialPage={3}
+        highlightQuote="regola X"
+        highlightRects={[{ page: 3, x: 0.1, y: 0.2, width: 0.3, height: 0.05 }]}
+      />
+    );
+    await waitFor(() => expect(screen.getByTestId('pdf-page')).toBeInTheDocument());
+    expect(screen.getByTestId('pdf-page')).toHaveAttribute('data-render-text-layer', 'false');
+    expect(screen.getByTestId('pdf-page')).toHaveAttribute('data-has-custom-renderer', 'false');
+    expect(screen.getByTestId('pdf-bbox-rect')).toBeInTheDocument();
+  });
+
+  it('keeps the quote text layer active when only highlightQuote is provided (Pattern A)', async () => {
+    render(<PdfInlineViewer documentId="doc-1" initialPage={3} highlightQuote="regola X" />);
+    await waitFor(() => expect(screen.getByTestId('pdf-page')).toBeInTheDocument());
+    expect(screen.getByTestId('pdf-page')).toHaveAttribute('data-render-text-layer', 'true');
+    expect(screen.getByTestId('pdf-page')).toHaveAttribute('data-has-custom-renderer', 'true');
+    expect(screen.queryByTestId('pdf-bbox-rect')).not.toBeInTheDocument();
+  });
+
+  // Geometry contract (SP-D #3408): the bbox overlay is a child of <Page> and anchors to its
+  // box, so that box MUST shrink-wrap the canvas. The canvas renders at scale×pageWidth (A4
+  // denominator) and is left-aligned; if the Page div filled the full container width the
+  // %-based rects would misalign for pages narrower than A4. A `justify-center` flex wrapper
+  // shrinks the Page ancestor to the canvas (mirrors PdfPageModal). Guard against its removal.
+  it('renders the PDF page inside a centering wrapper so the overlay anchors to the canvas', async () => {
+    render(<PdfInlineViewer documentId="doc-1" initialPage={1} />);
+    await waitFor(() => expect(screen.getByTestId('pdf-document')).toBeInTheDocument());
+    const wrapper = screen.getByTestId('pdf-document').parentElement;
+    expect(wrapper?.className).toContain('justify-center');
   });
 });

--- a/apps/web/src/components/pdf/__tests__/PdfQuoteViewer.test.tsx
+++ b/apps/web/src/components/pdf/__tests__/PdfQuoteViewer.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * PdfQuoteViewer — unit test del wiring verso PdfInlineViewer.
+ *
+ * SP0 (#3404, epic #3403): il viewer deve accettare un `features` opzionale così
+ * da poter essere montato con antiLeak nel percorso chat (CitationPdfTab), pur
+ * mantenendo il default storico {jumpToPage, zoom} per mechanic-card/admin.
+ */
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const inlineProps: any[] = [];
+
+vi.mock('../PdfInlineViewer', () => ({
+  PdfInlineViewer: (props: any) => {
+    inlineProps.push(props);
+    return <div data-testid="inline-viewer" />;
+  },
+}));
+
+import { PdfQuoteViewer } from '../PdfQuoteViewer';
+
+describe('PdfQuoteViewer features', () => {
+  beforeEach(() => {
+    inlineProps.length = 0;
+  });
+
+  it('defaults features to {jumpToPage, zoom} for backward compat', () => {
+    render(<PdfQuoteViewer documentId="d1" page={3} quote="regola" />);
+    expect(inlineProps[0].features).toEqual({ jumpToPage: true, zoom: true });
+    expect(inlineProps[0].highlightQuote).toBe('regola');
+  });
+
+  it('forwards a custom features prop (e.g. antiLeak) to PdfInlineViewer', () => {
+    render(
+      <PdfQuoteViewer documentId="d1" page={3} quote="regola" features={{ antiLeak: true }} />
+    );
+    expect(inlineProps[0].features).toEqual({ antiLeak: true });
+    expect(inlineProps[0].highlightQuote).toBe('regola');
+  });
+});

--- a/apps/web/src/hooks/queries/__tests__/useGameChat.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useGameChat.test.tsx
@@ -170,6 +170,41 @@ describe('useGameChat', () => {
     expect(agent.outOfContext).toBe(false);
   });
 
+  it('surfaces SP-C region grounding fields (regions/charStart/charEnd) from the type-1 event (#3407)', async () => {
+    // The BE Snippet now Full-gates + emits regions[]/charStart/charEnd on the type-1 CITATIONS
+    // event; mapSseCitation must forward them to the FE Citation so SP-D can draw the overlay.
+    const sseEvents = [
+      { type: 7, data: { token: 'Answer.' } },
+      {
+        type: 1,
+        data: {
+          citations: [
+            {
+              text: 'verbatim rule text',
+              source: 'PDF:doc-1',
+              page: 2,
+              line: 0,
+              score: 0.9,
+              regions: [{ page: 2, x: 0.1, y: 0.2, width: 0.3, height: 0.4 }],
+              charStart: 100,
+              charEnd: 250,
+            },
+          ],
+        },
+      },
+      { type: 4, data: { confidence: 0.8, citations: null } },
+    ];
+    vi.mocked(qaStream).mockReturnValueOnce(mockStream(sseEvents) as any);
+    const { result } = renderHook(() => useGameChat('azul'));
+    await act(async () => {
+      await result.current.ask('come si calcolano i punti?');
+    });
+    const cite = result.current.messages[1].citations?.[0];
+    expect(cite?.regions).toEqual([{ page: 2, x: 0.1, y: 0.2, width: 0.3, height: 0.4 }]);
+    expect(cite?.charStart).toBe(100);
+    expect(cite?.charEnd).toBe(250);
+  });
+
   it('derives outOfContext=true when no citations + confidence < 0.30', async () => {
     const oocEvents = [
       { type: 7, data: 'Non ho informazioni.' },

--- a/apps/web/src/hooks/queries/useGameChat.ts
+++ b/apps/web/src/hooks/queries/useGameChat.ts
@@ -85,11 +85,23 @@ interface ErrorPayload {
 // page, score }, while the type-4 COMPLETE payload carries citations:null in
 // production. Map that shape to the FE Citation type so the chat renders
 // CitationChip and can open the source PDF at the cited page.
+interface SseRegion {
+  readonly page: number;
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+}
+
 interface SseCitation {
   readonly text?: string;
   readonly source?: string;
   readonly page?: number;
   readonly score?: number;
+  // SP-C (#3407): Full-gated region grounding emitted by the BE Snippet (camelCase wire).
+  readonly regions?: ReadonlyArray<SseRegion> | null;
+  readonly charStart?: number | null;
+  readonly charEnd?: number | null;
 }
 
 function mapSseCitation(c: SseCitation): Citation {
@@ -99,6 +111,12 @@ function mapSseCitation(c: SseCitation): Citation {
     snippet: c.text ?? '',
     relevanceScore: c.score ?? 0,
     copyrightTier: 'full',
+    // SP-C (#3407): surface the region overlay + char offsets (already Full-gated by the BE).
+    regions: c.regions
+      ? c.regions.map(r => ({ page: r.page, x: r.x, y: r.y, width: r.width, height: r.height }))
+      : null,
+    charStart: c.charStart ?? null,
+    charEnd: c.charEnd ?? null,
   };
 }
 

--- a/apps/web/src/lib/api/schemas/__tests__/streaming.schemas.test.ts
+++ b/apps/web/src/lib/api/schemas/__tests__/streaming.schemas.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { CitationSchema } from '@/lib/api/schemas/streaming.schemas';
+
+/**
+ * SP-C (#3407): the streaming CitationSchema (session-agent + live chains) must additively carry
+ * the Full-gated region-grounding fields (regions/charStart/charEnd) emitted by the BE CitationDto.
+ * zod strips unknown keys by default, so without the schema extension `data.regions` is dropped.
+ */
+describe('CitationSchema — SP-C region fields', () => {
+  it('parses and retains regions[] from the wire', () => {
+    const result = CitationSchema.safeParse({
+      documentId: 'doc-1',
+      pageNumber: 2,
+      snippetPreview: 'verbatim rule text',
+      copyrightTier: 'full',
+      regions: [{ page: 2, x: 0.1, y: 0.2, width: 0.3, height: 0.4 }],
+      charStart: 100,
+      charEnd: 250,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.regions).toEqual([{ page: 2, x: 0.1, y: 0.2, width: 0.3, height: 0.4 }]);
+    expect(result.data.charStart).toBe(100);
+    expect(result.data.charEnd).toBe(250);
+  });
+
+  it('accepts a citation without region fields (backward-compat)', () => {
+    const result = CitationSchema.safeParse({
+      documentId: 'doc-2',
+      pageNumber: 1,
+      snippetPreview: 'text',
+      copyrightTier: 'protected',
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    // Absent → nullish, never throws.
+    expect(result.data.regions ?? null).toBeNull();
+    expect(result.data.charStart ?? null).toBeNull();
+  });
+});

--- a/apps/web/src/lib/api/schemas/streaming.schemas.ts
+++ b/apps/web/src/lib/api/schemas/streaming.schemas.ts
@@ -66,6 +66,23 @@ export const CitationSchema = z.object({
   copyrightTier: z.enum(['full', 'protected']).default('full'), // Default 'full' for backward compat
   paraphrasedSnippet: z.string().optional().nullable(),
   isPublic: z.boolean().optional().default(false),
+  // SP-C (#3407): Full-gated region grounding. `regions` are normalized [0,1] top-left bounding
+  // boxes for the PDF overlay (SP-D); BE emits them only for Full-tier citations. Additive/nullable
+  // so the current wire (no region fields) keeps safeParse-ing.
+  regions: z
+    .array(
+      z.object({
+        page: z.number(),
+        x: z.number(),
+        y: z.number(),
+        width: z.number(),
+        height: z.number(),
+      })
+    )
+    .optional()
+    .nullable(),
+  charStart: z.number().optional().nullable(),
+  charEnd: z.number().optional().nullable(),
 });
 
 export type Citation = z.infer<typeof CitationSchema>;

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -866,3 +866,18 @@
 .pdf-quote-highlight {
   background-color: rgba(255, 235, 59, 0.4);
 }
+
+/* ============================================================================
+ * PdfBBoxOverlay — region grounding overlay (SP-D #3408)
+ * Precise %-based rectangle drawn over the react-pdf <Page> for a citation's
+ * source region (Pattern B). Semantic --c-warning token (decorative fill +
+ * border), static (no animation) → no motion concern. Full-gated at the wire.
+ * ============================================================================ */
+
+.pdf-bbox-highlight {
+  position: absolute;
+  background-color: hsl(var(--c-warning) / 0.2);
+  border: 1px solid hsl(var(--c-warning));
+  border-radius: 2px;
+  pointer-events: none;
+}

--- a/apps/web/src/types/domain.ts
+++ b/apps/web/src/types/domain.ts
@@ -129,6 +129,19 @@ export interface Snippet {
 }
 
 /**
+ * SP-C (#3407): a normalized [0,1] top-left bounding box of a citation on its source PDF page.
+ * Page-relative coordinates enable a scale/DPR-independent %-based overlay (SP-D). Emitted by the
+ * BE only for Full-tier citations (DA-4 — drawing the verbatim region on a Protected doc would leak).
+ */
+export interface CitationRegion {
+  page: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/**
  * Citation from RAG response with relevance scoring (Issue #859, BGAI-074)
  */
 export interface Citation {
@@ -142,6 +155,15 @@ export interface Citation {
   paraphrasedSnippet?: string;
   /** Whether the game is publicly available (affects upsell CTA copy) */
   isPublic?: boolean;
+  /**
+   * SP-C (#3407): Full-gated PDF region overlay boxes (SP-D). Null/absent for the pre-coordinate
+   * corpus, the non-Unstructured branch, or Protected-tier citations.
+   */
+  regions?: CitationRegion[] | null;
+  /** SP-C (#3407): char offset (inclusive) of the chunk in the source PDF text. Full-gated. */
+  charStart?: number | null;
+  /** SP-C (#3407): char offset (exclusive) of the chunk in the source PDF text. Full-gated. */
+  charEnd?: number | null;
 }
 
 /**

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -24,6 +24,7 @@ export type {
   RuleSpecComment,
   Snippet,
   Citation,
+  CitationRegion,
   Message,
   QaResponse,
 } from './domain';

--- a/docs/for-developers/audits/2026-07-29-in-session-agent-grounding-audit.md
+++ b/docs/for-developers/audits/2026-07-29-in-session-agent-grounding-audit.md
@@ -16,7 +16,7 @@ Il difetto dominante, confermato da verifica avversariale e da consenso 5/5 del 
 
 **Verdict: fondamenta solide, contratto di affidabilità assente.** La base tecnica è di alta qualità, ma manca il prerequisito che il prodotto vende — la garanzia che una risposta non-grounded sia etichettata come tale.
 
-Finding tracciati come issue: **#3388** (P1), **#3389** (P2), **#3390** (epic).
+Programma di lavoro completo: issue-ombrello **#3397** (raggruppa e sequenzia gli 8 finding). Critici: **#3388** (P1), **#3389** (P2), **#3390** (epic).
 
 ---
 

--- a/docs/for-developers/audits/2026-07-29-in-session-agent-grounding-audit.md
+++ b/docs/for-developers/audits/2026-07-29-in-session-agent-grounding-audit.md
@@ -1,0 +1,88 @@
+# Audit: l'agente AI in-sessione e le sue opzionalità (Q&A gioco + sessione live)
+
+**Data:** 2026-07-29
+**Trigger (domanda utente):** analizzare l'agente dell'app e le opzionalità che fornisce quando risponde a domande di un gioco o gestisce una sessione.
+**Metodo:** `/sc:spec-panel`. (1) Ricostruzione della specifica *implicita* dal codice via 4 ricognizioni parallele (RAG/Q&A backend · sessione live backend · UI frontend · agent-config/toolkit). (2) **Verifica avversariale** dei 10 finding "da confermare": 1 verificatore per claim legge il codice reale, i 4 critici passano da un secondo verificatore con mandato di *confutare* (verdetti riportati § 2). (3) **Discussion panel** a 5 lenti indipendenti sui due finding critici confermati (§ 3). Tutti i riferimenti `file:line` sono stati letti sul codice, non inferiti.
+
+---
+
+## 1. Executive summary + verdict
+
+Le opzionalità dell'agente **esistono e sono profonde** (pipeline RAG con RRF+rerank+sentence-window, scoring polimorfico strategy-pattern, degradazione graziosa multi-livello, IDOR guard diffusi, 8 `AgentType` × 4 `AgentMode` configurabili). Il problema non è la mancanza di feature: è la **duplicazione non riconciliata** e le **promesse UI non mantenute**.
+
+Il difetto dominante, confermato da verifica avversariale e da consenso 5/5 del panel:
+
+> **Il grounding dell'agente in-sessione è una proprietà della *modalità di input*, non un invariante del sistema.** Lo scenario più naturale in-sessione — *"scatto una foto del tavolo e chiedo una regola"* — è esattamente quello che salta il rulebook e restituisce una risposta autorevole (`confidence 0.85`) **silenziosamente non-grounded**, senza alcun disclaimer.
+
+**Verdict: fondamenta solide, contratto di affidabilità assente.** La base tecnica è di alta qualità, ma manca il prerequisito che il prodotto vende — la garanzia che una risposta non-grounded sia etichettata come tale.
+
+Finding tracciati come issue: **#3388** (P1), **#3389** (P2), **#3390** (epic).
+
+---
+
+## 2. Verifica avversariale — 10 finding (6 confermati, 4 qualificati)
+
+| # | Claim | Verdetto | Adversariale | Correzione emersa |
+|---|---|---|---|---|
+| **C1** | Doppio backend chat in-session (testo→RAG citazioni / immagini→multimodale senza RAG) | 🟡 PARZIALE | STANDS | **Peggiore**: la risposta con immagine perde le citazioni **ma non mostra alcun disclaimer** → *silenziosamente non-grounded*. `SessionLiveView.tsx:1257`, `LiveAgentChat.tsx:240`, `ChatCommandHandlers.cs:193/201/244` |
+| **C2** | `userTier:null` nel path B disattiva gli enhancement RAG | 🟡 PARZIALE | STANDS | **Più forte**: enhancement (CRAG/RAPTOR/Fusion/Graph) **inattivi in ogni path utente**, solo debug admin (`StreamDebugQaQueryHandler.cs:249`). Il confronto "path A li attiva" era errato: `AskQuestionQueryHandler` è pipeline separata. Baseline hybrid+RRF+rerank+sentence-window resta attivo |
+| **C3** | Due enum ruolo con valori invertiti | 🟡 PARZIALE | STANDS | Fatti esatti, rischio **latente non attivo** (bridge `CreateSessionCommand` non trasporta il ruolo, enum persistiti per nome). Ma: **terzo enum omonimo** `GameManagement…Entities.ParticipantRole` (collisione di nome) + enum escono come **int verso il FE** (`SseJsonOptions.cs:15`) → rischio conflazione lato frontend |
+| **C4** | Budget in-sessione fail-open vs quota Q&A fail-closed | ✅ CONFERMATO | QUALIFIED | Asimmetria reale, ma: 403 fail-closed è **dead code oggi** (`NullPricingEngine`); il "modello di fallback" del path B **non esiste** (`hasBudget` scoped/mai riletto, log fuorviante); fail-open **documentato come scelta intenzionale** |
+| **C5** | `AgentModeSelector` (RulesClarifier/…) non montato | ✅ CONFERMATO | — | Orfano (0 route). L'omonimo **admin** `AgentModeSelector` *è* montato — componenti distinti |
+| **C6** | Note visibility private/shared solo-FE | ✅ CONFERMATO | — | Scartato già nel handler FE (`_visibility` unused), POST diary text-only, `DiaryEntry` senza campo visibility. Documentato (#2570) |
+| **C7** | `SelectedDocumentIds` accettato ma non persistito | ✅ CONFERMATO | — | Ignorato in scrittura e sempre vuoto in risposta. Documentato (MVP #657/#658) |
+| **C8** | Dispute Arbitro solo SignalR, no idratazione REST | ✅ CONFERMATO | — | L'endpoint REST **esiste già** (`GET /live-sessions/games/{gameId}/dispute-history`) + query per-sessione non wired; non perse lato server (EF-backed). **Fix = cablare l'endpoint esistente** |
+| **C9** | Status "online" mockati + latenza 42ms hardcoded | ✅ CONFERMATO | — | `AgentSelector` sempre "online" (POC, poll no-op); `ChatAgentPanel` pip "Online" statico + `42ms` hardcoded in 3 punti |
+| **C10** | Due sistemi di scoring indipendenti | ✅ CONFERMATO | — | Confermato; dentro `SessionTracking` ce ne sono **due** (polimorfico + storico) → ≥3 code-path. Nessuna sincronizzazione tra i BC |
+
+### Superficie di opzionalità (ricostruita)
+
+**Tassonomia agente** — 2 concetti (`AgentDefinition` template admin-only vs `AgentConfiguration`/`AgentConfig` runtime self-service); 8 `AgentType` (`RAG · Citation · Confidence · RulesInterpreter · Conversation · Strategist · Narrator · Tutor`); 4 `AgentMode` (`Chat · Player · Ledger · Arbiter`); provider `OpenRouter`/`Ollama`; routing per tier utente e complessità query.
+
+**Scenario A — Q&A su un gioco:** 3 famiglie di flussi (QA classico `AskQuestionQueryHandler` · chat sessione `ChatWithSessionAgentCommandHandler` · Arbitro `ValidateMoveCommand`); 4 strategie retrieval + 5 enhancement gated; citazioni con copyright tier; SSE streaming; AgentMemory (house rules/notes/preferences); degradazione `Full→Degraded(BGG)→None`.
+
+**Scenario B — sessione live:** ⚠️ **due aggregati paralleli** (`SessionTracking.Session` RowVersion vs `GameManagement.LiveGameSession` Xmin); scoring polimorfico `Points/BinaryWin/Objectives/Ranking` (solo Host edita); turni; note cifrate AES; widget/toolkit; dispute; real-time **doppio canale** (SignalR + SSE); gating agente `AgentSessionMode`; player User-linked vs guest + RSVP a fasi.
+
+---
+
+## 3. Discussion panel — 5 lenti sul grounding in-sessione
+
+**Consenso 5/5:** *lo stato di grounding deve diventare un invariante esplicito del contratto di risposta, non un effetto collaterale della modalità di input.*
+
+| Lente | Frase chiave | Rischio |
+|---|---|---|
+| 💬 Fiducia utente | «Un sistema onesto *a intermittenza* è meno affidabile di uno mai onesto.» | L'utente ha imparato *"nessun avviso = grounded"*; il path immagine infrange la promessa implicita nel momento di massimo bisogno |
+| 🔍 RAG quality | «Il grounding è proprietà della *modalità*, non invariante del *sistema*.» | Chiudere il gap costa poco (la query è il testo del turno); ⚠️ CRAG web-fallback su dominio chiuso **peggiora** la fedeltà |
+| 🛡️ Affidabilità prod | «Degrada *mentendo*: cieco sul peggior failure mode con strumenti che mentono.» | Log `"fallback model"` inesistente (↑MTTR); `confidence 0.85` = manometro dipinto; nessuna metrica grounded/non-grounded |
+| 🧪 Testing | «Non è un bug di codice: è un **buco di specifica**.» | Failure trust-critical invisibile alla CI: nessun invariante cross-path né negative-space assertion |
+| 🏗️ Architettura | «Il confine è tracciato lungo la costura sbagliata: la modalità di input ha *leakato* fino a biforcare la Published Language.» | Chi possiede "risposta grounded" (`KnowledgeBase`) deve possedere la risposta; `SessionTracking` deve *consumarla* |
+
+**Tensione:** warning fatigue vs onestà → risolta con copy calibrato per-modalità (spiega *cosa* ha grounded), non allarme generico.
+
+---
+
+## 4. Piano d'azione
+
+*Sequenza su cui il panel converge: prima rendere onesto il segnale, poi chiudere il gap di capacità — due lavori distinti, il primo non aspetta il secondo.*
+
+| Fase | Azione | Effort | Issue |
+|---|---|---|---|
+| **1 — Onestà** | Contratto condiviso `groundingStatus` non-nullable prodotto da entrambi gli handler; disclaimer per-modalità; **rimuovere confidence 0.85** | S/M | **#3388** (P1) |
+| **2a — Osservabilità** | Metrica `{path, groundingStatus, citationCount, retrievalProfile, enhancementsActive}` + alert; correggere log "fallback" menzognero | M | (in #3388/#3390) |
+| **2b — Quick win qualità** | Disaccoppiare profilo retrieval da `userTier` (profilo esplicito "live-session"); non tocca i confini | M | **#3389** (P2) |
+| **3 — Unificazione strutturale** | Turno multimodale attraverso il retrieval (vision=stato, testo=query→citazioni); `SessionTracking`→consumer | L | **#3390** (epic) |
+| **Prerequisito enhancement** | Eval set golden (recall@k + citation-accuracy) su 3-5 regolamenti prima di attivare enhancement; **disabilitare CRAG web-fallback** | L | (in #3390) |
+
+### Finding minori (non ancora tracciati come issue)
+
+- **C8** — cablare l'endpoint REST dispute-history esistente nel tab Arbitro (fix banale, alto valore).
+- **C6/C7/C9** — rimuovere/cablare le opzionalità "fantasma" (note-visibility solo-FE, `SelectedDocumentIds` non persistito, mock "online"/42ms).
+- **C3** — mapper esplicito + test ai confini per i due enum ruolo; valutare rinomina del terzo enum omonimo.
+- **C1/C10** — ADR che dichiara l'SSOT tra i due modelli di sessione e i due sistemi di scoring.
+
+---
+
+## 5. Note di metodo
+
+- I verdetti "PARZIALE" non indicano finding deboli: indicano che il *nucleo* è confermato ma il *framing* iniziale è stato corretto dalla verifica avversariale (in C1/C2 la realtà è **peggiore**; in C3/C4 più **sfumata**).
+- La verifica è stata condotta su `main-dev` al 2026-07-29. I punti marcati "mock/hardcoded/non persistito" sono i più a rischio di divergere dalla documentazione: ri-verificare prima di trattarli come definitivi in futuro.

--- a/docs/for-developers/audits/2026-07-29-in-session-agent-grounding-audit.md
+++ b/docs/for-developers/audits/2026-07-29-in-session-agent-grounding-audit.md
@@ -73,12 +73,13 @@ Finding tracciati come issue: **#3388** (P1), **#3389** (P2), **#3390** (epic).
 | **3 — Unificazione strutturale** | Turno multimodale attraverso il retrieval (vision=stato, testo=query→citazioni); `SessionTracking`→consumer | L | **#3390** (epic) |
 | **Prerequisito enhancement** | Eval set golden (recall@k + citation-accuracy) su 3-5 regolamenti prima di attivare enhancement; **disabilitare CRAG web-fallback** | L | (in #3390) |
 
-### Finding minori (non ancora tracciati come issue)
+### Finding minori (tracciati come issue)
 
-- **C8** — cablare l'endpoint REST dispute-history esistente nel tab Arbitro (fix banale, alto valore).
-- **C6/C7/C9** — rimuovere/cablare le opzionalità "fantasma" (note-visibility solo-FE, `SelectedDocumentIds` non persistito, mock "online"/42ms).
-- **C3** — mapper esplicito + test ai confini per i due enum ruolo; valutare rinomina del terzo enum omonimo.
-- **C1/C10** — ADR che dichiara l'SSOT tra i due modelli di sessione e i due sistemi di scoring.
+- **C8** → [#3391](https://github.com/meepleAi-app/meepleai-monorepo/issues/3391) — cablare l'endpoint REST dispute-history esistente nel tab Arbitro (fix banale, alto valore).
+- **C3** → [#3392](https://github.com/meepleAi-app/meepleai-monorepo/issues/3392) — mapper esplicito + rinomina del terzo enum ruolo omonimo.
+- **C6 + C9** → [#3393](https://github.com/meepleAi-app/meepleai-monorepo/issues/3393) — rimuovere/cablare le affordance decorative (note-visibility solo-FE, mock "online"/42ms).
+- **C7** → [#3394](https://github.com/meepleAi-app/meepleai-monorepo/issues/3394) — KB linking: `SelectedDocumentIds` accettato ma non persistito (deferral non più tracciato dopo la chiusura di #657/#658).
+- **C1 / C10** → [#3395](https://github.com/meepleAi-app/meepleai-monorepo/issues/3395) — ADR che dichiara l'SSOT tra i due modelli di sessione e i due sistemi di scoring.
 
 ---
 

--- a/docs/for-developers/operations/2026-07-26-corpus-reindex-runbook.md
+++ b/docs/for-developers/operations/2026-07-26-corpus-reindex-runbook.md
@@ -10,6 +10,39 @@ corpus**. Sub-project 3/4 of epic [#3266](https://github.com/meepleAi-app/meeple
 - **Slice 3 (this runbook)**: `make reindex-corpus ENV=…` — loops the Slice 1 endpoint until
   the corpus is drained + ADR [adr-086](../../for-claude/architecture/adr/adr-086-corpus-reindex-orchestration.md).
 
+> ### 🎯 SP-E addendum — coordinate-aware v1.2 (region grounding, #3409 / epic #3403)
+>
+> The same orchestration now also activates **PDF region grounding** (epic
+> [#3403](https://github.com/meepleAi-app/meepleai-monorepo/issues/3403)). The server's current
+> `IndexerVersion` was bumped **v1.1 → v1.2 (coordinate-aware)** in #3409, so `make reindex-corpus
+> ENV=…` re-extracts every Ready PDF and repopulates the normalized bounding boxes (SP-B #3406)
+> into `text_chunks.bounding_boxes_json`. The FE overlay (SP-D #3408) then renders the cited region
+> on real documents. Deltas vs the v1.1 procedure below:
+>
+> - **Target version** is now `v1.2` (not `v1.1`). The selector, drain loop, and idempotency are
+>   unchanged — `reindex-ready` picks every Ready PDF whose `IndexerVersion != v1.2`.
+> - **§1 precondition** is stronger: the `unstructured` container must be the **coordinate-aware
+>   (SP-B #3406) build**, not merely SP1. A stale (pre-SP-B) container extracts **without**
+>   coordinates → `bounding_boxes_json` stays NULL silently (the run still stamps v1.2, so it looks
+>   done but grounds nothing). Rebuild + verify the container emits a `bbox` field per element
+>   before running. Region grounding is **Unstructured-only** — SmolDocling/Docnet branches leave
+>   `bounding_boxes_json` NULL (expected; FE falls back to Pattern A).
+> - **§4 post-reindex assertion** additionally checks bbox coverage:
+>   ```sql
+>   -- Unstructured-branch Ready PDFs should have non-null bbox after the v1.2 reindex.
+>   SELECT COUNT(*) FILTER (WHERE bounding_boxes_json IS NOT NULL) AS with_bbox,
+>          COUNT(*) AS total
+>   FROM text_chunks tc
+>   JOIN pdf_documents pd ON pd.id = tc.pdf_document_id
+>   WHERE pd.processing_state = 'Ready' AND pd.indexer_version = 'v1.2';
+>   ```
+> - **§5 baseline**: re-capture the `rag-smoke` golden baseline after the reindex (the snapshot id +
+>   `indexer_version` change), per the [rag-smoke runbook](./rag-smoke-runbook.md).
+> - **Scope (DC-3)**: validate on **staging first**; the prod decision is taken separately after the
+>   staging FE-overlay check. **Extraction strategy (DC-2)** stays `fast` for this rollout — `fast`
+>   already emits coordinates; `hi_res` for table-heavy PDFs is a tracked follow-up
+>   ([#3419](https://github.com/meepleAi-app/meepleai-monorepo/issues/3419)), not required for the AC.
+
 ## Why a big-bang is needed
 
 The heading-aware pipeline is **latent**: it only runs on fresh ingests. The already-indexed

--- a/docs/superpowers/plans/2026-07-30-rag-citation-region-grounding.md
+++ b/docs/superpowers/plans/2026-07-30-rag-citation-region-grounding.md
@@ -1,0 +1,170 @@
+# RAG Citation Region Grounding — piano TDD
+
+Epic "RAG citation region grounding". Spec: [`docs/superpowers/specs/2026-07-30-rag-citation-region-grounding-design.md`](../specs/2026-07-30-rag-citation-region-grounding-design.md).
+Parent branch per ogni sub-progetto: `main-dev`.
+
+## Obiettivo
+Portare fino al FE `pdfDocumentId + pageNumber reale + chunkIndex + charStart/charEnd + regions[]`
+(bbox normalizzate [0,1] top-left) e disegnare un overlay preciso sul PDF nel percorso chat, con
+fallback graceful. Gate copyright: `regions` solo `CopyrightTier=Full`.
+
+## Non-goal
+Riscrittura estrazione tabelle in HTML/celle (Livello 2 separato) · grounding sub-riga
+parola/carattere · denormalizzazione bbox su `pgvector_embeddings` · unificazione completa dei 4
+wire (solo il minimo su Ask/legacy, DC-1).
+
+## Precondizioni operative
+- Container Docker `unstructured` DEVE essere ricostruito col codice coordinate-aware prima che
+  emetta `bbox` (come SP3 #3269: container stale → bbox null silenzioso).
+- bbox NON è recuperabile dal corpus esistente senza ri-estrazione (StructuredElementsJson salvato
+  non ha coordinate). Char-offset SÌ (basta re-index).
+
+---
+
+## SP0 — Quick-win: cablare l'highlight testuale nel percorso chat  (branch `feature/issue-<n>-chat-quote-highlight`)
+
+**Cosa**: il quote-highlight (`PdfQuoteViewer` + `makeQuoteTextRenderer`) esiste ma non è usato in
+chat. Passare `citation.snippet`/`paraphrasedSnippet` come `highlightQuote` in `CitationPdfTab` e
+sostituire/estendere `PdfPageModal` con `PdfQuoteViewer` (che già gestisce highlight + banner
+fallback).
+
+### TDD
+- **RED** (vitest): test che `CitationPdfTab` monta il viewer con `highlightQuote` = snippet tier
+  Full, e senza highlight per Protected (usa `paraphrasedSnippet`, che NON è verbatim → nessun
+  match forzato).
+- **RED**: test che quando il match fallisce compare `data-testid=pdf-quote-fallback`.
+- **GREEN**: wire prop; riuso `PdfQuoteViewer`.
+- **Regressione**: mechanic-card/admin che già usano `PdfQuoteViewer` restano invariati.
+
+**Valore**: da subito «Vedi nel PDF» apre la pagina reale ed evidenzia (best-effort) la regione,
+anche prima che le bbox esistano. Indipendente da tutto il resto.
+
+---
+
+## SP-A — Char-offset persistence + surfacing  (branch `feature/issue-<n>-chunk-char-offsets`)
+
+**Cosa**: persistere `char_start/char_end` (già calcolati, oggi scartati) e portarli nel DTO
+citazione + FE. Correggere `SearchResultDto.FromDomain` che scarta `PdfDocumentId/ChunkIndex`.
+
+### Slice A1 — persistenza
+- **RED** (unit `TextChunkEntity`/config): asserire nuove colonne `char_start/char_end` nullable.
+- **RED** (unit, 5 siti): `PdfProcessingPipelineService.SaveTextChunksAsync`, `IndexPdfCommandHandler`,
+  `UploadPdfCommandHandler.Processing`, `CompleteChunkedUploadCommandHandler`,
+  `ImportRagDataCommandHandler` → asserire che `chunk.CharStart/CharEnd` finiscono su `TextChunkEntity`.
+- **GREEN**: aggiungere proprietà + config EF (`.HasColumnName("char_start")…`) + 2 righe per sito.
+- **Migration**: `dotnet ef migrations add AddChunkCharOffsets` (da `apps/api/src/Api`,
+  solution `MeepleAI.Api.sln`). `AddColumn<int>` x2 nullable. Down = DropColumn x2.
+- **Integration** (Testcontainers): re-index di un PDF con `StructuredElementsJson` popola
+  `char_start/char_end`.
+
+### Slice A2 — surfacing DTO + FE
+- **RED**: `SearchResultDto.FromDomain` mantiene `PdfDocumentId`, `ChunkIndex`, `CharStart`, `CharEnd`.
+- **RED**: `CitationDto` (4-arg e 7-arg) espone `chunkId/charStart/charEnd`; FE `Citation` type +
+  zod `CitationSchema` accettano i campi (optional/nullable, backward-compat).
+- **GREEN**: estensioni additive.
+- **Gotcha**: fixare il cache-hit di `AskQuestionQueryHandler:222` che inventa `pageNumber` e svuota
+  `documentId` (DC-1 minimo).
+
+---
+
+## SP-B — Coordinate pipeline (greenfield)  (branch `feature/issue-<n>-coordinate-extraction`)
+
+**Cosa**: propagare le coordinate Unstructured normalizzate fino a `bounding_boxes_json`.
+
+### Slice B1 — Python
+- **RED** (pytest): `_normalized_bbox(el)` — element con `coordinates` PixelSpace → bbox atteso;
+  element senza coordinates (PageBreak) → None; **indipendenza da layout dims** (stesso box
+  relativo con W/H diversi).
+- **GREEN**: helper in `main.py` + `BBoxSchema`/`bbox: Optional` in `schemas.py`.
+
+### Slice B2 — C# plumbing
+- **RED** (unit): `UnstructuredElement.Bbox` deserializzato; `MapStructuredElements` produce
+  `ExtractedElement.BoundingBox`; `ExtractedElement` retro-compat (JSON senza bbox → null).
+- **RED**: `ExtractedDocumentFactory` → `DocumentSection.BBox = union(elements start page)`;
+  `AdvancedChunkingService.CreateChildChunks` → i child ereditano `section.BBox`;
+  `HierarchicalChunkMapper` → `DocumentChunk.BBox` non più scartato;
+  `EmbeddedTitleSplitter` → Title sintetico propaga la bbox del body.
+- **GREEN**: record esteso (param opzionale), union helper, mapping.
+
+### Slice B3 — persistenza bbox
+- **RED**: 5 siti insert scrivono `BoundingBoxesJson`; entity/config nuova colonna jsonb.
+- **GREEN** + **Migration** `AddChunkBoundingBoxes` (`AddColumn<string>("bounding_boxes_json",
+  type:"jsonb", nullable:true)`). Config `HasColumnType("jsonb").IsRequired(false)`.
+- **D**: bump `IndexerVersionRegistry` → `v1.2 — coordinate-aware` (`Current → v1.2`).
+- **Integration** (Testcontainers): ingest di un PDF fixture con coordinate → `bounding_boxes_json`
+  popolato, valori ∈ [0,1].
+
+**Precondizione**: rebuild container `unstructured` prima dell'integration.
+
+---
+
+## SP-C — Region DTO surfacing + copyright gating  (branch `feature/issue-<n>-citation-regions-dto`)
+
+**Cosa**: portare `regions[]` fino al FE su tutti i wire, gate `CopyrightTier=Full`, persistere in
+`citationsJson`.
+
+### TDD
+- **RED**: LEFT JOIN `text_chunks` in `PgVectorStoreAdapter` restituisce `bounding_boxes_json`
+  (pattern heading #3270); `SearchResult` porta `Regions`.
+- **RED** (gating, critico): per `CopyrightTier=Full` `CitationDto.Regions` valorizzato; per
+  `Protected` `Regions == null` (nessun highlight verbatim).
+- **RED**: `ChunkCitation.Regions` **senza `[JsonIgnore]`** → presente in `citationsJson`;
+  round-trip serialize/deserialize.
+- **RED**: `Snippet`/`InlineCitationMatch` estesi; `StreamQaQueryHandler` e
+  `ChatWithSessionAgentCommandHandler` popolano le regions.
+- **GREEN**: estensioni + `_copyrightTierResolver` gate.
+- **Baseline**: `ChunkPayloadTests`/`PgVectorEmbeddingEntityTests`/equality VO → aggiornare gli
+  `GetEqualityComponents` senza rompere i test esistenti.
+
+---
+
+## SP-D — FE overlay + wire chat  (branch `feature/issue-<n>-pdf-bbox-overlay`)
+
+**Cosa**: `PdfBBoxOverlay` + `PdfInlineViewer.highlightRects` + wire percorso chat.
+
+### TDD (vitest + Testing Library)
+- **RED**: `PdfBBoxOverlay` renderizza N `data-testid=pdf-bbox-rect` con `left/top/width/height` %
+  corretti da `regions[]`.
+- **RED**: `PdfInlineViewer` con `highlightRects` monta l'overlay e NON attiva il text layer;
+  senza `highlightRects` ma con `highlightQuote` mantiene Pattern A (regressione
+  `pdf-quote-fallback`/`onQuoteMatch`).
+- **RED**: `CitationModal`/`CitationPdfTab` passano `citation.regions` + `pageNumber` al viewer;
+  `regions` assenti → fallback Pattern A (SP0).
+- **GREEN**: componente + prop additive + CSS `.pdf-bbox-highlight` (token `--c-warning`,
+  `prefers-reduced-motion`).
+- **Test convenzione Y** (anti-mirroring): fixture con rect noto in alto pagina → `top` piccolo.
+
+---
+
+## SP-E — Re-extract/re-index corpus + rollout  (branch `feature/issue-<n>-corpus-reextract`)
+
+**Cosa**: attivare il grounding sui dati reali. bbox richiede ri-estrazione (non basta re-index).
+
+### TDD / deliverable
+- **D1**: comando/endpoint di re-extract big-bang su PDF Ready con `IndexerVersion != v1.2`
+  (riuso pattern `BulkReindexReadyCommand` #3269, ma con **ri-estrazione**, non solo re-chunk).
+  - **Gotcha null-trap SQL** (Npgsql): selettore `IndexerVersion == null || != target`
+    (test integrazione Gruppo C come SP3).
+  - Pacing su capacità coda; `ConflictException` per-PDF → skipped, mai abort.
+- **D2**: suite non-regressione retrieval EN+IT (rag-smoke estesa) su staging prima del big-bang.
+- **D3**: runbook per-env + rebuild container `unstructured` documentato; orchestrazione
+  `make reindex-corpus ENV=` (se allineato a SP3).
+- **AC**: post-reindex, i chunk dei PDF Ready hanno `bounding_boxes_json` non-null (ramo
+  Unstructured); citazioni nel FE mostrano l'overlay.
+
+---
+
+## Rischi/gotcha trasversali
+- **bbox non backfillabile** → limite noto; SP0+Pattern A coprono l'interim.
+- **Copyright** (DA-4) → gate tier Full, test dedicato.
+- **pgvector doppio-binario** → non toccare (DA-3), LEFT JOIN.
+- **5 siti insert** → helper centralizzato di serializzazione bbox.
+- **StructuredElementsJson retro-compat** → param opzionale su `ExtractedElement`.
+- **Convenzione Y** top-left → test anti-mirroring.
+- **Baseline test = 0 fail** (policy CLAUDE.md) + gate a11y/token verdi.
+
+## Decisioni (dal design)
+DA-1 normalizza in Python top-left [0,1] · DA-2 jsonb array su text_chunks · DA-3 no pgvector,
+LEFT JOIN · DA-4 regions solo tier Full · DA-5 overlay %-based child di `<Page>` · DA-6 char-offset
+subito · DA-7 char via re-index, bbox via re-extract · DA-8 union su start page.
+Da confermare: DC-1 (scope unificazione wire), DC-2 (fast vs hi_res), DC-3 (big-bang vs lazy).

--- a/docs/superpowers/specs/2026-07-30-rag-citation-region-grounding-design.md
+++ b/docs/superpowers/specs/2026-07-30-rag-citation-region-grounding-design.md
@@ -1,0 +1,293 @@
+# RAG Citation Region Grounding — mostrare la regione PDF sorgente della risposta
+
+**Data**: 2026-07-30
+**Tipo**: design (spec-panel + audit codice)
+**Epic proposta**: "RAG citation region grounding"
+**Stato**: design v1 — prodotto da spec-panel multi-esperto + 2 audit codice (8 finder)
+**Branch previsto epic**: feature branch per sub-progetto (parent `main-dev`)
+
+> **Origine**: segnalazione utente — «dopo la risposta di un agent, i riferimenti al PDF
+> sono tagliati (mancano lettere iniziali) e/o sono una sequenza di lettere/numeri,
+> probabilmente perché nel PDF sono in tabella. La cosa importante è permettere all'utente
+> di visualizzare la parte del PDF da cui l'agente ha dedotto la risposta.»
+
+---
+
+## 1. Diagnosi (verificata contro il codice)
+
+Il fenomeno ha **due cause distinte che si sommano**. Vanno trattate separatamente perché
+hanno costo e rimedio diversi.
+
+### 1.1 Causa A — il testo della citazione è brutto (troncato / garbled)
+
+Il layer di citazione **non introduce** il difetto. Ogni slice dello snippet taglia la *coda*,
+è char-based UTF-16, parte da indice 0 — nessun offset byte-vs-char, nessun taglio dell'inizio:
+
+- `AskQuestionQueryHandler.cs:574` → `Substring(0, Min(150, len))`
+- `RagPromptAssemblyService.cs:443` → `AsSpan(0,117)+"..."`
+- `StreamQaQueryHandler.cs:369` → testo **completo** (nessun taglio)
+
+Il testo "tagliato/garbled" **arriva già così dal DB** (`text_chunks.Content` /
+`pgvector_embeddings.text_content`), prodotto a monte da tre sorgenti:
+
+| Sintomo | Causa | Evidenza |
+|---|---|---|
+| «mancano lettere iniziali» | Chunk che iniziano a **metà parola** | `TextChunkingService.cs:122-124` (~71% chunk con frammento iniziale); mitigato da `SnapToWordStart` (commit #3241) |
+| «sequenza di lettere/numeri» (testo) | Marcatori **U+FFFE** al posto del trattino di sillabazione + parole spezzate su newline | `PdfTextProcessingDomainService.cs:62-79` (`NormalizeText`, riparato in #3241) |
+| «sequenza di lettere/numeri» (tabelle) | Tabelle **linearizzate**: `strategy='fast'` hardcoded, `text_as_html` mai serializzato, regola di merge che fonde i token | `UnstructuredPdfTextExtractor.cs:123`; `pdf_extraction_service.py:95`; merge `([a-z])\n([a-z])→$1$2` a `PdfTextProcessingDomainService.cs:79` |
+
+**Conseguenza operativa**: i fix #3241/#3282 sono già nel codice → i *nuovi* documenti sono a
+posto. I documenti indicizzati **prima** conservano chunk corrotti nel DB → la citazione li
+riproduce fedelmente. **Il codice è a posto, il corpus no.** Le tabelle **non** sono coperte da
+quei fix.
+
+### 1.2 Causa B — non si può vedere la sorgente PDF
+
+Il frontend **ha già** un viewer PDF completo (`react-pdf`/`pdfjs-dist`): `PdfInlineViewer`,
+`PdfQuoteViewer` (highlight + banner fallback), `PdfPageModal`, `CitationModal`. Il deep-link a
+**pagina** (`#page=N`, `initialPage`) esiste ovunque. L'highlight della **regione**
+(`highlightQuote` + `makeQuoteTextRenderer`) esiste come capacità **ma non è cablato nel percorso
+chat** — è usato solo in mechanic-card e admin. Nel percorso chat `CitationPdfTab.tsx:75` monta il
+viewer senza `highlightQuote`; `PdfPageModal.tsx` usa `renderTextLayer=false`.
+
+Metadati di grounding persistiti oggi: **solo `page_number`** (a volte *stimato*
+`charPos/2000+1` nel percorso flat → può puntare a pagina sbagliata), `chunk_index`, `heading`.
+`CharStart/CharEnd` **calcolati ma scartati** in tutti i siti di insert. Bounding box: il VO
+`ChunkMetadata.BBox` **esiste (ADR-016) ma non è mai popolato** — le coordinate di Unstructured
+muoiono al confine del DTO `UnstructuredElement`.
+
+### 1.3 Insight strategico
+
+**Risolvere B rende A molto meno grave**: anche con snippet testuale imperfetto, se l'utente vede
+la porzione reale del PDF evidenziata, la risposta è verificabile. Il requisito centrale
+dell'utente è B (grounding visivo), non lo snippet perfetto.
+
+---
+
+## 2. Obiettivo e requisiti
+
+**Obiettivo**: dato un messaggio dell'agente con citazione, un clic apre il PDF alla **pagina
+reale** con la **regione sorgente evidenziata** (rettangoli precisi), con fallback esplicito
+quando la regione non è disponibile.
+
+Requisiti (SMART):
+
+- **R1** — Ogni citazione porta fino al FE: `pdfDocumentId` risolto, `pageNumber` reale,
+  `chunkIndex`, `charStart/charEnd`, `regions[]` (bbox normalizzate [0,1] top-left).
+- **R2** — Il viewer disegna le `regions[]` come overlay preciso; se assenti, ripiega
+  sull'highlight testuale esistente; se anche quello fallisce, mostra il banner fallback.
+- **R3** — Le `regions[]` (highlight verbatim) sono esposte **solo per `CopyrightTier=Full`**;
+  per `Protected` nessun highlight geometrico verbatim (coerenza con il copyright leak guard #447 /
+  ADR-059).
+- **R4** — Il grounding è **best-effort e degradabile**: PDF via SmolDocling/Docnet o senza
+  text-layer (OCR) hanno `regions=null` → fallback a pagina + testo, senza errori.
+- **R5** — Nessuna regressione della baseline test (fail count = 0) né del gate a11y/token.
+
+Non-goal:
+
+- Riscrivere l'estrazione tabelle in HTML/celle (è il Livello 2 separato; qui le tabelle
+  beneficiano comunque di regione+pagina).
+- Grounding a livello di parola/carattere sub-riga (MVP = regione a livello di sezione/riga).
+- Denormalizzare bbox su `pgvector_embeddings` (si usa LEFT JOIN `text_chunks`).
+
+---
+
+## 3. Decisioni cardine
+
+| # | Decisione | Scelta | Motivazione |
+|---|---|---|---|
+| **DA-1** | Normalizzazione coordinate | **In Python, top-left [0,1]** dividendo per `layout_width/height` | Chiude il problema unità (punti fast vs pixel hi_res vs DPI) al boundary; il FE è zero-math |
+| **DA-2** | Persistenza bbox | Colonna **`bounding_boxes_json jsonb`** su `text_chunks` (array page-aware) | Un chunk parent copre più box/righe → serve un array, non 4 colonne float |
+| **DA-3** | Denormalizzazione pgvector | **No** — LEFT JOIN `text_chunks` su `source_chunk_id` | Evita il doppio-binario raw-SQL di `pgvector_embeddings`; pattern già usato per heading #3270 |
+| **DA-4** | Copyright gating | `regions[]` esposte **solo tier Full** | bbox = highlight verbatim → rischio leak su Protected (ADR-059/#447) |
+| **DA-5** | Overlay FE | **Pattern B** (rects %-based, child di `<Page>`) primario; **Pattern A** (quote text-match) fallback | %-based è scale/DPR-independent, zero conversione se il wire è già normalizzato |
+| **DA-6** | Char-offset | Persistere `char_start/char_end` (**già calcolati**) subito | Costo minimo (colonne + mapping), backfillabile via re-index, migliora il fallback text-highlight |
+| **DA-7** | Backfill | char-offset via **re-index** (basta `StructuredElementsJson`); bbox via **ri-estrazione** (nuovo `IndexerVersion` coordinate-aware) | Le coordinate non sono mai state salvate → il corpus va ri-estratto col servizio Python coordinate-enabled |
+| **DA-8** | Aggregazione box | MVP = **unione (min/max)** degli element della sezione sulla start page | Semplice; multi-pagina limitato alla start page (estensione futura: regione per pagina) |
+
+**Da confermare (DC)**:
+
+- **DC-1** — Unificare i 4 wire di citazione (risolvere `VectorDocumentId` vs `PdfDocumentId`,
+  uniformare snippet length) è **in scope** di questa epic o cleanup separato? (Raccomandato:
+  prerequisito minimo su Ask/legacy per keyare le regions su `PdfDocumentId+ChunkIndex`.)
+- **DC-2** — `strategy='fast'` (box a granularità pdfminer per-riga/word) vs `hi_res` (box
+  layout-block, più lento) per l'estrazione coordinate. Raccomandato: restare su `fast` (coordinate
+  già disponibili), `hi_res` solo on-demand per scansioni.
+- **DC-3** — Big-bang re-extract dell'intero corpus vs lazy on-next-reindex. Raccomandato:
+  big-bang per-env (pattern SP3 #3269), staging prima di prod.
+
+---
+
+## 4. Architettura della soluzione (data-flow proposto)
+
+```
+Unstructured (Python)
+  element.metadata.coordinates (points[4], system.width/height, PixelSpace top-left)
+   └─(NUOVO) _normalized_bbox → bbox {x,y,width,height} ∈ [0,1]      ← DROP #1 chiuso in main.py
+      ElementSchema.bbox: Optional[BBoxSchema]                        ← schema Python
+        │  HTTP JSON
+        ▼
+UnstructuredPdfTextExtractor.cs
+  UnstructuredElement.Bbox (NUOVO)  → MapStructuredElements
+   └─ ExtractedElement(Text, PageNumber, ElementType, ElementBoundingBox?)  ← record esteso (param opzionale)
+        │  (serializzato in PdfDocumentEntity.StructuredElementsJson — retro-compat: assente = null)
+        ▼
+ExtractedDocumentFactory.FromExtraction
+  DocumentSection.BBox = UnionNormalized(group.Elements su start page)  ← DROP #3 chiuso
+        ▼
+AdvancedChunkingService
+  parent.BBox = section.BBox (già copiato); child.BBox = section.BBox (NUOVO inherit)  ← DROP child chiuso
+        ▼
+HierarchicalChunkMapper → DocumentChunk.BBox (NUOVO campo)             ← DROP #4 chiuso
+        ▼
+5 siti insert  →  TextChunkEntity.CharStart/CharEnd (già calcolati) + BoundingBoxesJson (NUOVO)
+        ▼  [migration EF: char_start int, char_end int, bounding_boxes_json jsonb — tutti NULL]
+Retrieval  →  SearchResult (già ha PdfDocumentId+ChunkIndex+Heading)
+   └─ SearchResultDto (+ PdfDocumentId, ChunkIndex, CharStart, CharEnd, Regions)  ← PUNTO DI PERDITA #1 chiuso
+        ▼
+CitationDto (4-arg + 7-arg) / Snippet / InlineCitationMatch  (+ regions[], gated CopyrightTier=Full)
+        │  SSE / citationsJson
+        ▼
+FE Citation.regions[]  →  PdfBBoxOverlay (child di <Page>, rect %-based)  + fallback Pattern A
+```
+
+Le coordinate `regions` sopravvivono **solo** per il ramo di estrazione Unstructured (Stage 1).
+SmolDocling/Docnet → `regions=null` (degradazione R4).
+
+---
+
+## 5. Decomposizione in sub-progetti
+
+| SP | Cosa | Costo | Dipende da | Backfill |
+|----|------|-------|-----------|----------|
+| **SP0 — Quick-win chat highlight** | Cablare `PdfQuoteViewer` (highlight testuale già esistente) nel percorso chat (`CitationPdfTab`/`PdfPageModal`); passare `citation.snippet` come `highlightQuote` | XS | — | n/a (usa dato esistente) |
+| **SP-A — Char-offset persistence** | Colonne `char_start/char_end` + mapping 5 siti + `SearchResultDto`/`CitationDto` surfacing + FE consuma | S | — | re-index (StructuredElementsJson) |
+| **SP-B — Coordinate pipeline** | Python coordinates normalizzate → `ExtractedElement.BoundingBox` → union in factory → child inherit → `DocumentChunk.BBox` → `bounding_boxes_json`; nuovo `IndexerVersion v1.2` | L | — (greenfield) | ri-estrazione |
+| **SP-C — Region DTO surfacing + copyright gating** | `regions[]` in tutti i wire citazione, gate `CopyrightTier=Full`, persistenza `citationsJson`; FE types + zod | M | SP-B (contratto mockabile) | — |
+| **SP-D — FE overlay + wire** | `PdfBBoxOverlay` + `PdfInlineViewer.highlightRects` + wire `CitationModal`/`CitationPdfTab`/`PdfPageModal` + fallback Pattern A | M | SP-C | — |
+| **SP-E — Re-extract/re-index corpus + rollout** | Big-bang re-extract per-env + runbook + non-regression EN+IT | M | SP-B deployato | — |
+
+SP0 e SP-A sono spedibili subito e indipendenti; danno valore mentre SP-B (il grosso) matura.
+SP-C/SP-D sviluppabili in parallelo con contratto mockato.
+
+---
+
+## 6. Contratti proposti (shape concrete)
+
+### 6.1 Python — `ElementSchema` (unstructured-service)
+
+```jsonc
+// elemento attuale
+{ "text": "PREPARAZIONE", "page_number": 1, "category": "Title" }
+// proposto
+{ "text": "PREPARAZIONE", "page_number": 1, "category": "Title",
+  "bbox": { "x": 0.081, "y": 0.103, "width": 0.239, "height": 0.076 } // null se coords assenti
+}
+```
+
+Normalizzazione (Python, unico punto con `system.width/height`):
+```
+xs=[p[0] for p in coords.points]; ys=[p[1] for p in coords.points]
+x=min(xs)/W; y=min(ys)/H; w=(max(xs)-min(xs))/W; h=(max(ys)-min(ys))/H   # W,H = system.width/height; clamp [0,1]
+```
+`min/max` → robusto all'ordine dei points; divisione per W/H → zoom/DPI-independent. PixelSpace è
+**top-left, y-down** (fast e hi_res) → **nessun flip Y**.
+
+### 6.2 C# — record
+
+```csharp
+// DocumentProcessing (NON dipendere da KB)
+public record ExtractedElement(string Text, int PageNumber, string ElementType,
+                               ElementBoundingBox? BoundingBox = null); // param opzionale = retro-compat StructuredElementsJson
+public sealed record ElementBoundingBox(float X, float Y, float Width, float Height); // [0,1] top-left
+
+// DocumentChunk / DocumentChunkInput: CharStart/CharEnd già presenti; aggiungere:
+public IReadOnlyList<BoundingBox>? BoundingBoxes { get; init; } // KB.BoundingBox esteso con int Page
+```
+
+### 6.3 DB — `text_chunks` (migration `AddChunkCharOffsetsAndBoundingBoxes`)
+
+```sql
+ALTER TABLE public.text_chunks
+  ADD COLUMN char_start integer NULL,
+  ADD COLUMN char_end   integer NULL,
+  ADD COLUMN bounding_boxes_json jsonb NULL;
+```
+`bounding_boxes_json` = `[{ "page":3, "x":0.10, "y":0.16, "width":0.55, "height":0.02 }, …]`.
+`pgvector_embeddings` **non toccata** (DA-3). xmin non usato su `text_chunks` → nessun concurrency
+token. Colonne nullable → nessun backfill al deploy (no lock lunghi).
+
+### 6.4 DTO citazione (estensioni additive)
+
+```csharp
+record CitationRegionDto(float X, float Y, float W, float H); // [0,1] top-left
+// CitationDto 7-arg (+): int? ChunkIndex, int? CharStart, int? CharEnd, IReadOnlyList<CitationRegionDto>? Regions
+// CitationDto 4-arg (+): string? ChunkId, int? CharStart, int? CharEnd, IReadOnlyList<CitationRegionDto>? Regions
+// Snippet (+): int? charStart, int? charEnd, IReadOnlyList<CitationRegionDto>? boundingBoxes
+// InlineCitationMatch (+): string? ChunkId, int? PdfCharStart, int? PdfCharEnd, regions  (StartOffset/EndOffset restano answer-relative)
+// ChunkCitation (+, NO [JsonIgnore]): CharStart, CharEnd, Regions  → finiscono in citationsJson persistito
+```
+
+`SearchResultDto.FromDomain` deve smettere di scartare `PdfDocumentId`/`ChunkIndex` (già sul
+dominio `SearchResult`).
+
+### 6.5 FE
+
+```ts
+interface CitationRegion { x: number; y: number; w: number; h: number; } // [0,1] top-left
+interface Citation { /* … */ chunkId?: string; charStart?: number; charEnd?: number; regions?: CitationRegion[]; }
+```
+
+```tsx
+// nuovo componente, child di <Page> (che è position:relative) → % ancorate al wrapper
+function PdfBBoxOverlay({ rects }: { rects: readonly CitationRegion[] }) {
+  return <div aria-hidden className="pointer-events-none absolute inset-0">
+    {rects.map((r,i)=><div key={i} data-testid="pdf-bbox-rect" className="pdf-bbox-highlight absolute"
+       style={{left:`${r.x*100}%`,top:`${r.y*100}%`,width:`${r.w*100}%`,height:`${r.h*100}%`}}/>)}
+  </div>;
+}
+// PdfInlineViewer: renderTextLayer solo se (quote && !hasRects); Pattern A resta il fallback.
+```
+
+---
+
+## 7. Rischi e mitigazioni
+
+| Rischio | Mitigazione |
+|---|---|
+| **bbox non backfillabile** sul corpus esistente (StructuredElementsJson non ha mai avuto coords) | Comunicare come limite noto; big-bang re-extract per-env (SP-E); fallback Pattern A intanto |
+| **Copyright leak** (highlight verbatim su Protected) | DA-4: regions solo tier Full; test che asserisce `regions=null` per Protected |
+| **Convenzione Y errata** (bottom-left vs top-left) → rettangoli specchiati | Contratto esplicito "top-left, y-down, [0,1]"; test con pagina asimmetrica nota |
+| **Divergenza documentId** (VectorDocumentId vs PdfDocumentId su Ask/legacy) | DC-1: risolvere prima di keyare le regions; SP-A include il fix `SearchResultDto` |
+| **pgvector doppio-binario** (EF + raw SQL) → drift se si aggiunge colonna solo EF | DA-3: non toccare pgvector; LEFT JOIN `text_chunks` |
+| **5 siti di insert** (non 4: +`ImportRagDataCommandHandler`) → dimenticarne uno | Centralizzare la serializzazione bbox in un helper (come `HeadingAwareChunkAdapter`) |
+| **StructuredElementsJson retro-compat** | Solo parametro **opzionale** su `ExtractedElement` (assente = null in System.Text.Json) |
+| **Reference frame CharStart/CharEnd** = content ricostruito, non ExtractedText/PDF | Documentare; per l'highlight geometrico contano le `regions`, non il char-range |
+| **SmolDocling/Docnet no coords** | R4 degradazione: regions=null, fallback pagina+testo |
+| **Overlay disallineato** da `max-w-full`/overflow-hidden del viewer | Ancorare % al wrapper `.react-pdf__Page` (l'overlay è child del Page); verificare wrapper==canvas width |
+
+---
+
+## 8. Criteri di accettazione
+
+- **AC1** — Caricato un PDF (ramo Unstructured) e posta una domanda, la citazione nel FE espone
+  `regions[]` non vuoto e il viewer disegna il rettangolo sulla pagina reale.
+- **AC2** — Per un chunk di tabella, la regione evidenziata copre la porzione tabellare citata
+  (anche se lo snippet testuale resta linearizzato).
+- **AC3** — Per una citazione tier `Protected`, `regions=null` e nessun highlight verbatim.
+- **AC4** — Per un PDF estratto via SmolDocling/Docnet (o senza text-layer), il viewer apre la
+  pagina e mostra il banner fallback senza errori.
+- **AC5** — Nessuno snippet di citazione inizia a metà parola (test di regressione anti-mid-word).
+- **AC6** — Baseline unit-test fail = 0; gate a11y/token verdi; nessuna regressione.
+
+---
+
+## 9. Riferimenti
+
+- Audit pipeline citazione (workflow 4-finder) — estrazione, chunking, citation-gen, FE rendering.
+- Deep-dive L3 (workflow 4-finder) — coordinate Unstructured, contratto DTO, overlay react-pdf,
+  migration EF.
+- Epic RAG heading-aware #3266 (SP1-SP4), `IndexerVersionRegistry`, `BulkReindexReadyCommand` /
+  `ReindexDocumentCommand` (pattern re-index big-bang SP3 #3269).
+- ADR-016 (ChunkMetadata/BBox spina dorsale), ADR-059 (copyright posture), ADR-060 (persistence).
+- Fix a monte: #3241 (`SnapToWordStart` + de-sillabazione), #3282 (heading-aware re-index).

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -427,7 +427,10 @@ game-reset-rollback-rehearse: ## Run disposable docker rollback rehearsal
 
 # === Corpus re-index orchestration (issue #3269 SP3 Slice 3 / D4) ===
 # Script lives in infra/scripts/reindex-corpus/. Wraps POST /admin/queue/reindex-ready
-# in a drain loop until the whole Ready corpus is re-indexed to heading-aware v1.1.
+# in a drain loop until the whole Ready corpus is re-indexed to the server's current
+# IndexerVersion — now coordinate-aware v1.2 (region grounding, #3409 SP-E / epic #3403).
+# 🔴 Precondition: the `unstructured` container MUST be the SP-B coordinate-aware build,
+# else the re-extract silently produces bbox-less chunks (regions stay null).
 
 reindex-corpus-help: ## Show corpus re-index (SP3 #3269) workflow help
 	@echo "Corpus big-bang re-index (SP3 #3269 D4) — usage:"
@@ -441,7 +444,7 @@ reindex-corpus-help: ## Show corpus re-index (SP3 #3269) workflow help
 	@echo "Per env, create infra/scripts/reindex-corpus/.env.<ENV> from .env.example (NEVER commit filled files)."
 	@echo "Full runbook: docs/for-developers/operations/2026-07-26-corpus-reindex-runbook.md"
 
-reindex-corpus: ## Big-bang re-index Ready PDFs to heading-aware v1.1 (ENV=staging|prod|dev; EXTRA=--dry-run for preview; prod needs IMEANIT=--i-mean-it)
+reindex-corpus: ## Big-bang re-index Ready PDFs to coordinate-aware v1.2 (ENV=staging|prod|dev; EXTRA=--dry-run for preview; prod needs IMEANIT=--i-mean-it)
 	@test -n "$(ENV)" || (echo "ENV required: make reindex-corpus ENV=staging" && exit 64)
 	@test -f scripts/reindex-corpus/.env.$(ENV) || (echo "Missing scripts/reindex-corpus/.env.$(ENV) — copy from .env.example" && exit 66)
 	./scripts/reindex-corpus/reindex-corpus.sh scripts/reindex-corpus/.env.$(ENV) $(EXTRA) $(IMEANIT)

--- a/infra/fixtures/title-health-baseline.json
+++ b/infra/fixtures/title-health-baseline.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "_comment": "Epic #3338 WP3 extraction-quality regression guard. Per-game title-health (TitleHealthMetric over each shared game's distinct text_chunks.Heading), captured from the STAGING corpus via GET /api/v1/admin/kb/title-health. Asserted by .github/workflows/title-health-staging.yml (SSH-fetch from staging → scripts/title-health-assert.sh --current-file). It fails a run if a baselined game's band DOWNGRADES (green→yellow/red, yellow→red), its plausibleFraction drops by more than `fractionRegressionTolerance`, or a baselined game vanishes. New (unbaselined) games are a NOTICE, never a FAIL. Runs against STAGING (not the CI seed snapshot) because the snapshot is Docnet-extracted = headingless; staging carries the heading-aware re-indexed corpus. `games` starts EMPTY → the gate SKIPs (dormant) until captured via workflow_dispatch (update_baseline=true). Because staging is not version-pinned, RE-CAPTURE after any deliberate re-index; the guard still catches unintended downgrades between captures. Docs: docs/for-developers/operations/2026-07-28-wp3-title-health-go-no-go.md.",
   "fractionRegressionTolerance": 0.05,
-  "capturedAt": "2026-07-29T15:47:29Z",
+  "capturedAt": "2026-07-30T11:58:56Z",
   "games": {
     "013e4db3-6550-4283-b9a0-8d673cc18a34": {
       "gameTitle": "7 Wonders",
@@ -11,6 +11,22 @@
       "plausibleFraction": 0.8241,
       "canonicalCoverage": 0,
       "distinctHeadings": 108
+    },
+    "cef805bf-d933-4ef8-8504-8352834bc2e9": {
+      "gameTitle": "7 Wonders Duel",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.9916,
+      "canonicalCoverage": 3,
+      "distinctHeadings": 119
+    },
+    "03924dbd-f638-4eb8-bb93-71e694709501": {
+      "gameTitle": "A Feast for Odin",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.9064,
+      "canonicalCoverage": 3,
+      "distinctHeadings": 203
     },
     "5392922e-9102-4614-a972-58ec6bdb550d": {
       "gameTitle": "Aeon's End",
@@ -27,6 +43,22 @@
       "plausibleFraction": 0.6106,
       "canonicalCoverage": 4,
       "distinctHeadings": 113
+    },
+    "09b65b94-8f1a-4b35-91e8-76be8acfe804": {
+      "gameTitle": "Agricola (Revised Edition)",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.9091,
+      "canonicalCoverage": 5,
+      "distinctHeadings": 110
+    },
+    "600524e1-8423-41d5-9c4b-cacef3b9606e": {
+      "gameTitle": "Android: Netrunner",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.8943,
+      "canonicalCoverage": 5,
+      "distinctHeadings": 227
     },
     "8289f662-af64-49f4-aef4-2a47859b1f78": {
       "gameTitle": "Ark Nova",
@@ -52,6 +84,22 @@
       "canonicalCoverage": 8,
       "distinctHeadings": 96
     },
+    "e37c9cbf-3246-490f-956c-e60d5e98456d": {
+      "gameTitle": "Battlestar Galactica: The Board Game – Exodus Expansion",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.8615,
+      "canonicalCoverage": 2,
+      "distinctHeadings": 130
+    },
+    "918d9c9f-30bd-4ac3-9b1b-68db0bf66250": {
+      "gameTitle": "Blueprints",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.8261,
+      "canonicalCoverage": 0,
+      "distinctHeadings": 23
+    },
     "d6c80520-1c81-4a21-bb3c-949094c3fed1": {
       "gameTitle": "Brass: Birmingham",
       "language": "en",
@@ -59,6 +107,14 @@
       "plausibleFraction": 0.7216,
       "canonicalCoverage": 4,
       "distinctHeadings": 97
+    },
+    "67969638-7601-47db-a468-513e07ee8917": {
+      "gameTitle": "Brass: Lancashire",
+      "language": "en",
+      "band": "yellow",
+      "plausibleFraction": 0.7473,
+      "canonicalCoverage": 4,
+      "distinctHeadings": 91
     },
     "3122acc3-0f8b-4f8a-b188-74dc467e9712": {
       "gameTitle": "Carcassonne",
@@ -100,6 +156,22 @@
       "canonicalCoverage": 2,
       "distinctHeadings": 267
     },
+    "1d57e803-a25f-436f-888d-138c494a9281": {
+      "gameTitle": "Clank! Legacy: Acquisitions Incorporated",
+      "language": "en",
+      "band": "yellow",
+      "plausibleFraction": 0.6739,
+      "canonicalCoverage": 0,
+      "distinctHeadings": 46
+    },
+    "304ed4cb-bd5b-4ccf-9e04-47edab0f9377": {
+      "gameTitle": "Clank!: A Deck-Building Adventure",
+      "language": "en",
+      "band": "red",
+      "plausibleFraction": 0.4571,
+      "canonicalCoverage": 0,
+      "distinctHeadings": 35
+    },
     "880fefba-10f7-4d1a-b951-b7460ed2b3ef": {
       "gameTitle": "Codenames",
       "language": "en",
@@ -107,6 +179,14 @@
       "plausibleFraction": 1,
       "canonicalCoverage": 1,
       "distinctHeadings": 16
+    },
+    "d57a47e7-8b06-46e2-90fb-60c8105b27b9": {
+      "gameTitle": "Concordia",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.9351,
+      "canonicalCoverage": 6,
+      "distinctHeadings": 77
     },
     "5ce41d59-152a-4655-bc71-753259808137": {
       "gameTitle": "Coup",
@@ -116,6 +196,22 @@
       "canonicalCoverage": 0,
       "distinctHeadings": 1
     },
+    "13063389-c21f-456e-b9ea-81407dd47650": {
+      "gameTitle": "Cthulhu: Death May Die",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.9431,
+      "canonicalCoverage": 3,
+      "distinctHeadings": 123
+    },
+    "cbfa39cf-da18-43d7-ad26-88a0337f98a0": {
+      "gameTitle": "Darwin's Journey",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.8333,
+      "canonicalCoverage": 10,
+      "distinctHeadings": 132
+    },
     "9700e3ea-1f93-4ba8-a782-74b57b6dd380": {
       "gameTitle": "Descent: Journeys in the Dark (Second Edition)",
       "language": "it",
@@ -123,6 +219,14 @@
       "plausibleFraction": 0.75,
       "canonicalCoverage": 6,
       "distinctHeadings": 232
+    },
+    "ba9df1b5-0b63-4a28-a42b-2aeec76058d1": {
+      "gameTitle": "Disney Villainous: The Worst Takes it All",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.9643,
+      "canonicalCoverage": 4,
+      "distinctHeadings": 168
     },
     "7fc23de4-6889-4989-9c4a-59d06b6964c0": {
       "gameTitle": "Dixit",
@@ -172,6 +276,22 @@
       "canonicalCoverage": 1,
       "distinctHeadings": 91
     },
+    "ac4559c5-29f2-44e8-b248-994b3811220f": {
+      "gameTitle": "Eclipse: New Dawn for the Galaxy",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.8497,
+      "canonicalCoverage": 2,
+      "distinctHeadings": 173
+    },
+    "3ef53d84-76c2-411c-83a4-4ac9ba311d5a": {
+      "gameTitle": "Eclipse: Second Dawn for the Galaxy",
+      "language": "en",
+      "band": "yellow",
+      "plausibleFraction": 0.7231,
+      "canonicalCoverage": 7,
+      "distinctHeadings": 372
+    },
     "3fa7b545-fc09-42ab-ba83-9e04f1f73baa": {
       "gameTitle": "El Grande",
       "language": "en",
@@ -188,6 +308,38 @@
       "canonicalCoverage": 1,
       "distinctHeadings": 66
     },
+    "1676c377-fb00-4fca-b72b-fdabe3a3df87": {
+      "gameTitle": "Fields of Arle",
+      "language": "en",
+      "band": "yellow",
+      "plausibleFraction": 0.7308,
+      "canonicalCoverage": 1,
+      "distinctHeadings": 156
+    },
+    "417e9096-159b-443b-b651-7acb1c4aff76": {
+      "gameTitle": "Final Girl",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.9302,
+      "canonicalCoverage": 3,
+      "distinctHeadings": 86
+    },
+    "17b6c69a-4e30-42a2-83c8-21b43b8ac997": {
+      "gameTitle": "Five Tribes",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.8793,
+      "canonicalCoverage": 3,
+      "distinctHeadings": 58
+    },
+    "02370205-ff16-4a61-bff7-2e10786ae497": {
+      "gameTitle": "Food Chain Magnate",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.939,
+      "canonicalCoverage": 0,
+      "distinctHeadings": 82
+    },
     "38e028f8-73e6-4a14-8405-263c38ec346a": {
       "gameTitle": "Forbidden Island",
       "language": "en",
@@ -195,6 +347,22 @@
       "plausibleFraction": 0.9444,
       "canonicalCoverage": 1,
       "distinctHeadings": 18
+    },
+    "c91fc9b0-f525-40fa-a96e-96c2b9bee1d1": {
+      "gameTitle": "Frostpunk: The Board Game",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.8367,
+      "canonicalCoverage": 5,
+      "distinctHeadings": 343
+    },
+    "ec49190d-f3ee-44a6-bdac-531be9808701": {
+      "gameTitle": "Gaia Project",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.9481,
+      "canonicalCoverage": 15,
+      "distinctHeadings": 154
     },
     "214058c1-2eaa-46a2-8e91-aac0c114bfea": {
       "gameTitle": "Gloom",
@@ -212,6 +380,22 @@
       "canonicalCoverage": 0,
       "distinctHeadings": 191
     },
+    "19588603-d875-4759-a7c6-77a4380d99dc": {
+      "gameTitle": "Great Western Trail",
+      "language": "de",
+      "band": "yellow",
+      "plausibleFraction": 0.7487,
+      "canonicalCoverage": 0,
+      "distinctHeadings": 195
+    },
+    "2bfb4a3d-3c62-41ca-92b2-a82ae0aa9e83": {
+      "gameTitle": "Great Western Trail: Argentina",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.8466,
+      "canonicalCoverage": 5,
+      "distinctHeadings": 163
+    },
     "6ae83070-12e6-4f03-8c2d-1023182fc9bb": {
       "gameTitle": "Hanamikoji",
       "language": "en",
@@ -227,6 +411,22 @@
       "plausibleFraction": 0.9,
       "canonicalCoverage": 4,
       "distinctHeadings": 60
+    },
+    "2cf8adc9-39c9-4a0f-bd18-c88aa3b875f8": {
+      "gameTitle": "Heat: Pedal to the Metal",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.9412,
+      "canonicalCoverage": 1,
+      "distinctHeadings": 34
+    },
+    "5b38a53a-5115-4878-bbc9-445f419b3413": {
+      "gameTitle": "Hegemony: Lead Your Class to Victory",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.9355,
+      "canonicalCoverage": 12,
+      "distinctHeadings": 248
     },
     "2676681f-7bd1-4d7f-b139-4f79a95337c9": {
       "gameTitle": "Hero Realms",
@@ -252,6 +452,14 @@
       "canonicalCoverage": 2,
       "distinctHeadings": 42
     },
+    "8e77ad87-64df-4e79-aba3-553698e59ed4": {
+      "gameTitle": "Kanban EV",
+      "language": "en",
+      "band": "yellow",
+      "plausibleFraction": 0.7688,
+      "canonicalCoverage": 13,
+      "distinctHeadings": 160
+    },
     "cb7fd041-5e49-497d-896d-b366b52ef2ce": {
       "gameTitle": "King of Tokyo",
       "language": "en",
@@ -268,6 +476,14 @@
       "canonicalCoverage": 1,
       "distinctHeadings": 8
     },
+    "22fa380d-b4c5-4ac8-ae74-8d47bde9d6e5": {
+      "gameTitle": "Le Havre",
+      "language": "en",
+      "band": "yellow",
+      "plausibleFraction": 0.75,
+      "canonicalCoverage": 2,
+      "distinctHeadings": 24
+    },
     "5f64b70a-0ea0-44fd-b9fc-cb21a0873fb2": {
       "gameTitle": "Love Letter",
       "language": "en",
@@ -276,6 +492,62 @@
       "canonicalCoverage": 0,
       "distinctHeadings": 5
     },
+    "247ea37c-0bd0-4333-9f75-6ce62060efe1": {
+      "gameTitle": "Mage Knight Board Game",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.8387,
+      "canonicalCoverage": 2,
+      "distinctHeadings": 93
+    },
+    "ea3a1053-cb7c-46ff-afc5-5d24ce3c50b2": {
+      "gameTitle": "Maracaibo",
+      "language": "en",
+      "band": "yellow",
+      "plausibleFraction": 0.7537,
+      "canonicalCoverage": 13,
+      "distinctHeadings": 134
+    },
+    "7cefc9aa-d265-4a70-afce-1c750765778f": {
+      "gameTitle": "Marvel Champions: The Card Game",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.8636,
+      "canonicalCoverage": 1,
+      "distinctHeadings": 44
+    },
+    "9c860442-a6d0-43cf-923c-33c518c83f50": {
+      "gameTitle": "Marvel United",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.9286,
+      "canonicalCoverage": 2,
+      "distinctHeadings": 70
+    },
+    "b5c0486f-018d-4ad1-8fdb-e1da961e94c0": {
+      "gameTitle": "Massive Darkness",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.95,
+      "canonicalCoverage": 2,
+      "distinctHeadings": 40
+    },
+    "cb0765c0-1f12-4edd-ac38-15a10ec817e7": {
+      "gameTitle": "Masters of The Universe: Fields of Eternia The Board Game",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.8976,
+      "canonicalCoverage": 11,
+      "distinctHeadings": 293
+    },
+    "7481219a-274d-4288-82a4-cced1afb4785": {
+      "gameTitle": "Mechs vs. Minions",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.8947,
+      "canonicalCoverage": 0,
+      "distinctHeadings": 19
+    },
     "9d7a0061-56ac-4fcf-8adc-151aecabc0ab": {
       "gameTitle": "Munchkin",
       "language": "en",
@@ -283,6 +555,38 @@
       "plausibleFraction": 0.9556,
       "canonicalCoverage": 1,
       "distinctHeadings": 45
+    },
+    "d88dbbfd-a30b-4a18-a10a-74d182e12f72": {
+      "gameTitle": "Nemesis",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.8881,
+      "canonicalCoverage": 11,
+      "distinctHeadings": 286
+    },
+    "e045e05d-59c3-4a3b-96fa-85e7c88c560a": {
+      "gameTitle": "Orleans",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.9528,
+      "canonicalCoverage": 2,
+      "distinctHeadings": 127
+    },
+    "3597f07a-f665-429d-9431-55cccaf1c2a9": {
+      "gameTitle": "Paladins of the West Kingdom",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.9552,
+      "canonicalCoverage": 2,
+      "distinctHeadings": 67
+    },
+    "a1ceef25-6df1-45e3-b18f-b7d5d72656d8": {
+      "gameTitle": "Paleo",
+      "language": "en",
+      "band": "yellow",
+      "plausibleFraction": 0.7714,
+      "canonicalCoverage": 2,
+      "distinctHeadings": 35
     },
     "3bc0dcad-12d0-4e75-a8e1-98e5a87b7a49": {
       "gameTitle": "Pandemic",
@@ -316,6 +620,14 @@
       "canonicalCoverage": 2,
       "distinctHeadings": 28
     },
+    "4df4e142-9012-4313-841a-f32754ec0f48": {
+      "gameTitle": "Photosynthesis",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.8333,
+      "canonicalCoverage": 2,
+      "distinctHeadings": 12
+    },
     "a8262b0e-6f30-41f5-9ca0-28d8cd1f350c": {
       "gameTitle": "Power Grid",
       "language": "en",
@@ -331,6 +643,22 @@
       "plausibleFraction": 0.7556,
       "canonicalCoverage": 3,
       "distinctHeadings": 90
+    },
+    "b85f83fd-e1cf-4989-a9c0-9d9b6d7a477c": {
+      "gameTitle": "RONE: Invasion",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.9545,
+      "canonicalCoverage": 2,
+      "distinctHeadings": 88
+    },
+    "f696982b-3a07-4003-9415-4621e99becf9": {
+      "gameTitle": "Race for the Galaxy",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.9213,
+      "canonicalCoverage": 4,
+      "distinctHeadings": 127
     },
     "fcd6c710-ec33-4b51-821b-c50e1ee603ad": {
       "gameTitle": "Raiders of the North Sea",
@@ -348,6 +676,14 @@
       "canonicalCoverage": 0,
       "distinctHeadings": 85
     },
+    "2b3a60ed-7890-4e6f-9ecb-c7ac3ab7f2d8": {
+      "gameTitle": "Revive",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.8835,
+      "canonicalCoverage": 4,
+      "distinctHeadings": 103
+    },
     "4f1a7e16-7770-4764-8ccc-77732037e05e": {
       "gameTitle": "Roll Player",
       "language": "en",
@@ -355,6 +691,46 @@
       "plausibleFraction": 0.8571,
       "canonicalCoverage": 6,
       "distinctHeadings": 28
+    },
+    "95450369-09d7-4785-99b6-9a28ffdd9757": {
+      "gameTitle": "SETI: Search for Extraterrestrial Intelligence",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.9387,
+      "canonicalCoverage": 11,
+      "distinctHeadings": 212
+    },
+    "f88bb52e-4b6a-48b9-a7ac-04ef765acecc": {
+      "gameTitle": "Sagrada",
+      "language": "en",
+      "band": "yellow",
+      "plausibleFraction": 0.6154,
+      "canonicalCoverage": 2,
+      "distinctHeadings": 39
+    },
+    "3f56db0d-2736-42db-adf0-5e758f743fbe": {
+      "gameTitle": "Santorini",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.8482,
+      "canonicalCoverage": 4,
+      "distinctHeadings": 112
+    },
+    "d97655f3-0d72-4ad9-b9e5-832944818861": {
+      "gameTitle": "Skytear",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.8368,
+      "canonicalCoverage": 2,
+      "distinctHeadings": 380
+    },
+    "bcea103d-b957-4b76-87b8-9453edb99405": {
+      "gameTitle": "Slay the Spire: The Board Game",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.8872,
+      "canonicalCoverage": 4,
+      "distinctHeadings": 195
     },
     "40e733d1-9c86-4b90-aa65-2f2ad40278a4": {
       "gameTitle": "Sleeping Gods",
@@ -388,6 +764,22 @@
       "canonicalCoverage": 0,
       "distinctHeadings": 21
     },
+    "b03f840f-c23f-45c2-a2b4-f532f31f03ed": {
+      "gameTitle": "Star Wars: Imperial Assault",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.8389,
+      "canonicalCoverage": 2,
+      "distinctHeadings": 211
+    },
+    "89855dad-6cec-4e3c-a925-f89961a723b4": {
+      "gameTitle": "Star Wars: Rebellion",
+      "language": "en",
+      "band": "yellow",
+      "plausibleFraction": 0.5455,
+      "canonicalCoverage": 2,
+      "distinctHeadings": 198
+    },
     "603b9f1e-b39a-43af-ac1b-a3496a242e36": {
       "gameTitle": "Survive: Escape from Atlantis!",
       "language": "en",
@@ -403,6 +795,14 @@
       "plausibleFraction": 0.9355,
       "canonicalCoverage": 0,
       "distinctHeadings": 31
+    },
+    "06f7cd68-751e-4523-85ee-d6f64bd6b10b": {
+      "gameTitle": "Terra Mystica",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.8687,
+      "canonicalCoverage": 11,
+      "distinctHeadings": 99
     },
     "6ba11322-4dd9-46b8-8c86-d5c092c7a3bf": {
       "gameTitle": "Terraforming Mars",
@@ -428,6 +828,14 @@
       "canonicalCoverage": 0,
       "distinctHeadings": 46
     },
+    "b664ee2a-a11c-4bbb-a2bd-9d85565ccee8": {
+      "gameTitle": "The Lord of the Rings: The Card Game",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.8,
+      "canonicalCoverage": 1,
+      "distinctHeadings": 130
+    },
     "d9d5bcc1-0afc-4837-ad51-8d2663d4e048": {
       "gameTitle": "The Quacks of Quedlinburg",
       "language": "en",
@@ -452,6 +860,22 @@
       "canonicalCoverage": 2,
       "distinctHeadings": 57
     },
+    "fdfa50e0-70cb-42ed-ac3b-c6b807eeff75": {
+      "gameTitle": "Too Many Bones",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.945,
+      "canonicalCoverage": 0,
+      "distinctHeadings": 109
+    },
+    "512acb7a-4ad8-4d15-9613-298a3e506396": {
+      "gameTitle": "Townsfolk Tussle",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.9425,
+      "canonicalCoverage": 2,
+      "distinctHeadings": 174
+    },
     "7e2fde31-9a19-4520-ad76-e61768fcb91b": {
       "gameTitle": "Twilight Imperium: Fourth Edition",
       "language": "en",
@@ -459,6 +883,30 @@
       "plausibleFraction": 0.6236,
       "canonicalCoverage": 7,
       "distinctHeadings": 457
+    },
+    "25eb4f62-2457-43df-92d6-1fd19114ff0a": {
+      "gameTitle": "Twilight Struggle",
+      "language": "en",
+      "band": "yellow",
+      "plausibleFraction": 0.7368,
+      "canonicalCoverage": 2,
+      "distinctHeadings": 76
+    },
+    "cb873f01-72f1-4ea8-bd06-539f77adee29": {
+      "gameTitle": "Underwater Cities",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.9007,
+      "canonicalCoverage": 8,
+      "distinctHeadings": 141
+    },
+    "7f0cdbd8-1096-476a-aaff-8a43adadb66f": {
+      "gameTitle": "Viticulture Essential Edition",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.8676,
+      "canonicalCoverage": 2,
+      "distinctHeadings": 136
     },
     "06b6f080-9e46-4117-ab7f-9a21be217e18": {
       "gameTitle": "War of the Ring: Second Edition",
@@ -475,6 +923,14 @@
       "plausibleFraction": 0.902,
       "canonicalCoverage": 0,
       "distinctHeadings": 102
+    },
+    "7e723f7f-7738-4b9a-a270-595d3cc12556": {
+      "gameTitle": "Wingspan: Asia",
+      "language": "en",
+      "band": "green",
+      "plausibleFraction": 0.8058,
+      "canonicalCoverage": 5,
+      "distinctHeadings": 139
     }
   }
 }

--- a/infra/scripts/reindex-corpus/.env.example
+++ b/infra/scripts/reindex-corpus/.env.example
@@ -20,7 +20,7 @@ ADMIN_EMAIL="admin@example.com"
 ADMIN_PASSWORD="change-me"
 
 # OPTIONAL — target indexer version to re-index toward. Leave empty/unset to let the
-# server resolve its Current version (heading-aware v1.1). Set explicitly only to pin
+# server resolve its Current version (coordinate-aware v1.2). Set explicitly only to pin
 # a specific version during a controlled migration.
 TARGET_VERSION=""
 

--- a/infra/scripts/reindex-corpus/reindex-corpus.sh
+++ b/infra/scripts/reindex-corpus/reindex-corpus.sh
@@ -4,12 +4,12 @@
 #
 # Wraps the admin endpoint `POST /api/v1/admin/queue/reindex-ready` (Slice 1, #3269)
 # in a drain loop. That endpoint enqueues Ready PDFs whose IndexerVersion differs from
-# the target (heading-aware v1.1) but is capped by the processing queue (MaxQueueSize),
+# the target (coordinate-aware v1.2) but is capped by the processing queue (MaxQueueSize),
 # so a large corpus needs REPEATED calls. This script loops until EnqueuedCount == 0
 # (corpus drained), pacing between iterations so the Quartz rail can process the queue
 # before the next batch is enqueued.
 #
-# The selector skips already-v1.1 docs (IndexerVersion == target), so the loop is
+# The selector skips already-current docs (IndexerVersion == target), so the loop is
 # idempotent / resumable — a crash mid-run is safe to re-run: already-re-indexed PDFs
 # are not touched again.
 #
@@ -67,7 +67,7 @@ fi
 : "${API_BASE_URL:?API_BASE_URL must be set in $ENV_FILE}"
 : "${ADMIN_EMAIL:?ADMIN_EMAIL must be set in $ENV_FILE}"
 : "${ADMIN_PASSWORD:?ADMIN_PASSWORD must be set in $ENV_FILE}"
-TARGET_VERSION="${TARGET_VERSION:-}"      # empty → server resolves Current (v1.1)
+TARGET_VERSION="${TARGET_VERSION:-}"      # empty → server resolves Current (v1.2)
 PACING_SECONDS="${PACING_SECONDS:-5}"
 MAX_ITERATIONS="${MAX_ITERATIONS:-200}"
 
@@ -94,7 +94,7 @@ LOGIN_ENDPOINT="$API_BASE_URL/api/v1/auth/login"
 if [ -n "$TARGET_VERSION" ]; then
   BODY=$(jq -n --arg v "$TARGET_VERSION" '{targetVersion:$v}')
 else
-  BODY='{}'   # omit targetVersion → server uses Current (heading-aware v1.1)
+  BODY='{}'   # omit targetVersion → server uses Current (coordinate-aware v1.2)
 fi
 
 COOKIE=$(mktemp)
@@ -119,7 +119,7 @@ if [ "$DRY_RUN" = true ]; then
   log_info "DRY-RUN plan:"
   log_info "  Environment : $ENV_NAME"
   log_info "  Endpoint    : POST $REINDEX_ENDPOINT"
-  log_info "  Target ver  : ${TARGET_VERSION:-<server Current — heading-aware v1.1>}"
+  log_info "  Target ver  : ${TARGET_VERSION:-<server Current — coordinate-aware v1.2>}"
   log_info "  Pacing      : ${PACING_SECONDS}s between iterations"
   log_info "  Max iters   : $MAX_ITERATIONS (safety cap)"
   log_info "  Plan        : loop POST reindex-ready until EnqueuedCount==0 (corpus drained)."
@@ -131,7 +131,7 @@ fi
 # --- real run: login then drain-loop ---
 login
 
-log_info "Starting big-bang corpus re-index for ENV=$ENV_NAME (target=${TARGET_VERSION:-<server Current v1.1>})"
+log_info "Starting big-bang corpus re-index for ENV=$ENV_NAME (target=${TARGET_VERSION:-<server Current v1.2>})"
 total_enqueued=0
 iteration=0
 
@@ -179,7 +179,7 @@ while [ "$iteration" -lt "$MAX_ITERATIONS" ]; do
 done
 
 log_error "MAX_ITERATIONS ($MAX_ITERATIONS) exceeded without draining (EnqueuedCount never reached 0)."
-log_error "This signals a STUCK queue: PDFs are re-enqueued but not progressing to $([ -n "$TARGET_VERSION" ] && echo "$TARGET_VERSION" || echo 'v1.1'). Check:"
+log_error "This signals a STUCK queue: PDFs are re-enqueued but not progressing to $([ -n "$TARGET_VERSION" ] && echo "$TARGET_VERSION" || echo 'v1.2'). Check:"
 log_error "  - the 'unstructured' Docker container is rebuilt with SP1 code (stale → 0 elements → no version bump)"
 log_error "  - the Quartz processing rail is running and the queue is not paused"
 log_error "  - raise MAX_ITERATIONS only after confirming the queue is actually progressing"


### PR DESCRIPTION
## Release window main-dev → main-staging (14 commit)

Promuove principalmente l'**epic #3403 — RAG citation region grounding** (attivazione region grounding) + fix catalog cover + docs/audit.

### Contenuto
- **Epic #3403** (region grounding): SP0 #3411 · SP-A #3412 · SP-B #3413 · SP-C #3417 · SP-D #3418 · **SP-E #3420** (IndexerVersion → v1.2 coordinate-aware) + docs spec/plan #3410.
- **Catalog**: #3402 round-trip PDF cover fields · #3400 CoverKind key-builder + L3 custom-cover write fix.
- **Docs/audit**: #3396 in-session agent grounding audit · #3388-3397 finding tracciati · #3338 re-capture title-health baseline.

### Post-merge (attivazione region grounding su staging)
Il merge auto-deploya API/Web a v1.2. Poi (ops, in corso):
1. Rebuild container `unstructured` coordinate-aware (SP-B) via SSH — l'auto-deploy `ai-essential` non lo tocca.
2. `make reindex-corpus ENV=staging` (dry-run → real) per ri-estrarre il corpus a v1.2 → `bounding_boxes_json` popolato.
3. Verifica overlay FE + re-baseline `rag-smoke`.

Runbook: `docs/for-developers/operations/2026-07-26-corpus-reindex-runbook.md` (addendum SP-E).

🤖 Generated with [Claude Code](https://claude.com/claude-code)