### PR TITLE
fix(rag): profilo retrieval disaccoppiato dal tier in-sessione (#3389)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentCommandHandler.cs
@@ -10,6 +10,7 @@ using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
 using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
 using Api.BoundedContexts.GameManagement.Domain.Repositories;
 using Api.BoundedContexts.GameManagement.Application.Services;
 using Api.BoundedContexts.KnowledgeBase.Domain.Models;
@@ -251,7 +252,11 @@ internal sealed class ChatWithSessionAgentCommandHandler : IStreamingQueryHandle
             thread,
             userTier: null,
             agentLanguage: agentLanguage,
-            cancellationToken).ConfigureAwait(false);
+            cancellationToken,
+            // #3389: explicit LiveSession policy decouples retrieval from tier — the null tier above no
+            // longer silently means "Default profile + enhancements off". Enhancements stay off by policy
+            // (EnhancementsEnabled=false) until a golden eval set exists (#3390).
+            retrievalPolicy: RetrievalPolicy.LiveSession).ConfigureAwait(false);
 
         _logger.LogDebug(
             "Prompt assembled: {EstimatedTokens} tokens, {CitationCount} citations",

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/IRagPromptAssemblyService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/IRagPromptAssemblyService.cs
@@ -27,6 +27,8 @@ internal interface IRagPromptAssemblyService
     /// <param name="ct">Cancellation token</param>
     /// <param name="debugCollector">Optional collector for RAG debug events (null = no debug emission)</param>
     /// <param name="profileOverride">Optional retrieval profile override for debug/admin scenarios (null = use adaptive routing)</param>
+    /// <param name="retrievalPolicy">Optional explicit retrieval policy (base profile + enhancement gating) that
+    /// decouples retrieval from user tier for the in-session live path (#3389); null = legacy tier-gated behaviour.</param>
     /// <returns>Assembled prompt ready for LLM consumption</returns>
     Task<AssembledPrompt> AssemblePromptAsync(
         string agentTypology,
@@ -39,7 +41,8 @@ internal interface IRagPromptAssemblyService
         string agentLanguage,
         CancellationToken ct,
         IRagDebugEventCollector? debugCollector = null,
-        RetrievalProfile? profileOverride = null);
+        RetrievalProfile? profileOverride = null,
+        RetrievalPolicy? retrievalPolicy = null);
 
     /// <summary>
     /// Assembles a complete prompt from a pre-retrieved cross-game chunk list,

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyService.cs
@@ -102,7 +102,8 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
         string agentLanguage,
         CancellationToken ct,
         IRagDebugEventCollector? debugCollector = null,
-        RetrievalProfile? profileOverride = null)
+        RetrievalProfile? profileOverride = null,
+        RetrievalPolicy? retrievalPolicy = null)
     {
         ArgumentNullException.ThrowIfNull(agentTypology);
         ArgumentNullException.ThrowIfNull(gameTitle);
@@ -115,7 +116,7 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
         var hasExpansions = expansionGameIds.Count > 0;
 
         // Step 1: Retrieve RAG context (includes expansion boost), passing pre-resolved expansion IDs
-        var (ragContext, citations) = await RetrieveRagContextAsync(userQuestion, gameId, expansionGameIds, userTier, ct, debugCollector, profileOverride).ConfigureAwait(false);
+        var (ragContext, citations) = await RetrieveRagContextAsync(userQuestion, gameId, expansionGameIds, userTier, ct, debugCollector, profileOverride, retrievalPolicy).ConfigureAwait(false);
 
         // Step 2: Build system prompt (persona + RAG chunks + expansion priority + copyright instruction)
         var hasProtectedCitations = citations.Any(c => c.CopyrightTier == CopyrightTier.Protected);
@@ -165,16 +166,23 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
     private async Task<(string ragContext, List<ChunkCitation> citations)> RetrieveRagContextAsync(
         string userQuestion, Guid gameId, IReadOnlyList<Guid> expansionGameIds, UserTier? userTier, CancellationToken ct,
         IRagDebugEventCollector? debugCollector = null,
-        RetrievalProfile? profileOverride = null)
+        RetrievalProfile? profileOverride = null,
+        RetrievalPolicy? retrievalPolicy = null)
     {
         var citations = new List<ChunkCitation>();
 
         try
         {
             // === ADAPTIVE RAG ===
-            var profile = RetrievalProfile.Default;
+            // #3389: an explicit RetrievalPolicy decouples the base profile AND the enhancement gating
+            // from the user tier. A null policy preserves legacy behaviour (Default profile, enhancements
+            // gated only by tier presence). The in-session live path passes RetrievalPolicy.LiveSession so
+            // a null tier no longer silently means "Default profile + all enhancements off": the profile is
+            // an explicit named choice and enhancements are explicitly gated off (wiring deferred to #3390).
+            var profile = retrievalPolicy?.BaseProfile ?? RetrievalProfile.Default;
+            var enhancementsAllowed = retrievalPolicy?.EnhancementsEnabled ?? true;
             var activeEnhancements = RagEnhancement.None;
-            if (userTier != null)
+            if (enhancementsAllowed && userTier != null)
             {
                 activeEnhancements = await _ragEnhancementService
                     .GetActiveEnhancementsAsync(userTier, ct).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/ValueObjects/RetrievalPolicy.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/ValueObjects/RetrievalPolicy.cs
@@ -1,0 +1,24 @@
+namespace Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+
+/// <summary>
+/// Explicit retrieval capability for a prompt-assembly call (#3389): the base <see cref="RetrievalProfile"/>
+/// plus whether tier-derived RAG enhancements may be activated. Makes the in-session live path's retrieval
+/// an intentional, observable choice instead of a silent side-effect of a null user tier.
+/// </summary>
+/// <param name="BaseProfile">Baseline retrieval depth before adaptive routing / debug overrides.</param>
+/// <param name="EnhancementsEnabled">
+/// When <c>false</c>, tier-derived enhancements (AdaptiveRouting/CRAG/RAPTOR/Fusion/Graph) are NOT activated,
+/// even if a user tier is supplied. The live path uses <c>false</c> until a golden eval set exists (#3390).
+/// </param>
+internal sealed record RetrievalPolicy(RetrievalProfile BaseProfile, bool EnhancementsEnabled)
+{
+    /// <summary>Legacy behaviour: Default profile; enhancements gated only by the presence of a tier.</summary>
+    public static RetrievalPolicy Default => new(RetrievalProfile.Default, EnhancementsEnabled: true);
+
+    /// <summary>
+    /// In-session live chat (#3389): explicit LiveSession profile with enhancements intentionally OFF.
+    /// The live path is the hottest RAG path; enabling enhancements there needs a golden eval set (#3390)
+    /// and CRAG web-fallback disabled on the closed rulebook domain — deferred, not silently dormant.
+    /// </summary>
+    public static RetrievalPolicy LiveSession => new(RetrievalProfile.LiveSession, EnhancementsEnabled: false);
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/ValueObjects/RetrievalProfile.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/ValueObjects/RetrievalProfile.cs
@@ -14,4 +14,15 @@ internal sealed record RetrievalProfile(
 
     /// <summary>Baseline profile matching the original hardcoded constants.</summary>
     public static RetrievalProfile Default => _default;
+
+    private static readonly RetrievalProfile _liveSession = new(TopK: 5, MinScore: 0.55f, FtsTopK: 10, WindowRadius: 1);
+
+    /// <summary>
+    /// Explicit retrieval profile for the in-session live chat path (#3389). Decoupled from user tier:
+    /// a null tier must NOT silently fall back to <see cref="Default"/>. Currently mirrors Default's depth,
+    /// but is a NAMED, intentional choice so the live path's retrieval is observable and any future
+    /// calibration is centralized here rather than being a side-effect of an absent tier. Enhancement
+    /// wiring for the live path is deferred to #3390 (requires a golden eval set + CRAG web-fallback off).
+    /// </summary>
+    public static RetrievalProfile LiveSession => _liveSession;
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatSessionAgentBroadcastTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatSessionAgentBroadcastTests.cs
@@ -424,7 +424,7 @@ public class ChatSessionAgentBroadcastTests
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<GameState?>(),
                 It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<ChatThread?>(),
                 It.IsAny<SharedUserTier?>(), It.IsAny<string>(), It.IsAny<CancellationToken>(),
-                It.IsAny<IRagDebugEventCollector?>(), It.IsAny<RetrievalProfile?>()))
+                It.IsAny<IRagDebugEventCollector?>(), It.IsAny<RetrievalProfile?>(), It.IsAny<RetrievalPolicy?>()))
             .ReturnsAsync(assembled);
 
         // --- Copyright tier resolver → returns resolvedCitations as-is ---

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentMemoryContextTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentMemoryContextTests.cs
@@ -182,7 +182,7 @@ public class ChatWithSessionAgentMemoryContextTests
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<GameState?>(),
                 It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<ChatThread?>(),
                 It.IsAny<SharedUserTier?>(), It.IsAny<string>(), It.IsAny<CancellationToken>(),
-                It.IsAny<IRagDebugEventCollector?>(), It.IsAny<RetrievalProfile?>()))
+                It.IsAny<IRagDebugEventCollector?>(), It.IsAny<RetrievalProfile?>(), It.IsAny<RetrievalPolicy?>()))
             .ReturnsAsync(assembled);
 
         // --- Copyright tier resolver → returns citations as-is (empty) ---

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentMetricsTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentMetricsTests.cs
@@ -71,7 +71,7 @@ public sealed class ChatWithSessionAgentMetricsTests
         var observations = new List<double>();
         using var listener = BuildHistogramListener<double>(FirstTokenLatencyName, observations);
 
-        var handler = BuildHandler(resolvedCitations: new List<ChunkCitation>(), tokenContent: "Hello world");
+        var handler = BuildHandler(resolvedCitations: new List<ChunkCitation>(), ragPromptMock: out _, tokenContent: "Hello world");
         var command = BuildCommand();
 
         // Act — drain to completion
@@ -113,7 +113,7 @@ public sealed class ChatWithSessionAgentMetricsTests
         var observations = new List<long>();
         using var listener = BuildHistogramListener<long>(CitationsPerAnswerName, observations);
 
-        var handler = BuildHandler(resolvedCitations: citations, tokenContent: "Answer with citations");
+        var handler = BuildHandler(resolvedCitations: citations, ragPromptMock: out _, tokenContent: "Answer with citations");
         var command = BuildCommand();
 
         // Act
@@ -137,7 +137,7 @@ public sealed class ChatWithSessionAgentMetricsTests
         var observations = new List<long>();
         using var listener = BuildHistogramListener<long>(CitationsPerAnswerName, observations);
 
-        var handler = BuildHandler(resolvedCitations: new List<ChunkCitation>(), tokenContent: "Grounded but uncited");
+        var handler = BuildHandler(resolvedCitations: new List<ChunkCitation>(), ragPromptMock: out _, tokenContent: "Grounded but uncited");
         var command = BuildCommand();
 
         // Act
@@ -176,7 +176,7 @@ public sealed class ChatWithSessionAgentMetricsTests
                 IsPublic: true),
         };
 
-        var handler = BuildHandler(resolvedCitations: citations, tokenContent: "Answer with citation");
+        var handler = BuildHandler(resolvedCitations: citations, ragPromptMock: out _, tokenContent: "Answer with citation");
         var command = BuildCommand();
 
         // Act
@@ -200,7 +200,7 @@ public sealed class ChatWithSessionAgentMetricsTests
         using var latencyListener = BuildHistogramListener<double>(FirstTokenLatencyName, latencyObs);
         using var citationsListener = BuildHistogramListener<long>(CitationsPerAnswerName, citationsObs);
 
-        var handler = BuildHandler(resolvedCitations: new List<ChunkCitation>(), tokenContent: "Token");
+        var handler = BuildHandler(resolvedCitations: new List<ChunkCitation>(), ragPromptMock: out _, tokenContent: "Token");
         var command = BuildCommand();
 
         // Act
@@ -265,8 +265,37 @@ public sealed class ChatWithSessionAgentMetricsTests
     /// <paramref name="resolvedCitations"/> controls the citation list returned by the
     /// copyright resolver. <paramref name="tokenContent"/> controls what the LLM emits.
     /// </summary>
+    // ──────────────────────────────────────────────────────────────────────────
+    // #3389: live path passes an explicit RetrievalPolicy.LiveSession
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "#3389: in-session live path passes RetrievalPolicy.LiveSession (decoupled from tier, not silent Default)")]
+    public async Task Handle_LivePath_PassesLiveSessionRetrievalPolicy()
+    {
+        // Arrange
+        var handler = BuildHandler(
+            resolvedCitations: new List<ChunkCitation>(),
+            ragPromptMock: out var ragPromptMock,
+            tokenContent: "Answer");
+        var command = BuildCommand();
+
+        // Act — drain to completion
+        await foreach (var _ in handler.Handle(command, CancellationToken.None)) { }
+
+        // Assert — the live path assembled the prompt with the explicit LiveSession policy,
+        // so retrieval is decoupled from tier and never silently falls back to Default (#3389).
+        ragPromptMock.Verify(r => r.AssemblePromptAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<GameState?>(),
+            It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<ChatThread?>(),
+            It.IsAny<SharedUserTier?>(), It.IsAny<string>(), It.IsAny<CancellationToken>(),
+            It.IsAny<IRagDebugEventCollector?>(), It.IsAny<RetrievalProfile?>(),
+            It.Is<RetrievalPolicy?>(p => p == RetrievalPolicy.LiveSession)),
+            Times.Once);
+    }
+
     private static ChatWithSessionAgentCommandHandler BuildHandler(
         IReadOnlyList<ChunkCitation> resolvedCitations,
+        out Mock<IRagPromptAssemblyService> ragPromptMock,
         string tokenContent = "Hello world")
     {
         // --- AgentSession repo ---
@@ -346,8 +375,9 @@ public sealed class ChatWithSessionAgentMetricsTests
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<GameState?>(),
                 It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<ChatThread?>(),
                 It.IsAny<SharedUserTier?>(), It.IsAny<string>(), It.IsAny<CancellationToken>(),
-                It.IsAny<IRagDebugEventCollector?>(), It.IsAny<RetrievalProfile?>()))
+                It.IsAny<IRagDebugEventCollector?>(), It.IsAny<RetrievalProfile?>(), It.IsAny<RetrievalPolicy?>()))
             .ReturnsAsync(assembled);
+        ragPromptMock = ragPromptService;
 
         // --- Copyright tier resolver → pass-through ---
         var tierResolver = new Mock<ICopyrightTierResolver>();

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentPerChunkTimeoutTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentPerChunkTimeoutTests.cs
@@ -388,7 +388,7 @@ public sealed class ChatWithSessionAgentPerChunkTimeoutTests
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<GameState?>(),
                 It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<ChatThread?>(),
                 It.IsAny<SharedUserTier?>(), It.IsAny<string>(), It.IsAny<CancellationToken>(),
-                It.IsAny<IRagDebugEventCollector?>(), It.IsAny<RetrievalProfile?>()))
+                It.IsAny<IRagDebugEventCollector?>(), It.IsAny<RetrievalProfile?>(), It.IsAny<RetrievalPolicy?>()))
             .ReturnsAsync(assembled);
 
         var tierResolver = new Mock<ICopyrightTierResolver>();

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentStreamingSafetyTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentStreamingSafetyTests.cs
@@ -356,7 +356,7 @@ public sealed class ChatWithSessionAgentStreamingSafetyTests
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<GameState?>(),
                 It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<ChatThread?>(),
                 It.IsAny<SharedUserTier?>(), It.IsAny<string>(), It.IsAny<CancellationToken>(),
-                It.IsAny<IRagDebugEventCollector?>(), It.IsAny<RetrievalProfile?>()))
+                It.IsAny<IRagDebugEventCollector?>(), It.IsAny<RetrievalProfile?>(), It.IsAny<RetrievalPolicy?>()))
             .ReturnsAsync(assembled);
 
         var tierResolver = new Mock<ICopyrightTierResolver>();

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Unit/RagPromptAssemblyEnhancementsTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Unit/RagPromptAssemblyEnhancementsTests.cs
@@ -430,5 +430,35 @@ public class RagPromptAssemblyEnhancementsTests
             Times.AtLeastOnce);
     }
 
+    [Fact]
+    public async Task WhenLiveSessionPolicy_SkipsEnhancementsEvenWithTier()
+    {
+        // #3389: the in-session live path is explicitly decoupled from tier. Even with a tier present
+        // (which WOULD activate enhancements), RetrievalPolicy.LiveSession (EnhancementsEnabled=false)
+        // must NOT look up tier-derived enhancements — gating is an explicit capability, not a
+        // side-effect of the tier being null/non-null.
+        var tier = UserTier.Premium;
+        _ragEnhancementMock
+            .Setup(r => r.GetActiveEnhancementsAsync(tier, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RagEnhancement.AdaptiveRouting);
+        SetupTextSearchResults(CreateChunk("doc1", 0, 0.90f, "Pawns move forward."));
+        SetupRerankerPassthrough();
+        var service = CreateService();
+
+        // Act — explicit LiveSession policy alongside a tier that WOULD otherwise enable enhancements
+        await service.AssemblePromptAsync(
+            "tutor", "Chess", null, "How do pawns move?",
+            TestGameId, null, tier, "it", CancellationToken.None,
+            retrievalPolicy: RetrievalPolicy.LiveSession);
+
+        // Assert — enhancements gated off explicitly: no tier lookup, no adaptive routing
+        _ragEnhancementMock.Verify(
+            r => r.GetActiveEnhancementsAsync(It.IsAny<UserTier>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _complexityClassifierMock.Verify(
+            c => c.ClassifyAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
     #endregion
 }


### PR DESCRIPTION
## Contesto (finding, epic #3397)

Il path chat **live** (`ChatWithSessionAgentCommandHandler`) chiamava `AssemblePromptAsync` con `userTier: null`; poiché profilo + enhancement erano gated su `userTier != null`, girava **sempre** sul profilo `Default` con tutti gli enhancement spenti — un **side-effect silenzioso** dell'assenza di tier, non una scelta esplicita.

## Modifiche
- **`RetrievalPolicy`** (VO): `BaseProfile` + `EnhancementsEnabled`, come capability esplicita. Aggiunto **`RetrievalProfile.LiveSession`** nominato.
- **`RagPromptAssemblyService`**: profilo base e gating enhancement derivano dalla policy esplicita (`null` = comportamento legacy tier-gated). Il path live passa `RetrievalPolicy.LiveSession` → un tier null non significa più silenziosamente "Default + tutto spento".
- **Enhancement per il live**: OFF per scelta (`EnhancementsEnabled=false`), documentato; cablaggio (con eval-set golden + CRAG web-fallback off) **deferito a #3390**.

## DoD
- [x] Il path in-sessione risolve un profilo **esplicito** (non `Default` per `null`).
- [x] Gating enhancement = **capability-flag esplicito**, non side-effect del tier.
- [x] Decisione sugli enhancement dormienti documentata (**marcati inattivi**, cablaggio → #3390).
- [x] Test che il path live non ricade silenziosamente su `Default` (`WhenLiveSessionPolicy` + wiring handler).

## Test
Unit: servizio 8/8 (`RagPromptAssemblyEnhancementsTests`) + handler 43/43 (`ChatWithSessionAgent*`, incluso il nuovo wiring test). Aggiornati i mock Moq dei 5 handler test per il nuovo parametro opzionale.

Closes #3389

🤖 Generated with [Claude Code](https://claude.com/claude-code)