### PR TITLE
feat(rag): hi_res extraction for table PDFs via scoped selector (#3419)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
 using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.BoundedContexts.DocumentProcessing.Domain.Events;
+using Api.BoundedContexts.DocumentProcessing.Domain.Services;
 using Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects;
 using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
 using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
@@ -71,6 +72,11 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
     // chunk production falls back to the flat ITextChunkingService path (pre-Slice-D behaviour).
     private readonly IAdvancedChunkingService? _advancedChunking;
 
+    // DC-2 (#3419): scoped strategy selector — set per PDF before extraction so the same-scope
+    // UnstructuredPdfTextExtractor routes table-heavy PDFs to hi_res. Optional/nullable so the
+    // pre-#3419 test constructors compile unchanged; production DI always provides it.
+    private readonly IExtractionStrategySelector? _extractionStrategySelector;
+
     public PdfProcessingPipelineService(
         MeepleAiDbContext db,
         IPdfClaimService pdfClaimService,
@@ -92,7 +98,8 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
         IPdfCoverExtractor? pdfCoverExtractor = null,
         IDomainEventCollector? eventCollector = null,
         IPdfCoverUploadPipeline? pdfCoverUploadPipeline = null,
-        IAdvancedChunkingService? advancedChunking = null)
+        IAdvancedChunkingService? advancedChunking = null,
+        IExtractionStrategySelector? extractionStrategySelector = null)
     {
         _db = db ?? throw new ArgumentNullException(nameof(db));
         _pdfClaimService = pdfClaimService ?? throw new ArgumentNullException(nameof(pdfClaimService));
@@ -118,6 +125,7 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
         _eventCollector = eventCollector;
         _pdfCoverUploadPipeline = pdfCoverUploadPipeline;
         _advancedChunking = advancedChunking;
+        _extractionStrategySelector = extractionStrategySelector;
     }
 
     public async Task ProcessAsync(
@@ -510,6 +518,25 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
 
         await using (fileStream.ConfigureAwait(false))
         {
+            // DC-2 (#3419): route table-heavy PDFs to hi_res, decided from the PRIOR
+            // StructuredElementsJson (overwritten ~20 lines below with the fresh result). Published
+            // on the scoped selector, which the same-scope Unstructured extractor reads when building
+            // the multipart. Null selector (unit tests that don't exercise strategy) → no-op; the
+            // production DI graph always provides it.
+            if (_extractionStrategySelector is not null)
+            {
+                var strategy = ExtractionStrategyDecider.FromStructuredElements(pdfDoc.StructuredElementsJson);
+                _extractionStrategySelector.Current = strategy;
+                if (strategy == ExtractionStrategy.HiRes)
+                {
+                    // The feature is dark until a table-heavy PDF is re-extracted, so log the minority
+                    // hi_res case to let ops confirm activation on staging (epic #3403 grounding).
+                    _logger.LogInformation(
+                        "[PdfPipeline] DC-2: routing PDF {PdfId} to hi_res extraction (prior extraction detected a table)",
+                        pdfDoc.Id);
+                }
+            }
+
             var extractResult = await _pdfTextExtractor
                 .ExtractPagedTextAsync(fileStream, enableOcrFallback: true, cancellationToken)
                 .ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/DependencyInjection/DocumentProcessingServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/DependencyInjection/DocumentProcessingServiceExtensions.cs
@@ -106,6 +106,12 @@ internal static class DocumentProcessingServiceExtensions
         // ConflictException (409) instead of a 500.
         services.AddScoped<IPdfExtractorHealthProbe, UnstructuredExtractorHealthProbe>();
 
+        // DC-2 (#3419): scoped per-request extraction strategy selector. PdfProcessingPipelineService
+        // sets it per PDF and UnstructuredPdfTextExtractor — resolved in the SAME DI scope via the
+        // orchestrator's ctor graph — reads it. Registered unconditionally: harmless under
+        // non-Unstructured providers (the extractor that reads it simply isn't constructed).
+        services.AddScoped<IExtractionStrategySelector, ExtractionStrategySelector>();
+
         if (extractorProvider.Equals("Orchestrator", StringComparison.OrdinalIgnoreCase))
         {
             // BGAI-087 + ISSUE-1174: Register all extractors for orchestrator using keyed services

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/External/ExtractionStrategySelector.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/External/ExtractionStrategySelector.cs
@@ -1,0 +1,25 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Services;
+
+#pragma warning disable MA0048 // File name must match type name - interface + implementation in one file
+namespace Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
+
+/// <summary>
+/// DC-2 (#3419): per-request holder for the Unstructured extraction strategy. Registered
+/// <b>scoped</b> so <c>PdfProcessingPipelineService</c> can set it per PDF and
+/// <see cref="UnstructuredPdfTextExtractor"/> — resolved in the SAME DI scope via the
+/// orchestrator's constructor graph (<c>OrchestratedPdfTextExtractor</c> →
+/// <c>EnhancedPdfProcessingOrchestrator</c> → keyed extractor) — reads it. Because both
+/// consumers are constructor-injected within one scope, the value the pipeline sets is visible
+/// to the extractor regardless of the Quartz job's own scope. Defaults to
+/// <see cref="ExtractionStrategy.Fast"/> (cheap, coordinate-aware; hi_res is reserved for tables).
+/// </summary>
+internal interface IExtractionStrategySelector
+{
+    ExtractionStrategy Current { get; set; }
+}
+
+/// <inheritdoc cref="IExtractionStrategySelector"/>
+internal sealed class ExtractionStrategySelector : IExtractionStrategySelector
+{
+    public ExtractionStrategy Current { get; set; } = ExtractionStrategy.Fast;
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/External/UnstructuredPdfTextExtractor.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/External/UnstructuredPdfTextExtractor.cs
@@ -14,14 +14,19 @@ internal class UnstructuredPdfTextExtractor : IPdfTextExtractor
 {
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly ILogger<UnstructuredPdfTextExtractor> _logger;
+    private readonly IExtractionStrategySelector? _strategySelector;
     private readonly JsonSerializerOptions _jsonOptions;
 
     public UnstructuredPdfTextExtractor(
         IHttpClientFactory httpClientFactory,
-        ILogger<UnstructuredPdfTextExtractor> logger)
+        ILogger<UnstructuredPdfTextExtractor> logger,
+        IExtractionStrategySelector? strategySelector = null)
     {
         _httpClientFactory = httpClientFactory;
         _logger = logger;
+        // DC-2 (#3419): optional so DevTools + integration tests can construct without the scoped
+        // selector; production DI always injects it. Null → fall back to the historical "fast".
+        _strategySelector = strategySelector;
         _jsonOptions = new JsonSerializerOptions
         {
             PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
@@ -112,7 +117,7 @@ internal class UnstructuredPdfTextExtractor : IPdfTextExtractor
     /// <summary>
     /// Prepares multipart form data content for Unstructured API request.
     /// </summary>
-    private static MultipartFormDataContent PrepareMultipartContent(Stream pdfStream)
+    private MultipartFormDataContent PrepareMultipartContent(Stream pdfStream)
     {
         var content = new MultipartFormDataContent();
 #pragma warning disable CA2000 // Dispose objects before losing scope
@@ -120,13 +125,16 @@ internal class UnstructuredPdfTextExtractor : IPdfTextExtractor
         // OWNERSHIP TRANSFER: MultipartFormDataContent takes ownership of added content and disposes them when it is disposed
 #pragma warning restore S125
         var streamContent = new StreamContent(pdfStream);
-        var strategyContent = new StringContent("fast");
+        // DC-2 (#3419): route table-heavy PDFs to hi_res per the pipeline's per-request decision on
+        // the scoped selector. Null selector (DevTools/integration/fresh ingest) → historical "fast".
+        var strategyContent = new StringContent(
+            (_strategySelector?.Current ?? ExtractionStrategy.Fast).ToWireString());
         var languageContent = new StringContent("ita");
 #pragma warning restore CA2000
 
         streamContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/pdf");
         content.Add(streamContent, "file", "document.pdf");
-        content.Add(strategyContent, "strategy");  // Use fast strategy for <2s target
+        content.Add(strategyContent, "strategy");
         content.Add(languageContent, "language");
 
         return content;

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineStrategySelectorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineStrategySelectorTests.cs
@@ -1,0 +1,162 @@
+using System.Text.Json;
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Domain.Services;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
+using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Services;
+using Api.Services.Pdf;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Services;
+
+/// <summary>
+/// DC-2 (#3419): <see cref="PdfProcessingPipelineService"/> decides the Unstructured extraction
+/// strategy from the PDF's <b>prior</b> <c>StructuredElementsJson</c> (a <c>Table</c> ⇒ HiRes, else
+/// Fast) and publishes it on the scoped <see cref="IExtractionStrategySelector"/> BEFORE invoking the
+/// extractor — so the same-scope <c>UnstructuredPdfTextExtractor</c> reads it. The value is captured
+/// at the extractor call because the pipeline overwrites <c>StructuredElementsJson</c> with the fresh
+/// extraction result immediately afterwards.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "3419")]
+public sealed class PdfProcessingPipelineStrategySelectorTests : IDisposable
+{
+    private readonly MeepleAiDbContext _db;
+    private readonly Mock<IPdfTextExtractor> _pdfTextExtractorMock = new();
+    private readonly Mock<IBlobStorageService> _blobStorageServiceMock = new();
+    private readonly Mock<IChunkTranslationService> _chunkTranslationServiceMock = new();
+    private readonly Mock<ILanguageDetector> _languageDetectorMock = new();
+    private readonly ExtractionStrategySelector _selector = new();
+    private readonly Guid _pdfDocumentId = Guid.NewGuid();
+    private readonly Guid _gameId = Guid.NewGuid();
+
+    public PdfProcessingPipelineStrategySelectorTests()
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase(databaseName: $"PdfPipelineStrategyTest_{Guid.NewGuid()}")
+            .Options;
+        _db = new MeepleAiDbContext(
+            options,
+            new Mock<IMediator>().Object,
+            new Mock<IDomainEventCollector>().Object);
+
+        _languageDetectorMock
+            .Setup(l => l.Detect(It.IsAny<string>()))
+            .Returns(new LanguageDetectionResult("en", true, 0.95));
+    }
+
+    public void Dispose()
+    {
+        _db.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_PriorStructuredElementsContainTable_SelectsHiRes()
+    {
+        SeedPdfDocument(priorStructuredElementsJson: ElementsJson(("Title", 1), ("NarrativeText", 1), ("Table", 2)));
+        SetupBlobStorage();
+        var capturedStrategy = SetupExtractorCapturingStrategy();
+
+        await CreateSut().ProcessAsync(_pdfDocumentId, "/fake/path.pdf", Guid.NewGuid(), CancellationToken.None);
+
+        capturedStrategy().Should().Be(ExtractionStrategy.HiRes);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_PriorStructuredElementsHaveNoTable_SelectsFast()
+    {
+        SeedPdfDocument(priorStructuredElementsJson: ElementsJson(("Title", 1), ("NarrativeText", 1), ("ListItem", 2)));
+        SetupBlobStorage();
+        var capturedStrategy = SetupExtractorCapturingStrategy();
+
+        await CreateSut().ProcessAsync(_pdfDocumentId, "/fake/path.pdf", Guid.NewGuid(), CancellationToken.None);
+
+        capturedStrategy().Should().Be(ExtractionStrategy.Fast);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_NoPriorStructuredElements_SelectsFast()
+    {
+        // Fresh ingest: no prior elements → cannot know about tables → Fast.
+        SeedPdfDocument(priorStructuredElementsJson: null);
+        SetupBlobStorage();
+        var capturedStrategy = SetupExtractorCapturingStrategy();
+
+        await CreateSut().ProcessAsync(_pdfDocumentId, "/fake/path.pdf", Guid.NewGuid(), CancellationToken.None);
+
+        capturedStrategy().Should().Be(ExtractionStrategy.Fast);
+    }
+
+    // Mirror the pipeline's serialization: default JsonSerializer over List<ExtractedElement>.
+    private static string ElementsJson(params (string type, int page)[] els) =>
+        JsonSerializer.Serialize(
+            els.Select(e => new ExtractedElement($"{e.type} text", e.page, e.type)).ToList());
+
+    private PdfProcessingPipelineService CreateSut() =>
+        new(
+            _db,
+            new Api.Tests.TestHelpers.InMemoryPdfClaimService(_db),
+            _pdfTextExtractorMock.Object,
+            Mock.Of<IPdfTableExtractor>(),
+            Mock.Of<ITextChunkingService>(),
+            Mock.Of<IEmbeddingService>(),
+            _blobStorageServiceMock.Object,
+            TimeProvider.System,
+            NullLogger<PdfProcessingPipelineService>.Instance,
+            _languageDetectorMock.Object,
+            _chunkTranslationServiceMock.Object,
+            Mock.Of<IPdfIndexingPipeline>(),
+            extractionStrategySelector: _selector);
+
+    private void SeedPdfDocument(string? priorStructuredElementsJson)
+    {
+        _db.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = _pdfDocumentId,
+            PrivateGameId = _gameId,
+            FileName = "test.pdf",
+            FilePath = "/fake/path/test.pdf",
+            ContentType = "application/pdf",
+            FileSizeBytes = 1024,
+            UploadedByUserId = Guid.NewGuid(),
+            ProcessingState = "Pending",
+            StructuredElementsJson = priorStructuredElementsJson,
+            UploadedAt = DateTime.UtcNow
+        });
+        _db.SaveChanges();
+    }
+
+    private void SetupBlobStorage()
+    {
+        _blobStorageServiceMock
+            .Setup(b => b.RetrieveAsync(
+                It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MemoryStream(new byte[] { 0x25, 0x50, 0x44, 0x46 })); // %PDF header
+    }
+
+    /// <summary>
+    /// Captures <see cref="IExtractionStrategySelector.Current"/> at the exact moment the pipeline
+    /// invokes the extractor, then returns a failure so the pipeline short-circuits after the decision
+    /// (downstream chunking/embedding is irrelevant to this test — covered by the heading-aware suite).
+    /// </summary>
+    private Func<ExtractionStrategy?> SetupExtractorCapturingStrategy()
+    {
+        ExtractionStrategy? captured = null;
+        _pdfTextExtractorMock
+            .Setup(e => e.ExtractPagedTextAsync(It.IsAny<Stream>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .Callback(() => captured = _selector.Current)
+            .ReturnsAsync(PagedTextExtractionResult.CreateFailure("stop after strategy decision"));
+        return () => captured;
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/DI/ExtractionStrategySelectorRegistrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/DI/ExtractionStrategySelectorRegistrationTests.cs
@@ -1,0 +1,146 @@
+using System.Net;
+using System.Text;
+using Api.BoundedContexts.DocumentProcessing.Domain.Services;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.DependencyInjection;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
+using Api.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Infrastructure.DI;
+
+/// <summary>
+/// DC-2 (#3419): the hi_res routing relies on <see cref="IExtractionStrategySelector"/> being
+/// registered <b>scoped</b> so that <c>PdfProcessingPipelineService</c> (setter) and
+/// <see cref="UnstructuredPdfTextExtractor"/> (reader) — both resolved within the same per-PDF scope
+/// via the orchestrator's constructor graph — share ONE instance. A refactor to Transient/Singleton
+/// would silently break the routing (or leak strategy across PDFs), so pin the lifetime + semantics.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "3419")]
+public sealed class ExtractionStrategySelectorRegistrationTests
+{
+    private static IServiceCollection BuildServices()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddHttpClient();
+
+        var settings = new Dictionary<string, string>
+        {
+            ["PdfProcessing:Extractor:Provider"] = "Orchestrator",
+            ["PdfProcessing:Extractor:Unstructured:ApiUrl"] = "http://test:8001",
+            ["PdfProcessing:Extractor:SmolDocling:ApiUrl"] = "http://test:8002",
+            ["PdfProcessing:MaxFileSizeBytes"] = "104857600",
+            ["PdfProcessing:Quality:MinimumThreshold"] = "0.80",
+            ["PdfProcessing:Quality:MinCharsPerPage"] = "500"
+        };
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(settings!).Build();
+        services.AddSingleton<IConfiguration>(configuration);
+        // ITextChunkingService is an EnhancedPdfProcessingOrchestrator dependency the context expects
+        // to be present (mirrors ExtractorHealthProbeRegistrationTests).
+        services.AddScoped<ITextChunkingService, TextChunkingService>();
+
+        services.AddDocumentProcessingContext(configuration);
+        return services;
+    }
+
+    [Fact]
+    public void AddDocumentProcessingContext_RegistersSelector_AsScoped()
+    {
+        var services = BuildServices();
+
+        var descriptor = services.Single(d => d.ServiceType == typeof(IExtractionStrategySelector));
+
+        descriptor.Lifetime.Should().Be(ServiceLifetime.Scoped);
+        descriptor.ImplementationType.Should().Be(typeof(ExtractionStrategySelector));
+    }
+
+    [Fact]
+    public void Selector_IsSharedWithinScope_ButDistinctAcrossScopes()
+    {
+        using var provider = BuildServices().BuildServiceProvider();
+
+        using var scope1 = provider.CreateScope();
+        var a = scope1.ServiceProvider.GetRequiredService<IExtractionStrategySelector>();
+        var b = scope1.ServiceProvider.GetRequiredService<IExtractionStrategySelector>();
+
+        using var scope2 = provider.CreateScope();
+        var c = scope2.ServiceProvider.GetRequiredService<IExtractionStrategySelector>();
+
+        // Same scope ⇒ the pipeline's set is visible to the same-scope extractor.
+        a.Should().BeSameAs(b);
+        a.Current = ExtractionStrategy.HiRes;
+        b.Current.Should().Be(ExtractionStrategy.HiRes);
+
+        // Different scope (a different PDF's job) ⇒ no strategy bleed; starts at the safe default.
+        c.Should().NotBeSameAs(a);
+        c.Current.Should().Be(ExtractionStrategy.Fast);
+    }
+
+    /// <summary>
+    /// End-to-end DI proof: the keyed <see cref="UnstructuredPdfTextExtractor"/> resolved from a scope
+    /// reads the <see cref="IExtractionStrategySelector"/> set on that SAME scope — the exact guarantee
+    /// PdfProcessingPipelineService relies on (it sets the selector, the extractor built in its scope
+    /// graph reads it). Guards against a future refactor that resolves the extractor from a child scope.
+    /// </summary>
+    [Fact]
+    public async Task KeyedUnstructuredExtractor_ReadsSelectorSetOnItsScope()
+    {
+        string? capturedStrategy = null;
+        var handler = new Mock<HttpMessageHandler>();
+        handler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns<HttpRequestMessage, CancellationToken>(async (req, ct) =>
+            {
+                if (req.Content is MultipartFormDataContent multipart)
+                {
+                    foreach (var part in multipart)
+                    {
+                        if (string.Equals(
+                                part.Headers.ContentDisposition?.Name?.Trim('"'),
+                                "strategy",
+                                StringComparison.Ordinal))
+                        {
+                            capturedStrategy = await part.ReadAsStringAsync(ct).ConfigureAwait(false);
+                        }
+                    }
+                }
+
+                return new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent("{\"text\":\"\",\"chunks\":[],\"quality_score\":0.9,\"page_count\":1}")
+                };
+            });
+
+        var services = BuildServices();
+        // Swap the real socket handler for the capturing mock on the same named client (BaseAddress
+        // + Polly from AddDocumentProcessingContext are preserved).
+        services.AddHttpClient("UnstructuredService").ConfigurePrimaryHttpMessageHandler(() => handler.Object);
+        using var provider = services.BuildServiceProvider();
+
+        using var scope = provider.CreateScope();
+        // The pipeline would do this; here we set it directly on the scope's selector instance.
+        scope.ServiceProvider.GetRequiredService<IExtractionStrategySelector>().Current = ExtractionStrategy.HiRes;
+
+        var extractor = scope.ServiceProvider.GetRequiredKeyedService<IPdfTextExtractor>(
+            DocumentProcessingServiceExtensions.PdfExtractorKeys.Unstructured);
+
+        await extractor.ExtractPagedTextAsync(
+            new MemoryStream(Encoding.ASCII.GetBytes("%PDF-1.4\ntest")),
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        capturedStrategy.Should().Be("hi_res");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/External/UnstructuredPdfTextExtractorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/External/UnstructuredPdfTextExtractorTests.cs
@@ -30,7 +30,7 @@ public class UnstructuredPdfTextExtractorTests
         _mockHttpMessageHandler = new Mock<HttpMessageHandler>();
     }
 
-    private UnstructuredPdfTextExtractor CreateExtractor()
+    private UnstructuredPdfTextExtractor CreateExtractor(IExtractionStrategySelector? strategySelector = null)
     {
         var httpClient = new HttpClient(_mockHttpMessageHandler.Object)
         {
@@ -43,7 +43,62 @@ public class UnstructuredPdfTextExtractorTests
 
         return new UnstructuredPdfTextExtractor(
             _mockHttpClientFactory.Object,
-            _mockLogger.Object);
+            _mockLogger.Object,
+            strategySelector);
+    }
+
+    /// <summary>
+    /// DC-2 (#3419): builds an extractor whose HTTP handler reads the <c>strategy</c> multipart form
+    /// field posted to the Unstructured service, so a test can assert the exact value without fragile
+    /// raw-body parsing. The handler returns a canned success response.
+    /// </summary>
+    private (UnstructuredPdfTextExtractor extractor, Func<string?> capturedStrategy) CreateExtractorCapturingStrategy(
+        IExtractionStrategySelector? strategySelector)
+    {
+        string? strategy = null;
+        var httpClient = new HttpClient(_mockHttpMessageHandler.Object)
+        {
+            BaseAddress = new Uri("http://test-unstructured:8001")
+        };
+
+        _mockHttpClientFactory
+            .Setup(x => x.CreateClient("UnstructuredService"))
+            .Returns(httpClient);
+
+        _mockHttpMessageHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns<HttpRequestMessage, CancellationToken>(async (req, ct) =>
+            {
+                if (req.Content is MultipartFormDataContent multipart)
+                {
+                    foreach (var part in multipart)
+                    {
+                        if (string.Equals(
+                                part.Headers.ContentDisposition?.Name?.Trim('"'),
+                                "strategy",
+                                StringComparison.Ordinal))
+                        {
+                            strategy = await part.ReadAsStringAsync(ct).ConfigureAwait(false);
+                        }
+                    }
+                }
+
+                return new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(CreateSuccessResponse())
+                };
+            });
+
+        var extractor = new UnstructuredPdfTextExtractor(
+            _mockHttpClientFactory.Object,
+            _mockLogger.Object,
+            strategySelector);
+        return (extractor, () => strategy);
     }
 
     private Stream CreateTestPdfStream()
@@ -113,6 +168,44 @@ public class UnstructuredPdfTextExtractorTests
             metadata = new { extraction_duration_ms = 10, strategy_used = "fast", language = "ita", detected_tables = 0, detected_structures = new[] { "Title" }, quality_breakdown = new { text_coverage_score = 0.4, structure_detection_score = 0.2, table_detection_score = 0.0, page_coverage_score = 0.2 } }
         };
         return JsonSerializer.Serialize(response, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower });
+    }
+
+    [Fact]
+    [Trait("Issue", "3419")]
+    public async Task ExtractPagedTextAsync_WhenSelectorHiRes_SendsHiResStrategyField()
+    {
+        // DC-2 (#3419): a table-heavy PDF routed to hi_res must post strategy=hi_res.
+        var (extractor, capturedStrategy) = CreateExtractorCapturingStrategy(
+            new ExtractionStrategySelector { Current = ExtractionStrategy.HiRes });
+
+        await extractor.ExtractPagedTextAsync(CreateTestPdfStream(), cancellationToken: TestCancellationToken);
+
+        capturedStrategy().Should().Be("hi_res");
+    }
+
+    [Fact]
+    [Trait("Issue", "3419")]
+    public async Task ExtractPagedTextAsync_WhenSelectorFast_SendsFastStrategyField()
+    {
+        var (extractor, capturedStrategy) = CreateExtractorCapturingStrategy(
+            new ExtractionStrategySelector { Current = ExtractionStrategy.Fast });
+
+        await extractor.ExtractPagedTextAsync(CreateTestPdfStream(), cancellationToken: TestCancellationToken);
+
+        capturedStrategy().Should().Be("fast");
+    }
+
+    [Fact]
+    [Trait("Issue", "3419")]
+    public async Task ExtractTextAsync_WhenNoSelector_DefaultsToFastStrategyField()
+    {
+        // Backward-compat: manual construction (DevTools + integration tests) passes no selector →
+        // the extractor must fall back to the historical hard-coded "fast".
+        var (extractor, capturedStrategy) = CreateExtractorCapturingStrategy(strategySelector: null);
+
+        await extractor.ExtractTextAsync(CreateTestPdfStream(), cancellationToken: TestCancellationToken);
+
+        capturedStrategy().Should().Be("fast");
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/Unit/DocumentProcessing/ExtractionStrategySelectorTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/DocumentProcessing/ExtractionStrategySelectorTests.cs
@@ -1,0 +1,46 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Services;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Unit.DocumentProcessing;
+
+/// <summary>
+/// DC-2 (#3419): scoped per-request holder that carries the chosen <see cref="ExtractionStrategy"/>
+/// from <c>PdfProcessingPipelineService</c> (setter) to <c>UnstructuredPdfTextExtractor</c> (reader),
+/// which share a DI scope via the orchestrator's constructor graph. Defaults to <see cref="ExtractionStrategy.Fast"/>.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "3419")]
+public sealed class ExtractionStrategySelectorTests
+{
+    [Fact]
+    public void Current_Defaults_ToFast()
+    {
+        var sut = new ExtractionStrategySelector();
+
+        sut.Current.Should().Be(ExtractionStrategy.Fast);
+    }
+
+    [Fact]
+    public void Current_WhenSetToHiRes_ReturnsHiRes()
+    {
+        var sut = new ExtractionStrategySelector { Current = ExtractionStrategy.HiRes };
+
+        sut.Current.Should().Be(ExtractionStrategy.HiRes);
+    }
+
+    [Fact]
+    public void Current_IsReassignable_AcrossReuse()
+    {
+        var sut = new ExtractionStrategySelector();
+
+        sut.Current = ExtractionStrategy.HiRes;
+        sut.Current.Should().Be(ExtractionStrategy.HiRes);
+
+        sut.Current = ExtractionStrategy.Fast;
+        sut.Current.Should().Be(ExtractionStrategy.Fast);
+    }
+}


### PR DESCRIPTION
## What & why

**DC-2** (issue #3419, follow-up of SP-E #3409 under epic #3403): route the Unstructured PDF extractor to **`hi_res`** **only for table-heavy PDFs**, otherwise **`fast`**. `hi_res` grounds table regions more precisely for the RAG citation grounding, but is CPU/memory-heavy (OOM/timeout risk on the 8GB staging box), so it must be applied selectively.

## Approach — scoped selector (zero interface change)

The groundwork (#3428) shipped `ExtractionStrategy` + `ExtractionStrategyDecider`. Threading a `strategy` parameter through `IPdfTextExtractor` (issue scope §1–2) was **tried and rejected**: it breaks ~89 test call-sites (positional `CancellationToken` as the last arg) and violates **`CA1068`** (escalated to error — `CancellationToken` must be last). Pivot to a **scoped context** (spec DA-2, decision stays in the pipeline — no command/migration threading):

- New **scoped** `IExtractionStrategySelector { Current }` (default `Fast`).
- `PdfProcessingPipelineService` sets `Current = ExtractionStrategyDecider.FromStructuredElements(pdfDoc.StructuredElementsJson)` **before** extraction — reading the **PRIOR** extraction's structured elements (overwritten with the fresh result ~15 lines later). Fresh ingest (null) → `Fast`.
- `UnstructuredPdfTextExtractor` — resolved in the **same DI scope** via the orchestrator's ctor graph (`Orchestrated → Orchestrator [FromKeyedServices] → keyed Unstructured`, all `Scoped`, all constructor-injected, no lazy `IServiceProvider`/`CreateScope`) — reads `Current` when composing the multipart (`fast`/`hi_res`).
- **Zero** change to `IPdfTextExtractor`, the orchestrator, the other 5 implementers, or any call-site. Optional-nullable ctor params keep every construction site compiling; DI always injects the scoped selector.

**Scope-sharing** is guaranteed by constructor injection (the extractor is built inside the pipeline's own scope graph) and is **robust to the Quartz job's own scope**: the pipeline sets the selector before every extraction and `[DisallowConcurrentExecution]` ⇒ serial per-PDF processing, so the value is always correct at extraction time and cannot bleed across PDFs.

`hi_res` selection is logged (Info) so ops can confirm activation during the staging re-index (the feature is otherwise dark until table PDFs are re-extracted).

## Tests — all green, 0 regression

| Slice | Class |
|---|---|
| Selector default/set | `ExtractionStrategySelectorTests` |
| Extractor posts `fast`/`hi_res`/default | `UnstructuredPdfTextExtractorTests` (+3) |
| Pipeline decides HiRes/Fast/null from prior JSON | `PdfProcessingPipelineStrategySelectorTests` |
| DI `Scoped` + scoped semantics + **e2e**: keyed extractor from a scope reads the scope's selector → posts `hi_res` | `ExtractionStrategySelectorRegistrationTests` |

Full `DocumentProcessing` unit suite: **0 failures**. Reviewed at `/code-review xhigh` + a 4-finder adversarial pass (`0` confirmed defects). No `CA1068`, no new warnings.

## Notes

- **Not blocking** the epic #3403 AC (`fast` already emits coordinates). The hi_res effect on tables is visible only on **re-extraction of table PDFs after deploy**.
- The heuristic (`fast` must have already surfaced a `Table` element) is accepted per spec DA-3/DA-5.
- Spec: `docs/superpowers/specs/2026-07-31-hires-tables-extraction-strategy-design.md` · Plan: `docs/superpowers/plans/2026-07-31-hires-tables-extraction-strategy.md`.

Closes #3419

🤖 Generated with [Claude Code](https://claude.com/claude-code)
