### PR TITLE
fix(docprocessing): add SkiaSharp native deps to API image (#3454)

### DIFF
--- a/apps/api/src/Api/Dockerfile
+++ b/apps/api/src/Api/Dockerfile
@@ -57,9 +57,16 @@ RUN --mount=type=cache,target=/root/.nuget/packages \
 FROM mcr.microsoft.com/dotnet/aspnet:9.0
 WORKDIR /app
 
-# Install curl for healthcheck, create non-root user, prepare directories — single layer
+# Install curl for healthcheck + SkiaSharp native runtime deps, create non-root
+# user, prepare directories — single layer.
+#
+# libfontconfig1 + libfreetype6: required by SkiaSharp's libSkiaSharp.so on Linux.
+# Without them the `SKObject` static initializer throws
+# "The type initializer for 'SkiaSharp.SKObject' threw an exception", which
+# broke PDF cover generation on staging (Debian 12 arm64 image shipped
+# libSkiaSharp.so but not its fontconfig/freetype deps) — see #3454.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl \
+    && apt-get install -y --no-install-recommends curl libfontconfig1 libfreetype6 \
     && rm -rf /var/lib/apt/lists/* \
     && adduser --disabled-password --gecos '' --uid 1001 apiuser \
     && mkdir -p /app/pdf_uploads


### PR DESCRIPTION
Parte di #3454 (Fase 1). Sblocca la generazione delle cover-da-PDF su staging.

## Problema

L'immagine API di staging (Debian 12 **arm64**) include `libSkiaSharp.so` ma **non** le sue dipendenze runtime `libfontconfig1`/`libfreetype6`, quindi lo static initializer di `SKObject` lancia a ogni estrazione cover-da-PDF:
`The type initializer for 'SkiaSharp.SKObject' threw an exception.`

Evidenza staging (`meepleai_staging`): 135 `pdf_documents`, **0 Generated** — 99 Failed con l'errore SkiaSharp, 8 "PDF binary not found", 28 Skipped (euristica). Diagnostica read-only nel container `meepleai-api`: `libfontconfig1`/`libfreetype6` assenti (`ldconfig -p` non li trova).

## Fix

Installo `libfontconfig1` + `libfreetype6` nel runtime stage del `Dockerfile` API — le dipendenze native documentate di SkiaSharp su Linux.

## Verifica

- `dotnet build` (pre-push) ✅ — ma **non** esercita il layer Docker.
- ⚠️ **La verifica reale richiede un deploy staging**: il fallimento è runtime arm64-only. Post-deploy: confermare che un `MaterializePdfCover` riesca.

## Follow-up post-deploy (in #3454 Fase 1)

- Reset dei 128 PDF `Failed → Pending` (hanno `cover_generation_attempts=0` → non si auto-riparano) → `BackfillPdfCoversJob` rigenera.
- Investigare gli 8 "PDF binary not found" (record orfani).

Generated with Claude Code