### PR TITLE
fix(shared-games): render resolved coverUrl on public catalog grid + detail hero (#3449)

### DIFF
--- a/apps/web/src/app/(public)/shared-games/[id]/page-client.tsx
+++ b/apps/web/src/app/(public)/shared-games/[id]/page-client.tsx
@@ -339,7 +339,7 @@ export function SharedGameDetailPageClient({
       <div className="mx-auto flex max-w-[1024px] flex-col gap-6 px-4 py-8 sm:px-6 lg:px-8">
         <Hero
           title={resolvedTitle}
-          coverUrl={game.imageUrl && game.imageUrl.length > 0 ? game.imageUrl : null}
+          coverUrl={game.coverUrl ?? null}
           year={game.yearPublished > 0 ? game.yearPublished : null}
           minPlayers={game.minPlayers > 0 ? game.minPlayers : null}
           maxPlayers={game.maxPlayers > 0 ? game.maxPlayers : null}

--- a/apps/web/src/app/(public)/shared-games/page-client.tsx
+++ b/apps/web/src/app/(public)/shared-games/page-client.tsx
@@ -227,7 +227,8 @@ export function SharedGamesPageClient({
     return items.map(g => ({
       id: g.id,
       title: g.title,
-      coverUrl: g.imageUrl && g.imageUrl.length > 0 ? g.imageUrl : null,
+      // #3449 — use the R2-resolved coverUrl; imageUrl is a #2123 tombstone (always empty).
+      coverUrl: g.coverUrl ?? null,
       year: g.yearPublished > 0 ? g.yearPublished : null,
       // Backend `averageRating` is on a 0..10 scale (BGG-style). Convert to 0..5.
       rating: g.averageRating != null ? g.averageRating / 2 : 0,

--- a/apps/web/src/lib/api/schemas/shared-games.schemas.ts
+++ b/apps/web/src/lib/api/schemas/shared-games.schemas.ts
@@ -317,6 +317,12 @@ export const SharedGameDetailSchema = z.object({
   averageRating: z.number().nullable(),
   imageUrl: z.string().catch(''), // coerce null/missing to empty string
   thumbnailUrl: z.string().catch(''), // coerce null/missing to empty string
+  // Issue #2123 / #3449 — R2-resolved cover URL. Preferred over imageUrl/thumbnailUrl,
+  // which are kept as legacy tombstones. Backend SharedGameDetailDto already returns it
+  // (GetSharedGameByIdQueryHandler, resolved via CoverUrlResolver); null when no cover
+  // has been generated yet — consumers MUST fall back to the deterministic placeholder
+  // via `lib/games/cover-utils.ts`.
+  coverUrl: z.string().url().nullable().optional(),
   rules: GameRulesSchema.nullable(),
   status: GameStatusSchema, // Now string enum with JsonStringEnumConverter
   createdBy: z.string().uuid(),

--- a/apps/web/src/lib/api/shared-games.test.ts
+++ b/apps/web/src/lib/api/shared-games.test.ts
@@ -263,6 +263,16 @@ describe('getSharedGameDetail', () => {
     expect(result.kbs).toEqual([]);
   });
 
+  it('parses the R2-resolved coverUrl through schema (#3449)', async () => {
+    const withCover = {
+      ...SAMPLE_DETAIL,
+      coverUrl: 'https://r2.example.test/covers/pdf/33333333/cover-preview.webp',
+    };
+    fetchSpy.mockResolvedValueOnce(makeJsonResponse(withCover));
+    const result = await getSharedGameDetail(withCover.id);
+    expect(result.coverUrl).toBe(withCover.coverUrl);
+  });
+
   it('parses populated nested arrays through schema', async () => {
     const populated = {
       ...SAMPLE_DETAIL,


### PR DESCRIPTION
Closes #3449

## Problema

Le pagine **pubbliche** `/shared-games` (griglia catalogo/Discover + hero del dettaglio) mostravano **sempre il placeholder** anche quando il backend aveva risolto una cover reale (R2 presigned). Le cover apparivano correttamente altrove (Dashboard, Hub, Library, Featured carousel) perché quei consumer leggono `coverUrl`.

## Root cause

Entrambe le pagine consumavano il campo legacy **`imageUrl`** (tombstone #2123, `z.string().catch('')` -> sempre vuoto) invece del risolto **`coverUrl`**:
- `page-client.tsx:230` (griglia)
- `[id]/page-client.tsx:342` (hero)

Asimmetria: `SharedGameDtoSchema` (griglia) esponeva gia `coverUrl`; il backend `SharedGameDetailDto` **ritorna gia** `CoverUrl` (`GetSharedGameByIdQueryHandler.cs:396-439` via `CoverUrlResolver.ResolvePublicAsync`), ma `SharedGameDetailSchema` (FE) **non lo dichiarava** -> zod lo scartava.

## Fix (FE-only)

- griglia `page-client.tsx` -> `g.coverUrl ?? null`
- `SharedGameDetailSchema` -> dichiara `coverUrl` (mirror di `SharedGameDtoSchema`)
- hero `[id]/page-client.tsx` -> `game.coverUrl ?? null`
- test: `shared-games.test.ts` asserisce il parsing di `coverUrl` nel dettaglio (TDD: rosso->verde)

## Verifica

- `pnpm typecheck` OK (exit 0)
- test schema `shared-games.test.ts` OK 21/21
- test componenti `shared-games-grid.test.tsx` + `[id]/__tests__/page.test.tsx` OK 19/19

## Fuori scope (follow-up)

OpenGraph metadata `[id]/page.tsx:141` legge anch'esso `detail.imageUrl` (social-preview image sempre omessa). Stessa radice, concern separato con test dedicato -> issue separata.

Generated with Claude Code