### PR TITLE
fix(ai): grounding as a contract invariant (#3388)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentCommandHandler.cs
@@ -716,7 +716,8 @@ internal sealed class ChatWithSessionAgentCommandHandler : IStreamingQueryHandle
                 totalTokens: totalTokens,
                 confidence: RagPromptAssemblyService.ComputeConfidence(assembled.Citations, responseText),
                 chatThreadId: thread.Id,
-                Citations: citationDtos));
+                Citations: citationDtos,
+                GroundingStatus: citationDtos.Count > 0 ? "Grounded" : "Ungrounded"));
     }
 
     private async Task GenerateConversationSummaryAsync(Guid threadId)

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/CrossGameStreamQa/CrossGameStreamQaQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/CrossGameStreamQa/CrossGameStreamQaQueryHandler.cs
@@ -85,7 +85,7 @@ internal sealed class CrossGameStreamQaQueryHandler : IStreamingQueryHandler<Cro
             yield return CreateEvent(StreamingEventType.StateUpdate,
                 new StreamingStateUpdate("Ricerca nella tua libreria..."));
             yield return CreateEvent(StreamingEventType.Complete,
-                new StreamingComplete(0, 0, 0, 0, null));
+                new StreamingComplete(0, 0, 0, 0, null, GroundingStatus: "Ungrounded"));
             yield break;
         }
 
@@ -150,7 +150,8 @@ internal sealed class CrossGameStreamQaQueryHandler : IStreamingQueryHandler<Cro
                 promptTokens: llmUsage?.PromptTokens ?? 0,
                 completionTokens: llmUsage?.CompletionTokens ?? tokenEvents.Count,
                 totalTokens: llmUsage?.TotalTokens ?? tokenEvents.Count,
-                confidence: null));
+                confidence: null,
+                GroundingStatus: snippets.Count > 0 ? "Grounded" : "Ungrounded"));
 
         _logger.LogInformation(
             "[CrossGameAsk] Complete for user {UserId}, tokens: {Tokens}",

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamDebugQaQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamDebugQaQueryHandler.cs
@@ -133,7 +133,8 @@ internal class StreamDebugQaQueryHandler : IStreamingQueryHandler<StreamDebugQaQ
 
             yield return CreateEvent(StreamingEventType.Complete,
                 new StreamingComplete(0, cachedResponse.promptTokens, cachedResponse.completionTokens,
-                    cachedResponse.totalTokens, cachedResponse.confidence));
+                    cachedResponse.totalTokens, cachedResponse.confidence,
+                    GroundingStatus: cachedResponse.snippets.Count > 0 ? "Grounded" : "Ungrounded"));
             yield break;
         }
 
@@ -372,7 +373,8 @@ internal class StreamDebugQaQueryHandler : IStreamingQueryHandler<StreamDebugQaQ
 
         yield return CreateEvent(StreamingEventType.Complete,
             new StreamingComplete(0, llmUsage?.PromptTokens ?? 0, tokenCount,
-                llmUsage?.TotalTokens ?? tokenCount, confidence));
+                llmUsage?.TotalTokens ?? tokenCount, confidence,
+                GroundingStatus: snippets.Count > 0 ? "Grounded" : "Ungrounded"));
 
         // ── Step 13: Validation pipeline (async, best-effort) ────────────
         if (_validationPipelineService != null)

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamExplainQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamExplainQueryHandler.cs
@@ -114,7 +114,8 @@ internal class StreamExplainQueryHandler : IStreamingQueryHandler<StreamExplainQ
         var maxConfidence = searchResults!.Max(r => r.Score);
 
         yield return CreateEvent(StreamingEventType.Complete,
-            new StreamingComplete(estimatedMinutes, 0, 0, 0, maxConfidence));
+            new StreamingComplete(estimatedMinutes, 0, 0, 0, maxConfidence,
+                GroundingStatus: citations.Count > 0 ? "Grounded" : "Ungrounded"));
 
         _logger.LogInformation("Streaming explain completed for game {GameId}, topic: {Topic}",
             query.GameId, query.Topic);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamQaQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamQaQueryHandler.cs
@@ -185,7 +185,8 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
                     cachedResponse.promptTokens,
                     cachedResponse.completionTokens,
                     cachedResponse.totalTokens,
-                    cachedResponse.confidence));
+                    cachedResponse.confidence,
+                    GroundingStatus: cachedResponse.snippets.Count > 0 ? "Grounded" : "Ungrounded"));
 
             yield break;
         }
@@ -311,7 +312,8 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
             tokenCount, cacheKey, llmUsage, llmCost, injectClaims, cancellationToken).ConfigureAwait(false);
 
         yield return CreateEvent(StreamingEventType.Complete,
-            new StreamingComplete(0, 0, tokenCount, tokenCount, overallConfidence.Value));
+            new StreamingComplete(0, 0, tokenCount, tokenCount, overallConfidence.Value,
+                GroundingStatus: allSnippets.Count > 0 ? "Grounded" : "Ungrounded"));
 
         // Emit inline citation matches (over RAG + claim citations, so [Vk] claim markers can match too)
         var inlineCitations = _citationMatcher.Match(answerBuilder.ToString(), allSnippets);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamSetupGuideQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamSetupGuideQueryHandler.cs
@@ -354,9 +354,16 @@ TASK: Generate a step-by-step setup guide for this board game. Focus on the init
             steps.Count, estimatedTime);
 
         // Emit final complete event
-        // #3388: this handler never surfaces a citations list to the caller (no
-        // StreamingCitations event is emitted anywhere in this flow), so there is no
-        // per-request citation count to derive grounding from — default to Ungrounded.
+        // #3388: derive grounding status from whether any streamed step actually
+        // carries retrieved rulebook references (each StreamingSetupStep embeds its
+        // own `references`, so this reflects what the caller receives even though no
+        // separate StreamingCitations event is emitted). Mirrors the sibling handlers'
+        // `snippets.Count > 0 ? "Grounded" : "Ungrounded"` pattern (StreamQaQueryHandler,
+        // StreamExplainQueryHandler, ChatWithSessionAgentCommandHandler). Default/fallback
+        // steps always carry empty reference lists (CreateDefaultSetupStepsStatic), so
+        // that path stays Ungrounded.
+        var hasGroundedReferences = steps.Any(s => s.references.Count > 0);
+
         yield return CreateEvent(StreamingEventType.Complete,
             new StreamingComplete(
                 estimatedTime,
@@ -364,7 +371,7 @@ TASK: Generate a step-by-step setup guide for this board game. Focus on the init
                 completionTokens,
                 totalTokens,
                 confidence,
-                GroundingStatus: "Ungrounded"));
+                GroundingStatus: hasGroundedReferences ? "Grounded" : "Ungrounded"));
     }
     /// <summary>
     /// Parse LLM-generated steps response into structured SetupGuideStep objects

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamSetupGuideQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamSetupGuideQueryHandler.cs
@@ -354,13 +354,17 @@ TASK: Generate a step-by-step setup guide for this board game. Focus on the init
             steps.Count, estimatedTime);
 
         // Emit final complete event
+        // #3388: this handler never surfaces a citations list to the caller (no
+        // StreamingCitations event is emitted anywhere in this flow), so there is no
+        // per-request citation count to derive grounding from — default to Ungrounded.
         yield return CreateEvent(StreamingEventType.Complete,
             new StreamingComplete(
                 estimatedTime,
                 promptTokens,
                 completionTokens,
                 totalTokens,
-                confidence));
+                confidence,
+                GroundingStatus: "Ungrounded"));
     }
     /// <summary>
     /// Parse LLM-generated steps response into structured SetupGuideStep objects

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ChatCommandHandlers.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ChatCommandHandlers.cs
@@ -8,6 +8,7 @@ using Api.Middleware.Exceptions;
 using Api.Services;
 using Api.Services.ImageProcessing;
 using Api.Services.LlmClients;
+using Api.SharedKernel.Domain.Enums;
 using Microsoft.Extensions.Logging;
 
 namespace Api.BoundedContexts.SessionTracking.Application.Commands;
@@ -198,7 +199,7 @@ internal class AskSessionAgentCommandHandler : IRequestHandler<AskSessionAgentCo
                 if (result.Success)
                 {
                     answer = result.Response;
-                    confidence = 0.85f;
+                    confidence = null; // #3388: no fabricated confidence — vision path is not grounded in retrieval
                 }
                 else
                 {
@@ -221,7 +222,7 @@ internal class AskSessionAgentCommandHandler : IRequestHandler<AskSessionAgentCo
                 if (result.Success)
                 {
                     answer = result.Response;
-                    confidence = 0.85f;
+                    confidence = null; // #3388: no fabricated confidence — text-only path is not grounded in retrieval
                 }
                 else
                 {
@@ -263,7 +264,8 @@ internal class AskSessionAgentCommandHandler : IRequestHandler<AskSessionAgentCo
             TurnNumber = request.TurnNumber,
         }, cancellationToken).ConfigureAwait(false);
 
-        return new AskSessionAgentResult(agentMessage.Id, answer, agentType, agentMessage.Confidence, null);
+        // This path never produces citations (no retrieval grounding), so it is always Ungrounded (#3388).
+        return new AskSessionAgentResult(agentMessage.Id, answer, agentType, agentMessage.Confidence, null, GroundingStatus.Ungrounded);
     }
 }
 

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ChatCommands.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ChatCommands.cs
@@ -1,3 +1,4 @@
+using Api.SharedKernel.Domain.Enums;
 using MediatR;
 
 namespace Api.BoundedContexts.SessionTracking.Application.Commands;
@@ -47,7 +48,8 @@ public record AskSessionAgentResult(
     string Answer,
     string AgentType,
     float? Confidence,
-    string? CitationsJson
+    string? CitationsJson,
+    GroundingStatus GroundingStatus
 );
 
 /// <summary>

--- a/apps/api/src/Api/Models/Contracts.cs
+++ b/apps/api/src/Api/Models/Contracts.cs
@@ -155,7 +155,15 @@ internal record StreamingComplete(
     double? routingLatencyMs = null,
     string? strategyTier = null,
     Guid? executionId = null,
-    IReadOnlyList<CitationDto>? Citations = null);
+    IReadOnlyList<CitationDto>? Citations = null,
+    // #3388: grounding-contract invariant. Every producer below explicitly passes this
+    // (derived from its own citation count: Grounded iff count>0, else Ungrounded) rather
+    // than relying on the default — the default only exists because C# requires optional
+    // positional params to trail required ones, and this must stay the LAST param per the
+    // plan. Wire value is the enum NAME string ("Grounded"/"Partial"/"Ungrounded"), NOT the
+    // GroundingStatus enum — SSE serializes C# enums numerically, so a string keeps this
+    // path wire-consistent with the REST path's JsonStringEnumConverter output.
+    string GroundingStatus = "Ungrounded");
 
 internal record CitationDto(
     string DocumentId,

--- a/apps/api/src/Api/SharedKernel/Domain/Enums/GroundingStatus.cs
+++ b/apps/api/src/Api/SharedKernel/Domain/Enums/GroundingStatus.cs
@@ -1,0 +1,14 @@
+namespace Api.SharedKernel.Domain.Enums;
+
+/// <summary>
+/// Grounding status of an AI agent answer, shared across bounded contexts.
+/// Derived from citations: <see cref="Grounded"/> iff the answer carries at
+/// least one citation, otherwise <see cref="Ungrounded"/>. <see cref="Partial"/>
+/// is reserved for future use (#3390) and has no producer yet.
+/// </summary>
+public enum GroundingStatus
+{
+    Grounded = 0,
+    Partial = 1,
+    Ungrounded = 2
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/GenerateSetupChecklistCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/GenerateSetupChecklistCommandHandlerTests.cs
@@ -101,7 +101,7 @@ public class GenerateSetupChecklistCommandHandlerTests
             new(StreamingEventType.SetupStep, new StreamingSetupStep(steps[0]), DateTime.UtcNow),
             new(StreamingEventType.SetupStep, new StreamingSetupStep(steps[1]), DateTime.UtcNow),
             new(StreamingEventType.SetupStep, new StreamingSetupStep(steps[2]), DateTime.UtcNow),
-            new(StreamingEventType.Complete, new StreamingComplete(10, 100, 50, 150, 0.85), DateTime.UtcNow)
+            new(StreamingEventType.Complete, new StreamingComplete(10, 100, 50, 150, 0.85, GroundingStatus: "Grounded"), DateTime.UtcNow)
         };
 
         _mediatorMock

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentMetricsTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentMetricsTests.cs
@@ -141,13 +141,50 @@ public sealed class ChatWithSessionAgentMetricsTests
         var command = BuildCommand();
 
         // Act
-        await foreach (var _ in handler.Handle(command, CancellationToken.None)) { }
+        var complete = await DrainAndCaptureCompleteAsync(handler, command);
 
         // Assert
         observations.Should().ContainSingle(
             "citations-per-answer must be recorded exactly once even when there are no citations");
         observations[0].Should().Be(0L,
             "grounded-but-uncited signal: le=0 bucket must be populated");
+
+        // #3388 (Task 2): mode-parity signal — the SSE RAG path must emit a non-nullable
+        // grounding string on StreamingComplete, mirroring Task 1's REST-path assertion
+        // (AskSessionAgentResult.GroundingStatus) so both in-session agent paths carry the
+        // same grounding contract for a zero-citation answer.
+        complete.Should().NotBeNull();
+        complete!.GroundingStatus.Should().Be("Ungrounded");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // T2-AC-3b (#3388): with-citations case emits GroundingStatus="Grounded"
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "T2-AC-3b (#3388): with-citations case emits GroundingStatus=\"Grounded\" on StreamingComplete")]
+    public async Task Handle_StreamedChatWithCitations_EmitsGroundedStatus()
+    {
+        // Arrange — one Full-tier citation
+        var citations = new List<ChunkCitation>
+        {
+            new ChunkCitation(
+                DocumentId: "doc-1",
+                PageNumber: 1,
+                RelevanceScore: 0.9f,
+                SnippetPreview: "snippet A",
+                CopyrightTier: CopyrightTier.Full,
+                IsPublic: true),
+        };
+
+        var handler = BuildHandler(resolvedCitations: citations, tokenContent: "Answer with citation");
+        var command = BuildCommand();
+
+        // Act
+        var complete = await DrainAndCaptureCompleteAsync(handler, command);
+
+        // Assert — mode-parity signal (see zero-citation test comment above)
+        complete.Should().NotBeNull();
+        complete!.GroundingStatus.Should().Be("Grounded");
     }
 
     // ──────────────────────────────────────────────────────────────────────────
@@ -195,6 +232,26 @@ public sealed class ChatWithSessionAgentMetricsTests
         listener.SetMeasurementEventCallback<T>((_, value, _, _) => observations.Add(value));
         listener.Start();
         return listener;
+    }
+
+    /// <summary>
+    /// Drains the handler's streamed events and returns the <see cref="StreamingComplete"/>
+    /// payload carried by the terminal <see cref="StreamingEventType.Complete"/> event.
+    /// </summary>
+    private static async Task<StreamingComplete?> DrainAndCaptureCompleteAsync(
+        ChatWithSessionAgentCommandHandler handler,
+        ChatWithSessionAgentCommand command)
+    {
+        StreamingComplete? complete = null;
+        await foreach (var evt in handler.Handle(command, CancellationToken.None))
+        {
+            if (evt.Type == StreamingEventType.Complete)
+            {
+                complete = evt.Data as StreamingComplete;
+            }
+        }
+
+        return complete;
     }
 
     private static ChatWithSessionAgentCommand BuildCommand() =>

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/StreamSetupGuideQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/StreamSetupGuideQueryHandlerTests.cs
@@ -168,6 +168,13 @@ public class StreamSetupGuideQueryHandlerTests
                 It.IsAny<RequestSource>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
+
+        // #3388: grounding-contract — parsed steps carry the retrieved rulebook
+        // reference, so the terminal Complete event must report "Grounded".
+        var completeEvent = events.LastOrDefault(e => e.Type == StreamingEventType.Complete);
+        completeEvent.Should().NotBeNull();
+        var complete = completeEvent!.Data.Should().BeOfType<StreamingComplete>().Which;
+        complete.GroundingStatus.Should().Be("Grounded");
     }
 
     [Fact]
@@ -227,6 +234,11 @@ public class StreamSetupGuideQueryHandlerTests
         completeEvent.Should().NotBeNull();
         var complete = completeEvent.Data.Should().BeOfType<StreamingComplete>().Which;
         complete.totalTokens.Should().Be(0); // No LLM call, so 0 tokens
+
+        // #3388: grounding-contract — default fallback steps carry no rulebook
+        // references (CreateDefaultSetupStepsStatic), so the terminal Complete event
+        // must report "Ungrounded".
+        complete.GroundingStatus.Should().Be("Ungrounded");
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/ChatCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/ChatCommandHandlerTests.cs
@@ -6,6 +6,7 @@ using Api.Middleware.Exceptions;
 using Api.Services;
 using Api.BoundedContexts.SessionTracking.Application.Services;
 using Api.Services.ImageProcessing;
+using Api.SharedKernel.Domain.Enums;
 using Api.Tests.Constants;
 using MediatR;
 using Microsoft.Extensions.Logging;
@@ -239,7 +240,8 @@ public class AskSessionAgentCommandHandlerTests
 
         // Assert
         result.MessageId.Should().NotBe(Guid.Empty);
-        result.Confidence.Should().Be(0.85f); // LLM success returns 0.85 confidence
+        result.Confidence.Should().BeNull(); // #3388: no fabricated confidence on the REST path
+        result.GroundingStatus.Should().Be(GroundingStatus.Ungrounded); // #3388: REST path never has citations
         result.AgentType.Should().Be("tutor");
         saveCalledAfterFirstAdd.Should().BeTrue("SaveChangesAsync should be called after the first AddAsync (user message) to prevent sequence number race condition");
         _mockChatRepo.Verify(r => r.AddAsync(It.IsAny<SessionChatMessage>(), It.IsAny<CancellationToken>()), Times.Exactly(2));

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/ChatCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/ChatCommandHandlerTests.cs
@@ -13,6 +13,8 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
 using FluentAssertions;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Api.Tests.BoundedContexts.SessionTracking.Application.Handlers;
 
@@ -539,5 +541,45 @@ public class ChatQueryHandlerTests
         _mockChatRepo.Verify(
             r => r.GetBySessionIdAsync(It.IsAny<Guid>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()),
             Times.Never);
+    }
+}
+
+/// <summary>
+/// #3388: guards the wire casing of <see cref="AskSessionAgentResult.GroundingStatus"/>.
+/// The FE image-path disclaimer keys off the exact serialized value
+/// <c>"groundingStatus":"Ungrounded"</c> (camelCase property name, PascalCase enum
+/// value) produced by the global JSON options configured in
+/// <c>Program.cs</c> (<c>ConfigureHttpJsonOptions</c>: camelCase naming policy +
+/// <see cref="JsonStringEnumConverter"/>). This test mirrors those two settings so a
+/// regression to numeric enum serialization or snake/Pascal-case property naming
+/// fails fast here instead of silently breaking the FE contract.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SessionTracking")]
+public class AskSessionAgentResultSerializationTests
+{
+    private static readonly JsonSerializerOptions WireOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    [Fact]
+    public void Serialize_UngroundedResult_ProducesCamelCasePropertyWithPascalCaseEnumValue()
+    {
+        // Arrange
+        var result = new AskSessionAgentResult(
+            MessageId: Guid.NewGuid(),
+            Answer: "The rulebook does not cover this.",
+            AgentType: "qa",
+            Confidence: null,
+            CitationsJson: null,
+            GroundingStatus: GroundingStatus.Ungrounded);
+
+        // Act
+        var json = JsonSerializer.Serialize(result, WireOptions);
+
+        // Assert
+        json.Should().Contain("\"groundingStatus\":\"Ungrounded\"");
     }
 }

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
@@ -1174,8 +1174,10 @@ export function SessionLiveView(): ReactElement {
       visibility: 'shared' as const,
       timestamp: m.timestamp,
       citations: m.citations,
-      // AC-CHAT-3: propagate isNonGrounded ONLY from hook messages.
-      // System status messages (prepended below) do NOT get this flag → no disclaimer.
+      // Task 3 (#3388): propagate the server-authoritative groundingStatus alongside
+      // isNonGrounded — ONLY from hook messages (system status messages prepended
+      // below never carry either field, so they never show the disclaimer).
+      groundingStatus: m.groundingStatus,
       isNonGrounded: m.isNonGrounded,
     }));
 
@@ -1253,7 +1255,13 @@ export function SessionLiveView(): ReactElement {
             body: fd,
           });
           if (!res.ok) throw new Error(`ask-agent ${res.status}`);
-          const json = (await res.json()) as { answer?: string; confidence?: number };
+          // Task 3 (#3388): the multipart JSON response now carries a top-level
+          // groundingStatus (string, PascalCase — same wire contract as the SSE path).
+          const json = (await res.json()) as {
+            answer?: string;
+            confidence?: number;
+            groundingStatus?: string;
+          };
           setImageMessages(prev => [
             ...prev,
             {
@@ -1265,6 +1273,12 @@ export function SessionLiveView(): ReactElement {
                 intl.formatMessage({ id: 'pages.sessionLive.chatAgent.imageAsk.fallbackResponse' }),
               visibility: 'shared' as const,
               timestamp: new Date().toISOString(),
+              groundingStatus: json.groundingStatus as
+                | 'Grounded'
+                | 'Partial'
+                | 'Ungrounded'
+                | undefined,
+              isNonGrounded: json.groundingStatus === 'Ungrounded',
             },
           ]);
         } catch {

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
@@ -1279,6 +1279,9 @@ export function SessionLiveView(): ReactElement {
                 | 'Ungrounded'
                 | undefined,
               isNonGrounded: json.groundingStatus === 'Ungrounded',
+              // Task 4 (#3388): tag as image-modality so the disclaimer copy reflects
+              // that the answer came from the photo, not the rulebook.
+              modality: 'image',
             },
           ]);
         } catch {

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
@@ -1958,6 +1958,34 @@ describe('SessionLiveView — #2588 A3: dual-path image/text send handler', () =
     expect((init as RequestInit).method).toBe('POST');
     expect((init as RequestInit).body).toBeInstanceOf(FormData);
   });
+
+  it('A3-3 (Task 3 #3388): image response groundingStatus="Ungrounded" flags the agent message non-grounded', async () => {
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ answer: 'Risposta immagine.', groundingStatus: 'Ungrounded' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { container } = renderWithIntl(<SessionLiveView />);
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    expect(fileInput).not.toBeNull();
+
+    const file = new File(['x'], 'board.jpg', { type: 'image/jpeg' });
+    await act(async () => {
+      fireEvent.change(fileInput, { target: { files: [file] } });
+    });
+
+    const sendBtn = screen.getAllByRole('button', { name: 'Invia messaggio' })[0];
+    await act(async () => {
+      fireEvent.click(sendBtn);
+    });
+
+    expect(
+      container.querySelector('[data-slot="chat-nongrounded-disclaimer"]')
+    ).toBeInTheDocument();
+  });
 });
 
 // ─── #2505 — viewerRole derivation + AddPlayerDialog wiring ──────────────────

--- a/apps/web/src/components/features/session-live/LiveAgentChat.tsx
+++ b/apps/web/src/components/features/session-live/LiveAgentChat.tsx
@@ -50,6 +50,12 @@ export interface ChatMessage {
   readonly timestamp: string;
   readonly citations?: readonly ChatCitation[];
   /**
+   * Task 3 (#3388): server-authoritative grounding contract, propagated verbatim from
+   * `useSessionAgentChat.ChatMessage.groundingStatus` (SSE path) or set directly from
+   * the `/chat/ask-agent` JSON response (image path). Absent on system status messages.
+   */
+  readonly groundingStatus?: 'Grounded' | 'Partial' | 'Ungrounded';
+  /**
    * AC-CHAT-3: when true, the agent answered without any grounding citations.
    * Shows a discrete disclaimer below the bubble. NEVER true on system status messages
    * (those are injected by SessionLiveView without this flag).

--- a/apps/web/src/components/features/session-live/LiveAgentChat.tsx
+++ b/apps/web/src/components/features/session-live/LiveAgentChat.tsx
@@ -61,6 +61,13 @@ export interface ChatMessage {
    * (those are injected by SessionLiveView without this flag).
    */
   readonly isNonGrounded?: boolean;
+  /**
+   * Task 4 (#3388): source modality of the answer, used to pick the per-modality
+   * non-grounded disclaimer copy. Absent/'text' → text-RAG SSE path copy;
+   * 'image' → multimodal /ask-agent JSON path copy (SessionLiveView sets this on
+   * the image-branch agent message).
+   */
+  readonly modality?: 'text' | 'image';
 }
 
 // ─── Labels ───────────────────────────────────────────────────────────────────
@@ -242,7 +249,9 @@ export function LiveAgentChat({
                 )}
                 {/* AC-CHAT-3: non-grounded disclaimer — only for agent messages with
                     zero citations and explicit isNonGrounded flag.
-                    NEVER shown on system status messages (those lack the flag). */}
+                    NEVER shown on system status messages (those lack the flag).
+                    Task 4 (#3388): copy varies by modality — image path answers are
+                    derived from the photo + model knowledge, not the rulebook. */}
                 {msg.isNonGrounded === true && !isOwn && (
                   <p
                     data-slot="chat-nongrounded-disclaimer"
@@ -250,7 +259,10 @@ export function LiveAgentChat({
                   >
                     <span aria-hidden="true">⚠️</span>
                     {intl.formatMessage({
-                      id: 'pages.sessionLive.chatAgent.nonGroundedDisclaimer',
+                      id:
+                        msg.modality === 'image'
+                          ? 'pages.sessionLive.chatAgent.nonGroundedDisclaimerImage'
+                          : 'pages.sessionLive.chatAgent.nonGroundedDisclaimer',
                     })}
                   </p>
                 )}

--- a/apps/web/src/components/features/session-live/__tests__/LiveAgentChat.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/LiveAgentChat.test.tsx
@@ -31,6 +31,8 @@ const INTL_MESSAGES = {
   'pages.sessionLive.chat.newMessagesToast':
     '{count, plural, one {# nuovo messaggio} other {# nuovi messaggi}}',
   'pages.sessionLive.chatAgent.nonGroundedDisclaimer': 'Risposta non basata sul regolamento',
+  'pages.sessionLive.chatAgent.nonGroundedDisclaimerImage':
+    'Ho risposto dalla foto e dalla mia conoscenza del gioco, non dal regolamento ufficiale — verifica sul manuale',
   'pages.sessionLive.chat.removeImageAriaLabel': 'Rimuovi immagine {n}',
 };
 
@@ -391,6 +393,59 @@ describe('#2500 AC-CHAT-3 — non-grounded disclaimer', () => {
     expect(
       container.querySelector('[data-slot="chat-nongrounded-disclaimer"]')
     ).not.toBeInTheDocument();
+  });
+
+  it('messaggio assistant isNonGrounded:true + modality:"image" -> disclaimer copy immagine', () => {
+    const msgNonGroundedImage: ChatMessage = {
+      id: 'msg-ng-image',
+      senderId: 'agent',
+      senderName: 'MeepleAI',
+      content: 'Risposta dalla foto.',
+      visibility: 'shared',
+      timestamp: '2026-06-23T10:00:00Z',
+      isNonGrounded: true,
+      modality: 'image',
+    };
+    const { container } = renderChat({ messages: [msgNonGroundedImage] });
+    const disclaimer = container.querySelector('[data-slot="chat-nongrounded-disclaimer"]');
+    expect(disclaimer).toBeInTheDocument();
+    expect(disclaimer?.textContent).toContain(
+      'Ho risposto dalla foto e dalla mia conoscenza del gioco, non dal regolamento ufficiale'
+    );
+    expect(disclaimer?.textContent).not.toContain('Risposta non basata sul regolamento');
+  });
+
+  it('messaggio assistant isNonGrounded:true + modality:"text" -> disclaimer copy testo esistente', () => {
+    const msgNonGroundedText: ChatMessage = {
+      id: 'msg-ng-text',
+      senderId: 'agent',
+      senderName: 'MeepleAI',
+      content: 'Risposta senza fonti.',
+      visibility: 'shared',
+      timestamp: '2026-06-23T10:00:00Z',
+      isNonGrounded: true,
+      modality: 'text',
+    };
+    const { container } = renderChat({ messages: [msgNonGroundedText] });
+    const disclaimer = container.querySelector('[data-slot="chat-nongrounded-disclaimer"]');
+    expect(disclaimer).toBeInTheDocument();
+    expect(disclaimer?.textContent).toContain('Risposta non basata sul regolamento');
+  });
+
+  it('messaggio assistant isNonGrounded:true + modality assente -> disclaimer copy testo esistente (default)', () => {
+    const msgNonGroundedDefault: ChatMessage = {
+      id: 'msg-ng-default',
+      senderId: 'agent',
+      senderName: 'MeepleAI',
+      content: 'Risposta senza fonti.',
+      visibility: 'shared',
+      timestamp: '2026-06-23T10:00:00Z',
+      isNonGrounded: true,
+    };
+    const { container } = renderChat({ messages: [msgNonGroundedDefault] });
+    const disclaimer = container.querySelector('[data-slot="chat-nongrounded-disclaimer"]');
+    expect(disclaimer).toBeInTheDocument();
+    expect(disclaimer?.textContent).toContain('Risposta non basata sul regolamento');
   });
 });
 

--- a/apps/web/src/lib/domain-hooks/__tests__/useSessionAgentChat.test.ts
+++ b/apps/web/src/lib/domain-hooks/__tests__/useSessionAgentChat.test.ts
@@ -41,10 +41,20 @@ function sseToken(token: string): string {
   return `data: ${JSON.stringify({ type: 7, data: { token }, timestamp: new Date().toISOString() })}\n\n`;
 }
 
-function sseComplete(chatThreadId: string, citations?: unknown[]): string {
+function sseComplete(
+  chatThreadId: string,
+  citations?: unknown[],
+  groundingStatus?: string
+): string {
   return `data: ${JSON.stringify({
     type: 4,
-    data: { chatThreadId, citations: citations ?? [], totalTokens: 10, confidence: 0.9 },
+    data: {
+      chatThreadId,
+      citations: citations ?? [],
+      totalTokens: 10,
+      confidence: 0.9,
+      groundingStatus,
+    },
     timestamp: new Date().toISOString(),
   })}\n\n`;
 }
@@ -552,6 +562,59 @@ describe('useSessionAgentChat', () => {
 
       const lastMsg = result.current.messages[result.current.messages.length - 1];
       expect(lastMsg.role).toBe('assistant');
+      expect(lastMsg.isNonGrounded).toBeFalsy();
+    });
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Task 3 (#3388): server-authoritative groundingStatus on the SSE Complete
+    // event now drives isNonGrounded instead of the citations heuristic.
+    // ─────────────────────────────────────────────────────────────────────
+
+    it('SSE complete groundingStatus="Ungrounded" → message carries groundingStatus + isNonGrounded:true', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          body: makeReadableStream([
+            sseToken('Risposta.'),
+            sseComplete('t-gs-ungrounded', [], 'Ungrounded'),
+          ]),
+        } as unknown as Response)
+      );
+
+      const { result } = renderHook(() => useSessionAgentChat('game-sess-gs-1', 'agent-gs-1'));
+
+      await act(async () => {
+        await result.current.ask('Domanda');
+      });
+
+      const lastMsg = result.current.messages[result.current.messages.length - 1];
+      expect(lastMsg.role).toBe('assistant');
+      expect(lastMsg.groundingStatus).toBe('Ungrounded');
+      expect(lastMsg.isNonGrounded).toBe(true);
+    });
+
+    it('SSE complete groundingStatus="Grounded" (with citations) → groundingStatus set + isNonGrounded falsy', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          body: makeReadableStream([
+            sseToken('Risposta.'),
+            sseComplete('t-gs-grounded', [makeCitationDto()], 'Grounded'),
+          ]),
+        } as unknown as Response)
+      );
+
+      const { result } = renderHook(() => useSessionAgentChat('game-sess-gs-2', 'agent-gs-2'));
+
+      await act(async () => {
+        await result.current.ask('Domanda');
+      });
+
+      const lastMsg = result.current.messages[result.current.messages.length - 1];
+      expect(lastMsg.role).toBe('assistant');
+      expect(lastMsg.groundingStatus).toBe('Grounded');
       expect(lastMsg.isNonGrounded).toBeFalsy();
     });
 

--- a/apps/web/src/lib/domain-hooks/useSessionAgentChat.ts
+++ b/apps/web/src/lib/domain-hooks/useSessionAgentChat.ts
@@ -28,9 +28,18 @@ export interface ChatMessage {
   timestamp: string;
   citations?: ChatCitation[];
   /**
+   * Task 3 (#3388): server-authoritative grounding contract, read verbatim from the
+   * SSE `Complete` event's `data.groundingStatus` (string, PascalCase — see
+   * `Api.SharedKernel.Domain.Enums.GroundingStatus`). Absent on user messages and on
+   * history-hydrated messages (the thread DTO does not carry this field).
+   */
+  groundingStatus?: 'Grounded' | 'Partial' | 'Ungrounded';
+  /**
    * AC-CHAT-3: true only when this is a genuine RAG assistant response with zero citations
    * (i.e., the agent answered but found no grounding in the rulebook).
    * Never set on user messages or system status messages injected by SessionLiveView.
+   * Derived from `groundingStatus` when present (Task 3 #3388); falls back to the
+   * citations heuristic when the server did not send `groundingStatus`.
    */
   isNonGrounded?: boolean;
 }
@@ -120,6 +129,9 @@ export function useSessionAgentChat(
   const [streamingContent, setStreamingContent] = useState('');
   const threadIdRef = useRef<string | undefined>(undefined);
   const citationsRef = useRef<ChatCitation[]>([]);
+  // Task 3 (#3388): server-authoritative groundingStatus captured from the SSE
+  // Complete event, consumed when building the assistant message below.
+  const groundingStatusRef = useRef<ChatMessage['groundingStatus']>(undefined);
   const abortRef = useRef<AbortController | null>(null);
   // Ref-based guard prevents double-submit race regardless of stale closure timing
   const isLoadingRef = useRef(false);
@@ -208,6 +220,7 @@ export function useSessionAgentChat(
       setError(null);
       setStreamingContent('');
       citationsRef.current = [];
+      groundingStatusRef.current = undefined;
 
       const userMsg: ChatMessage = {
         id: crypto.randomUUID(),
@@ -320,6 +333,7 @@ export function useSessionAgentChat(
                     const d = event.data as {
                       chatThreadId?: string;
                       citations?: unknown[];
+                      groundingStatus?: string;
                     };
                     if (d.chatThreadId) {
                       threadIdRef.current = d.chatThreadId;
@@ -334,6 +348,14 @@ export function useSessionAgentChat(
                       )
                         .map(mapCitationToChatCitation)
                         .filter((x): x is ChatCitation => x !== null);
+                    }
+                    // Task 3 (#3388): server-authoritative grounding contract.
+                    if (
+                      d.groundingStatus === 'Grounded' ||
+                      d.groundingStatus === 'Partial' ||
+                      d.groundingStatus === 'Ungrounded'
+                    ) {
+                      groundingStatusRef.current = d.groundingStatus;
                     }
                   } else if (event.type === SSE_ERROR) {
                     const d = event.data as { errorMessage?: string; errorCode?: string };
@@ -351,15 +373,24 @@ export function useSessionAgentChat(
           reader.releaseLock();
         }
 
-        // AC-CHAT-3: if the RAG response produced zero citations, flag as non-grounded.
+        // Task 3 (#3388): prefer the server-authoritative groundingStatus; fall back to
+        // the citations heuristic (AC-CHAT-3) only when the server did not send it.
         const hasCitations = citationsRef.current.length > 0;
+        const groundingStatus = groundingStatusRef.current;
+        const isNonGrounded =
+          groundingStatus !== undefined
+            ? groundingStatus === 'Ungrounded'
+            : hasCitations
+              ? undefined
+              : true;
         const assistantMsg: ChatMessage = {
           id: crypto.randomUUID(),
           role: 'assistant',
           content: accumulated,
           timestamp: new Date().toISOString(),
           citations: hasCitations ? citationsRef.current : undefined,
-          isNonGrounded: hasCitations ? undefined : true,
+          groundingStatus,
+          isNonGrounded,
         };
         setMessages(prev => [...prev, assistantMsg]);
         setStreamingContent('');

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -3893,6 +3893,7 @@
         "errorMessage": "Could not start the assistant. Try again later.",
         "statusAriaLabel": "Assistant status",
         "nonGroundedDisclaimer": "Answer not grounded in the rulebook",
+        "nonGroundedDisclaimerImage": "I answered from the photo and my game knowledge, not the official rulebook — check the manual",
         "imageAsk": {
           "defaultQuestion": "Analyse this image",
           "fallbackResponse": "Response not available.",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -3957,6 +3957,7 @@
         "errorMessage": "Impossibile avviare l'assistente. Riprova più tardi.",
         "statusAriaLabel": "Stato assistente",
         "nonGroundedDisclaimer": "Risposta non basata sul regolamento",
+        "nonGroundedDisclaimerImage": "Ho risposto dalla foto e dalla mia conoscenza del gioco, non dal regolamento ufficiale — verifica sul manuale",
         "imageAsk": {
           "defaultQuestion": "Analizza questa immagine",
           "fallbackResponse": "Risposta non disponibile.",

--- a/docs/superpowers/plans/2026-08-01-grounding-contract.md
+++ b/docs/superpowers/plans/2026-08-01-grounding-contract.md
@@ -1,0 +1,98 @@
+# Grounding Contract Invariant (#3388) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development or superpowers:executing-plans. Steps use `- [ ]`.
+
+**Goal:** Make `groundingStatus` a non-nullable contract invariant emitted by BOTH in-session agent paths (text-RAG SSE + image/text multimodal REST), remove the fabricated `confidence=0.85`, and surface a per-modality FE disclaimer for every ungrounded answer.
+
+**Architecture:** New `GroundingStatus` enum in `Api.SharedKernel`. Derived from citations (`Grounded` iff citations>0, else `Ungrounded`; `Partial` reserved for #3390, no producer now). No EF migration — re-derivable from persisted `CitationsJson`. Wire representation is **string** on both paths (REST enum→`JsonStringEnumConverter`→PascalCase; SSE emits the enum's `.ToString()` string to avoid the numeric-enum SSE regime).
+
+**Tech Stack:** .NET 9 (MediatR, SSE), Next.js/React (Vitest), xUnit + FluentAssertions + Moq.
+
+## Global Constraints
+
+- Issue #3388; branch `feature/issue-3388-grounding-contract` (parent `main-dev`).
+- `enum GroundingStatus { Grounded = 0, Partial = 1, Ungrounded = 2 }`, namespace `Api.SharedKernel.Domain.Enums` (mirror `UserAccountStatus.cs`: file-scoped namespace, XML `<summary>`, `public enum`, numeric values).
+- Wire value is the enum NAME string: `"Grounded"` / `"Partial"` / `"Ungrounded"` (PascalCase) on BOTH paths. FE compares `=== 'Ungrounded'`.
+- `Grounded` iff `citations.Count > 0` else `Ungrounded`. No `Partial` producer.
+- Remove fabricated `confidence 0.85f` (`ChatCommandHandlers.cs:201`, `:224`) → `null`. The SSE path's `confidence` is real (`ComputeConfidence`) — leave it.
+- No EF migration. CQRS unchanged. Commit after each task. Kill testhost before BE runs. FE tests: `cd apps/web && pnpm test <file>`.
+
+---
+
+### Task 1: `GroundingStatus` enum + REST path (AskSessionAgent)
+
+**Files:**
+- Create: `apps/api/src/Api/SharedKernel/Domain/Enums/GroundingStatus.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ChatCommands.cs:45-51` (add param), `.../Commands/ChatCommandHandlers.cs:201,224,266` (null confidence + emit grounding)
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/ChatCommandHandlerTests.cs:242`
+
+**Interfaces:**
+- Produces: `public enum GroundingStatus { Grounded=0, Partial=1, Ungrounded=2 }`; `AskSessionAgentResult(Guid MessageId, string Answer, string AgentType, float? Confidence, string? CitationsJson, GroundingStatus GroundingStatus)`.
+
+- [ ] **Step 1 (RED):** In `ChatCommandHandlerTests.cs` (the `AskSessionAgentCommandHandler` test that today asserts `result.Confidence.Should().Be(0.85f)` at `:242`): change it to `result.Confidence.Should().BeNull()` AND add `result.GroundingStatus.Should().Be(GroundingStatus.Ungrounded)` (add `using Api.SharedKernel.Domain.Enums;`).
+- [ ] **Step 2:** Run `dotnet test ...Api.Tests.csproj --filter "FullyQualifiedName~ChatCommandHandlerTests" --nologo -v minimal` → FAIL (still 0.85 / no GroundingStatus member).
+- [ ] **Step 3 (GREEN):** Create `GroundingStatus.cs`. In `ChatCommands.cs` add the positional param `GroundingStatus GroundingStatus` to `AskSessionAgentResult` (+ `using Api.SharedKernel.Domain.Enums;`). In `ChatCommandHandlers.cs`: replace `confidence = 0.85f;` at `:201` and `:224` with `confidence = null;`. At the return (`:266`) compute grounding = `Ungrounded` (this path never has citations) and pass it: `new AskSessionAgentResult(agentMessage.Id, answer, agentType, agentMessage.Confidence, null, GroundingStatus.Ungrounded)`. Add the `using`.
+- [ ] **Step 4:** Run the filter → PASS. Also `--filter "Category=Unit&BoundedContext=SessionTracking"` (chat subset) → green.
+- [ ] **Step 5:** Commit `feat(ai): GroundingStatus enum + honest confidence on image path (#3388)`.
+
+---
+
+### Task 2: SSE RAG path emits server-side `groundingStatus`
+
+**Files:**
+- Modify: `apps/api/src/Api/Models/Contracts.cs:147-158` (add field to `StreamingComplete`), `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentCommandHandler.cs:710-719`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentMetricsTests.cs`
+
+**Interfaces:**
+- Consumes: nothing from Task 1 except the concept (SSE emits a **string**, not the enum, to stay wire-consistent).
+- Produces: `StreamingComplete` gains a trailing `string GroundingStatus` (string, not the enum — SSE serializes enums numerically). Value `"Grounded"`/`"Ungrounded"`.
+
+- [ ] **Step 1 (RED):** In `ChatWithSessionAgentMetricsTests.cs`, in the zero-citation test (~`:46`) drain the stream, capture the `StreamingComplete` from the terminal `Complete` event, and assert its `GroundingStatus == "Ungrounded"`; add a with-citations case asserting `"Grounded"`. (Mirror the existing `BuildHandler(resolvedCitations, ...)` + `await foreach` drain pattern.)
+- [ ] **Step 2:** Run `--filter "FullyQualifiedName~ChatWithSessionAgentMetricsTests"` → FAIL (no GroundingStatus member).
+- [ ] **Step 3 (GREEN):** Add `string GroundingStatus` as a trailing param on `record StreamingComplete(...)` (`Contracts.cs`). At `ChatWithSessionAgentCommandHandler.cs:710-719` set it: `GroundingStatus: citationDtos.Count > 0 ? "Grounded" : "Ungrounded"`. (Keep the real `confidence` unchanged.)
+- [ ] **Step 4:** Run the filter → PASS. `--filter "Category=Unit&BoundedContext=KnowledgeBase&FullyQualifiedName~ChatWithSessionAgent"` green.
+- [ ] **Step 5:** Commit `feat(ai): SSE RAG path emits groundingStatus in StreamingComplete (#3388)`.
+
+---
+
+### Task 3: FE reads server `groundingStatus` on both paths
+
+**Files:**
+- Modify: `apps/web/src/lib/domain-hooks/useSessionAgentChat.ts:24-36,319-337,354-363`, `apps/web/src/components/features/session-live/LiveAgentChat.tsx:44-58`, `apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx:1256-1269`
+- Test: `apps/web/src/lib/domain-hooks/__tests__/useSessionAgentChat.test.ts`, `.../_components/__tests__/SessionLiveView.test.tsx`
+
+**Interfaces:**
+- Consumes: backend `groundingStatus` string (`"Grounded"|"Partial"|"Ungrounded"`) on SSE `StreamingComplete.data` and on the multipart JSON response.
+- Produces: `ChatMessage.groundingStatus?: 'Grounded'|'Partial'|'Ungrounded'` on BOTH the hook interface (`useSessionAgentChat.ts:24`) and the component interface (`LiveAgentChat.tsx:44`). `isNonGrounded` becomes derived from `groundingStatus === 'Ungrounded'` (keep the field for the disclaimer condition).
+
+- [ ] **Step 1 (RED):** In `useSessionAgentChat.test.ts`, extend the `sseComplete(...)` wire builder to include `groundingStatus: 'Ungrounded'` in the `data`, and assert the produced assistant `ChatMessage` has `groundingStatus === 'Ungrounded'` (and `isNonGrounded === true`). In `SessionLiveView.test.tsx` (image branch, near the `:450` disclaimer stub), assert the image-branch agent message carries grounding when the mocked `/chat/ask-agent` JSON returns `{ answer, groundingStatus: 'Ungrounded' }`.
+- [ ] **Step 2:** Run `pnpm test src/lib/domain-hooks/__tests__/useSessionAgentChat.test.ts` (and the SessionLiveView test) → FAIL.
+- [ ] **Step 3 (GREEN):** Add `groundingStatus?: 'Grounded'|'Partial'|'Ungrounded'` to both `ChatMessage` interfaces. In `useSessionAgentChat.ts` SSE_COMPLETE handler (`:319`) read `(event.data as {...; groundingStatus?: string}).groundingStatus` and set it on the assistant message (`:354-363`); derive `isNonGrounded = groundingStatus === 'Ungrounded'` (fallback to the old citations heuristic only if `groundingStatus` is absent, for resilience). In `SessionLiveView.tsx:1256` widen the cast to `{ answer?: string; confidence?: number; groundingStatus?: string }` and set `groundingStatus`/`isNonGrounded: json.groundingStatus === 'Ungrounded'` on the message object (`:1259-1268`).
+- [ ] **Step 4:** Run both tests → PASS; `pnpm typecheck` clean.
+- [ ] **Step 5:** Commit `feat(ai): FE reads server groundingStatus on both agent paths (#3388)`.
+
+---
+
+### Task 4: Per-modality disclaimer + remove fabricated confidence from UI
+
+**Files:**
+- Modify: `apps/web/src/components/features/session-live/LiveAgentChat.tsx:240-250`, `apps/web/src/locales/it.json`, `apps/web/src/locales/en.json`
+- Test: `apps/web/src/components/features/session-live/__tests__/LiveAgentChat.test.tsx`
+
+**Interfaces:**
+- Consumes: `ChatMessage.groundingStatus` (Task 3). Needs a way to know the modality — the image-branch messages already differ; add an optional `modality?: 'text' | 'image'` to the component `ChatMessage` (default text), set `'image'` on the image-branch message in `SessionLiveView.tsx`.
+
+- [ ] **Step 1 (RED):** In `LiveAgentChat.test.tsx`, add a test: an ungrounded agent message with `modality: 'image'` renders the image-specific disclaimer copy (assert `data-slot="chat-nongrounded-disclaimer"` present and text = the new image key), and an ungrounded text message renders the existing copy. Add the two new i18n keys to the test's `INTL_MESSAGES`.
+- [ ] **Step 2:** Run `pnpm test src/components/features/session-live/__tests__/LiveAgentChat.test.tsx` → FAIL.
+- [ ] **Step 3 (GREEN):** Add i18n keys under `pages.sessionLive.chatAgent`: keep `nonGroundedDisclaimer` (text) and add `nonGroundedDisclaimerImage` = IT `"Ho risposto dalla foto e dalla mia conoscenza del gioco, non dal regolamento ufficiale — verifica sul manuale"`, EN `"I answered from the photo and my game knowledge, not the official rulebook — check the manual"`. In `LiveAgentChat.tsx:240-250` pick the key by `msg.modality === 'image' ? '...Image' : 'nonGroundedDisclaimer'`. Add `modality?: 'text'|'image'` to the component `ChatMessage` interface; in `SessionLiveView.tsx` set `modality: 'image'` on the image-branch message. Grep the file for any rendered `confidence` on the agent bubble and remove it if shown as a measured value (the image JSON `confidence` is now `null`; ensure nothing renders it as authoritative).
+- [ ] **Step 4:** Run the test → PASS; `pnpm typecheck` + `pnpm lint` clean.
+- [ ] **Step 5:** Commit `feat(ai): per-modality non-grounded disclaimer + drop fabricated confidence (#3388)`.
+
+---
+
+## Self-Review
+
+- **Spec/DoD coverage:** groundingStatus non-nullable both paths → T1 (REST) + T2 (SSE). image→Ungrounded → T1. FE disclaimer both modalities → T3+T4. No fabricated confidence → T1 (BE null) + T4 (UI). Mode-parity test → T1 asserts `AskSessionAgentResult.GroundingStatus` non-null Ungrounded; T2 asserts `StreamingComplete.GroundingStatus` emitted — together they prove both contracts carry a non-nullable grounding signal for the same (non-grounded) question. Add a one-line comment in the T2 test referencing the parity intent.
+- **Type consistency:** enum `GroundingStatus` (BE, T1) vs wire **string** `"Grounded"/"Ungrounded"` (SSE T2 + REST via converter) vs FE union `'Grounded'|'Partial'|'Ungrounded'` (T3). Casing PascalCase throughout — FE compares `=== 'Ungrounded'`.
+- **Two-serialization-regime risk (documented):** SSE would render a C# enum numerically; T2 emits a `string` on `StreamingComplete` to match the REST string. Verify the SSE test asserts the string, not a number.
+- **Out of scope:** routing the image path through retrieval (#3390); a `Partial` producer.

--- a/docs/superpowers/specs/2026-08-01-grounding-contract-design.md
+++ b/docs/superpowers/specs/2026-08-01-grounding-contract-design.md
@@ -1,0 +1,57 @@
+# Grounding come invariante di contratto — Design
+
+**Issue**: #3388 (epic P1 #3397, Blocco 1 "pavimento di correttezza") · **Data**: 2026-08-01
+
+## Problema
+
+La chat con l'agente in-sessione instrada su **due backend** a seconda che il messaggio contenga immagini, con contratti divergenti:
+- **Solo testo** → SSE `ChatWithSessionAgentCommandHandler` (BC KnowledgeBase): RAG con citazioni; grounding **inferito dal FE** (`isNonGrounded` se citations==0).
+- **Con immagini** → `AskSessionAgentCommandHandler` (BC SessionTracking): LLM multimodale, **nessun retrieval**, `citationsJson=null`, `confidence` **hard-coded a `0.85`**; il FE **non** imposta `isNonGrounded` → **nessun disclaimer**.
+
+Lo scenario di punta ("scatto una foto del tavolo e chiedo una regola") restituisce una risposta autorevole (`confidence 0.85`) **silenziosamente non-grounded**. Il grounding è oggi proprietà della *modalità di input*, non un invariante di sistema.
+
+## Decisioni (brainstorming 2026-08-01)
+
+- **`enum GroundingStatus { Grounded, Partial, Ungrounded }`** in `Api.SharedKernel` (Published Language neutra, condivisa da KnowledgeBase + SessionTracking). `Partial` è nel contratto per l'epic futura multimodale→RAG (#3390) ma **nessun path lo emette ora**.
+- **Derivato dai citations, nessuna migration**: `groundingStatus = citations.Count > 0 ? Grounded : Ungrounded`, calcolato a response-time e **ri-derivabile da `CitationsJson`** già persistito su `SessionChatMessage` al reload. Nessun campo/migration EF.
+- **`confidence` fabbricata rimossa** → `null` onesto (nessuna metrica reale disponibile; "numero fabbricato mostrato come misurato" per 3 lenti del panel).
+- **Disclaimer calibrato per modalità** (non generico, per evitare banner-blindness).
+
+## Componenti
+
+### BE-1 — enum condiviso
+`Api.SharedKernel/.../GroundingStatus.cs`: `enum GroundingStatus { Grounded, Partial, Ungrounded }`. Serializzato come stringa camelCase nel JSON di risposta (coerente con il resto delle API).
+
+### BE-2 — path immagine/text-only (`AskSessionAgentCommandHandler`, BC SessionTracking)
+- Rimuovere `confidence=0.85f` (`ChatCommandHandlers.cs:201`, `:224`) → `confidence=null`.
+- Aggiungere `GroundingStatus` (non-nullable) a `AskSessionAgentResult`; valore `Ungrounded` per costruzione (`citationsJson=null`, nessun retrieval). L'endpoint serializza il result → il campo appare nel JSON.
+
+### BE-3 — path RAG SSE (`ChatWithSessionAgentCommandHandler`, BC KnowledgeBase)
+- Emettere `groundingStatus` **server-side** nel contratto/evento terminale: `Grounded` se citations>0, `Ungrounded` se 0. Promuove la logica da FE-derivata a invariante di contratto.
+
+### FE-1 — lettura uniforme
+- Tipizzare `groundingStatus: 'grounded'|'partial'|'ungrounded'` in `ChatMessage` (`useSessionAgentChat.ts`); leggerlo da **entrambi** i path (SSE + immagine `SessionLiveView.tsx:1256-1269`), non più inferirlo da citations.
+
+### FE-2 — disclaimer + rimozione confidence fabbricata
+- `LiveAgentChat.tsx:240`: mostrare il disclaimer per **ogni** risposta `ungrounded`, su entrambe le modalità, con copy **per-modalità**:
+  - immagine: *"Ho risposto dalla foto e dalla mia conoscenza del gioco, non dal regolamento ufficiale — verifica sul manuale"*.
+  - testo (0 citazioni): copy esistente del disclaimer RAG.
+- Chiavi i18n in `it.json`/`en.json`.
+- Rimuovere qualsiasi `confidence` fabbricata renderizzata come "misurata".
+
+## Definition of Done (dalla issue)
+
+- [ ] `groundingStatus` non-nullable esposto da **entrambi** i path.
+- [ ] Path immagine mappa `citationsJson=null` → `Ungrounded`.
+- [ ] FE mostra il disclaimer per ogni `ungrounded`, su entrambe le modalità.
+- [ ] Nessuna `confidence` fabbricata restituita/mostrata.
+- [ ] Test di **parità di modalità**: stessa domanda testo-vs-immagine → stesso *tipo* di segnale di grounding (non-nullable).
+
+## Fuori scope
+
+- Chiudere il **gap di capacità** (far passare il multimodale attraverso il retrieval) = epic #3390, non questa issue. Qui si rende **onesto il segnale**, non si aggiunge grounding al path immagine.
+- `Partial` producer (nessuno finché #3390 non introduce il grounding parziale).
+
+## Riferimenti
+
+Audit: `docs/for-developers/audits/2026-07-29-in-session-agent-grounding-audit.md` (Fase 1).

--- a/docs/superpowers/specs/2026-08-01-grounding-contract-design.md
+++ b/docs/superpowers/specs/2026-08-01-grounding-contract-design.md
@@ -20,7 +20,7 @@ Lo scenario di punta ("scatto una foto del tavolo e chiedo una regola") restitui
 ## Componenti
 
 ### BE-1 — enum condiviso
-`Api.SharedKernel/.../GroundingStatus.cs`: `enum GroundingStatus { Grounded, Partial, Ungrounded }`. Serializzato come stringa camelCase nel JSON di risposta (coerente con il resto delle API).
+`Api.SharedKernel/.../GroundingStatus.cs`: `enum GroundingStatus { Grounded, Partial, Ungrounded }`. Sul wire il **valore** è il nome dell'enum in **PascalCase** (`"Grounded"`/`"Ungrounded"`) — via `JsonStringEnumConverter` sul path REST e come stringa letterale sul path SSE (che serializza gli enum numericamente); la **chiave** JSON è camelCase (`groundingStatus`). Il FE confronta `=== 'Ungrounded'`.
 
 ### BE-2 — path immagine/text-only (`AskSessionAgentCommandHandler`, BC SessionTracking)
 - Rimuovere `confidence=0.85f` (`ChatCommandHandlers.cs:201`, `:224`) → `confidence=null`.


### PR DESCRIPTION
## Sommario

Closes #3388. Rende `groundingStatus` un **invariante di contratto** emesso da **entrambi** i path della chat agente in-sessione, rimuove la `confidence 0.85` fabbricata, e mostra un disclaimer **calibrato per modalità**. È il Blocco 1 ("pavimento di correttezza") dell'epic P1 #3397.

## Problema

La chat instrada su due backend a seconda che il messaggio contenga immagini: testo → SSE RAG (con citazioni), immagine → multimodale REST (nessun retrieval, `citationsJson=null`). Il path immagine restituiva `confidence 0.85` **fabbricata** e il FE **non** mostrava disclaimer → lo scenario "scatto una foto del tavolo e chiedo una regola" dava una risposta autorevole **silenziosamente non-grounded**.

## Cosa cambia (4 task, TDD)

1. **`enum GroundingStatus { Grounded, Partial, Ungrounded }`** in `Api.SharedKernel`; `AskSessionAgentResult` guadagna `GroundingStatus` (`Ungrounded` per il path immagine/text-only, per costruzione); `confidence 0.85f` → `null`.
2. **`StreamingComplete.GroundingStatus`** (string) emesso **server-side** dal path SSE (`Grounded` se citations>0). Il record positional-change ha esteso il grounding coerentemente a **tutti i 9 producer SSE** (StreamQa/SetupGuide/Explain/CrossGameStreamQa/DebugQa), ciascuno derivato dal proprio conteggio citazioni.
3. **FE**: `groundingStatus` su entrambe le `ChatMessage` interface (hook + component), letto da SSE `data.groundingStatus` e dalla REST JSON; `isNonGrounded` derivato dal server (fallback citations per storico/server vecchi).
4. **FE**: disclaimer **per-modalità** (`nonGroundedDisclaimerImage` in it.json+en.json), copy calibrata immagine vs testo; nessuna `confidence` fabbricata renderizzata.

## Wire

Il **valore** di `groundingStatus` è il nome dell'enum in **PascalCase** (`"Grounded"`/`"Ungrounded"`) su entrambi i path (REST via `JsonStringEnumConverter`, SSE come stringa letterale — l'SSE serializza gli enum numericamente); la **chiave** JSON è camelCase. Il FE confronta `=== 'Ungrounded'`.

## Fuori scope

Far passare il path immagine **attraverso il retrieval** (chiudere il gap di capacità) = epic #3390. Qui si rende **onesto il segnale**, non si aggiunge grounding. Nessun producer `Partial` (riservato a #3390).

## Qualità

- Whole-branch review (multi-agente, opus): **0 Critical / 0 Important**. I 3 Minor fixati in-PR: setup-guide grounding derivato (non più hardcoded), test di round-trip sul wire casing REST, correzione nota casing nella spec.
- Test: BE (`ChatCommandHandlerTests` 47/47, SSE metrics target 5/5, serialization round-trip), FE (`useSessionAgentChat` 23/23, `SessionLiveView` 123/123, `LiveAgentChat` 44/44, i18n parity 26/26).
- **Nota**: flake pre-esistente `MeterListener`/parallelismo in `ChatWithSessionAgentMetricsTests` (riprodotto su baseline via `git stash`, **non** regressione di questa PR).

Spec: `docs/superpowers/specs/2026-08-01-grounding-contract-design.md` · Plan: `docs/superpowers/plans/2026-08-01-grounding-contract.md`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
