### PR TITLE
fix(rag): stamp IndexerVersion on ingest + guard bulk reindex (#3425)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs
@@ -537,6 +537,12 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
             // Mark as completed
             pdfDoc.ProcessingState = nameof(PdfProcessingState.Ready);
             pdfDoc.ProcessedAt = _timeProvider.GetUtcNow().UtcDateTime;
+            // #3425 / #3269 (SP3): stamp the current indexer version on the completed fresh ingest
+            // (mirrors PdfProcessingPipelineService, the Quartz path). Null-coalescing so an explicit
+            // reindex-chosen version survives; IndexerVersion == null then means only true
+            // pre-versioning legacy, keeping the bulk re-index selector from redundantly re-processing
+            // fresh docs. pdfDoc is tracked (AsTracking at load), so this write persists.
+            pdfDoc.IndexerVersion ??= IndexerVersionRegistry.Current.Version;
             try
             {
                 await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/Queue/BulkReindexReadyCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/Queue/BulkReindexReadyCommandHandler.cs
@@ -5,6 +5,7 @@ using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
 using Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects;
 using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
 using Api.Infrastructure;
+using Api.Infrastructure.Entities;
 using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using MediatR;
@@ -68,12 +69,16 @@ internal sealed class BulkReindexReadyCommandHandler
         var candidateIds = await _dbContext.PdfDocuments
             .Where(p => p.ProcessingState == nameof(PdfProcessingState.Ready))
             .Where(p => p.IndexerVersion == null || p.IndexerVersion != targetVersion)
-            // #3425: skip import-only docs that have no source PDF. ImportRagData creates Ready
-            // documents from pre-computed external embeddings with FilePath = "" (and no versioning
-            // stamp). ReindexDocumentCommand re-extracts from the source PDF, so re-indexing such a
-            // doc would fail. Excluding empty FilePath here keeps them out of the bulk selection even
-            // as Current advances (which would otherwise re-select them on every version bump).
+            // #3425: skip docs with no real source blob to re-extract. ReindexDocumentCommand
+            // deletes chunks + resets Ready->Pending, then extraction fetches the blob and fails
+            // (-> Failed) when there is none. Two source-less, IndexerVersion==null, Ready classes
+            // would otherwise be selected and destructively re-processed on every version bump:
+            //  1. ImportRagData docs: external pre-computed embeddings, FilePath = "".
+            //  2. Demo-mock dogfood placeholders (seed/ prefix): FilePath is non-empty but points
+            //     at no blob — same sibling guard used by ProcessPendingPdfs / StalePdfRecovery /
+            //     SeedStateHealthCheck (PdfDocumentEntity.DemoMockFilePathPrefix, #3075).
             .Where(p => !string.IsNullOrEmpty(p.FilePath))
+            .Where(p => !p.FilePath.StartsWith(PdfDocumentEntity.DemoMockFilePathPrefix))
             .OrderBy(p => p.UploadedAt)
             .Select(p => p.Id)
             .ToListAsync(cancellationToken)

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/Queue/BulkReindexReadyCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/Queue/BulkReindexReadyCommandHandler.cs
@@ -68,6 +68,12 @@ internal sealed class BulkReindexReadyCommandHandler
         var candidateIds = await _dbContext.PdfDocuments
             .Where(p => p.ProcessingState == nameof(PdfProcessingState.Ready))
             .Where(p => p.IndexerVersion == null || p.IndexerVersion != targetVersion)
+            // #3425: skip import-only docs that have no source PDF. ImportRagData creates Ready
+            // documents from pre-computed external embeddings with FilePath = "" (and no versioning
+            // stamp). ReindexDocumentCommand re-extracts from the source PDF, so re-indexing such a
+            // doc would fail. Excluding empty FilePath here keeps them out of the bulk selection even
+            // as Current advances (which would otherwise re-select them on every version bump).
+            .Where(p => !string.IsNullOrEmpty(p.FilePath))
             .OrderBy(p => p.UploadedAt)
             .Select(p => p.Id)
             .ToListAsync(cancellationToken)

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandlerHeadingAwareTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandlerHeadingAwareTests.cs
@@ -3,6 +3,7 @@ using Api.BoundedContexts.DocumentProcessing.Application.Services;
 using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
 using Api.BoundedContexts.DocumentProcessing.Domain.Services;
+using Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects;
 using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
 using Api.BoundedContexts.KnowledgeBase.Application.Services;
 using Api.BoundedContexts.KnowledgeBase.Application.Services.Chunking;
@@ -204,6 +205,116 @@ public class CompleteChunkedUploadCommandHandlerHeadingAwareTests
             childEntity.Heading.Should().Be("Setup");
             childEntity.Level.Should().Be((short)2);
             childEntity.ParentChunkId.Should().Be(parentEntity.Id);
+        }
+        finally
+        {
+            File.Delete(tmp);
+        }
+    }
+
+    [Fact]
+    public async Task TriggerPdfProcessing_FreshIngestReachingReady_StampsCurrentIndexerVersion()
+    {
+        // #3425: a chunked-upload fresh ingest that completes to Ready must stamp the current
+        // indexer version (mirrors PdfProcessingPipelineService, the Quartz path). Otherwise the
+        // doc keeps IndexerVersion == null and the bulk re-index selector re-processes it as
+        // legacy on every run. Same NoTracking + fresh-context assertion discipline as above.
+        var dbName = $"complete_chunked_indexerversion_{Guid.NewGuid():N}";
+        var pdfId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+
+        await using (var seedDb = CreateNoTrackingInMemoryDbContext(dbName))
+        {
+            seedDb.PdfDocuments.Add(new PdfDocumentEntity
+            {
+                Id = pdfId,
+                SharedGameId = gameId,
+                UploadedByUserId = Guid.NewGuid(),
+                FileName = "test.pdf",
+                FilePath = "/test/test.pdf",
+                FileSizeBytes = 1024,
+                ContentType = "application/pdf",
+                UploadedAt = DateTime.UtcNow,
+                ProcessingState = nameof(PdfProcessingState.Extracting)
+            });
+            await seedDb.SaveChangesAsync();
+        }
+
+        var tmp = Path.GetTempFileName();
+        await File.WriteAllTextAsync(tmp, "dummy pdf bytes");
+
+        try
+        {
+            var structuredElements = new List<ExtractedElement>
+            {
+                new("Setup", 1, "Title"),
+                new("Place the board in the middle of the table.", 1, "NarrativeText")
+            };
+
+            var extractorMock = new Mock<IPdfTextExtractor>();
+            extractorMock
+                .Setup(e => e.ExtractPagedTextAsync(It.IsAny<Stream>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(PagedTextExtractionResult.CreateSuccess(
+                    new[] { new PageTextChunk(1, "Setup\n\nPlace the board in the middle of the table.", 0, 50) },
+                    totalPages: 1,
+                    totalCharacters: 50,
+                    ocrTriggered: false,
+                    structuredElements: structuredElements));
+
+            var tableExtractorMock = new Mock<IPdfTableExtractor>();
+            tableExtractorMock
+                .Setup(t => t.ExtractStructuredContentAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(StructuredContentResult.CreateFailure("no structured content in test"));
+
+            var parentMetadata = new ChunkMetadata { Heading = "Setup", Page = 1, ElementType = "Title" };
+            var parent = HierarchicalChunk.CreateParent("Setup section", parentMetadata);
+            var childMetadata = new ChunkMetadata { Heading = "Setup", Page = 1, ElementType = "NarrativeText" };
+            var child = HierarchicalChunk.CreateChild("Place the board in the middle of the table.", 2, childMetadata, parent.Id);
+
+            var advancedChunkingMock = new Mock<IAdvancedChunkingService>();
+            advancedChunkingMock
+                .Setup(x => x.ChunkDocumentAsync(It.IsAny<ExtractedDocument>(), It.IsAny<ChunkingConfiguration?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<HierarchicalChunk> { parent, child });
+
+            var chunkingServiceMock = new Mock<ITextChunkingService>();
+
+            var embeddingMock = new Mock<IEmbeddingService>();
+            embeddingMock
+                .Setup(e => e.GenerateEmbeddingsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((List<string> texts, CancellationToken _) =>
+                    EmbeddingResult.CreateSuccess(texts.Select(t => new float[] { 0.1f, 0.2f, 0.3f }).ToList()));
+
+            var sc = new ServiceCollection();
+            sc.AddScoped<MeepleAiDbContext>(_ => CreateNoTrackingInMemoryDbContext(dbName));
+            sc.AddScoped(_ => chunkingServiceMock.Object);
+            sc.AddScoped(_ => advancedChunkingMock.Object);
+            sc.AddScoped(_ => embeddingMock.Object);
+            sc.AddScoped(_ => Mock.Of<IPdfIndexingPipeline>());
+            var provider = sc.BuildServiceProvider();
+            var scopeFactory = provider.GetRequiredService<IServiceScopeFactory>();
+
+            var handler = new CompleteChunkedUploadCommandHandler(
+                Mock.Of<IChunkedUploadSessionRepository>(),
+                CreateNoTrackingInMemoryDbContext(dbName),
+                Mock.Of<IBlobStorageService>(),
+                Mock.Of<IBackgroundTaskService>(),
+                NullLogger<CompleteChunkedUploadCommandHandler>.Instance,
+                scopeFactory,
+                extractorMock.Object,
+                tableExtractorMock.Object,
+                Mock.Of<IMediator>(),
+                Mock.Of<IPdfDeduplicationService>(),
+                TimeProvider.System);
+
+            await handler.TriggerPdfProcessingAsync(pdfId.ToString(), tmp, CancellationToken.None);
+
+            await using var assertDb = CreateNoTrackingInMemoryDbContext(dbName);
+            var updatedPdf = await assertDb.PdfDocuments.FirstOrDefaultAsync(p => p.Id == pdfId);
+            updatedPdf.Should().NotBeNull();
+            updatedPdf!.ProcessingState.Should().Be(nameof(PdfProcessingState.Ready));
+            updatedPdf.IndexerVersion.Should().Be(IndexerVersionRegistry.Current.Version,
+                "a completed fresh ingest must carry the current pipeline version so the bulk " +
+                "re-index selector does not treat it as legacy (null)");
         }
         finally
         {

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Commands/ExtractPdfTextCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Commands/ExtractPdfTextCommandHandlerTests.cs
@@ -75,6 +75,10 @@ public sealed class ExtractPdfTextCommandHandlerTests : IDisposable
         reloaded.PageCount.Should().Be(extraction.totalPages);
         reloaded.CharacterCount.Should().Be(extraction.totalCharacters);
         reloaded.ProcessingError.Should().BeNull("a successful extraction clears any prior error");
+        reloaded.IndexerVersion.Should().BeNull(
+            "#3425: text-only extraction must NOT stamp an indexer version — the document is not yet " +
+            "indexed (still Extracting). IndexPdfCommand stamps the current version on the " +
+            "Extracting → Indexing → Ready path; stamping here would mark an unindexed doc as current.");
         result.CharacterCount.Should().Be(extraction.totalCharacters);
         result.PageCount.Should().Be(extraction.totalPages);
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/Queue/BulkReindexReadyCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/Queue/BulkReindexReadyCommandHandlerTests.cs
@@ -74,13 +74,14 @@ public sealed class BulkReindexReadyCommandHandlerTests : IAsyncLifetime
     private async Task<PdfDocumentEntity> SeedPdfAsync(
         string state = "Ready",
         string? indexerVersion = null,
-        DateTime? uploadedAt = null)
+        DateTime? uploadedAt = null,
+        string filePath = "/tmp/test.pdf")
     {
         var pdf = new PdfDocumentEntity
         {
             Id = Guid.NewGuid(),
             FileName = "test.pdf",
-            FilePath = "/tmp/test.pdf",
+            FilePath = filePath,
             FileSizeBytes = 1024,
             ContentType = "application/pdf",
             UploadedByUserId = Guid.NewGuid(),
@@ -119,6 +120,27 @@ public sealed class BulkReindexReadyCommandHandlerTests : IAsyncLifetime
     public async Task Handle_ReadyPdfAlreadyAtTargetVersion_IsIdempotentSkip()
     {
         await SeedPdfAsync(indexerVersion: IndexerVersionRegistry.Current.Version);
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(
+            new BulkReindexReadyCommand(Guid.NewGuid()), CancellationToken.None);
+
+        _mediator.Verify(
+            m => m.Send(It.IsAny<ReindexDocumentCommand>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        result.EnqueuedCount.Should().Be(0);
+        result.SkippedCount.Should().Be(0);
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_ReadyPdfWithEmptyFilePath_IsNotSelected()
+    {
+        // #3425: ImportRagData creates Ready docs with FilePath="" (external pre-computed
+        // embeddings, no source PDF) and IndexerVersion=null. The bulk re-index fans out
+        // ReindexDocumentCommand, which re-extracts from the source PDF — a doc with no file
+        // would fail. Such non-reprocessable docs must be skipped by the selector, not enqueued.
+        await SeedPdfAsync(indexerVersion: null, filePath: string.Empty);
         var handler = CreateHandler();
 
         var result = await handler.Handle(

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/Queue/BulkReindexReadyCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/Queue/BulkReindexReadyCommandHandlerTests.cs
@@ -154,6 +154,31 @@ public sealed class BulkReindexReadyCommandHandlerTests : IAsyncLifetime
         result.Errors.Should().BeEmpty();
     }
 
+    [Fact]
+    public async Task Handle_ReadyDemoMockDoc_IsNotSelected()
+    {
+        // #3425 (code review): demo-mock dogfood placeholders (SeedBadswormPersonaCommandHandler)
+        // are seeded Ready with IndexerVersion=null and FilePath="seed/badsworm/.../rulebook.pdf"
+        // — a NON-empty prefix but with NO real blob. They must NOT be bulk-reindexed:
+        // ReindexDocumentCommand would delete their chunks, reset Ready->Pending, and the extraction
+        // would then fail on the missing blob (Failed), destroying active fixtures. Mirrors the
+        // sibling guard used by ProcessPendingPdfs / StalePdfRecovery / SeedStateHealthCheck.
+        await SeedPdfAsync(
+            indexerVersion: null,
+            filePath: $"{PdfDocumentEntity.DemoMockFilePathPrefix}badsworm/badsworm/rulebook.pdf");
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(
+            new BulkReindexReadyCommand(Guid.NewGuid()), CancellationToken.None);
+
+        _mediator.Verify(
+            m => m.Send(It.IsAny<ReindexDocumentCommand>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        result.EnqueuedCount.Should().Be(0);
+        result.SkippedCount.Should().Be(0);
+        result.Errors.Should().BeEmpty();
+    }
+
     [Theory]
     [InlineData("Pending")]
     [InlineData("Failed")]

--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/BulkReindexReadySelectorIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/BulkReindexReadySelectorIntegrationTests.cs
@@ -107,13 +107,14 @@ public sealed class BulkReindexReadySelectorIntegrationTests : IAsyncLifetime
         await _dbContext.SaveChangesAsync(TestCancellationToken);
     }
 
-    private async Task<PdfDocumentEntity> SeedPdfAsync(string state, string? indexerVersion)
+    private async Task<PdfDocumentEntity> SeedPdfAsync(
+        string state, string? indexerVersion, string filePath = "/tmp/bulk-reindex.pdf")
     {
         var pdf = new PdfDocumentEntity
         {
             Id = Guid.NewGuid(),
             FileName = "bulk-reindex.pdf",
-            FilePath = "/tmp/bulk-reindex.pdf",
+            FilePath = filePath,
             FileSizeBytes = 1024,
             ContentType = "application/pdf",
             UploadedByUserId = TestUserId,
@@ -126,7 +127,7 @@ public sealed class BulkReindexReadySelectorIntegrationTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task Handle_SelectsNullVersionReadyRow_ExcludesTargetVersionAndNonReady()
+    public async Task Handle_SelectsNullVersionReadyRow_ExcludesTargetVersionNonReadyAndSourceless()
     {
         // PDF-A: Ready + IndexerVersion = NULL  → MUST be selected (null-comparison guard).
         var pdfA = await SeedPdfAsync("Ready", indexerVersion: null);
@@ -134,6 +135,13 @@ public sealed class BulkReindexReadySelectorIntegrationTests : IAsyncLifetime
         await SeedPdfAsync("Ready", indexerVersion: IndexerVersionRegistry.Current.Version);
         // PDF-C: Failed + NULL                 → excluded (non-Ready).
         await SeedPdfAsync("Failed", indexerVersion: null);
+        // #3425 — source-less Ready + NULL docs must be excluded on REAL Npgsql (StartsWith → LIKE,
+        // IsNullOrEmpty → IS NULL OR = ''), not just InMemory:
+        // PDF-D: Ready + NULL + FilePath = ""              → excluded (ImportRagData import doc).
+        await SeedPdfAsync("Ready", indexerVersion: null, filePath: string.Empty);
+        // PDF-E: Ready + NULL + FilePath = "seed/…"        → excluded (demo-mock dogfood placeholder).
+        await SeedPdfAsync("Ready", indexerVersion: null,
+            filePath: $"{PdfDocumentEntity.DemoMockFilePathPrefix}badsworm/badsworm/rulebook.pdf");
 
         var sentIds = new List<Guid>();
         var mediatorMock = new Mock<IMediator>();
@@ -162,8 +170,9 @@ public sealed class BulkReindexReadySelectorIntegrationTests : IAsyncLifetime
         var result = await handler.Handle(
             new BulkReindexReadyCommand(TestUserId), TestCancellationToken);
 
-        // Exactly one reindex, for the NULL-version Ready row. This is the assertion that fails
-        // against real Npgsql if the selector drops the `IndexerVersion == null ||` clause.
+        // Exactly one reindex, for the NULL-version Ready row (PDF-A). Fails against real Npgsql if
+        // the selector drops the `IndexerVersion == null ||` clause (PDF-A vanishes) OR either
+        // source-less guard (PDF-D/PDF-E would leak in, breaking ContainSingle).
         sentIds.Should().ContainSingle().Which.Should().Be(pdfA.Id);
         result.EnqueuedCount.Should().Be(1);
         result.SkippedCount.Should().Be(0);


### PR DESCRIPTION
## Sommario

Closes #3425. Due fix correlati perché il bulk re-index selector (SP3, issue 3269) non ri-processi più documenti che non dovrebbe, più un characterization test che blinda la scelta di `ExtractPdfText`.

## Contesto

Emerso a chiusura di SP3 (issue 3269): i fresh-ingest attraverso i finalizer alternati restavano con `IndexerVersion = null` → il `BulkReindexReadyCommand` li tratta come legacy e li ri-seleziona a ogni run. Investigando è emerso che i 3 handler sospetti hanno semantiche **diverse**.

## Cosa cambia

**1. `CompleteChunkedUploadCommandHandler` → stampa `IndexerVersion`**
Fresh-ingest reale della pipeline heading-aware/coordinate-aware. Alla Ready-transition ora fa `pdfDoc.IndexerVersion ??= IndexerVersionRegistry.Current.Version` — identico a `PdfProcessingPipelineService` (il path Quartz). Entity tracciata (`.AsTracking()`), nessun rischio del bug NoTracking (PR 3305).

**2. `BulkReindexReadyCommandHandler` → guard `FilePath` (root cause)**
`ImportRagData` crea doc `Ready` da embedding esterni pre-calcolati con **`FilePath = ""`** (nessun PDF sorgente). Il bulk re-estrae dal PDF → per questi doc fallirebbe. Aggiunto `.Where(p => !string.IsNullOrEmpty(p.FilePath))`: i doc non ri-processabili restano fuori dalla selezione anche quando `Current` avanza (che altrimenti li ri-selezionerebbe a ogni bump di versione). `ImportRagData` resta quindi `null` di proposito (import esterno, versione ignota) — il guard è la fix corretta, non uno stamp `Current` semanticamente falso.

**3. `ExtractPdfTextCommandHandler` → characterization test (nessun cambio di produzione)**
La issue lo elencava tra i finalizer, ma B13 lo lascia deliberatamente in `Extracting` (nessun chunk/embed/index ancora avvenuto; la state-machine vieta `Extracting → Ready`). `IndexPdfCommand` stampa la versione sul path `Extracting → Indexing → Ready`. Aggiunto un assert che pinna `IndexerVersion == null` dopo l'extract, per prevenire un "completamento" futuro errato che marcherebbe come indicizzato un doc non indicizzato.

## Test (TDD)

- `Handle_ReadyPdfWithEmptyFilePath_IsNotSelected` (bulk guard) — red→green
- `TriggerPdfProcessing_FreshIngestReachingReady_StampsCurrentIndexerVersion` (stamp) — red→green
- `Handle_TextOnlyExtraction_LeavesDocumentExtracting_NotReady` esteso con l'assert `IndexerVersion == null`

**513/513** unit test `Category=Unit&BoundedContext=DocumentProcessing` verdi, 0 regressioni.

## Decisione di scope

`ImportRagData` **non** viene modificato (scelta confermata): marcare `Current` un import esterno afferma falsamente "coordinate-aware". Il guard nel selettore è la soluzione robusta e semanticamente onesta.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
