### PR TITLE
fix(session-live): idrata lo storico dispute via REST nel tab Arbitro (#3391)

### DIFF
--- a/apps/api/src/Api/Routing/LiveSessionEndpoints.cs
+++ b/apps/api/src/Api/Routing/LiveSessionEndpoints.cs
@@ -340,6 +340,17 @@ internal static class LiveSessionEndpoints
             .WithSummary("Tally dispute votes")
             .WithDescription("Tallies all cast votes on a dispute and determines the final outcome.");
 
+        group.MapGet("/live-sessions/{sessionId}/disputes", HandleGetSessionDisputes)
+            .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
+            .Produces<GetSessionDisputesResult>(200)
+            .Produces(401)
+            .Produces(403)
+            .Produces(404)
+            .WithTags("LiveSessions")
+            .WithSummary("Get the dispute history for a live session")
+            .WithDescription("Returns all rule disputes recorded in a single live session, ordered by timestamp ascending. Powers the Arbitro tab's REST hydration on reload (#3391).");
+
         group.MapGet("/games/{gameId}/dispute-history", HandleGetDisputeHistory)
             .RequireAuthenticatedUser()
             .Produces<GetGameDisputeHistoryResult>(200)
@@ -884,6 +895,16 @@ internal static class LiveSessionEndpoints
     {
         var result = await mediator.Send(
             new GetGameDisputeHistoryQuery(gameId), cancellationToken).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> HandleGetSessionDisputes(
+        Guid sessionId,
+        [FromServices] IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(
+            new GetSessionDisputesQuery(sessionId), cancellationToken).ConfigureAwait(false);
         return Results.Ok(result);
     }
 

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/GetSessionDisputesEndpointTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/GetSessionDisputesEndpointTests.cs
@@ -1,0 +1,260 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
+using Api.BoundedContexts.GameManagement.Application.Queries.GameNight;
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.GameManagement;
+
+/// <summary>
+/// Integration tests for the per-session dispute-history endpoint:
+///   GET /api/v1/live-sessions/{sessionId}/disputes
+///
+/// Issue #3391 (finding C8): wire the existing (but unwired) GetSessionDisputesQuery so the
+/// Arbitro tab can hydrate its dispute history on reload (REST), not only via SignalR.
+///
+/// Scope decision: per-session (not the pre-existing per-game /games/{gameId}/dispute-history),
+/// because the Arbitro tab is scoped to a single live session and cross-session history is a
+/// separate future concern (DisputeHistory.gameId prop is "reserved for future").
+///
+/// Test strategy mirrors LiveSessionDiaryEndpointTests:
+/// - IntegrationWebApplicationFactory + SharedTestcontainersFixture (isolated DB per class)
+/// - TestSessionHelper for auth (session cookie)
+/// - IMediator to create sessions; DisputesJson seeded directly (same camelCase shape the
+///   LiveGameSessionMapper reads back) to avoid depending on the multi-step Arbitro LLM flow.
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "3391")]
+public sealed class GetSessionDisputesEndpointTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _databaseName = $"session_disputes_{Guid.NewGuid():N}";
+    private WebApplicationFactory<Program> _factory = null!;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    // Mirrors the mapper's write options so the seeded DisputesJson round-trips through ToDomain.
+    private static readonly JsonSerializerOptions CamelCaseOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    public GetSessionDisputesEndpointTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        await TestcontainersWaitHelpers.WaitForPostgresReadyAsync(connectionString);
+
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        await db.Database.MigrateAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_factory != null)
+            await _factory.DisposeAsync();
+
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Scenario 1: participant GET on a session with disputes → 200 + ordered list
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "GET disputes returns the session's persisted disputes ordered by timestamp asc")]
+    public async Task Get_SessionWithDisputes_ReturnsOrderedList()
+    {
+        // Arrange — create session, seed two disputes out of chronological order
+        var (client, sessionId) = await CreateSessionWithClientAsync();
+
+        var older = new RuleDisputeEntry(
+            Guid.NewGuid(), "Can I play two cards?", "No — one card per turn.",
+            new List<string> { "p.12" }, "Alice", DateTime.UtcNow.AddMinutes(-10));
+        var newer = new RuleDisputeEntry(
+            Guid.NewGuid(), "Does a tie break by score?", "Yes — highest score wins ties.",
+            new List<string> { "p.4", "p.5" }, "Bob", DateTime.UtcNow.AddMinutes(-2));
+
+        // Seed newest-first to prove the handler orders ascending.
+        await SeedDisputesAsync(sessionId, newer, older);
+
+        // Act
+        var getRequest = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/live-sessions/{sessionId}/disputes",
+            GetTokenFromClient(client));
+        var response = await client.SendAsync(getRequest);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<GetSessionDisputesResult>(JsonOptions);
+        result.Should().NotBeNull();
+        result!.SessionId.Should().Be(sessionId);
+        result.Disputes.Should().HaveCount(2);
+        result.Disputes[0].Id.Should().Be(older.Id, "disputes must be ordered by timestamp ascending");
+        result.Disputes[0].RaisedByPlayerName.Should().Be("Alice");
+        result.Disputes[0].Verdict.Should().Be("No — one card per turn.");
+        result.Disputes[0].RuleReferences.Should().ContainSingle().Which.Should().Be("p.12");
+        result.Disputes[1].Id.Should().Be(newer.Id);
+        result.Disputes[1].RuleReferences.Should().BeEquivalentTo(new[] { "p.4", "p.5" });
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Scenario 2: authenticated non-participant → 403 (IDOR guard)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "GET disputes returns 403 when caller is authenticated but not a participant")]
+    public async Task Get_NonParticipant_Returns403()
+    {
+        var (_, sessionId) = await CreateSessionWithClientAsync();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, tokenB) = await TestSessionHelper.CreateUserSessionAsync(db);
+
+        var clientB = _factory.CreateClient();
+        clientB.DefaultRequestHeaders.Add("Cookie", $"{TestSessionHelper.SessionCookieName}={tokenB}");
+
+        var getRequest = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/live-sessions/{sessionId}/disputes",
+            tokenB);
+        var response = await clientB.SendAsync(getRequest);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "an authenticated user who is not a participant must receive 403");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Scenario 3: unauthenticated caller → 401
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "GET disputes returns 401 when caller is not authenticated")]
+    public async Task Get_Unauthenticated_Returns401()
+    {
+        var anonClient = _factory.CreateClient();
+        var sessionId = Guid.NewGuid(); // irrelevant — auth check fires first
+
+        var response = await anonClient.GetAsync($"/api/v1/live-sessions/{sessionId}/disputes");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized,
+            "RequireAuthenticatedUser() must reject unauthenticated callers");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Scenario 4: session with no disputes → 200 + empty list
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "GET disputes on a session with no disputes returns 200 empty list")]
+    public async Task Get_SessionWithNoDisputes_Returns200EmptyList()
+    {
+        var (client, sessionId) = await CreateSessionWithClientAsync();
+
+        var getRequest = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/live-sessions/{sessionId}/disputes",
+            GetTokenFromClient(client));
+        var response = await client.SendAsync(getRequest);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<GetSessionDisputesResult>(JsonOptions);
+        result.Should().NotBeNull();
+        result!.Disputes.Should().BeEmpty("no disputes were raised in this session");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────────────────
+
+    private async Task<(HttpClient Client, Guid SessionId)> CreateSessionWithClientAsync()
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+        var userId = await SeedUserAsync(db);
+        var (_, token) = await TestSessionHelper.CreateUserSessionAsync(db, userId);
+
+        var sessionId = await mediator.Send(new CreateLiveSessionCommand(
+            UserId: userId,
+            GameName: "Dispute Test Game",
+            GameId: null));
+
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("Cookie", $"{TestSessionHelper.SessionCookieName}={token}");
+        client.DefaultRequestHeaders.Add("X-Test-Session-Token", token);
+
+        return (client, sessionId);
+    }
+
+    /// <summary>
+    /// Seeds disputes directly onto the session's DisputesJson column using the same camelCase
+    /// shape the LiveGameSessionMapper writes, so ToDomain reads them back verbatim.
+    /// Uses ExecuteUpdateAsync (a direct SQL UPDATE) to bypass the change tracker and the xmin
+    /// optimistic-concurrency token, and asserts exactly one row was written so a persistence
+    /// failure surfaces here instead of as an empty read downstream.
+    /// </summary>
+    private async Task SeedDisputesAsync(Guid sessionId, params RuleDisputeEntry[] disputes)
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var json = JsonSerializer.Serialize(disputes.ToList(), CamelCaseOptions);
+        var affected = await db.LiveGameSessions
+            .Where(e => e.Id == sessionId)
+            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DisputesJson, json));
+
+        affected.Should().Be(1, "the seed must update exactly the target session's DisputesJson");
+    }
+
+    private static string GetTokenFromClient(HttpClient client)
+    {
+        return client.DefaultRequestHeaders.TryGetValues("X-Test-Session-Token", out var values)
+            ? values.First()
+            : throw new InvalidOperationException("X-Test-Session-Token not set on client");
+    }
+
+    private static async Task<Guid> SeedUserAsync(MeepleAiDbContext db)
+    {
+        var userId = Guid.NewGuid();
+        db.Users.Add(new UserEntity
+        {
+            Id = userId,
+            Email = $"dispute-test-{userId:N}@test.local",
+            DisplayName = "Dispute Test User",
+            PasswordHash = "not-a-real-hash",
+            Role = "user",
+            Tier = "free",
+            Status = "Active",
+            EmailVerified = true,
+            CreatedAt = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync();
+        return userId;
+    }
+}

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
@@ -55,6 +55,19 @@ vi.mock('@/lib/domain-hooks/useSignalrSession', () => ({
   useSignalRSession: (...args: unknown[]) => useSignalRSessionMock(...args),
 }));
 
+// #3391: AgentDisputeTabContent now mounts useLiveSessionDisputes (REST hydration via useQuery).
+// Mock it to a no-op so these tests need neither a QueryClientProvider nor an
+// api.liveSessions.getDisputes mock — REST hydration is covered in
+// AgentDisputeTabContent.hydration.test.tsx.
+vi.mock('@/hooks/queries/useLiveSessionDisputes', () => ({
+  useLiveSessionDisputes: vi.fn(() => ({
+    data: [],
+    isLoading: false,
+    isSuccess: true,
+    isError: false,
+  })),
+}));
+
 // ─── next/navigation mocks ────────────────────────────────────────────────
 
 const searchParamsMap: Record<string, string> = {};

--- a/apps/web/src/components/features/session-live/AgentDisputeTabContent.tsx
+++ b/apps/web/src/components/features/session-live/AgentDisputeTabContent.tsx
@@ -6,16 +6,18 @@
  * Renders the "Arbitro" tab content for the canonical session-live view.
  * Hosts ArbitroModal (open-dispute CTA + form) and DisputeHistory (past verdicts).
  *
- * Dispute hydration: `useSignalRSession` is mounted at the SessionLiveView
- * orchestrator level (NOT here) so the SignalR connection persists across tab
- * changes and populates `useLiveSessionStore.disputes` in real-time.
+ * Dispute hydration (two paths):
+ *   - REST (#3391): `useLiveSessionDisputes` loads the persisted history on mount and syncs it
+ *     into `useLiveSessionStore.disputes`, so the history survives a reload.
+ *   - SignalR: `useSignalRSession` (mounted at the SessionLiveView orchestrator level so the
+ *     connection persists across tab changes) keeps the store live on 'DisputeResolved'.
  *
  * Known limitations:
- *   - No REST hydration on mount: disputes are SignalR-only (lost on reload).
  *   - Dual transport: disputes come via SignalR; rest of live state via SSE.
  *
  * @see ArbitroModal  — self-contained, POSTs to legacy endpoint, owns verdict UX.
  * @see DisputeHistory — reads disputes from useLiveSessionStore.
+ * @see useLiveSessionDisputes — REST hydration on mount (setDisputes).
  * @see useSignalRSession — wired in SessionLiveView, populates store on 'DisputeResolved'.
  */
 
@@ -23,6 +25,7 @@ import type { ReactElement } from 'react';
 
 import { ArbitroModal } from '@/components/session/live/ArbitroModal';
 import { DisputeHistory } from '@/components/session/live/DisputeHistory';
+import { useLiveSessionDisputes } from '@/hooks/queries/useLiveSessionDisputes';
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
@@ -39,6 +42,9 @@ export function AgentDisputeTabContent({
   sessionId,
   players,
 }: AgentDisputeTabContentProps): ReactElement {
+  // #3391: hydrate the persisted dispute history from REST on mount (survives reload).
+  useLiveSessionDisputes(sessionId);
+
   return (
     <div data-slot="agent-dispute-tab-content" className="flex flex-col gap-4 p-3">
       {/* Open-dispute CTA — ArbitroModal self-manages open/close state.

--- a/apps/web/src/components/features/session-live/__tests__/AgentDisputeTabContent.hydration.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/AgentDisputeTabContent.hydration.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * AgentDisputeTabContent — REST hydration tests (#3391, finding C8)
+ *
+ * The Arbitro tab previously read disputes ONLY from SignalR-populated store state, so on a
+ * page reload the dispute history was empty until a new SignalR event arrived. These tests
+ * exercise the real pipeline (REST client → hydration hook → live-session store → DisputeHistory)
+ * to prove the history is restored on mount.
+ *
+ * Unlike AgentDisputeTabContent.test.tsx, this file uses the REAL store (not a mock) so the
+ * hydration effect's setDisputes call is observable through the rendered DisputeHistory.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AgentDisputeTabContent } from '../AgentDisputeTabContent';
+
+import { useLiveSessionStore } from '@/lib/stores/live-session-store';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const getDisputesMock = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    liveSessions: {
+      submitDispute: vi.fn(),
+      getDisputes: (sessionId: string) => getDisputesMock(sessionId),
+    },
+  },
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const PLAYERS = [
+  { id: 'p1', name: 'Marco' },
+  { id: 'p2', name: 'Anna' },
+];
+
+function renderContent(sessionId = 'sess-001'): ReturnType<typeof render> {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const ui: ReactElement = (
+    <QueryClientProvider client={queryClient}>
+      <AgentDisputeTabContent sessionId={sessionId} players={PLAYERS} />
+    </QueryClientProvider>
+  );
+  return render(ui);
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('AgentDisputeTabContent — REST hydration on reload (#3391)', () => {
+  beforeEach(() => {
+    useLiveSessionStore.getState().reset();
+    getDisputesMock.mockReset();
+    getDisputesMock.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    useLiveSessionStore.getState().reset();
+  });
+
+  it('hydrates the dispute history from REST on mount (store starts empty, as after reload)', async () => {
+    getDisputesMock.mockResolvedValue([
+      {
+        id: 'd1',
+        description: 'Può giocare questa carta?',
+        verdict: 'No, non può.',
+        ruleReferences: ['Rule 5.3'],
+        raisedByPlayerName: 'Marco',
+        timestamp: '2026-06-30T10:00:00Z',
+      },
+    ]);
+
+    renderContent('sess-001');
+
+    // DisputeHistory renders the collapsed toggle only when disputes exist → proves the store
+    // was hydrated from the REST snapshot after mount (it started empty).
+    expect(
+      await screen.findByRole('button', { name: /Verdetti precedenti \(1\)/i })
+    ).toBeInTheDocument();
+
+    expect(getDisputesMock).toHaveBeenCalledWith('sess-001');
+  });
+
+  it('shows no history when the session has no persisted disputes', async () => {
+    getDisputesMock.mockResolvedValue([]);
+
+    renderContent('sess-002');
+
+    // Give the query a chance to resolve, then assert the toggle never appears.
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    await screen.findByRole('button', { name: /Arbitro/i }); // tab is rendered
+    expect(screen.queryByRole('button', { name: /Verdetti precedenti/i })).not.toBeInTheDocument();
+  });
+
+  // Regression guard for the review finding: on a remount served by a stale/empty REST cache,
+  // hydration must NOT drop a dispute already appended live via SignalR (store singleton).
+  it('preserves a live SignalR-appended dispute when hydrating a REST snapshot that lacks it', async () => {
+    // A dispute already in the store (as if addDispute fired from a SignalR 'DisputeResolved').
+    useLiveSessionStore.getState().addDispute({
+      id: 'live-1',
+      description: 'Live dispute via SignalR',
+      verdict: 'Sì.',
+      ruleReferences: [],
+      raisedByPlayerName: 'Alice',
+      timestamp: '2026-06-30T12:05:00Z',
+    });
+    // REST snapshot with a DIFFERENT persisted dispute but NOT the live one (e.g. a cache
+    // predating the SignalR append). A blind replace would drop 'live-1'; a merge keeps both.
+    // Returning a distinct id makes the clobber observable stably (waiting on 'rest-1' proves
+    // hydration applied before we assert 'live-1' survived).
+    getDisputesMock.mockResolvedValue([
+      {
+        id: 'rest-1',
+        description: 'Persisted dispute',
+        verdict: 'No.',
+        ruleReferences: ['p.1'],
+        raisedByPlayerName: 'Bob',
+        timestamp: '2026-06-30T12:00:00Z',
+      },
+    ]);
+
+    renderContent('sess-003');
+
+    // Wait until hydration has applied the REST snapshot...
+    await waitFor(() =>
+      expect(useLiveSessionStore.getState().disputes.map((d) => d.id)).toContain('rest-1')
+    );
+    // ...then the live SignalR dispute must still be present (merge, not blind replace).
+    expect(useLiveSessionStore.getState().disputes.map((d) => d.id)).toContain('live-1');
+  });
+});

--- a/apps/web/src/components/features/session-live/__tests__/AgentDisputeTabContent.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/AgentDisputeTabContent.test.tsx
@@ -9,6 +9,7 @@
  *   - DisputeHistory shows verdicts from useLiveSessionStore.disputes
  */
 
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -17,11 +18,13 @@ import { AgentDisputeTabContent } from '../AgentDisputeTabContent';
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
-// Mock the api (ArbitroModal calls api.liveSessions.submitDispute)
+// Mock the api. ArbitroModal calls submitDispute; AgentDisputeTabContent now also mounts
+// useLiveSessionDisputes → api.liveSessions.getDisputes (#3391), so it must exist on the mock.
 vi.mock('@/lib/api', () => ({
   api: {
     liveSessions: {
       submitDispute: vi.fn(),
+      getDisputes: vi.fn(() => Promise.resolve([])),
     },
   },
 }));
@@ -36,11 +39,16 @@ let mockDisputes: Array<{
   timestamp: string;
 }> = [];
 
-vi.mock('@/lib/stores/live-session-store', () => ({
-  useLiveSessionStore: (
-    selector: (s: { disputes: typeof mockDisputes; addDispute: () => void }) => unknown
-  ) => selector({ disputes: mockDisputes, addDispute: vi.fn() }),
-}));
+vi.mock('@/lib/stores/live-session-store', () => {
+  const state = () => ({ disputes: mockDisputes, addDispute: vi.fn(), setDisputes: vi.fn() });
+  // useLiveSessionDisputes reads useLiveSessionStore.getState().disputes (merge on hydration),
+  // so the mock must expose getState in addition to the selector-call form.
+  const useLiveSessionStore = Object.assign(
+    (selector: (s: ReturnType<typeof state>) => unknown) => selector(state()),
+    { getState: state }
+  );
+  return { useLiveSessionStore };
+});
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -50,7 +58,12 @@ const PLAYERS = [
 ];
 
 function renderContent(sessionId = 'sess-001') {
-  return render(<AgentDisputeTabContent sessionId={sessionId} players={PLAYERS} />);
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AgentDisputeTabContent sessionId={sessionId} players={PLAYERS} />
+    </QueryClientProvider>
+  );
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────

--- a/apps/web/src/hooks/queries/useLiveSessionDisputes.ts
+++ b/apps/web/src/hooks/queries/useLiveSessionDisputes.ts
@@ -1,0 +1,64 @@
+/**
+ * useLiveSessionDisputes — TanStack Query loader that hydrates the Arbitro tab's dispute history.
+ *
+ * Issue #3391 (finding C8): the dispute history was SignalR-only, so reopening/reloading a session
+ * showed no prior verdicts until a new SignalR event arrived. This hook loads the persisted history
+ * from REST on mount and syncs it into the live-session store (`setDisputes`), the same store slice
+ * that `useSignalRSession` keeps live via `addDispute`. The disputes key nests under
+ * liveSessionKeys.detail(id) so dispute mutations can invalidate it.
+ */
+import { useEffect } from 'react';
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { liveSessionKeys } from '@/hooks/queries/useLiveSession';
+import { api } from '@/lib/api';
+import type { RuleDisputeDto } from '@/lib/api/schemas/improvvisata.schemas';
+import { useLiveSessionStore, type RuleDispute } from '@/lib/stores/live-session-store';
+
+export const liveSessionDisputeKeys = {
+  detail: (id: string) => [...liveSessionKeys.detail(id), 'disputes'] as const,
+};
+
+/** Maps the REST DTO to the store's RuleDispute model. v2 badge fields arrive via SignalR only. */
+function toRuleDispute(dto: RuleDisputeDto): RuleDispute {
+  return {
+    id: dto.id,
+    description: dto.description,
+    verdict: dto.verdict,
+    ruleReferences: dto.ruleReferences,
+    raisedByPlayerName: dto.raisedByPlayerName,
+    timestamp: dto.timestamp,
+  };
+}
+
+export function useLiveSessionDisputes(
+  sessionId: string,
+  enabled: boolean = true
+): UseQueryResult<RuleDisputeDto[], Error> {
+  // Zustand action selector — stable reference across renders, safe as an effect dependency.
+  const setDisputes = useLiveSessionStore(s => s.setDisputes);
+
+  const query = useQuery({
+    queryKey: liveSessionDisputeKeys.detail(sessionId),
+    queryFn: () => api.liveSessions.getDisputes(sessionId),
+    enabled: enabled && !!sessionId,
+    staleTime: 30 * 1000,
+  });
+
+  useEffect(() => {
+    if (!query.data) return;
+    // Merge the authoritative REST snapshot with any live (SignalR-appended) disputes not yet
+    // reflected in it, dedup by id, so a stale-cache remount within staleTime never drops a
+    // dispute newer than the last fetch (#3391 review). On id collision the store entry wins:
+    // it carries the live v2 badge fields (confidence/outcome/votes) the REST summary omits.
+    // `addDispute` remains the live append path; this only reconciles on (re)hydration.
+    const byId = new Map<string, RuleDispute>();
+    for (const d of query.data.map(toRuleDispute)) byId.set(d.id, d);
+    for (const d of useLiveSessionStore.getState().disputes) byId.set(d.id, d);
+    const merged = [...byId.values()].sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+    setDisputes(merged);
+  }, [query.data, setDisputes]);
+
+  return query;
+}

--- a/apps/web/src/lib/api/clients/liveSessionsClient.ts
+++ b/apps/web/src/lib/api/clients/liveSessionsClient.ts
@@ -12,7 +12,9 @@ import { z } from 'zod';
 import {
   RuleDisputeResponseSchema,
   CreatePauseSnapshotResponseSchema,
+  SessionDisputesResultSchema,
   type RuleDisputeResponse,
+  type RuleDisputeDto,
   type CreatePauseSnapshotResponse,
 } from '../schemas/improvvisata.schemas';
 import {
@@ -190,6 +192,12 @@ export interface LiveSessionsClient {
   /** Get all diary entries for the session, ordered by createdAt ascending. */
   getDiary(sessionId: string): Promise<LiveSessionDiaryEntryDto[]>;
 
+  /**
+   * Get all rule disputes for the session, ordered by timestamp ascending (#3391).
+   * Powers the Arbitro tab's REST hydration on reload (SignalR keeps it live thereafter).
+   */
+  getDisputes(sessionId: string): Promise<RuleDisputeDto[]>;
+
   // ========== AI Score Tracking (Issue #121) ==========
 
   /** Parse a natural language message for score data, optionally auto-record */
@@ -344,6 +352,14 @@ export function createLiveSessionsClient({
         `${BASE}/${encodeURIComponent(sessionId)}/diary`
       );
       return z.array(LiveSessionDiaryEntryDtoSchema).parse(response ?? []);
+    },
+
+    async getDisputes(sessionId) {
+      const response = await httpClient.get<unknown>(
+        `${BASE}/${encodeURIComponent(sessionId)}/disputes`
+      );
+      if (!response) return [];
+      return SessionDisputesResultSchema.parse(response).disputes;
     },
 
     async getPlayers(sessionId) {

--- a/apps/web/src/lib/api/schemas/improvvisata.schemas.ts
+++ b/apps/web/src/lib/api/schemas/improvvisata.schemas.ts
@@ -54,6 +54,15 @@ export const GameDisputeHistoryItemSchema = z.object({
 
 export type GameDisputeHistoryItem = z.infer<typeof GameDisputeHistoryItemSchema>;
 
+// Per-session dispute history (#3391): GET /live-sessions/{id}/disputes → GetSessionDisputesResult.
+// Same shape as a single GameDisputeHistoryItem group but scoped to one live session (no startedAt).
+export const SessionDisputesResultSchema = z.object({
+  sessionId: z.string().uuid(),
+  disputes: z.array(RuleDisputeDtoSchema),
+});
+
+export type SessionDisputesResult = z.infer<typeof SessionDisputesResultSchema>;
+
 // ──────────────────────────────────────────────
 // Pause Snapshot
 // ──────────────────────────────────────────────

--- a/apps/web/src/lib/stores/__tests__/live-session-store.test.ts
+++ b/apps/web/src/lib/stores/__tests__/live-session-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, beforeEach } from 'vitest';
 
-import { useLiveSessionStore } from '@/lib/stores/live-session-store';
+import { useLiveSessionStore, type RuleDispute } from '@/lib/stores/live-session-store';
 import type { TurnOrderType } from '@/lib/session-live/turn-state';
 
 describe('useLiveSessionStore — Block A #2389 contract evolution', () => {
@@ -155,5 +155,60 @@ describe('useLiveSessionStore — Block A #2389 contract evolution', () => {
     useLiveSessionStore.getState().setGameState({ round: 5 });
     useLiveSessionStore.getState().reset();
     expect(useLiveSessionStore.getState().gameState).toBeNull();
+  });
+
+  // #3391 (finding C8) — setDisputes bulk-hydration for REST reload of the Arbitro tab
+  it('initial state — disputes is empty', () => {
+    expect(useLiveSessionStore.getState().disputes).toEqual([]);
+  });
+
+  it('setDisputes replaces the dispute list (bulk hydration on reload)', () => {
+    // A stale SignalR-appended dispute should be replaced by the authoritative REST snapshot.
+    useLiveSessionStore.getState().addDispute({
+      id: 'stale',
+      description: 'stale',
+      verdict: 'x',
+      ruleReferences: [],
+      raisedByPlayerName: 'X',
+      timestamp: '2020-01-01T00:00:00Z',
+    });
+
+    const hydrated: RuleDispute[] = [
+      {
+        id: 'd1',
+        description: 'Can I play two cards?',
+        verdict: 'No — one per turn.',
+        ruleReferences: ['p.12'],
+        raisedByPlayerName: 'Alice',
+        timestamp: '2026-01-01T00:00:00Z',
+      },
+      {
+        id: 'd2',
+        description: 'Does a tie break by score?',
+        verdict: 'Yes.',
+        ruleReferences: ['p.4', 'p.5'],
+        raisedByPlayerName: 'Bob',
+        timestamp: '2026-01-01T00:05:00Z',
+      },
+    ];
+
+    useLiveSessionStore.getState().setDisputes(hydrated);
+
+    expect(useLiveSessionStore.getState().disputes).toEqual(hydrated);
+  });
+
+  it('reset() clears disputes to an empty list', () => {
+    useLiveSessionStore.getState().setDisputes([
+      {
+        id: 'd1',
+        description: 'x',
+        verdict: 'y',
+        ruleReferences: [],
+        raisedByPlayerName: 'A',
+        timestamp: '2026-01-01T00:00:00Z',
+      },
+    ]);
+    useLiveSessionStore.getState().reset();
+    expect(useLiveSessionStore.getState().disputes).toEqual([]);
   });
 });

--- a/apps/web/src/lib/stores/live-session-store.ts
+++ b/apps/web/src/lib/stores/live-session-store.ts
@@ -100,6 +100,12 @@ interface LiveSessionState {
   addProposal: (proposal: ScoreProposal) => void;
   resolveProposal: (proposalId: string, accepted: boolean) => void;
   addDispute: (dispute: RuleDispute) => void;
+  /**
+   * #3391 (finding C8): bulk-hydrate the dispute list from the REST snapshot on reload.
+   * Replaces (not appends) so the authoritative server history supersedes SignalR-appended
+   * entries when the Arbitro tab remounts. `addDispute` remains the live SignalR append path.
+   */
+  setDisputes: (disputes: RuleDispute[]) => void;
   setConnected: (connected: boolean) => void;
   setOffline: (offline: boolean) => void;
   reset: () => void;
@@ -115,6 +121,7 @@ const initialState: Omit<
   | 'addProposal'
   | 'resolveProposal'
   | 'addDispute'
+  | 'setDisputes'
   | 'setConnected'
   | 'setOffline'
   | 'reset'
@@ -189,6 +196,8 @@ export const useLiveSessionStore = create<LiveSessionState>()(
           false,
           'addDispute'
         ),
+
+      setDisputes: disputes => set({ disputes: [...disputes] }, false, 'setDisputes'),
 
       setConnected: connected => set({ isConnected: connected }, false, 'setConnected'),
 


### PR DESCRIPTION
## Contesto (finding C8, epic #3397)

Il tab **Arbitro** leggeva le dispute solo dallo store popolato via SignalR, quindi al **reload** lo storico spariva finché non arrivava un nuovo evento. Le dispute sono EF-backed (ADR-060), non perse lato server: mancava solo l'idratazione REST.

**Scope: per-sessione** (non il pre-esistente per-game `/games/{gameId}/dispute-history`, che mostrerebbe dispute di *altre* sessioni nel tab di UNA sessione live).

## Modifiche

- **BE**: nuovo endpoint `GET /live-sessions/{sessionId}/disputes` che cabla la query già esistente-ma-orfana `GetSessionDisputesQuery`, con `RequireLiveSessionParticipant` (IDOR-guard). Integration test: partecipante 200+ordinate, non-partecipante 403, anonimo 401, sessione senza dispute 200+vuota.
- **FE**: azione store `setDisputes` (bulk-hydration); hook `useLiveSessionDisputes` (query REST + sync store on mount); client `liveSessions.getDisputes` + schema Zod (riuso `RuleDisputeDtoSchema`); wiring in `AgentDisputeTabContent`. Aggiornato il test consumer + nuovo test di idratazione al reload.

## Fix da review adversariale (#3397)

L'idratazione riconcilia via **merge-by-id** (REST ∪ store live, store-priority sulle collisioni) invece di replace cieco, così un re-mount del tab con cache stale entro `staleTime` **non droppa** le dispute aggiunte via SignalR. Test di regressione dedicato.

## Test
- BE: 4/4 (`GetSessionDisputesEndpointTests`)
- FE: 34/34 (store + component + hydration) · typecheck 0 · lint 0

Closes #3391

🤖 Generated with [Claude Code](https://claude.com/claude-code)