### PR TITLE
release: promote main-dev → main-staging (2026-08-01 retry, fix #3444)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Evaluation/Services/EvaluationReportFormatter.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Evaluation/Services/EvaluationReportFormatter.cs
@@ -40,7 +40,14 @@ internal static class EvaluationReportFormatter
             .GroupBy(s => s.Id, StringComparer.Ordinal)
             .ToDictionary(
                 g => g.Key,
-                g => string.IsNullOrEmpty(g.First().Language) ? "unknown" : g.First().Language,
+                g =>
+                {
+                    // Extract into a local so IsNullOrEmpty's [NotNullWhen(false)] narrows the
+                    // else branch to non-null string (a second g.First().Language call would not
+                    // be narrowed), keeping the dictionary value type non-nullable.
+                    var language = g.First().Language;
+                    return string.IsNullOrEmpty(language) ? "unknown" : language;
+                },
                 StringComparer.Ordinal);
 
         var byLanguage = new Dictionary<string, EvaluationMetrics>(StringComparer.Ordinal);


### PR DESCRIPTION
## Release promote (retry): main-dev → main-staging (2026-08-01 #2)

Ri-promozione dopo il fix-forward **#3444** che risolve il fallimento di
`deploy-staging.yml` (job Build Images) del promote precedente **#3442**.

### Contenuto
- **1 commit**: `fix(rag): CS8604 nullable in EvaluationReportFormatter Release build (#3444)`

I 20 commit del promote #3442 sono già presenti su main-staging; questo giro aggiunge
solo il fix di compilazione che sblocca `dotnet publish -c Release` nel Build Images.

### Note
- Merge **merge-commit** (non squash) per preservare gli hotfix `release/*` di main-staging
- Fix verificato in locale: `dotnet publish -c Release` → success (SDK 9.0.316, identico al Docker)
- Il merge ri-triggera `deploy-staging.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
