### PR TITLE
feat(rag): ExtractionStrategy decider groundwork for hi_res tables (#3419)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Services/ExtractionStrategy.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Services/ExtractionStrategy.cs
@@ -1,0 +1,56 @@
+using System.Text.Json;
+
+namespace Api.BoundedContexts.DocumentProcessing.Domain.Services;
+
+/// <summary>
+/// Unstructured extraction strategy (DC-2 #3419). Maps to the Python service's <c>strategy</c>
+/// request field (<c>Literal["fast", "hi_res"]</c>). Default <see cref="Fast"/> — cheap, and it
+/// already emits normalized coordinates (SP-B #3406); <see cref="HiRes"/> is reserved for
+/// table-heavy PDFs where it grounds table regions more precisely.
+/// </summary>
+public enum ExtractionStrategy
+{
+    Fast,
+    HiRes,
+}
+
+public static class ExtractionStrategyExtensions
+{
+    /// <summary>The wire token accepted by the Unstructured service (schemas.py <c>Literal["fast","hi_res"]</c>).</summary>
+    public static string ToWireString(this ExtractionStrategy strategy) =>
+        strategy == ExtractionStrategy.HiRes ? "hi_res" : "fast";
+}
+
+/// <summary>
+/// Decides the extraction strategy from a PDF's <b>prior</b> <c>StructuredElementsJson</c>
+/// (DC-2 #3419): <see cref="ExtractionStrategy.HiRes"/> when any element is a <c>Table</c>,
+/// otherwise <see cref="ExtractionStrategy.Fast"/>. Null/empty/invalid input → Fast (safe default:
+/// fresh ingests have no prior elements, and hi_res only makes sense once fast has surfaced a table).
+/// </summary>
+public static class ExtractionStrategyDecider
+{
+    public static ExtractionStrategy FromStructuredElements(string? structuredElementsJson)
+    {
+        if (string.IsNullOrWhiteSpace(structuredElementsJson))
+        {
+            return ExtractionStrategy.Fast;
+        }
+
+        try
+        {
+            var elements = JsonSerializer.Deserialize<List<ExtractedElement>>(structuredElementsJson);
+            if (elements is null || elements.Count == 0)
+            {
+                return ExtractionStrategy.Fast;
+            }
+
+            return elements.Any(e => string.Equals(e.ElementType, "Table", StringComparison.Ordinal))
+                ? ExtractionStrategy.HiRes
+                : ExtractionStrategy.Fast;
+        }
+        catch (JsonException)
+        {
+            return ExtractionStrategy.Fast;
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/Unit/DocumentProcessing/ExtractionStrategyDeciderTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/DocumentProcessing/ExtractionStrategyDeciderTests.cs
@@ -1,0 +1,55 @@
+using System.Text.Json;
+using Api.BoundedContexts.DocumentProcessing.Domain.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Unit.DocumentProcessing;
+
+/// <summary>
+/// DC-2 (#3419): route re-extraction to hi_res only for PDFs whose prior extraction
+/// (StructuredElementsJson) contains a Table element; otherwise fast.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "3419")]
+public sealed class ExtractionStrategyDeciderTests
+{
+    // Mirror the pipeline's serialization: default JsonSerializer over List<ExtractedElement>.
+    private static string ElementsJson(params (string type, int page)[] els) =>
+        JsonSerializer.Serialize(
+            els.Select(e => new ExtractedElement($"{e.type} text", e.page, e.type)).ToList());
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("{ not valid json")]
+    [InlineData("[]")]
+    public void FromStructuredElements_NullEmptyOrInvalid_ReturnsFast(string? json)
+    {
+        ExtractionStrategyDecider.FromStructuredElements(json).Should().Be(ExtractionStrategy.Fast);
+    }
+
+    [Fact]
+    public void FromStructuredElements_WithTableElement_ReturnsHiRes()
+    {
+        var json = ElementsJson(("Title", 1), ("NarrativeText", 1), ("Table", 2));
+        ExtractionStrategyDecider.FromStructuredElements(json).Should().Be(ExtractionStrategy.HiRes);
+    }
+
+    [Fact]
+    public void FromStructuredElements_NoTableElement_ReturnsFast()
+    {
+        var json = ElementsJson(("Title", 1), ("NarrativeText", 1), ("ListItem", 2));
+        ExtractionStrategyDecider.FromStructuredElements(json).Should().Be(ExtractionStrategy.Fast);
+    }
+
+    [Theory]
+    [InlineData(ExtractionStrategy.Fast, "fast")]
+    [InlineData(ExtractionStrategy.HiRes, "hi_res")]
+    public void ToWireString_MapsToUnstructuredTokens(ExtractionStrategy strategy, string expected)
+    {
+        strategy.ToWireString().Should().Be(expected);
+    }
+}

--- a/docs/superpowers/plans/2026-07-31-hires-tables-extraction-strategy.md
+++ b/docs/superpowers/plans/2026-07-31-hires-tables-extraction-strategy.md
@@ -1,0 +1,75 @@
+# DC-2 hi_res-per-tabelle — piano TDD (#3419)
+
+Spec: [`2026-07-31-hires-tables-extraction-strategy-design.md`](../specs/2026-07-31-hires-tables-extraction-strategy-design.md).
+Parent branch: `main-dev`. Solution BE: `apps/api/MeepleAI.Api.sln`.
+
+> ## ⚠️ Stato + revisione approccio (2026-07-31)
+> **Groundwork shippato** (Slice 1): `ExtractionStrategy` enum + `ExtractionStrategyDecider.FromStructuredElements`
+> (Domain/Services) con test 9/9 verdi. NON tocca `IPdfTextExtractor` → zero blast radius.
+>
+> **Il wiring via param sull'interface (Slice 2 originale) è stato TENTATO e RIGETTATO**: aggiungere
+> `strategy` a `IPdfTextExtractor.ExtractText/PagedTextAsync` rompe **~89 call-site** nel test project
+> (chiamate posizionali con `CancellationToken` come 3° arg + i Moq setup). Mettere `strategy` PRIMA di CT
+> (per non rompere i posizionali) viola **CA1068** (CT deve essere l'ultimo param, escalato a error) →
+> reorder che rompe comunque decine di call-site. Blast radius inaccettabile per un follow-up di qualità.
+>
+> **Approccio raccomandato per la sessione dedicata — scoped context (nessun cambio interface):**
+> - Nuovo servizio **scoped** `IExtractionStrategySelector { ExtractionStrategy Current { get; set; } }`
+>   (default `Fast`), registrato scoped.
+> - `UnstructuredPdfTextExtractor` inietta il selector e legge `Current` in `PrepareMultipartContent`
+>   (al posto dell'hardcoded/param). Gli altri extractor lo ignorano (non lo iniettano).
+> - `PdfProcessingPipelineService` inietta il selector e fa `selector.Current = ExtractionStrategyDecider.FromStructuredElements(pdfDoc.StructuredElementsJson)`
+>   PRIMA di chiamare `ExtractPagedTextAsync`. Scope per-request → pipeline + extractor condividono lo scope.
+> - **Zero** modifiche a `IPdfTextExtractor`/orchestrator/call-site/test → nessun blast radius.
+> - TDD: selector default Fast; Unstructured legge il selector nel multipart; pipeline setta il selector da StructuredElements.
+> - Nota concorrenza: scoped = per-request; non usare singleton/`AsyncLocal` cross-request.
+
+## Obiettivo
+Instradare l'estrazione Unstructured a `hi_res` **solo per i PDF con tabelle** (rilevate dal
+`StructuredElementsJson` precedente), altrimenti `fast`. Additivo, zero regressione sui path fresh-ingest.
+
+## Slice 1 — `ExtractionStrategy` + decider (dominio, no dipendenze esterne)
+- **RED** (unit): `ExtractionStrategyDecider.FromStructuredElements(json)` →
+  - `null`/vuoto/JSON malformato → `Fast` (default sicuro).
+  - JSON con un elemento `ElementType=="Table"` → `HiRes`.
+  - JSON senza `Table` (solo Title/NarrativeText) → `Fast`.
+  - case-insensitive su "table"? (decidi: match esatto "Table" come emesso da Unstructured).
+- **GREEN**: `enum ExtractionStrategy { Fast, HiRes }` + decider che deserializza `List<ExtractedElement>`
+  (riusa il tipo già persistito) e cerca `Any(e => e.ElementType == "Table")`. Robusto a JSON invalido (try/catch → Fast).
+
+## Slice 2 — `IPdfTextExtractor` + Unstructured usa la strategy
+- **RED** (unit `UnstructuredPdfTextExtractor`): con `strategy: HiRes` il multipart contiene il campo
+  `strategy="hi_res"`; con `Fast` (o default) → `"fast"`. (Testare `PrepareMultipartContent` o via mock HTTP handler
+  ispezionando il body inviato.)
+- **GREEN**: aggiungere `ExtractionStrategy strategy = ExtractionStrategy.Fast` come **ultimo** param a
+  `ExtractTextAsync`/`ExtractPagedTextAsync` (interface + Unstructured). `PrepareMultipartContent` prende la strategy →
+  `strategy.ToWireString()` (`Fast→"fast"`, `HiRes→"hi_res"`). Rimuovere l'hardcoded `"fast"`.
+- **GREEN (mechanical)**: aggiungere il param (accept-and-ignore) a SmolDocling, Docnet, i 2 DevTools mock.
+- **Regressione**: i 7 call-site esterni compilano invariati (param con default).
+
+## Slice 3 — Orchestrated + Orchestrator threading
+- **RED** (unit): `OrchestratedPdfTextExtractor.ExtractPagedTextAsync(..., HiRes)` → l'orchestrator riceve `HiRes` →
+  l'extractor keyed Unstructured riceve `HiRes`. (Mock dell'orchestrator/extractor keyed, assert sul param.)
+- **GREEN**: `EnhancedPdfProcessingOrchestrator.Extract*WithFallbackAsync` + `TryExtract*WithStage` + i punti
+  `extractor.Extract*Async(...)` (righe 252, 538; stage-3 Docnet 339/364 opzionale, ignora) threadano `strategy`.
+  `OrchestratedPdfTextExtractor` passa il param ai metodi pubblici dell'orchestrator.
+
+## Slice 4 — decision-site nella pipeline
+- **RED** (unit/integration `PdfProcessingPipelineService`): con `pdfDoc.StructuredElementsJson` contenente un
+  `Table` → l'estrazione è invocata con `HiRes`; senza tabelle/null → `Fast`. (Mock `IPdfTextExtractor`, assert sul
+  param strategy.)
+- **GREEN**: prima di `ExtractPagedTextAsync` (`:514`), `var strategy = ExtractionStrategyDecider.FromStructuredElements(pdfDoc.StructuredElementsJson);`
+  e passarlo. **Ordine**: leggere PRIMA della riga `:528` che sovrascrive `StructuredElementsJson`.
+- **Nota**: gli altri 3 call-site (fresh ingest) NON passano strategy → default `Fast` (corretto: nessun elemento precedente).
+
+## Slice 5 — verifica + PR
+- Build solution 0 err; unit test nuovi verdi; non-regressione DocumentProcessing (extractor/orchestrator/pipeline).
+- `/code-review` xhigh + review avversariale (Workflow find→verify) sul diff.
+- PR → `main-dev` (chiude #3419). Commit-msg subject ≤90 char.
+
+## Rischi/gotcha
+- Param dopo `CancellationToken` (non-convenzionale ma necessario per i call-site posizionali) — commentare.
+- 6 implementer + 2 mock: dimenticarne uno = build error (lo cattura il compilatore).
+- `ExtractedElement` deserializzazione: riusare lo stesso `JsonSerializerOptions` con cui è serializzato
+  `StructuredElementsJson` (verificare naming policy).
+- Baseline test = 0 fail; il ramo hi_res è dark finché un PDF con tabelle non viene re-estratto.

--- a/docs/superpowers/specs/2026-07-31-hires-tables-extraction-strategy-design.md
+++ b/docs/superpowers/specs/2026-07-31-hires-tables-extraction-strategy-design.md
@@ -1,0 +1,86 @@
+# DC-2 — `hi_res` extraction strategy for table-heavy PDFs (design)
+
+**Issue**: [#3419](https://github.com/meepleAi-app/meepleai-monorepo/issues/3419) · **Epic**: #3403 (RAG citation region grounding) · **Follow-up di**: SP-E #3409
+
+## Problema
+
+Il region grounding (epic #3403) è attivo con `strategy=fast`, che emette già coordinate bbox
+(strategy-independent). Ma per le **tabelle**, `hi_res` produce coordinate/struttura più precise.
+DC-2 (deciso 2026-07-30): usare `hi_res` **solo per i PDF con tabelle**, non globalmente
+(`hi_res` è pesante: CPU/memoria, rischio OOM/timeout sul box staging 8GB).
+
+Oggi la strategy è **hardcoded `"fast"`** in `UnstructuredPdfTextExtractor.cs:123`
+(`PrepareMultipartContent`), e `IPdfTextExtractor` non ha un parametro strategy. Il servizio
+Python **accetta già** `strategy: Literal["fast","hi_res"]` per-request (`schemas.py:11`) → il
+lavoro è tutto lato C#.
+
+## Non-goal
+
+- Non serve al grounding di base (`fast` fornisce già coordinate). Puro miglioramento qualità
+  sulle regioni tabellari.
+- Nessun cambiamento al servizio Python (già pronto).
+- Nessun threading di strategy attraverso `ProcessingJob`/`EnqueuePdfCommand`/migration (vedi DA-2).
+
+## Discovery (fatti verificati)
+
+| Fatto | Riferimento |
+|---|---|
+| `IPdfTextExtractor` **internal**, 2 metodi `ExtractTextAsync`/`ExtractPagedTextAsync(Stream, bool enableOcrFallback=true, CancellationToken=default)` | `Infrastructure/External/IPdfTextExtractor.cs:19-34` |
+| **6 implementer**: Unstructured, SmolDocling, Docnet, **Orchestrated** (default via provider "Orchestrator"), + 2 DevTools mock | discovery |
+| Default DI = `OrchestratedPdfTextExtractor` → `EnhancedPdfProcessingOrchestrator` → keyed Unstructured. Solo Unstructured consuma la strategy | `OrchestratedPdfTextExtractor.cs:28-65`, `EnhancedPdfProcessingOrchestrator.cs:121,467,231-255,517-538` |
+| Hardcode `"fast"` in `PrepareMultipartContent` (usato da entrambi i metodi, righe 48 e 234) | `UnstructuredPdfTextExtractor.cs:123,129` |
+| 7 call-site esterni (tutti passano `cancellationToken` **posizionale** come 3° arg) | discovery |
+| `ExtractedElement.ElementType` porta la categoria Unstructured incl. **`"Table"`** | `Domain/Services/ExtractedElement.cs:9-13` |
+| `PdfDocumentEntity.StructuredElementsJson` persiste la lista di `ExtractedElement` | `Infrastructure/Entities/.../PdfDocumentEntity.cs` |
+| `detected_tables`/`detected_structures` **NON** persistiti (solo nel DTO response transiente) | `UnstructuredPdfTextExtractor.cs:389-390` |
+| Il reindex processa via `EnqueuePdfCommand → ProcessingJob → PdfProcessingQuartzJob → PdfProcessingPipelineService` | `Application/Jobs/PdfProcessingQuartzJob.cs` |
+| `PdfProcessingPipelineService:528` **sovrascrive** `StructuredElementsJson` DOPO l'estrazione → prima della chiamata (`:514`) il valore è ancora quello **precedente** | `PdfProcessingPipelineService.cs:514,528` |
+| `appsettings.json:217` ha `"Strategy": "fast"` — config **esistente ma ignorata** | — |
+
+## Decisioni
+
+| ID | Decisione | Perché |
+|---|---|---|
+| **DA-1** | Enum dominio `ExtractionStrategy { Fast, HiRes }`; `UnstructuredPdfTextExtractor` mappa enum→`"fast"`/`"hi_res"` | Type-safe; il resto degli implementer lo ignora |
+| **DA-2** | La **decisione** strategy sta nella **pipeline** (`PdfProcessingPipelineService`), NON threadata da `ReindexDocumentCommand`/`ProcessingJob` | La pipeline ha già `pdfDoc.StructuredElementsJson`; evita colonna/migration/command changes. Blast radius = solo interface + orchestrator + il decision-site |
+| **DA-3** | Table detection = `StructuredElementsJson` (precedente) contiene un `ElementType=="Table"` → `HiRes`, altrimenti `Fast` | Unico segnale persistito. Euristica: `fast` rileva già `Table`; se ne trova → serve precisione hi_res |
+| **DA-4** | Param `strategy` aggiunto come **ultimo** (4°, dopo `CancellationToken`) con default `Fast` | I 7 call-site passano CT posizionale come 3° arg → un 4° param con default li lascia compilare invariati (solo la pipeline lo passa esplicito, named) |
+| **DA-5** | Fresh ingest (nessun `StructuredElementsJson` precedente) → `Fast` | Non si possono conoscere le tabelle prima della 1ª estrazione; hi_res parte solo al **re-extract** (caso d'uso SP-E) |
+| **DA-6** | Threading via `OrchestratedPdfTextExtractor` + `EnhancedPdfProcessingOrchestrator` (`Extract*WithFallbackAsync` → `TryExtract*WithStage`) | È la catena reale del default DI; senza, la strategy non arriva a Unstructured |
+
+## Contratto (estensioni additive)
+
+```csharp
+public enum ExtractionStrategy { Fast, HiRes }   // Domain/Services
+
+// IPdfTextExtractor (entrambi i metodi): + ExtractionStrategy strategy = ExtractionStrategy.Fast (4° param)
+// EnhancedPdfProcessingOrchestrator.Extract*WithFallbackAsync: + strategy, threadato a TryExtract*WithStage → extractor
+// UnstructuredPdfTextExtractor.PrepareMultipartContent(Stream, ExtractionStrategy): "fast"|"hi_res"
+// Table detection: static helper su ExtractedElement[]/StructuredElementsJson → bool HasTables
+```
+
+Decision-site (`PdfProcessingPipelineService`, prima di `ExtractPagedTextAsync`):
+```csharp
+var strategy = ExtractionStrategyDecider.FromStructuredElements(pdfDoc.StructuredElementsJson);
+// ... ExtractPagedTextAsync(stream, enableOcrFallback: true, cancellationToken, strategy);
+```
+
+## Rischi
+
+| Rischio | Mitigazione |
+|---|---|
+| Blast radius interface (6 implementer + orchestrator) | Param additivo con default; 5/6 implementer accept-and-ignore; TDD per ognuno |
+| Regressione pipeline PDF (alto valore) | TDD + non-regressione; feature attiva solo su re-extract con tabelle rilevate |
+| `hi_res` più lento/pesante (OOM/timeout box 8GB) | Solo per PDF con tabelle (minoranza); il fix #3424 (timeout 120s + file-size 100MB) già alza i limiti; `mem_limit 3g` + concurrency=1 |
+| Euristica table-detection imperfetta (fast può mancare tabelle) | Accettata: se `fast` non trova tabelle, `hi_res` non aggiungerebbe regioni tabellari comunque; nessun peggioramento |
+| `Strategy` config in appsettings ignorata | Fuori scope: la decisione è table-based, non config-based (nota per non confondere) |
+
+## Criteri di accettazione
+
+- **AC1**: `IPdfTextExtractor` accetta `strategy`; `UnstructuredPdfTextExtractor` invia il campo
+  `strategy` corretto (`fast`/`hi_res`) nel multipart (test unit).
+- **AC2**: `PdfProcessingPipelineService` sceglie `HiRes` quando `StructuredElementsJson` contiene
+  un `ElementType=="Table"`, altrimenti `Fast` (test unit/integration).
+- **AC3**: I 5 implementer non-Unstructured + i 7 call-site esistenti restano invariati/compilano
+  (nessuna regressione).
+- **AC4**: Il ramo Orchestrated threada la strategy fino a Unstructured (test).


### PR DESCRIPTION
## DC-2 groundwork (epic #3403 follow-up)

Landa il **groundwork self-contained** per instradare la re-estrazione a `hi_res` solo per i PDF con tabelle. Il wiring completo è **rimandato** a una sessione dedicata (vedi sotto).

### Cosa
- `ExtractionStrategy { Fast, HiRes }` + `ToWireString()` (token wire `fast`/`hi_res`).
- `ExtractionStrategyDecider.FromStructuredElements(json)`: `HiRes` sse lo `StructuredElementsJson` precedente contiene un elemento `Table`; `Fast` su null/empty/invalid (safe default). Pura logica di dominio.
- Spec + plan TDD.
- **9/9 unit test** verdi; nessun cambio a `IPdfTextExtractor` → **zero blast radius**.

### ⚠️ Wiring rimandato (finding)
Aggiungere un param `strategy` a `IPdfTextExtractor.ExtractText/PagedTextAsync` rompe **~89 call-site** nel test project (CancellationToken posizionale 3° arg + Moq setup); metterlo prima di CT viola **CA1068** (CT ultimo, escalato a error). Blast radius inaccettabile per un follow-up di qualità.

**Pivot raccomandato** (dettagliato nel plan + issue #3419): scoped `IExtractionStrategySelector` che la pipeline setta e `UnstructuredPdfTextExtractor` legge → **zero cambio interface**.

Non bloccante per l'AC dell'epic (`fast` emette già coordinate) — miglioramento di qualità sulle regioni tabellari.

Refs #3419 (epic #3403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)