### PR TITLE
refactor(session): elimina collisione nome enum ParticipantRole (#3392)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/Session/JoinSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/Session/JoinSessionCommandHandler.cs
@@ -80,14 +80,14 @@ internal sealed class JoinSessionCommandHandler : IRequestHandler<JoinSessionCom
             var user = await _dbContext.Users.FirstOrDefaultAsync(u => u.Id == request.UserId.Value, cancellationToken)
                 .ConfigureAwait(false);
             var displayName = user?.DisplayName ?? user?.Email;
-            participant = SessionParticipant.CreateRegistered(invite.SessionId, request.UserId.Value, ParticipantRole.Player, displayName);
+            participant = SessionParticipant.CreateRegistered(invite.SessionId, request.UserId.Value, SessionParticipantRole.Player, displayName);
         }
         else
         {
             if (string.IsNullOrWhiteSpace(request.GuestName))
                 throw new SharedKernel.Domain.Exceptions.ValidationException("GuestName", "Guest name is required for anonymous join");
 
-            participant = SessionParticipant.CreateGuest(invite.SessionId, request.GuestName, ParticipantRole.Player);
+            participant = SessionParticipant.CreateGuest(invite.SessionId, request.GuestName, SessionParticipantRole.Player);
         }
 
         _dbContext.SessionParticipants.Add(new SessionParticipantEntity

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/SessionParticipant.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/SessionParticipant.cs
@@ -12,7 +12,7 @@ public class SessionParticipant
     public Guid SessionId { get; private set; }
     public Guid? UserId { get; private set; }
     public string? GuestName { get; private set; }
-    public ParticipantRole Role { get; private set; }
+    public SessionParticipantRole Role { get; private set; }
     public bool AgentAccessEnabled { get; private set; }
     public string ConnectionToken { get; private set; } = null!;
     public DateTime JoinedAt { get; private set; }
@@ -28,7 +28,7 @@ public class SessionParticipant
     /// <summary>
     /// Creates a guest participant (no registered user account).
     /// </summary>
-    public static SessionParticipant CreateGuest(Guid sessionId, string guestName, ParticipantRole role)
+    public static SessionParticipant CreateGuest(Guid sessionId, string guestName, SessionParticipantRole role)
     {
         if (string.IsNullOrWhiteSpace(guestName))
             throw new ArgumentException("Guest name is required", nameof(guestName));
@@ -49,7 +49,7 @@ public class SessionParticipant
     /// Creates a registered user participant.
     /// Hosts automatically get agent access enabled.
     /// </summary>
-    public static SessionParticipant CreateRegistered(Guid sessionId, Guid userId, ParticipantRole role, string? displayName = null)
+    public static SessionParticipant CreateRegistered(Guid sessionId, Guid userId, SessionParticipantRole role, string? displayName = null)
     {
         return new SessionParticipant
         {
@@ -58,7 +58,7 @@ public class SessionParticipant
             UserId = userId,
             RegisteredDisplayName = displayName,
             Role = role,
-            AgentAccessEnabled = role == ParticipantRole.Host,
+            AgentAccessEnabled = role == SessionParticipantRole.Host,
             ConnectionToken = GeneratePin(),
             JoinedAt = DateTime.UtcNow
         };

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/ValueObjects/ParticipantRole.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/ValueObjects/ParticipantRole.cs
@@ -1,6 +1,0 @@
-namespace Api.BoundedContexts.GameManagement.Domain.Entities;
-
-/// <summary>
-/// Defines the role of a participant in a live game session.
-/// </summary>
-public enum ParticipantRole { Host, Player, Spectator }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/ValueObjects/SessionParticipantRole.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/ValueObjects/SessionParticipantRole.cs
@@ -1,0 +1,17 @@
+namespace Api.BoundedContexts.GameManagement.Domain.Entities;
+
+/// <summary>
+/// Defines the role of a <see cref="SessionParticipant"/> in a live game session
+/// (invite/join flow in the GameManagement bounded context).
+///
+/// <para>Renamed from the former <c>ParticipantRole</c> (issue #3392) to eliminate the
+/// name collision with <see cref="Api.BoundedContexts.SessionTracking.Domain.Enums.ParticipantRole"/>,
+/// which has the SAME member names but the OPPOSITE numeric ordering
+/// (SessionTracking: Spectator=0, Player=1, Host=2). The colliding name was a real vector
+/// for an incorrect <c>using</c> import mixing the two contracts.</para>
+///
+/// <para>These values are persisted BY NAME (string), so the rename does not affect stored
+/// data. The numeric ordering here is NOT used for ordinal comparisons — this enum is only
+/// ever compared with equality.</para>
+/// </summary>
+public enum SessionParticipantRole { Host, Player, Spectator }

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Enums/ParticipantRole.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Enums/ParticipantRole.cs
@@ -5,6 +5,15 @@ namespace Api.BoundedContexts.SessionTracking.Domain.Enums;
 /// Determines which actions the participant can perform.
 /// Issue #4765 - Player Action Endpoints + Host Validation
 /// </summary>
+/// <remarks>
+/// LOAD-BEARING NUMERIC ORDERING — DO NOT REORDER (issue #3392).
+/// The values are privilege-ascending (Spectator=0 &lt; Player=1 &lt; Host=2) and are compared
+/// ORDINALLY in <see cref="Api.BoundedContexts.SessionTracking.Application.Behaviors.ValidatePlayerRoleBehavior{TRequest,TResponse}"/>
+/// (<c>participant.Role &lt; request.MinimumRole</c>). Reordering or renumbering these members
+/// would silently invert authorization checks. Note this is the OPPOSITE ordering of the
+/// GameManagement <see cref="Api.BoundedContexts.GameManagement.Domain.Entities.SessionParticipantRole"/>
+/// enum (Host=0), which is only ever compared with equality — the two must never be conflated.
+/// </remarks>
 public enum ParticipantRole
 {
     /// <summary>

--- a/apps/api/src/Api/Infrastructure/Entities/GameManagement/SessionParticipantEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/GameManagement/SessionParticipantEntity.cs
@@ -17,7 +17,7 @@ public class SessionParticipantEntity
     public string? RegisteredDisplayName { get; set; }
 
     // Role & Access
-    public string Role { get; set; } = default!; // ParticipantRole enum stored as string
+    public string Role { get; set; } = default!; // SessionParticipantRole enum stored as string
     public bool AgentAccessEnabled { get; set; }
     public string ConnectionToken { get; set; } = default!; // 6-char PIN
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/SessionParticipant/SessionParticipantTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/SessionParticipant/SessionParticipantTests.cs
@@ -19,13 +19,13 @@ public class SessionParticipantTests
     public void CreateGuest_ShouldSetGuestNameAndNullUserId()
     {
         var participant = Api.BoundedContexts.GameManagement.Domain.Entities.SessionParticipant.CreateGuest(
-            _sessionId, ValidGuestName, ParticipantRole.Player);
+            _sessionId, ValidGuestName, SessionParticipantRole.Player);
 
         participant.Id.Should().NotBe(Guid.Empty);
         participant.SessionId.Should().Be(_sessionId);
         participant.UserId.Should().BeNull();
         participant.GuestName.Should().Be(ValidGuestName);
-        participant.Role.Should().Be(ParticipantRole.Player);
+        participant.Role.Should().Be(SessionParticipantRole.Player);
         (participant.AgentAccessEnabled).Should().BeFalse();
         (participant.JoinedAt <= DateTime.UtcNow).Should().BeTrue();
         participant.LeftAt.Should().BeNull();
@@ -39,7 +39,7 @@ public class SessionParticipantTests
     {
         var act = () =>
             Api.BoundedContexts.GameManagement.Domain.Entities.SessionParticipant.CreateGuest(
-                _sessionId, guestName!, ParticipantRole.Player);
+                _sessionId, guestName!, SessionParticipantRole.Player);
         act.Should().Throw<ArgumentException>();
     }
 
@@ -47,7 +47,7 @@ public class SessionParticipantTests
     public void CreateGuest_ShouldTrimGuestName()
     {
         var participant = Api.BoundedContexts.GameManagement.Domain.Entities.SessionParticipant.CreateGuest(
-            _sessionId, "  Alice  ", ParticipantRole.Player);
+            _sessionId, "  Alice  ", SessionParticipantRole.Player);
 
         participant.GuestName.Should().Be("Alice");
     }
@@ -60,13 +60,13 @@ public class SessionParticipantTests
     public void CreateRegistered_ShouldSetUserIdAndNullGuestName()
     {
         var participant = Api.BoundedContexts.GameManagement.Domain.Entities.SessionParticipant.CreateRegistered(
-            _sessionId, _userId, ParticipantRole.Player);
+            _sessionId, _userId, SessionParticipantRole.Player);
 
         participant.Id.Should().NotBe(Guid.Empty);
         participant.SessionId.Should().Be(_sessionId);
         participant.UserId.Should().Be(_userId);
         participant.GuestName.Should().BeNull();
-        participant.Role.Should().Be(ParticipantRole.Player);
+        participant.Role.Should().Be(SessionParticipantRole.Player);
         (participant.JoinedAt <= DateTime.UtcNow).Should().BeTrue();
         participant.LeftAt.Should().BeNull();
     }
@@ -75,7 +75,7 @@ public class SessionParticipantTests
     public void CreateRegistered_AsHost_ShouldEnableAgentAccess()
     {
         var participant = Api.BoundedContexts.GameManagement.Domain.Entities.SessionParticipant.CreateRegistered(
-            _sessionId, _userId, ParticipantRole.Host);
+            _sessionId, _userId, SessionParticipantRole.Host);
 
         (participant.AgentAccessEnabled).Should().BeTrue();
     }
@@ -84,7 +84,7 @@ public class SessionParticipantTests
     public void CreateRegistered_AsPlayer_ShouldDisableAgentAccess()
     {
         var participant = Api.BoundedContexts.GameManagement.Domain.Entities.SessionParticipant.CreateRegistered(
-            _sessionId, _userId, ParticipantRole.Player);
+            _sessionId, _userId, SessionParticipantRole.Player);
 
         (participant.AgentAccessEnabled).Should().BeFalse();
     }
@@ -93,7 +93,7 @@ public class SessionParticipantTests
     public void CreateRegistered_AsSpectator_ShouldDisableAgentAccess()
     {
         var participant = Api.BoundedContexts.GameManagement.Domain.Entities.SessionParticipant.CreateRegistered(
-            _sessionId, _userId, ParticipantRole.Spectator);
+            _sessionId, _userId, SessionParticipantRole.Spectator);
 
         (participant.AgentAccessEnabled).Should().BeFalse();
     }
@@ -106,7 +106,7 @@ public class SessionParticipantTests
     public void ToggleAgentAccess_ShouldFlip()
     {
         var participant = Api.BoundedContexts.GameManagement.Domain.Entities.SessionParticipant.CreateGuest(
-            _sessionId, ValidGuestName, ParticipantRole.Player);
+            _sessionId, ValidGuestName, SessionParticipantRole.Player);
 
         (participant.AgentAccessEnabled).Should().BeFalse();
 
@@ -125,7 +125,7 @@ public class SessionParticipantTests
     public void Leave_ShouldSetLeftAt()
     {
         var participant = Api.BoundedContexts.GameManagement.Domain.Entities.SessionParticipant.CreateGuest(
-            _sessionId, ValidGuestName, ParticipantRole.Player);
+            _sessionId, ValidGuestName, SessionParticipantRole.Player);
 
         (participant.IsActive).Should().BeTrue();
 
@@ -144,7 +144,7 @@ public class SessionParticipantTests
     public void ConnectionToken_ShouldBe6Chars()
     {
         var participant = Api.BoundedContexts.GameManagement.Domain.Entities.SessionParticipant.CreateGuest(
-            _sessionId, ValidGuestName, ParticipantRole.Player);
+            _sessionId, ValidGuestName, SessionParticipantRole.Player);
 
         participant.ConnectionToken.Length.Should().Be(6);
     }
@@ -156,7 +156,7 @@ public class SessionParticipantTests
         for (var i = 0; i < 50; i++)
         {
             var participant = Api.BoundedContexts.GameManagement.Domain.Entities.SessionParticipant.CreateGuest(
-                _sessionId, ValidGuestName, ParticipantRole.Player);
+                _sessionId, ValidGuestName, SessionParticipantRole.Player);
 
             participant.ConnectionToken.Should().NotContain("O");
             participant.ConnectionToken.Should().NotContain("0");
@@ -171,7 +171,7 @@ public class SessionParticipantTests
     {
         var tokens = Enumerable.Range(0, 20)
             .Select(_ => Api.BoundedContexts.GameManagement.Domain.Entities.SessionParticipant.CreateGuest(
-                _sessionId, ValidGuestName, ParticipantRole.Player).ConnectionToken)
+                _sessionId, ValidGuestName, SessionParticipantRole.Player).ConnectionToken)
             .ToHashSet();
 
         // With 6 chars from 32-char alphabet, collisions in 20 tokens are extremely unlikely
@@ -186,7 +186,7 @@ public class SessionParticipantTests
     public void DisplayName_Guest_ShouldReturnGuestName()
     {
         var participant = Api.BoundedContexts.GameManagement.Domain.Entities.SessionParticipant.CreateGuest(
-            _sessionId, ValidGuestName, ParticipantRole.Player);
+            _sessionId, ValidGuestName, SessionParticipantRole.Player);
 
         participant.DisplayName.Should().Be(ValidGuestName);
     }
@@ -195,7 +195,7 @@ public class SessionParticipantTests
     public void DisplayName_RegisteredUser_ShouldReturnUserFallback()
     {
         var participant = Api.BoundedContexts.GameManagement.Domain.Entities.SessionParticipant.CreateRegistered(
-            _sessionId, _userId, ParticipantRole.Player);
+            _sessionId, _userId, SessionParticipantRole.Player);
 
         participant.DisplayName.Should().Be("User");
     }
@@ -208,9 +208,9 @@ public class SessionParticipantTests
     public void IsRegisteredUser_ShouldReflectUserId()
     {
         var guest = Api.BoundedContexts.GameManagement.Domain.Entities.SessionParticipant.CreateGuest(
-            _sessionId, ValidGuestName, ParticipantRole.Player);
+            _sessionId, ValidGuestName, SessionParticipantRole.Player);
         var registered = Api.BoundedContexts.GameManagement.Domain.Entities.SessionParticipant.CreateRegistered(
-            _sessionId, _userId, ParticipantRole.Player);
+            _sessionId, _userId, SessionParticipantRole.Player);
 
         (guest.IsRegisteredUser).Should().BeFalse();
         (registered.IsRegisteredUser).Should().BeTrue();

--- a/apps/web/src/lib/session-live/__tests__/numeric-role-contracts.test.ts
+++ b/apps/web/src/lib/session-live/__tests__/numeric-role-contracts.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Boundary guard for the two backend role enums' numeric wire contracts (issue #3392).
+ *
+ * Backend `SseJsonOptions` disables JsonStringEnumConverter, so role enums cross the wire as
+ * INTEGERS. Two different backend enums share overlapping member names but map to OPPOSITE
+ * numbers:
+ *
+ *   SessionTracking.ParticipantRole        → Spectator=0, Player=1, Host=2
+ *   GameManagement.SessionParticipantRole  → Host=0,      Player=1, Spectator=2
+ *
+ * These tests pin each contract and assert the two are NOT conflated. Any future edit that
+ * makes the two numbering schemes agree at index 0 or 2 (the real conflation vector) fails here.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  SESSION_TRACKING_ROLE_BY_NUMBER,
+  GAME_MANAGEMENT_ROLE_BY_NUMBER,
+  decodeSessionTrackingRole,
+  decodeGameManagementRole,
+} from '../participant-role';
+
+describe('SessionTracking numeric role contract (Spectator=0, Player=1, Host=2)', () => {
+  it('maps each integer to the SessionTracking role', () => {
+    expect(SESSION_TRACKING_ROLE_BY_NUMBER[0]).toBe('Spectator');
+    expect(SESSION_TRACKING_ROLE_BY_NUMBER[1]).toBe('Player');
+    expect(SESSION_TRACKING_ROLE_BY_NUMBER[2]).toBe('Host');
+  });
+
+  it('decodeSessionTrackingRole resolves each integer correctly', () => {
+    expect(decodeSessionTrackingRole(0)).toBe('Spectator');
+    expect(decodeSessionTrackingRole(1)).toBe('Player');
+    expect(decodeSessionTrackingRole(2)).toBe('Host');
+  });
+
+  it('decodeSessionTrackingRole falls back to Player for out-of-range values', () => {
+    expect(decodeSessionTrackingRole(-1)).toBe('Player');
+    expect(decodeSessionTrackingRole(3)).toBe('Player');
+    expect(decodeSessionTrackingRole(99)).toBe('Player');
+  });
+});
+
+describe('GameManagement numeric role contract (Host=0, Player=1, Spectator=2)', () => {
+  it('maps each integer to the GameManagement role', () => {
+    expect(GAME_MANAGEMENT_ROLE_BY_NUMBER[0]).toBe('Host');
+    expect(GAME_MANAGEMENT_ROLE_BY_NUMBER[1]).toBe('Player');
+    expect(GAME_MANAGEMENT_ROLE_BY_NUMBER[2]).toBe('Spectator');
+  });
+
+  it('decodeGameManagementRole resolves each integer correctly', () => {
+    expect(decodeGameManagementRole(0)).toBe('Host');
+    expect(decodeGameManagementRole(1)).toBe('Player');
+    expect(decodeGameManagementRole(2)).toBe('Spectator');
+  });
+
+  it('decodeGameManagementRole falls back to Player for out-of-range values', () => {
+    expect(decodeGameManagementRole(-1)).toBe('Player');
+    expect(decodeGameManagementRole(3)).toBe('Player');
+  });
+});
+
+describe('the two contracts must NOT be conflated (issue #3392 core guard)', () => {
+  it('index 0 means the OPPOSITE role in each contract (Spectator vs Host)', () => {
+    expect(SESSION_TRACKING_ROLE_BY_NUMBER[0]).toBe('Spectator');
+    expect(GAME_MANAGEMENT_ROLE_BY_NUMBER[0]).toBe('Host');
+    expect(SESSION_TRACKING_ROLE_BY_NUMBER[0]).not.toBe(GAME_MANAGEMENT_ROLE_BY_NUMBER[0]);
+  });
+
+  it('index 2 means the OPPOSITE role in each contract (Host vs Spectator)', () => {
+    expect(SESSION_TRACKING_ROLE_BY_NUMBER[2]).toBe('Host');
+    expect(GAME_MANAGEMENT_ROLE_BY_NUMBER[2]).toBe('Spectator');
+    expect(SESSION_TRACKING_ROLE_BY_NUMBER[2]).not.toBe(GAME_MANAGEMENT_ROLE_BY_NUMBER[2]);
+  });
+
+  it('index 1 is the only value the two contracts agree on (Player)', () => {
+    expect(SESSION_TRACKING_ROLE_BY_NUMBER[1]).toBe('Player');
+    expect(GAME_MANAGEMENT_ROLE_BY_NUMBER[1]).toBe('Player');
+  });
+
+  it('decoding the same integer against each contract yields inverted roles at 0 and 2', () => {
+    expect(decodeSessionTrackingRole(0)).not.toBe(decodeGameManagementRole(0));
+    expect(decodeSessionTrackingRole(2)).not.toBe(decodeGameManagementRole(2));
+    // Cross-check: SessionTracking Host (2) would be mis-decoded as Spectator under the GM contract.
+    expect(decodeGameManagementRole(2)).toBe('Spectator');
+    expect(decodeSessionTrackingRole(2)).toBe('Host');
+  });
+});

--- a/apps/web/src/lib/session-live/participant-role.ts
+++ b/apps/web/src/lib/session-live/participant-role.ts
@@ -36,3 +36,62 @@ export function hasRequiredRole(viewerRole: ParticipantRole, minRole: Participan
   };
   return hierarchy[viewerRole] >= hierarchy[minRole];
 }
+
+// ============================================================================
+// Numeric wire contracts (issue #3392)
+// ============================================================================
+//
+// `SseJsonOptions` on the backend
+// (apps/api/src/Api/Infrastructure/Serialization/SseJsonOptions.cs) disables
+// JsonStringEnumConverter, so backend role enums serialize as INTEGERS on the wire.
+// TWO different backend enums share overlapping member names but map to OPPOSITE numbers:
+//
+//   SessionTracking.ParticipantRole        → Spectator=0, Player=1, Host=2
+//       (privilege-ascending, LOAD-BEARING: compared ordinally in ValidatePlayerRoleBehavior)
+//   GameManagement.SessionParticipantRole  → Host=0, Player=1, Spectator=2
+//       (equality-only; formerly the homonymous `ParticipantRole`, renamed in #3392)
+//
+// The two constants below pin each numeric contract as code so a raw wire integer is never
+// decoded against the wrong enum. Conflating the two schemes (e.g. reusing one map for the
+// other backend) will fail participant-role.test.ts.
+
+/**
+ * SessionTracking.ParticipantRole numeric contract (Spectator=0, Player=1, Host=2).
+ * Mirror of apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Enums/ParticipantRole.cs.
+ */
+export const SESSION_TRACKING_ROLE_BY_NUMBER = {
+  0: 'Spectator',
+  1: 'Player',
+  2: 'Host',
+} as const satisfies Record<0 | 1 | 2, ParticipantRole>;
+
+/**
+ * GameManagement.SessionParticipantRole numeric contract (Host=0, Player=1, Spectator=2).
+ * Mirror of apps/api/src/Api/BoundedContexts/GameManagement/Domain/ValueObjects/SessionParticipantRole.cs.
+ */
+export const GAME_MANAGEMENT_ROLE_BY_NUMBER = {
+  0: 'Host',
+  1: 'Player',
+  2: 'Spectator',
+} as const satisfies Record<0 | 1 | 2, ParticipantRole>;
+
+function decodeRole(contract: Record<0 | 1 | 2, ParticipantRole>, value: number): ParticipantRole {
+  // Narrow to the known indices; anything else is an out-of-range wire value → safe default.
+  return value === 0 || value === 1 || value === 2 ? contract[value] : 'Player';
+}
+
+/**
+ * Decode a numeric wire value using the SessionTracking contract (Spectator=0, Player=1, Host=2).
+ * Out-of-range values fall back to 'Player'.
+ */
+export function decodeSessionTrackingRole(value: number): ParticipantRole {
+  return decodeRole(SESSION_TRACKING_ROLE_BY_NUMBER, value);
+}
+
+/**
+ * Decode a numeric wire value using the GameManagement contract (Host=0, Player=1, Spectator=2).
+ * Out-of-range values fall back to 'Player'.
+ */
+export function decodeGameManagementRole(value: number): ParticipantRole {
+  return decodeRole(GAME_MANAGEMENT_ROLE_BY_NUMBER, value);
+}


### PR DESCRIPTION
Closes #3392

## Contesto (finding C3)

L'audit `docs/for-developers/audits/2026-07-29-in-session-agent-grounding-audit.md` ha rilevato **tre** enum di ruolo, due dei quali **omonimi** (`ParticipantRole`) ma con **ordinamento numerico opposto**:

| Enum | Valori | Uso |
|------|--------|-----|
| `SessionTracking.Domain.Enums.ParticipantRole` | Spectator=0, Player=1, Host=2 | **load-bearing**: confronto ordinale `Role < MinimumRole` in `ValidatePlayerRoleBehavior` |
| `GameManagement.Domain.Enums.PlayerRole` | Host=0, Player=1, Spectator=2 | solo uguaglianza (innocuo) |
| `GameManagement.Domain.Entities.ParticipantRole` (3° enum omonimo) | Host=0, Player=1, Spectator=2 | solo uguaglianza |

Il nome condiviso `ParticipantRole` (Spectator=0 vs Host=0) era un vettore reale di `using` errato. Inoltre `SseJsonOptions` disabilita `JsonStringEnumConverter` → gli enum escono come **int** verso il FE, spostando il rischio sulla conflazione dei due contratti numerici lato frontend.

## Modifiche

1. **Rinomina** del 3° enum omonimo `GameManagement…Entities.ParticipantRole` → **`SessionParticipantRole`** (nome allineato all'entità `SessionParticipant` che lo usa, coerente con la convenzione `PlayerRole`). Aggiornate **tutte** le referenze: `SessionParticipant`, `JoinSessionCommandHandler`, `SessionParticipantTests`, commento in `SessionParticipantEntity`. L'enum è persistito **per nome** (stringa `.ToString()`) → **nessun impatto sui dati** né migrazione necessaria.
2. **Ordinamento load-bearing documentato**: aggiunto `<remarks>` XML-doc su `SessionTracking.ParticipantRole` che dichiara l'ordinamento privilegio-crescente come load-bearing (confronto ordinale in `ValidatePlayerRoleBehavior`) — **non riordinare** — con cross-reference all'enum GM opposto.
3. **Test FE di confine** (`apps/web/src/lib/session-live/`):
   - `participant-role.ts`: pinning dei due contratti numerici come codice (`SESSION_TRACKING_ROLE_BY_NUMBER` = {0:Spectator,1:Player,2:Host}, `GAME_MANAGEMENT_ROLE_BY_NUMBER` = {0:Host,1:Player,2:Spectator}) + helper `decodeSessionTrackingRole` / `decodeGameManagementRole`.
   - `__tests__/numeric-role-contracts.test.ts`: 15 test che asseriscono l'interpretazione corretta di ciascun contratto e che i due sono **invertiti** agli indici 0 e 2 (guard anti-conflazione).

## Mapper esplicito — OMESSO (YAGNI)

Il deliverable "mapper esplicito quando un ruolo attraversa un confine BC come int" è stato **volutamente omesso** perché **non esiste alcun crossing int reale**:
- Il bridge cross-BC `SessionTracking.CreateSessionCommand` **non trasporta** il ruolo: `ParticipantDto` porta solo `IsOwner` (bool), e il ruolo viene **ri-derivato** internamente (`Role = IsOwner ? Host : Player` in `Session.AddParticipant`).
- Entrambi gli enum sono persistiti **per nome** (stringa), non per valore numerico.
- Ogni stream SSE serializza il proprio enum indipendentemente; non c'è scambio di valori numerici tra i due contratti.

Aggiungere un mapper sarebbe codice speculativo. Il rischio di conflazione **numerica lato FE** (l'unico attivo dato `SseJsonOptions`) è coperto dal test-guard sopra.

> Nota latente (fuori scope, non modificata): `parse-sse-event.ts::toRole()` decodifica oggi solo i **nomi stringa** dei ruoli (default `Player` per tutto il resto); la decodifica numerica non è cablata. Gli helper `decode*Role` aggiunti sono il modo contract-safe per decodificare gli int se/quando servirà.

## Verifica

**Backend** (`dotnet build` su `apps/api/src/Api` e `apps/api/tests/Api.Tests`): **0 errori**.
Test unit toccati/rilevanti — tutti verdi:
- `SessionParticipantTests` + role ST (`ValidatePlayerRoleBehaviorTests`, `PlayerActionDomainTests`, `AssignParticipantRoleDomainTests`, `JoinAndRoleHandlerTests`, `JoinAndRoleValidatorTests`): **48/48** passati.
- `JoinSessionCommandHandlerTests` (GameManagement): **11/11** passati.

**Frontend**:
- `pnpm typecheck`: **0 errori**.
- `numeric-role-contracts.test.ts` + `participant-role.test.ts` + `parse-sse-event.test.ts`: **100/100** passati (15 nuovi guard).
- `eslint` su `participant-role.ts`: pulito.

## Definition of Done

- [x] Nessuna collisione di nome tra enum di ruolo.
- [x] Test di confine / interpretazione FE dei contratti numerici.
- [x] Ordinamento load-bearing documentato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
