### PR TITLE
fix(pdf): align Unstructured file-size to 100MB + timeout to 120s (#3424)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/DependencyInjection/DocumentProcessingServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/DependencyInjection/DocumentProcessingServiceExtensions.cs
@@ -439,7 +439,10 @@ internal static class DocumentProcessingServiceExtensions
                              ?? "http://unstructured-service:8001";
                 client.BaseAddress = new Uri(apiUrl);
 
-                var timeoutSeconds = configuration.GetValue<int?>("PdfProcessing:Extractor:Unstructured:TimeoutSeconds") ?? 35;
+                // 120s (was 35s): large rulebooks with coordinate-aware extraction (epic #3403)
+                // legitimately exceed 35s; the staging re-index timed out on ~5 PDFs. appsettings
+                // sets 120 explicitly; this is the fallback when config is absent.
+                var timeoutSeconds = configuration.GetValue<int?>("PdfProcessing:Extractor:Unstructured:TimeoutSeconds") ?? 120;
                 client.Timeout = TimeSpan.FromSeconds(timeoutSeconds);
 
                 client.DefaultRequestHeaders.Add("User-Agent", "MeepleAI-Backend/1.0");

--- a/apps/api/src/Api/appsettings.json
+++ b/apps/api/src/Api/appsettings.json
@@ -212,7 +212,7 @@
       "Provider": "Docnet",
       "Unstructured": {
         "ApiUrl": "http://unstructured-service:8001",
-        "TimeoutSeconds": 35,
+        "TimeoutSeconds": 120,
         "MaxRetries": 3,
         "Strategy": "fast",
         "Language": "ita"

--- a/apps/unstructured-service/src/config/settings.py
+++ b/apps/unstructured-service/src/config/settings.py
@@ -11,7 +11,10 @@ class Settings(BaseSettings):
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR"] = "INFO"
 
     # File Processing
-    max_file_size: int = 52428800  # 50MB in bytes
+    # 100MB — aligned with the API's PdfProcessing:MaxFileSizeBytes (104857600). A lower cap here
+    # silently 413s large rulebooks the API already accepted (staging region-grounding re-index
+    # #3403 hit this on 55-65MB PDFs). Override per-env with MAX_FILE_SIZE.
+    max_file_size: int = 104857600  # 100MB in bytes
     timeout: int = 30  # seconds
     temp_dir: Path = Path("/tmp/pdf-extraction")
 

--- a/apps/unstructured-service/tests/test_api.py
+++ b/apps/unstructured-service/tests/test_api.py
@@ -114,18 +114,32 @@ class TestExtractEndpoint:
         assert "detail" in data and "error" in data["detail"]
         assert data["detail"]["error"]["code"] == "UNSUPPORTED_MEDIA_TYPE"
 
+    def test_settings_default_max_file_size_is_100mb(self):
+        """The default max_file_size must match the API's PdfProcessing:MaxFileSizeBytes (100MB).
+
+        A lower Python-side cap silently 413s large rulebooks the API already accepted, so the
+        two limits MUST stay aligned (staging re-index #3403 hit this: 55-65MB PDFs rejected).
+        """
+        from src.config.settings import Settings
+
+        assert Settings().max_file_size == 104857600  # 100 MB
+
     @patch("src.main.pdf_service.extract")
     def test_extract_file_too_large(self, mock_extract, client):
-        """Test extraction with file exceeding size limit returns 413"""
-        # Arrange
-        large_content = BytesIO(b"A" * (60 * 1024 * 1024))  # 60MB (exceeds 50MB limit)
+        """A file exceeding the configured size limit returns 413.
 
-        # Act
-        response = client.post(
-            "/api/v1/extract",
-            files={"file": ("large.pdf", large_content, "application/pdf")},
-            data={"strategy": "fast"},
-        )
+        The limit is patched to a small value so the test stays fast + independent of the default.
+        """
+        from src.config.settings import settings
+
+        # Arrange — cap at 1MB, upload 2MB
+        with patch.object(settings, "max_file_size", 1 * 1024 * 1024):
+            large_content = BytesIO(b"A" * (2 * 1024 * 1024))
+            response = client.post(
+                "/api/v1/extract",
+                files={"file": ("large.pdf", large_content, "application/pdf")},
+                data={"strategy": "fast"},
+            )
 
         # Assert
         assert response.status_code == 413


### PR DESCRIPTION
## Fix config mismatch pre-esistenti (sorti dal rollout staging #3403)

Durante il re-index staging del region grounding (epic #3403), **9/117 PDF** sono falliti per config mismatch **non correlati** al region grounding:

### 1. File-size mismatch → 4 PDF (55-65MB) 413 FILE_TOO_LARGE
L'API accetta fino a **100MB** (`PdfProcessing:MaxFileSizeBytes = 104857600`), ma il servizio Python `unstructured` rifiutava **>50MB** (`settings.max_file_size`). Un PDF accettato dall'API veniva poi 413-ato dall'extractor → estrazione impossibile.
→ `max_file_size` Python **50→100MB** (allineato; override env `MAX_FILE_SIZE`).

### 2. Timeout troppo basso → 5 PDF "timeout after 35s"
`PdfProcessing:Extractor:Unstructured:TimeoutSeconds = 35` troppo stretto per i rulebook grandi con estrazione coordinate-aware (il timeout HTTP generale è già 120s).
→ **35→120s** (`appsettings.json` + fallback `DocumentProcessingServiceExtensions`).

### Test
- **TDD Python**: nuovo test sul default 100MB (RED→GREEN) + `test_extract_file_too_large` aggiornato (limite patchato piccolo per restare veloce). Suite `unstructured-service` **32/32** verde (coverage 84%).
- **C#**: build Api pulita; `PdfProcessingConfigurationValidator` (1-300s) copre 120.

### Fuori scope (data/storage, tracciato in #3424)
8 seed doc con blob mancante in R2 (`seed/badsworm/*/rulebook.pdf`) → richiede re-seed/cleanup, non code-fixable qui.

Closes #3424

🤖 Generated with [Claude Code](https://claude.com/claude-code)