### PR TITLE
fix(shared-games): prefer resolved coverUrl for OG image (#3452)

### DIFF
--- a/apps/web/src/app/(public)/shared-games/[id]/__tests__/page.test.tsx
+++ b/apps/web/src/app/(public)/shared-games/[id]/__tests__/page.test.tsx
@@ -253,6 +253,17 @@ describe('SharedGameDetailPage (Wave A.4 — Issue #616)', () => {
       expect(meta.openGraph?.images).toEqual([{ url: SAMPLE_DETAIL.imageUrl }]);
     });
 
+    it('prefers the resolved coverUrl over the imageUrl tombstone for OG image (#3452)', async () => {
+      const coverUrl = 'https://r2.example.test/covers/33333333/cover.webp';
+      mockGetDetail.mockResolvedValue({ ...SAMPLE_DETAIL, coverUrl, imageUrl: '' });
+
+      const meta = await generateMetadata({
+        params: Promise.resolve({ id: SAMPLE_ID }),
+      });
+
+      expect(meta.openGraph?.images).toEqual([{ url: coverUrl }]);
+    });
+
     it('truncates description to 200 chars', async () => {
       const longDescription = 'x'.repeat(300);
       mockGetDetail.mockResolvedValue({ ...SAMPLE_DETAIL, description: longDescription });

--- a/apps/web/src/app/(public)/shared-games/[id]/page.tsx
+++ b/apps/web/src/app/(public)/shared-games/[id]/page.tsx
@@ -129,6 +129,11 @@ export async function generateMetadata({ params }: SharedGameDetailPageProps): P
       ? detail.description.slice(0, 200)
       : SSR_METADATA.descriptionFallback;
 
+  // #3452 — prefer the R2-resolved coverUrl; imageUrl is a #2123 tombstone
+  // (always empty in prod) and is kept only as a defensive fallback.
+  const ogImage =
+    detail?.coverUrl ?? (detail?.imageUrl && detail.imageUrl.length > 0 ? detail.imageUrl : null);
+
   return {
     title: fullTitle,
     description,
@@ -137,8 +142,7 @@ export async function generateMetadata({ params }: SharedGameDetailPageProps): P
       title: fullTitle,
       description,
       type: 'website',
-      images:
-        detail?.imageUrl && detail.imageUrl.length > 0 ? [{ url: detail.imageUrl }] : undefined,
+      images: ogImage ? [{ url: ogImage }] : undefined,
     },
   };
 }


### PR DESCRIPTION
Closes #3452 (follow-up di #3449, stessa root cause).

## Problema

`generateMetadata` del dettaglio pubblico costruiva `openGraph.images` dal campo legacy `imageUrl` (tombstone #2123, sempre vuoto in prod) → **l'immagine OpenGraph era sempre omessa**, anche con una cover R2 risolta. Le anteprime social dei giochi condivisi non mostravano mai la copertina.

## Fix (FE-only)

`page.tsx` `generateMetadata`: nuovo `ogImage = detail?.coverUrl ?? (imageUrl se non vuoto)` usato in `openGraph.images`. Preferisce la cover R2 risolta (`coverUrl` è ritornato dal detail DTO e dichiarato su `SharedGameDetailSchema` da #3449); `imageUrl` resta solo come fallback difensivo.

## Verifica

- Test `page.test.tsx`: nuovo caso "prefers resolved coverUrl over imageUrl tombstone" (TDD rosso→verde); i due test OG esistenti restano verdi (fixture senza `coverUrl` → fallback a `imageUrl`). 13/13.
- `pnpm typecheck` + eslint (pre-commit) verdi.

Con questa PR il bug cover è chiuso su tutte le superfici pubbliche (griglia + hero via #3449, OG metadata qui).

Generated with Claude Code