### PR TITLE
fix(rag): CS8604 nullable in EvaluationReportFormatter Release build (fix-forward #3441)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Evaluation/Services/EvaluationReportFormatter.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Evaluation/Services/EvaluationReportFormatter.cs
@@ -40,7 +40,14 @@ internal static class EvaluationReportFormatter
             .GroupBy(s => s.Id, StringComparer.Ordinal)
             .ToDictionary(
                 g => g.Key,
-                g => string.IsNullOrEmpty(g.First().Language) ? "unknown" : g.First().Language,
+                g =>
+                {
+                    // Extract into a local so IsNullOrEmpty's [NotNullWhen(false)] narrows the
+                    // else branch to non-null string (a second g.First().Language call would not
+                    // be narrowed), keeping the dictionary value type non-nullable.
+                    var language = g.First().Language;
+                    return string.IsNullOrEmpty(language) ? "unknown" : language;
+                },
                 StringComparer.Ordinal);
 
         var byLanguage = new Dictionary<string, EvaluationMetrics>(StringComparer.Ordinal);


### PR DESCRIPTION
## Fix-forward: deploy-staging failure dopo promote #3442

### Problema
Il merge di promozione **#3442** (main-dev → main-staging) ha triggerato `deploy-staging.yml`, il cui job **Build Images** è **fallito** su errore di compilazione:

```
EvaluationReportFormatter.cs(53,24): error CS8604: Possible null reference argument
for parameter 'key' in 'Dictionary<string, EvaluationMetrics>.this[string key]'
→ dotnet publish -c Release ... Api.csproj exit code: 1
```

Introdotto dalla RAG evaluation suite (**#3441**). Il ternario
`string.IsNullOrEmpty(g.First().Language) ? "unknown" : g.First().Language` richiama
`g.First().Language` una seconda volta nel ramo `else`: il flow-analysis di
`[NotNullWhen(false)]` non può restringere una nuova invocazione, quindi il value del
dictionary diventa `string?`, propaga a `group.Key` → CS8604.

Con `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>` questo rompe
`dotnet publish -c Release` (SDK 9.0.316 nel Docker build). È passato sulla CI di dev
(SDK più permissivo / no publish Release), da cui il verde ingannevole.

### Fix
Estrazione del valore in una variabile locale, così il ramo `else` è ristretto a
`string` non-null (elimina la nullability alla radice; rimuove anche la doppia
chiamata `g.First()`).

### Verifica
- ✅ `dotnet publish -c Release -p:SkipAnalyzers=true -p:GenerateDocumentationFile=false` → **success** locale (SDK 9.0.316, identico al Docker)
- ✅ `dotnet format` → nessuna modifica
- ✅ pre-commit (typecheck FE) passato

Dopo il merge questo fix va ri-promosso a main-staging per sbloccare il deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
