### PR TITLE
release: promote main-dev -> main-staging (cover fixes #3449/#3452/#3457 + RAG image-table grounding + session-live)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,6 +289,8 @@ tests/                    # Api.Tests, k6, api-smoke, llm-eval, fixtures — see
 
 **Live-session scoring** (epic #2354): polymorphic ScoreType (Points/BinaryWin/Objectives/Ranking) is the current pattern; write scores via `useUpdateSessionScores`, never the store directly (ESLint `local/no-store-scores-direct` = **error**). Shipped-implementation diaries (Asse A–D, Session-live G1/G5a): [claude-md-history.md](./docs/for-claude/claude-md-history.md#gamenight--session-asse-ad--shipped-implementation-diaries).
 
+**🔴 SSOT sessione + scoring** ([ADR-089](./docs/for-claude/architecture/adr/adr-089-session-scoring-ssot.md), #3395): tre aggregati (`GameSession` = lifecycle/quota/history · `LiveGameSession` = runtime in-play + **scoring in-play SSOT** round-based · `SessionTracking.Session` = companion chat/note/media). I link `TrackingSessionId`/`CorrelatedGameSessionId` (Saga, ADR-083) portano **solo id** per lifecycle/quota/companion — **NON** sincronizzano lo scoring: `RoundScores` ↔ `ScoreData`/`ScoreEntry` non si parlano e non vanno ponticellati. Scegli l'SSOT per contesto, non riconciliare i modelli.
+
 ### Known Pitfalls (Issues)
 
 | Issue | Rule |

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/SeedPdfImageRegionsCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/SeedPdfImageRegionsCommand.cs
@@ -1,0 +1,10 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Commands;
+
+/// <summary>
+/// #3447 slice: seed image-table regions for a PDF from a raw Unstructured hi_res JSON.
+/// Idempotent (replace-by-pdf). Invoked by an admin endpoint; the productionized async trigger
+/// that runs hi_res on its own is the full feature (deferred, #3435). Returns the count inserted.
+/// </summary>
+internal sealed record SeedPdfImageRegionsCommand(Guid PdfId, string HiResJson) : ICommand<int>;

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/SeedPdfImageRegionsCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/SeedPdfImageRegionsCommandHandler.cs
@@ -1,0 +1,65 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Commands;
+
+internal class SeedPdfImageRegionsCommandHandler : ICommandHandler<SeedPdfImageRegionsCommand, int>
+{
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<SeedPdfImageRegionsCommandHandler> _logger;
+
+    public SeedPdfImageRegionsCommandHandler(
+        MeepleAiDbContext dbContext,
+        ILogger<SeedPdfImageRegionsCommandHandler> logger)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<int> Handle(SeedPdfImageRegionsCommand command, CancellationToken cancellationToken)
+    {
+        // Guard the FK: seeding regions for a non-existent PDF would violate
+        // FK_pdf_image_regions_pdf_documents on SaveChanges → 500. Fail with a clean 404 instead
+        // (repo convention #2568 — NotFoundException for missing entities, never InvalidOperation/500).
+        var pdfExists = await _dbContext.PdfDocuments
+            .AnyAsync(p => p.Id == command.PdfId, cancellationToken)
+            .ConfigureAwait(false);
+        if (!pdfExists)
+        {
+            throw new NotFoundException("PdfDocument", command.PdfId.ToString());
+        }
+
+        var regions = ImageRegionExtractor.FromHiResJson(command.HiResJson);
+
+        var existing = await _dbContext.PdfImageRegions
+            .Where(r => r.PdfDocumentId == command.PdfId)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+        if (existing.Count > 0)
+        {
+            _dbContext.PdfImageRegions.RemoveRange(existing);
+        }
+
+        foreach (var r in regions)
+        {
+            _dbContext.PdfImageRegions.Add(new PdfImageRegionEntity
+            {
+                PdfDocumentId = command.PdfId,
+                PageNumber = r.Page,
+                X = r.X,
+                Y = r.Y,
+                Width = r.Width,
+                Height = r.Height,
+                ElementType = r.ElementType
+            });
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        _logger.LogInformation("Seeded {Count} image regions for PDF {PdfId}", regions.Count, command.PdfId);
+        return regions.Count;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetPdfImageRegionsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetPdfImageRegionsQuery.cs
@@ -1,0 +1,13 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Queries;
+
+/// <summary>
+/// #3447 slice: returns the persisted hi_res image-table regions for a PDF (for the viewer overlay).
+/// Owner-or-shared-game scoped (mirror <c>GetPdfTextQuery</c> #3222): shared-game PDFs are public,
+/// private PDFs require ownership, admins bypass. Copyright-tier gating remains deferred (slice spec S-4).
+/// </summary>
+internal sealed record GetPdfImageRegionsQuery(Guid PdfId, Guid UserId, bool IsAdmin)
+    : IQuery<IReadOnlyList<ImageRegionDto>>;
+
+internal record ImageRegionDto(int Page, double X, double Y, double Width, double Height, string ElementType);

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetPdfImageRegionsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetPdfImageRegionsQueryHandler.cs
@@ -1,0 +1,52 @@
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Queries;
+
+internal class GetPdfImageRegionsQueryHandler
+    : IQueryHandler<GetPdfImageRegionsQuery, IReadOnlyList<ImageRegionDto>>
+{
+    private readonly MeepleAiDbContext _dbContext;
+
+    public GetPdfImageRegionsQueryHandler(MeepleAiDbContext dbContext)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+    }
+
+    public async Task<IReadOnlyList<ImageRegionDto>> Handle(
+        GetPdfImageRegionsQuery query, CancellationToken cancellationToken)
+    {
+        // Owner-or-shared-game scoping (mirror GetPdfTextQueryHandler #3222): shared-game PDFs are
+        // public (citation viewer); private PDFs require ownership; admins bypass. A missing or
+        // unauthorized PDF returns an empty list — indistinguishable from a region-less PDF, so it
+        // leaks neither existence nor another user's table/figure layout.
+        var pdf = await _dbContext.PdfDocuments
+            .Where(p => p.Id == query.PdfId)
+            .AsNoTracking()
+            .Select(p => new { p.SharedGameId, p.UploadedByUserId })
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (pdf is null)
+        {
+            return Array.Empty<ImageRegionDto>();
+        }
+
+        var isSharedGamePdf = pdf.SharedGameId.HasValue;
+        var isOwner = pdf.UploadedByUserId == query.UserId;
+        if (!query.IsAdmin && !isSharedGamePdf && !isOwner)
+        {
+            return Array.Empty<ImageRegionDto>();
+        }
+
+        var regions = await _dbContext.PdfImageRegions
+            .Where(r => r.PdfDocumentId == query.PdfId)
+            .OrderBy(r => r.PageNumber)
+            .AsNoTracking()
+            .Select(r => new ImageRegionDto(r.PageNumber, r.X, r.Y, r.Width, r.Height, r.ElementType))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+        return regions;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/ImageRegionExtractor.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/ImageRegionExtractor.cs
@@ -1,0 +1,67 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Services;
+
+/// <summary>
+/// Image-table slice (#3447): extracts Image/FigureCaption regions (with bbox) from the raw Unstructured
+/// hi_res response. These are exactly the elements the normal pipeline drops (empty text) in
+/// <c>UnstructuredPdfTextExtractor.MapStructuredElements</c>, so we parse the wire format directly.
+/// Safe on null/empty/invalid input → empty. bbox clamped to [0,1].
+/// </summary>
+public static class ImageRegionExtractor
+{
+    private static readonly HashSet<string> RegionCategories =
+        new(StringComparer.Ordinal) { "Image", "FigureCaption" };
+
+    public static IReadOnlyList<ExtractedImageRegion> FromHiResJson(string? hiResJson)
+    {
+        if (string.IsNullOrWhiteSpace(hiResJson))
+        {
+            return Array.Empty<ExtractedImageRegion>();
+        }
+
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<HiResEnvelope>(hiResJson);
+            if (parsed?.Elements is null)
+            {
+                return Array.Empty<ExtractedImageRegion>();
+            }
+
+            return parsed.Elements
+                .Where(e => e.Category is not null && RegionCategories.Contains(e.Category) && e.Bbox is not null)
+                .Select(e => new ExtractedImageRegion(
+                    Page: e.PageNumber > 0 ? e.PageNumber : 1,
+                    X: Clamp01(e.Bbox!.X),
+                    Y: Clamp01(e.Bbox!.Y),
+                    Width: Clamp01(e.Bbox!.Width),
+                    Height: Clamp01(e.Bbox!.Height),
+                    ElementType: e.Category!))
+                .ToList();
+        }
+        catch (JsonException)
+        {
+            return Array.Empty<ExtractedImageRegion>();
+        }
+    }
+
+    private static double Clamp01(double v) => Math.Clamp(v, 0.0, 1.0);
+
+    private sealed record HiResEnvelope(
+        [property: JsonPropertyName("elements")] List<HiResElement>? Elements);
+
+    private sealed record HiResElement(
+        [property: JsonPropertyName("page_number")] int PageNumber,
+        [property: JsonPropertyName("category")] string? Category,
+        [property: JsonPropertyName("bbox")] HiResBbox? Bbox);
+
+    private sealed record HiResBbox(
+        [property: JsonPropertyName("x")] double X,
+        [property: JsonPropertyName("y")] double Y,
+        [property: JsonPropertyName("width")] double Width,
+        [property: JsonPropertyName("height")] double Height);
+}
+
+public sealed record ExtractedImageRegion(
+    int Page, double X, double Y, double Width, double Height, string ElementType);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/Session/JoinSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/Session/JoinSessionCommandHandler.cs
@@ -80,14 +80,14 @@ internal sealed class JoinSessionCommandHandler : IRequestHandler<JoinSessionCom
             var user = await _dbContext.Users.FirstOrDefaultAsync(u => u.Id == request.UserId.Value, cancellationToken)
                 .ConfigureAwait(false);
             var displayName = user?.DisplayName ?? user?.Email;
-            participant = SessionParticipant.CreateRegistered(invite.SessionId, request.UserId.Value, ParticipantRole.Player, displayName);
+            participant = SessionParticipant.CreateRegistered(invite.SessionId, request.UserId.Value, SessionParticipantRole.Player, displayName);
         }
         else
         {
             if (string.IsNullOrWhiteSpace(request.GuestName))
                 throw new SharedKernel.Domain.Exceptions.ValidationException("GuestName", "Guest name is required for anonymous join");
 
-            participant = SessionParticipant.CreateGuest(invite.SessionId, request.GuestName, ParticipantRole.Player);
+            participant = SessionParticipant.CreateGuest(invite.SessionId, request.GuestName, SessionParticipantRole.Player);
         }
 
         _dbContext.SessionParticipants.Add(new SessionParticipantEntity

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/SessionParticipant.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/SessionParticipant.cs
@@ -12,7 +12,7 @@ public class SessionParticipant
     public Guid SessionId { get; private set; }
     public Guid? UserId { get; private set; }
     public string? GuestName { get; private set; }
-    public ParticipantRole Role { get; private set; }
+    public SessionParticipantRole Role { get; private set; }
     public bool AgentAccessEnabled { get; private set; }
     public string ConnectionToken { get; private set; } = null!;
     public DateTime JoinedAt { get; private set; }
@@ -28,7 +28,7 @@ public class SessionParticipant
     /// <summary>
     /// Creates a guest participant (no registered user account).
     /// </summary>
-    public static SessionParticipant CreateGuest(Guid sessionId, string guestName, ParticipantRole role)
+    public static SessionParticipant CreateGuest(Guid sessionId, string guestName, SessionParticipantRole role)
     {
         if (string.IsNullOrWhiteSpace(guestName))
             throw new ArgumentException("Guest name is required", nameof(guestName));
@@ -49,7 +49,7 @@ public class SessionParticipant
     /// Creates a registered user participant.
     /// Hosts automatically get agent access enabled.
     /// </summary>
-    public static SessionParticipant CreateRegistered(Guid sessionId, Guid userId, ParticipantRole role, string? displayName = null)
+    public static SessionParticipant CreateRegistered(Guid sessionId, Guid userId, SessionParticipantRole role, string? displayName = null)
     {
         return new SessionParticipant
         {
@@ -58,7 +58,7 @@ public class SessionParticipant
             UserId = userId,
             RegisteredDisplayName = displayName,
             Role = role,
-            AgentAccessEnabled = role == ParticipantRole.Host,
+            AgentAccessEnabled = role == SessionParticipantRole.Host,
             ConnectionToken = GeneratePin(),
             JoinedAt = DateTime.UtcNow
         };

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/ValueObjects/ParticipantRole.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/ValueObjects/ParticipantRole.cs
@@ -1,6 +1,0 @@
-namespace Api.BoundedContexts.GameManagement.Domain.Entities;
-
-/// <summary>
-/// Defines the role of a participant in a live game session.
-/// </summary>
-public enum ParticipantRole { Host, Player, Spectator }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/ValueObjects/SessionParticipantRole.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/ValueObjects/SessionParticipantRole.cs
@@ -1,0 +1,17 @@
+namespace Api.BoundedContexts.GameManagement.Domain.Entities;
+
+/// <summary>
+/// Defines the role of a <see cref="SessionParticipant"/> in a live game session
+/// (invite/join flow in the GameManagement bounded context).
+///
+/// <para>Renamed from the former <c>ParticipantRole</c> (issue #3392) to eliminate the
+/// name collision with <see cref="Api.BoundedContexts.SessionTracking.Domain.Enums.ParticipantRole"/>,
+/// which has the SAME member names but the OPPOSITE numeric ordering
+/// (SessionTracking: Spectator=0, Player=1, Host=2). The colliding name was a real vector
+/// for an incorrect <c>using</c> import mixing the two contracts.</para>
+///
+/// <para>These values are persisted BY NAME (string), so the rename does not affect stored
+/// data. The numeric ordering here is NOT used for ordinal comparisons — this enum is only
+/// ever compared with equality.</para>
+/// </summary>
+public enum SessionParticipantRole { Host, Player, Spectator }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentCommandHandler.cs
@@ -716,7 +716,8 @@ internal sealed class ChatWithSessionAgentCommandHandler : IStreamingQueryHandle
                 totalTokens: totalTokens,
                 confidence: RagPromptAssemblyService.ComputeConfidence(assembled.Citations, responseText),
                 chatThreadId: thread.Id,
-                Citations: citationDtos));
+                Citations: citationDtos,
+                GroundingStatus: citationDtos.Count > 0 ? "Grounded" : "Ungrounded"));
     }
 
     private async Task GenerateConversationSummaryAsync(Guid threadId)

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentCommandHandler.cs
@@ -10,6 +10,7 @@ using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
 using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
 using Api.BoundedContexts.GameManagement.Domain.Repositories;
 using Api.BoundedContexts.GameManagement.Application.Services;
 using Api.BoundedContexts.KnowledgeBase.Domain.Models;
@@ -251,7 +252,11 @@ internal sealed class ChatWithSessionAgentCommandHandler : IStreamingQueryHandle
             thread,
             userTier: null,
             agentLanguage: agentLanguage,
-            cancellationToken).ConfigureAwait(false);
+            cancellationToken,
+            // #3389: explicit LiveSession policy decouples retrieval from tier — the null tier above no
+            // longer silently means "Default profile + enhancements off". Enhancements stay off by policy
+            // (EnhancementsEnabled=false) until a golden eval set exists (#3390).
+            retrievalPolicy: RetrievalPolicy.LiveSession).ConfigureAwait(false);
 
         _logger.LogDebug(
             "Prompt assembled: {EstimatedTokens} tokens, {CitationCount} citations",

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/CrossGameStreamQa/CrossGameStreamQaQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/CrossGameStreamQa/CrossGameStreamQaQueryHandler.cs
@@ -85,7 +85,7 @@ internal sealed class CrossGameStreamQaQueryHandler : IStreamingQueryHandler<Cro
             yield return CreateEvent(StreamingEventType.StateUpdate,
                 new StreamingStateUpdate("Ricerca nella tua libreria..."));
             yield return CreateEvent(StreamingEventType.Complete,
-                new StreamingComplete(0, 0, 0, 0, null));
+                new StreamingComplete(0, 0, 0, 0, null, GroundingStatus: "Ungrounded"));
             yield break;
         }
 
@@ -150,7 +150,8 @@ internal sealed class CrossGameStreamQaQueryHandler : IStreamingQueryHandler<Cro
                 promptTokens: llmUsage?.PromptTokens ?? 0,
                 completionTokens: llmUsage?.CompletionTokens ?? tokenEvents.Count,
                 totalTokens: llmUsage?.TotalTokens ?? tokenEvents.Count,
-                confidence: null));
+                confidence: null,
+                GroundingStatus: snippets.Count > 0 ? "Grounded" : "Ungrounded"));
 
         _logger.LogInformation(
             "[CrossGameAsk] Complete for user {UserId}, tokens: {Tokens}",

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamDebugQaQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamDebugQaQueryHandler.cs
@@ -133,7 +133,8 @@ internal class StreamDebugQaQueryHandler : IStreamingQueryHandler<StreamDebugQaQ
 
             yield return CreateEvent(StreamingEventType.Complete,
                 new StreamingComplete(0, cachedResponse.promptTokens, cachedResponse.completionTokens,
-                    cachedResponse.totalTokens, cachedResponse.confidence));
+                    cachedResponse.totalTokens, cachedResponse.confidence,
+                    GroundingStatus: cachedResponse.snippets.Count > 0 ? "Grounded" : "Ungrounded"));
             yield break;
         }
 
@@ -372,7 +373,8 @@ internal class StreamDebugQaQueryHandler : IStreamingQueryHandler<StreamDebugQaQ
 
         yield return CreateEvent(StreamingEventType.Complete,
             new StreamingComplete(0, llmUsage?.PromptTokens ?? 0, tokenCount,
-                llmUsage?.TotalTokens ?? tokenCount, confidence));
+                llmUsage?.TotalTokens ?? tokenCount, confidence,
+                GroundingStatus: snippets.Count > 0 ? "Grounded" : "Ungrounded"));
 
         // ── Step 13: Validation pipeline (async, best-effort) ────────────
         if (_validationPipelineService != null)

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamExplainQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamExplainQueryHandler.cs
@@ -114,7 +114,8 @@ internal class StreamExplainQueryHandler : IStreamingQueryHandler<StreamExplainQ
         var maxConfidence = searchResults!.Max(r => r.Score);
 
         yield return CreateEvent(StreamingEventType.Complete,
-            new StreamingComplete(estimatedMinutes, 0, 0, 0, maxConfidence));
+            new StreamingComplete(estimatedMinutes, 0, 0, 0, maxConfidence,
+                GroundingStatus: citations.Count > 0 ? "Grounded" : "Ungrounded"));
 
         _logger.LogInformation("Streaming explain completed for game {GameId}, topic: {Topic}",
             query.GameId, query.Topic);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamQaQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamQaQueryHandler.cs
@@ -185,7 +185,8 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
                     cachedResponse.promptTokens,
                     cachedResponse.completionTokens,
                     cachedResponse.totalTokens,
-                    cachedResponse.confidence));
+                    cachedResponse.confidence,
+                    GroundingStatus: cachedResponse.snippets.Count > 0 ? "Grounded" : "Ungrounded"));
 
             yield break;
         }
@@ -311,7 +312,8 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
             tokenCount, cacheKey, llmUsage, llmCost, injectClaims, cancellationToken).ConfigureAwait(false);
 
         yield return CreateEvent(StreamingEventType.Complete,
-            new StreamingComplete(0, 0, tokenCount, tokenCount, overallConfidence.Value));
+            new StreamingComplete(0, 0, tokenCount, tokenCount, overallConfidence.Value,
+                GroundingStatus: allSnippets.Count > 0 ? "Grounded" : "Ungrounded"));
 
         // Emit inline citation matches (over RAG + claim citations, so [Vk] claim markers can match too)
         var inlineCitations = _citationMatcher.Match(answerBuilder.ToString(), allSnippets);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamSetupGuideQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamSetupGuideQueryHandler.cs
@@ -354,13 +354,24 @@ TASK: Generate a step-by-step setup guide for this board game. Focus on the init
             steps.Count, estimatedTime);
 
         // Emit final complete event
+        // #3388: derive grounding status from whether any streamed step actually
+        // carries retrieved rulebook references (each StreamingSetupStep embeds its
+        // own `references`, so this reflects what the caller receives even though no
+        // separate StreamingCitations event is emitted). Mirrors the sibling handlers'
+        // `snippets.Count > 0 ? "Grounded" : "Ungrounded"` pattern (StreamQaQueryHandler,
+        // StreamExplainQueryHandler, ChatWithSessionAgentCommandHandler). Default/fallback
+        // steps always carry empty reference lists (CreateDefaultSetupStepsStatic), so
+        // that path stays Ungrounded.
+        var hasGroundedReferences = steps.Any(s => s.references.Count > 0);
+
         yield return CreateEvent(StreamingEventType.Complete,
             new StreamingComplete(
                 estimatedTime,
                 promptTokens,
                 completionTokens,
                 totalTokens,
-                confidence));
+                confidence,
+                GroundingStatus: hasGroundedReferences ? "Grounded" : "Ungrounded"));
     }
     /// <summary>
     /// Parse LLM-generated steps response into structured SetupGuideStep objects

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/IRagPromptAssemblyService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/IRagPromptAssemblyService.cs
@@ -27,6 +27,8 @@ internal interface IRagPromptAssemblyService
     /// <param name="ct">Cancellation token</param>
     /// <param name="debugCollector">Optional collector for RAG debug events (null = no debug emission)</param>
     /// <param name="profileOverride">Optional retrieval profile override for debug/admin scenarios (null = use adaptive routing)</param>
+    /// <param name="retrievalPolicy">Optional explicit retrieval policy (base profile + enhancement gating) that
+    /// decouples retrieval from user tier for the in-session live path (#3389); null = legacy tier-gated behaviour.</param>
     /// <returns>Assembled prompt ready for LLM consumption</returns>
     Task<AssembledPrompt> AssemblePromptAsync(
         string agentTypology,
@@ -39,7 +41,8 @@ internal interface IRagPromptAssemblyService
         string agentLanguage,
         CancellationToken ct,
         IRagDebugEventCollector? debugCollector = null,
-        RetrievalProfile? profileOverride = null);
+        RetrievalProfile? profileOverride = null,
+        RetrievalPolicy? retrievalPolicy = null);
 
     /// <summary>
     /// Assembles a complete prompt from a pre-retrieved cross-game chunk list,

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyService.cs
@@ -102,7 +102,8 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
         string agentLanguage,
         CancellationToken ct,
         IRagDebugEventCollector? debugCollector = null,
-        RetrievalProfile? profileOverride = null)
+        RetrievalProfile? profileOverride = null,
+        RetrievalPolicy? retrievalPolicy = null)
     {
         ArgumentNullException.ThrowIfNull(agentTypology);
         ArgumentNullException.ThrowIfNull(gameTitle);
@@ -115,7 +116,7 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
         var hasExpansions = expansionGameIds.Count > 0;
 
         // Step 1: Retrieve RAG context (includes expansion boost), passing pre-resolved expansion IDs
-        var (ragContext, citations) = await RetrieveRagContextAsync(userQuestion, gameId, expansionGameIds, userTier, ct, debugCollector, profileOverride).ConfigureAwait(false);
+        var (ragContext, citations) = await RetrieveRagContextAsync(userQuestion, gameId, expansionGameIds, userTier, ct, debugCollector, profileOverride, retrievalPolicy).ConfigureAwait(false);
 
         // Step 2: Build system prompt (persona + RAG chunks + expansion priority + copyright instruction)
         var hasProtectedCitations = citations.Any(c => c.CopyrightTier == CopyrightTier.Protected);
@@ -165,16 +166,23 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
     private async Task<(string ragContext, List<ChunkCitation> citations)> RetrieveRagContextAsync(
         string userQuestion, Guid gameId, IReadOnlyList<Guid> expansionGameIds, UserTier? userTier, CancellationToken ct,
         IRagDebugEventCollector? debugCollector = null,
-        RetrievalProfile? profileOverride = null)
+        RetrievalProfile? profileOverride = null,
+        RetrievalPolicy? retrievalPolicy = null)
     {
         var citations = new List<ChunkCitation>();
 
         try
         {
             // === ADAPTIVE RAG ===
-            var profile = RetrievalProfile.Default;
+            // #3389: an explicit RetrievalPolicy decouples the base profile AND the enhancement gating
+            // from the user tier. A null policy preserves legacy behaviour (Default profile, enhancements
+            // gated only by tier presence). The in-session live path passes RetrievalPolicy.LiveSession so
+            // a null tier no longer silently means "Default profile + all enhancements off": the profile is
+            // an explicit named choice and enhancements are explicitly gated off (wiring deferred to #3390).
+            var profile = retrievalPolicy?.BaseProfile ?? RetrievalProfile.Default;
+            var enhancementsAllowed = retrievalPolicy?.EnhancementsEnabled ?? true;
             var activeEnhancements = RagEnhancement.None;
-            if (userTier != null)
+            if (enhancementsAllowed && userTier != null)
             {
                 activeEnhancements = await _ragEnhancementService
                     .GetActiveEnhancementsAsync(userTier, ct).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/ValueObjects/RetrievalPolicy.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/ValueObjects/RetrievalPolicy.cs
@@ -1,0 +1,24 @@
+namespace Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+
+/// <summary>
+/// Explicit retrieval capability for a prompt-assembly call (#3389): the base <see cref="RetrievalProfile"/>
+/// plus whether tier-derived RAG enhancements may be activated. Makes the in-session live path's retrieval
+/// an intentional, observable choice instead of a silent side-effect of a null user tier.
+/// </summary>
+/// <param name="BaseProfile">Baseline retrieval depth before adaptive routing / debug overrides.</param>
+/// <param name="EnhancementsEnabled">
+/// When <c>false</c>, tier-derived enhancements (AdaptiveRouting/CRAG/RAPTOR/Fusion/Graph) are NOT activated,
+/// even if a user tier is supplied. The live path uses <c>false</c> until a golden eval set exists (#3390).
+/// </param>
+internal sealed record RetrievalPolicy(RetrievalProfile BaseProfile, bool EnhancementsEnabled)
+{
+    /// <summary>Legacy behaviour: Default profile; enhancements gated only by the presence of a tier.</summary>
+    public static RetrievalPolicy Default => new(RetrievalProfile.Default, EnhancementsEnabled: true);
+
+    /// <summary>
+    /// In-session live chat (#3389): explicit LiveSession profile with enhancements intentionally OFF.
+    /// The live path is the hottest RAG path; enabling enhancements there needs a golden eval set (#3390)
+    /// and CRAG web-fallback disabled on the closed rulebook domain — deferred, not silently dormant.
+    /// </summary>
+    public static RetrievalPolicy LiveSession => new(RetrievalProfile.LiveSession, EnhancementsEnabled: false);
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/ValueObjects/RetrievalProfile.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/ValueObjects/RetrievalProfile.cs
@@ -14,4 +14,15 @@ internal sealed record RetrievalProfile(
 
     /// <summary>Baseline profile matching the original hardcoded constants.</summary>
     public static RetrievalProfile Default => _default;
+
+    private static readonly RetrievalProfile _liveSession = new(TopK: 5, MinScore: 0.55f, FtsTopK: 10, WindowRadius: 1);
+
+    /// <summary>
+    /// Explicit retrieval profile for the in-session live chat path (#3389). Decoupled from user tier:
+    /// a null tier must NOT silently fall back to <see cref="Default"/>. Currently mirrors Default's depth,
+    /// but is a NAMED, intentional choice so the live path's retrieval is observable and any future
+    /// calibration is centralized here rather than being a side-effect of an absent tier. Enhancement
+    /// wiring for the live path is deferred to #3390 (requires a golden eval set + CRAG web-fallback off).
+    /// </summary>
+    public static RetrievalProfile LiveSession => _liveSession;
 }

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ChatCommandHandlers.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ChatCommandHandlers.cs
@@ -8,6 +8,7 @@ using Api.Middleware.Exceptions;
 using Api.Services;
 using Api.Services.ImageProcessing;
 using Api.Services.LlmClients;
+using Api.SharedKernel.Domain.Enums;
 using Microsoft.Extensions.Logging;
 
 namespace Api.BoundedContexts.SessionTracking.Application.Commands;
@@ -198,7 +199,7 @@ internal class AskSessionAgentCommandHandler : IRequestHandler<AskSessionAgentCo
                 if (result.Success)
                 {
                     answer = result.Response;
-                    confidence = 0.85f;
+                    confidence = null; // #3388: no fabricated confidence — vision path is not grounded in retrieval
                 }
                 else
                 {
@@ -221,7 +222,7 @@ internal class AskSessionAgentCommandHandler : IRequestHandler<AskSessionAgentCo
                 if (result.Success)
                 {
                     answer = result.Response;
-                    confidence = 0.85f;
+                    confidence = null; // #3388: no fabricated confidence — text-only path is not grounded in retrieval
                 }
                 else
                 {
@@ -263,7 +264,8 @@ internal class AskSessionAgentCommandHandler : IRequestHandler<AskSessionAgentCo
             TurnNumber = request.TurnNumber,
         }, cancellationToken).ConfigureAwait(false);
 
-        return new AskSessionAgentResult(agentMessage.Id, answer, agentType, agentMessage.Confidence, null);
+        // This path never produces citations (no retrieval grounding), so it is always Ungrounded (#3388).
+        return new AskSessionAgentResult(agentMessage.Id, answer, agentType, agentMessage.Confidence, null, GroundingStatus.Ungrounded);
     }
 }
 

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ChatCommands.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ChatCommands.cs
@@ -1,3 +1,4 @@
+using Api.SharedKernel.Domain.Enums;
 using MediatR;
 
 namespace Api.BoundedContexts.SessionTracking.Application.Commands;
@@ -47,7 +48,8 @@ public record AskSessionAgentResult(
     string Answer,
     string AgentType,
     float? Confidence,
-    string? CitationsJson
+    string? CitationsJson,
+    GroundingStatus GroundingStatus
 );
 
 /// <summary>

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Enums/ParticipantRole.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Enums/ParticipantRole.cs
@@ -5,6 +5,15 @@ namespace Api.BoundedContexts.SessionTracking.Domain.Enums;
 /// Determines which actions the participant can perform.
 /// Issue #4765 - Player Action Endpoints + Host Validation
 /// </summary>
+/// <remarks>
+/// LOAD-BEARING NUMERIC ORDERING — DO NOT REORDER (issue #3392).
+/// The values are privilege-ascending (Spectator=0 &lt; Player=1 &lt; Host=2) and are compared
+/// ORDINALLY in <see cref="Api.BoundedContexts.SessionTracking.Application.Behaviors.ValidatePlayerRoleBehavior{TRequest,TResponse}"/>
+/// (<c>participant.Role &lt; request.MinimumRole</c>). Reordering or renumbering these members
+/// would silently invert authorization checks. Note this is the OPPOSITE ordering of the
+/// GameManagement <see cref="Api.BoundedContexts.GameManagement.Domain.Entities.SessionParticipantRole"/>
+/// enum (Host=0), which is only ever compared with equality — the two must never be conflated.
+/// </remarks>
 public enum ParticipantRole
 {
     /// <summary>

--- a/apps/api/src/Api/Dockerfile
+++ b/apps/api/src/Api/Dockerfile
@@ -57,9 +57,16 @@ RUN --mount=type=cache,target=/root/.nuget/packages \
 FROM mcr.microsoft.com/dotnet/aspnet:9.0
 WORKDIR /app
 
-# Install curl for healthcheck, create non-root user, prepare directories — single layer
+# Install curl for healthcheck + SkiaSharp native runtime deps, create non-root
+# user, prepare directories — single layer.
+#
+# libfontconfig1 + libfreetype6: required by SkiaSharp's libSkiaSharp.so on Linux.
+# Without them the `SKObject` static initializer throws
+# "The type initializer for 'SkiaSharp.SKObject' threw an exception", which
+# broke PDF cover generation on staging (Debian 12 arm64 image shipped
+# libSkiaSharp.so but not its fontconfig/freetype deps) — see #3454.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl \
+    && apt-get install -y --no-install-recommends curl libfontconfig1 libfreetype6 \
     && rm -rf /var/lib/apt/lists/* \
     && adduser --disabled-password --gecos '' --uid 1001 apiuser \
     && mkdir -p /app/pdf_uploads

--- a/apps/api/src/Api/Infrastructure/Entities/DocumentProcessing/PdfImageRegionEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/DocumentProcessing/PdfImageRegionEntity.cs
@@ -1,0 +1,19 @@
+namespace Api.Infrastructure.Entities;
+
+/// <summary>
+/// Image-table region (#3447): a hi_res Image/FigureCaption bbox for a PDF page, persisted so the
+/// viewer can highlight table graphics. Normalized [0,1] top-left. See slice spec 2026-08-01.
+/// </summary>
+public class PdfImageRegionEntity
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid PdfDocumentId { get; set; }
+    public PdfDocumentEntity PdfDocument { get; set; } = null!;
+    public int PageNumber { get; set; }
+    public double X { get; set; }
+    public double Y { get; set; }
+    public double Width { get; set; }
+    public double Height { get; set; }
+    public string ElementType { get; set; } = "Image";
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/apps/api/src/Api/Infrastructure/Entities/GameManagement/SessionParticipantEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/GameManagement/SessionParticipantEntity.cs
@@ -17,7 +17,7 @@ public class SessionParticipantEntity
     public string? RegisteredDisplayName { get; set; }
 
     // Role & Access
-    public string Role { get; set; } = default!; // ParticipantRole enum stored as string
+    public string Role { get; set; } = default!; // SessionParticipantRole enum stored as string
     public bool AgentAccessEnabled { get; set; }
     public string ConnectionToken { get; set; } = default!; // 6-char PIN
 

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/DocumentProcessing/PdfImageRegionEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/DocumentProcessing/PdfImageRegionEntityConfiguration.cs
@@ -1,0 +1,25 @@
+using Api.Infrastructure.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.EntityConfigurations;
+
+internal class PdfImageRegionEntityConfiguration : IEntityTypeConfiguration<PdfImageRegionEntity>
+{
+    public void Configure(EntityTypeBuilder<PdfImageRegionEntity> builder)
+    {
+        builder.ToTable("pdf_image_regions");
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.PdfDocumentId).HasColumnName("pdf_document_id");
+        builder.Property(e => e.PageNumber).HasColumnName("page_number");
+        builder.Property(e => e.X).HasColumnName("x");
+        builder.Property(e => e.Y).HasColumnName("y");
+        builder.Property(e => e.Width).HasColumnName("width");
+        builder.Property(e => e.Height).HasColumnName("height");
+        builder.Property(e => e.ElementType).HasColumnName("element_type").HasMaxLength(64).IsRequired();
+        builder.Property(e => e.CreatedAt).HasColumnName("created_at");
+        builder.HasOne(e => e.PdfDocument).WithMany()
+            .HasForeignKey(e => e.PdfDocumentId).OnDelete(DeleteBehavior.Cascade);
+        builder.HasIndex(e => e.PdfDocumentId).HasDatabaseName("ix_pdf_image_regions_pdf_document_id");
+    }
+}

--- a/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+++ b/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
@@ -120,6 +120,7 @@ public class MeepleAiDbContext : DbContext
     public DbSet<ChatThreadEntity> ChatThreads => Set<ChatThreadEntity>(); // DDD-PHASE3: KnowledgeBase ChatThread aggregate
     public DbSet<ChatLogEntity> ChatLogs => Set<ChatLogEntity>();
     public DbSet<PdfDocumentEntity> PdfDocuments => Set<PdfDocumentEntity>();
+    public DbSet<PdfImageRegionEntity> PdfImageRegions => Set<PdfImageRegionEntity>(); // #3447: image-table regions
     public DbSet<ProcessingMetricEntity> ProcessingMetrics => Set<ProcessingMetricEntity>(); // ISSUE-4212: Historical metrics storage
     public DbSet<ProcessingJobEntity> ProcessingJobs => Set<ProcessingJobEntity>(); // ISSUE-4730: Processing queue management
     public DbSet<ProcessingStepEntity> ProcessingSteps => Set<ProcessingStepEntity>(); // ISSUE-4730: Processing queue steps

--- a/apps/api/src/Api/Infrastructure/Migrations/20260801104312_AddPdfImageRegions.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260801104312_AddPdfImageRegions.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260801104312_AddPdfImageRegions")]
+    partial class AddPdfImageRegions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260801104312_AddPdfImageRegions.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260801104312_AddPdfImageRegions.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPdfImageRegions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "pdf_image_regions",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    pdf_document_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    page_number = table.Column<int>(type: "integer", nullable: false),
+                    x = table.Column<double>(type: "double precision", nullable: false),
+                    y = table.Column<double>(type: "double precision", nullable: false),
+                    width = table.Column<double>(type: "double precision", nullable: false),
+                    height = table.Column<double>(type: "double precision", nullable: false),
+                    element_type = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_pdf_image_regions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_pdf_image_regions_pdf_documents_pdf_document_id",
+                        column: x => x.pdf_document_id,
+                        principalTable: "pdf_documents",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_pdf_image_regions_pdf_document_id",
+                table: "pdf_image_regions",
+                column: "pdf_document_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "pdf_image_regions");
+        }
+    }
+}

--- a/apps/api/src/Api/Models/Contracts.cs
+++ b/apps/api/src/Api/Models/Contracts.cs
@@ -155,7 +155,15 @@ internal record StreamingComplete(
     double? routingLatencyMs = null,
     string? strategyTier = null,
     Guid? executionId = null,
-    IReadOnlyList<CitationDto>? Citations = null);
+    IReadOnlyList<CitationDto>? Citations = null,
+    // #3388: grounding-contract invariant. Every producer below explicitly passes this
+    // (derived from its own citation count: Grounded iff count>0, else Ungrounded) rather
+    // than relying on the default — the default only exists because C# requires optional
+    // positional params to trail required ones, and this must stay the LAST param per the
+    // plan. Wire value is the enum NAME string ("Grounded"/"Partial"/"Ungrounded"), NOT the
+    // GroundingStatus enum — SSE serializes C# enums numerically, so a string keeps this
+    // path wire-consistent with the REST path's JsonStringEnumConverter output.
+    string GroundingStatus = "Ungrounded");
 
 internal record CitationDto(
     string DocumentId,

--- a/apps/api/src/Api/Routing/AdminPdfManagementEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminPdfManagementEndpoints.cs
@@ -32,6 +32,11 @@ internal static class AdminPdfManagementEndpoints
             .WithName("ReindexDocument")
             .WithSummary("Reindex a PDF document (delete chunks, reset to Pending)");
 
+        // #3447 slice: seed image-table regions from a raw Unstructured hi_res JSON body
+        group.MapPost("/{pdfId:guid}/seed-image-regions", SeedImageRegions)
+            .WithName("SeedPdfImageRegions")
+            .WithSummary("Seed image-table regions from a raw Unstructured hi_res JSON body (#3447 slice)");
+
         group.MapPost("/maintenance/purge-stale", PurgeStale)
             .WithName("PurgeStaleDocuments")
             .WithSummary("Mark documents stuck in processing (>24h) as failed");
@@ -66,6 +71,18 @@ internal static class AdminPdfManagementEndpoints
             new ReindexDocumentCommand(pdfId, request?.IndexerVersion),
             cancellationToken).ConfigureAwait(false);
         return Results.Ok(new { success = true, message = "Document queued for reindexing" });
+    }
+
+    private static async Task<IResult> SeedImageRegions(
+        Guid pdfId,
+        SeedImageRegionsRequest request,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var count = await mediator.Send(
+            new SeedPdfImageRegionsCommand(pdfId, request.HiResJson),
+            cancellationToken).ConfigureAwait(false);
+        return Results.Ok(new { success = true, seeded = count });
     }
 
     private static async Task<IResult> PurgeStale(
@@ -107,3 +124,4 @@ internal static class AdminPdfManagementEndpoints
 
 internal record BulkDeletePdfsRequest(List<Guid> PdfIds);
 internal record ReindexDocumentRequest(string? IndexerVersion);
+internal record SeedImageRegionsRequest(string HiResJson);

--- a/apps/api/src/Api/Routing/LiveSessionEndpoints.cs
+++ b/apps/api/src/Api/Routing/LiveSessionEndpoints.cs
@@ -340,6 +340,17 @@ internal static class LiveSessionEndpoints
             .WithSummary("Tally dispute votes")
             .WithDescription("Tallies all cast votes on a dispute and determines the final outcome.");
 
+        group.MapGet("/live-sessions/{sessionId}/disputes", HandleGetSessionDisputes)
+            .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
+            .Produces<GetSessionDisputesResult>(200)
+            .Produces(401)
+            .Produces(403)
+            .Produces(404)
+            .WithTags("LiveSessions")
+            .WithSummary("Get the dispute history for a live session")
+            .WithDescription("Returns all rule disputes recorded in a single live session, ordered by timestamp ascending. Powers the Arbitro tab's REST hydration on reload (#3391).");
+
         group.MapGet("/games/{gameId}/dispute-history", HandleGetDisputeHistory)
             .RequireAuthenticatedUser()
             .Produces<GetGameDisputeHistoryResult>(200)
@@ -884,6 +895,16 @@ internal static class LiveSessionEndpoints
     {
         var result = await mediator.Send(
             new GetGameDisputeHistoryQuery(gameId), cancellationToken).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> HandleGetSessionDisputes(
+        Guid sessionId,
+        [FromServices] IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(
+            new GetSessionDisputesQuery(sessionId), cancellationToken).ConfigureAwait(false);
         return Results.Ok(result);
     }
 

--- a/apps/api/src/Api/Routing/Pdf/PdfRetrievalEndpoints.cs
+++ b/apps/api/src/Api/Routing/Pdf/PdfRetrievalEndpoints.cs
@@ -90,6 +90,14 @@ internal static class PdfRetrievalEndpoints
             .Produces(401)
             .Produces(403)
             .Produces(404);
+
+        // #3447 slice: hi_res image-table regions for the viewer overlay (region-only, no VLM).
+        group.MapGet("/pdf/{pdfId:guid}/image-regions", HandleGetImageRegions)
+            .RequireSession()
+            .WithName("GetPdfImageRegions")
+            .WithTags("PDF")
+            .WithSummary("Persisted hi_res Image/FigureCaption regions for the PDF (viewer overlay)")
+            .Produces(401);
     }
 
     private static void MapPdfLanguageEndpoints(RouteGroupBuilder group)
@@ -172,6 +180,18 @@ internal static class PdfRetrievalEndpoints
         }
 
         return Results.Json(pdf);
+    }
+
+    // #3447 slice: owner-or-shared-game scoping (mirror HandleGetPdfText #3222); admins bypass.
+    // The handler returns an empty list (no existence leak) for missing/unauthorized PDFs.
+    private static async Task<IResult> HandleGetImageRegions(Guid pdfId, HttpContext context, IMediator mediator, CancellationToken ct)
+    {
+        var session = (SessionStatusDto)context.Items[nameof(SessionStatusDto)]!;
+        var userId = session!.Principal!.Subject.Id;
+        bool isAdmin = string.Equals(session!.Principal!.EffectiveActor.Role, UserRole.Admin.ToString(), StringComparison.OrdinalIgnoreCase);
+
+        var regions = await mediator.Send(new GetPdfImageRegionsQuery(pdfId, userId, isAdmin), ct).ConfigureAwait(false);
+        return Results.Json(new { regions });
     }
 
     private static async Task<IResult> HandleGetPageText(

--- a/apps/api/src/Api/SharedKernel/Domain/Enums/GroundingStatus.cs
+++ b/apps/api/src/Api/SharedKernel/Domain/Enums/GroundingStatus.cs
@@ -1,0 +1,14 @@
+namespace Api.SharedKernel.Domain.Enums;
+
+/// <summary>
+/// Grounding status of an AI agent answer, shared across bounded contexts.
+/// Derived from citations: <see cref="Grounded"/> iff the answer carries at
+/// least one citation, otherwise <see cref="Ungrounded"/>. <see cref="Partial"/>
+/// is reserved for future use (#3390) and has no producer yet.
+/// </summary>
+public enum GroundingStatus
+{
+    Grounded = 0,
+    Partial = 1,
+    Ungrounded = 2
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/GenerateSetupChecklistCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/GenerateSetupChecklistCommandHandlerTests.cs
@@ -101,7 +101,7 @@ public class GenerateSetupChecklistCommandHandlerTests
             new(StreamingEventType.SetupStep, new StreamingSetupStep(steps[0]), DateTime.UtcNow),
             new(StreamingEventType.SetupStep, new StreamingSetupStep(steps[1]), DateTime.UtcNow),
             new(StreamingEventType.SetupStep, new StreamingSetupStep(steps[2]), DateTime.UtcNow),
-            new(StreamingEventType.Complete, new StreamingComplete(10, 100, 50, 150, 0.85), DateTime.UtcNow)
+            new(StreamingEventType.Complete, new StreamingComplete(10, 100, 50, 150, 0.85, GroundingStatus: "Grounded"), DateTime.UtcNow)
         };
 
         _mediatorMock

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/SessionParticipant/SessionParticipantTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/SessionParticipant/SessionParticipantTests.cs
@@ -19,13 +19,13 @@ public class SessionParticipantTests
     public void CreateGuest_ShouldSetGuestNameAndNullUserId()
     {
         var participant = Api.BoundedContexts.GameManagement.Domain.Entities.SessionParticipant.CreateGuest(
-            _sessionId, ValidGuestName, ParticipantRole.Player);
+            _sessionId, ValidGuestName, SessionParticipantRole.Player);
 
         participant.Id.Should().NotBe(Guid.Empty);
         participant.SessionId.Should().Be(_sessionId);
         participant.UserId.Should().BeNull();
         participant.GuestName.Should().Be(ValidGuestName);
-        participant.Role.Should().Be(ParticipantRole.Player);
+        participant.Role.Should().Be(SessionParticipantRole.Player);
         (participant.AgentAccessEnabled).Should().BeFalse();
         (participant.JoinedAt <= DateTime.UtcNow).Should().BeTrue();
         participant.LeftAt.Should().BeNull();
@@ -39,7 +39,7 @@ public class SessionParticipantTests
     {
         var act = () =>
             Api.BoundedContexts.GameManagement.Domain.Entities.SessionParticipant.CreateGuest(
-                _sessionId, guestName!, ParticipantRole.Player);
+                _sessionId, guestName!, SessionParticipantRole.Player);
         act.Should().Throw<ArgumentException>();
     }
 
@@ -47,7 +47,7 @@ public class SessionParticipantTests
     public void CreateGuest_ShouldTrimGuestName()
     {
         var participant = Api.BoundedContexts.GameManagement.Domain.Entities.SessionParticipant.CreateGuest(
-            _sessionId, "  Alice  ", ParticipantRole.Player);
+            _sessionId, "  Alice  ", SessionParticipantRole.Player);
 
         participant.GuestName.Should().Be("Alice");
     }
@@ -60,13 +60,13 @@ public class SessionParticipantTests
     public void CreateRegistered_ShouldSetUserIdAndNullGuestName()
     {
         var participant = Api.BoundedContexts.GameManagement.Domain.Entities.SessionParticipant.CreateRegistered(
-            _sessionId, _userId, ParticipantRole.Player);
+            _sessionId, _userId, SessionParticipantRole.Player);
 
         participant.Id.Should().NotBe(Guid.Empty);
         participant.SessionId.Should().Be(_sessionId);
         participant.UserId.Should().Be(_userId);
         participant.GuestName.Should().BeNull();
-        participant.Role.Should().Be(ParticipantRole.Player);
+        participant.Role.Should().Be(SessionParticipantRole.Player);
         (participant.JoinedAt <= DateTime.UtcNow).Should().BeTrue();
         participant.LeftAt.Should().BeNull();
     }
@@ -75,7 +75,7 @@ public class SessionParticipantTests
     public void CreateRegistered_AsHost_ShouldEnableAgentAccess()
     {
         var participant = Api.BoundedContexts.GameManagement.Domain.Entities.SessionParticipant.CreateRegistered(
-            _sessionId, _userId, ParticipantRole.Host);
+            _sessionId, _userId, SessionParticipantRole.Host);
 
         (participant.AgentAccessEnabled).Should().BeTrue();
     }
@@ -84,7 +84,7 @@ public class SessionParticipantTests
     public void CreateRegistered_AsPlayer_ShouldDisableAgentAccess()
     {
         var participant = Api.BoundedContexts.GameManagement.Domain.Entities.SessionParticipant.CreateRegistered(
-            _sessionId, _userId, ParticipantRole.Player);
+            _sessionId, _userId, SessionParticipantRole.Player);
 
         (participant.AgentAccessEnabled).Should().BeFalse();
     }
@@ -93,7 +93,7 @@ public class SessionParticipantTests
     public void CreateRegistered_AsSpectator_ShouldDisableAgentAccess()
     {
         var participant = Api.BoundedContexts.GameManagement.Domain.Entities.SessionParticipant.CreateRegistered(
-            _sessionId, _userId, ParticipantRole.Spectator);
+            _sessionId, _userId, SessionParticipantRole.Spectator);
 
         (participant.AgentAccessEnabled).Should().BeFalse();
     }
@@ -106,7 +106,7 @@ public class SessionParticipantTests
     public void ToggleAgentAccess_ShouldFlip()
     {
         var participant = Api.BoundedContexts.GameManagement.Domain.Entities.SessionParticipant.CreateGuest(
-            _sessionId, ValidGuestName, ParticipantRole.Player);
+            _sessionId, ValidGuestName, SessionParticipantRole.Player);
 
         (participant.AgentAccessEnabled).Should().BeFalse();
 
@@ -125,7 +125,7 @@ public class SessionParticipantTests
     public void Leave_ShouldSetLeftAt()
     {
         var participant = Api.BoundedContexts.GameManagement.Domain.Entities.SessionParticipant.CreateGuest(
-            _sessionId, ValidGuestName, ParticipantRole.Player);
+            _sessionId, ValidGuestName, SessionParticipantRole.Player);
 
         (participant.IsActive).Should().BeTrue();
 
@@ -144,7 +144,7 @@ public class SessionParticipantTests
     public void ConnectionToken_ShouldBe6Chars()
     {
         var participant = Api.BoundedContexts.GameManagement.Domain.Entities.SessionParticipant.CreateGuest(
-            _sessionId, ValidGuestName, ParticipantRole.Player);
+            _sessionId, ValidGuestName, SessionParticipantRole.Player);
 
         participant.ConnectionToken.Length.Should().Be(6);
     }
@@ -156,7 +156,7 @@ public class SessionParticipantTests
         for (var i = 0; i < 50; i++)
         {
             var participant = Api.BoundedContexts.GameManagement.Domain.Entities.SessionParticipant.CreateGuest(
-                _sessionId, ValidGuestName, ParticipantRole.Player);
+                _sessionId, ValidGuestName, SessionParticipantRole.Player);
 
             participant.ConnectionToken.Should().NotContain("O");
             participant.ConnectionToken.Should().NotContain("0");
@@ -171,7 +171,7 @@ public class SessionParticipantTests
     {
         var tokens = Enumerable.Range(0, 20)
             .Select(_ => Api.BoundedContexts.GameManagement.Domain.Entities.SessionParticipant.CreateGuest(
-                _sessionId, ValidGuestName, ParticipantRole.Player).ConnectionToken)
+                _sessionId, ValidGuestName, SessionParticipantRole.Player).ConnectionToken)
             .ToHashSet();
 
         // With 6 chars from 32-char alphabet, collisions in 20 tokens are extremely unlikely
@@ -186,7 +186,7 @@ public class SessionParticipantTests
     public void DisplayName_Guest_ShouldReturnGuestName()
     {
         var participant = Api.BoundedContexts.GameManagement.Domain.Entities.SessionParticipant.CreateGuest(
-            _sessionId, ValidGuestName, ParticipantRole.Player);
+            _sessionId, ValidGuestName, SessionParticipantRole.Player);
 
         participant.DisplayName.Should().Be(ValidGuestName);
     }
@@ -195,7 +195,7 @@ public class SessionParticipantTests
     public void DisplayName_RegisteredUser_ShouldReturnUserFallback()
     {
         var participant = Api.BoundedContexts.GameManagement.Domain.Entities.SessionParticipant.CreateRegistered(
-            _sessionId, _userId, ParticipantRole.Player);
+            _sessionId, _userId, SessionParticipantRole.Player);
 
         participant.DisplayName.Should().Be("User");
     }
@@ -208,9 +208,9 @@ public class SessionParticipantTests
     public void IsRegisteredUser_ShouldReflectUserId()
     {
         var guest = Api.BoundedContexts.GameManagement.Domain.Entities.SessionParticipant.CreateGuest(
-            _sessionId, ValidGuestName, ParticipantRole.Player);
+            _sessionId, ValidGuestName, SessionParticipantRole.Player);
         var registered = Api.BoundedContexts.GameManagement.Domain.Entities.SessionParticipant.CreateRegistered(
-            _sessionId, _userId, ParticipantRole.Player);
+            _sessionId, _userId, SessionParticipantRole.Player);
 
         (guest.IsRegisteredUser).Should().BeFalse();
         (registered.IsRegisteredUser).Should().BeTrue();

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatSessionAgentBroadcastTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatSessionAgentBroadcastTests.cs
@@ -424,7 +424,7 @@ public class ChatSessionAgentBroadcastTests
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<GameState?>(),
                 It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<ChatThread?>(),
                 It.IsAny<SharedUserTier?>(), It.IsAny<string>(), It.IsAny<CancellationToken>(),
-                It.IsAny<IRagDebugEventCollector?>(), It.IsAny<RetrievalProfile?>()))
+                It.IsAny<IRagDebugEventCollector?>(), It.IsAny<RetrievalProfile?>(), It.IsAny<RetrievalPolicy?>()))
             .ReturnsAsync(assembled);
 
         // --- Copyright tier resolver → returns resolvedCitations as-is ---

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentMemoryContextTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentMemoryContextTests.cs
@@ -182,7 +182,7 @@ public class ChatWithSessionAgentMemoryContextTests
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<GameState?>(),
                 It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<ChatThread?>(),
                 It.IsAny<SharedUserTier?>(), It.IsAny<string>(), It.IsAny<CancellationToken>(),
-                It.IsAny<IRagDebugEventCollector?>(), It.IsAny<RetrievalProfile?>()))
+                It.IsAny<IRagDebugEventCollector?>(), It.IsAny<RetrievalProfile?>(), It.IsAny<RetrievalPolicy?>()))
             .ReturnsAsync(assembled);
 
         // --- Copyright tier resolver → returns citations as-is (empty) ---

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentMetricsTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentMetricsTests.cs
@@ -71,7 +71,7 @@ public sealed class ChatWithSessionAgentMetricsTests
         var observations = new List<double>();
         using var listener = BuildHistogramListener<double>(FirstTokenLatencyName, observations);
 
-        var handler = BuildHandler(resolvedCitations: new List<ChunkCitation>(), tokenContent: "Hello world");
+        var handler = BuildHandler(resolvedCitations: new List<ChunkCitation>(), ragPromptMock: out _, tokenContent: "Hello world");
         var command = BuildCommand();
 
         // Act — drain to completion
@@ -113,7 +113,7 @@ public sealed class ChatWithSessionAgentMetricsTests
         var observations = new List<long>();
         using var listener = BuildHistogramListener<long>(CitationsPerAnswerName, observations);
 
-        var handler = BuildHandler(resolvedCitations: citations, tokenContent: "Answer with citations");
+        var handler = BuildHandler(resolvedCitations: citations, ragPromptMock: out _, tokenContent: "Answer with citations");
         var command = BuildCommand();
 
         // Act
@@ -137,7 +137,7 @@ public sealed class ChatWithSessionAgentMetricsTests
         var observations = new List<long>();
         using var listener = BuildHistogramListener<long>(CitationsPerAnswerName, observations);
 
-        var handler = BuildHandler(resolvedCitations: new List<ChunkCitation>(), tokenContent: "Grounded but uncited");
+        var handler = BuildHandler(resolvedCitations: new List<ChunkCitation>(), ragPromptMock: out _, tokenContent: "Grounded but uncited");
         var command = BuildCommand();
 
         // Act
@@ -176,7 +176,7 @@ public sealed class ChatWithSessionAgentMetricsTests
                 IsPublic: true),
         };
 
-        var handler = BuildHandler(resolvedCitations: citations, tokenContent: "Answer with citation");
+        var handler = BuildHandler(resolvedCitations: citations, ragPromptMock: out _, tokenContent: "Answer with citation");
         var command = BuildCommand();
 
         // Act
@@ -200,7 +200,7 @@ public sealed class ChatWithSessionAgentMetricsTests
         using var latencyListener = BuildHistogramListener<double>(FirstTokenLatencyName, latencyObs);
         using var citationsListener = BuildHistogramListener<long>(CitationsPerAnswerName, citationsObs);
 
-        var handler = BuildHandler(resolvedCitations: new List<ChunkCitation>(), tokenContent: "Token");
+        var handler = BuildHandler(resolvedCitations: new List<ChunkCitation>(), ragPromptMock: out _, tokenContent: "Token");
         var command = BuildCommand();
 
         // Act
@@ -265,8 +265,37 @@ public sealed class ChatWithSessionAgentMetricsTests
     /// <paramref name="resolvedCitations"/> controls the citation list returned by the
     /// copyright resolver. <paramref name="tokenContent"/> controls what the LLM emits.
     /// </summary>
+    // ──────────────────────────────────────────────────────────────────────────
+    // #3389: live path passes an explicit RetrievalPolicy.LiveSession
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "#3389: in-session live path passes RetrievalPolicy.LiveSession (decoupled from tier, not silent Default)")]
+    public async Task Handle_LivePath_PassesLiveSessionRetrievalPolicy()
+    {
+        // Arrange
+        var handler = BuildHandler(
+            resolvedCitations: new List<ChunkCitation>(),
+            ragPromptMock: out var ragPromptMock,
+            tokenContent: "Answer");
+        var command = BuildCommand();
+
+        // Act — drain to completion
+        await foreach (var _ in handler.Handle(command, CancellationToken.None)) { }
+
+        // Assert — the live path assembled the prompt with the explicit LiveSession policy,
+        // so retrieval is decoupled from tier and never silently falls back to Default (#3389).
+        ragPromptMock.Verify(r => r.AssemblePromptAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<GameState?>(),
+            It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<ChatThread?>(),
+            It.IsAny<SharedUserTier?>(), It.IsAny<string>(), It.IsAny<CancellationToken>(),
+            It.IsAny<IRagDebugEventCollector?>(), It.IsAny<RetrievalProfile?>(),
+            It.Is<RetrievalPolicy?>(p => p == RetrievalPolicy.LiveSession)),
+            Times.Once);
+    }
+
     private static ChatWithSessionAgentCommandHandler BuildHandler(
         IReadOnlyList<ChunkCitation> resolvedCitations,
+        out Mock<IRagPromptAssemblyService> ragPromptMock,
         string tokenContent = "Hello world")
     {
         // --- AgentSession repo ---
@@ -346,8 +375,9 @@ public sealed class ChatWithSessionAgentMetricsTests
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<GameState?>(),
                 It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<ChatThread?>(),
                 It.IsAny<SharedUserTier?>(), It.IsAny<string>(), It.IsAny<CancellationToken>(),
-                It.IsAny<IRagDebugEventCollector?>(), It.IsAny<RetrievalProfile?>()))
+                It.IsAny<IRagDebugEventCollector?>(), It.IsAny<RetrievalProfile?>(), It.IsAny<RetrievalPolicy?>()))
             .ReturnsAsync(assembled);
+        ragPromptMock = ragPromptService;
 
         // --- Copyright tier resolver → pass-through ---
         var tierResolver = new Mock<ICopyrightTierResolver>();

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentMetricsTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentMetricsTests.cs
@@ -141,13 +141,50 @@ public sealed class ChatWithSessionAgentMetricsTests
         var command = BuildCommand();
 
         // Act
-        await foreach (var _ in handler.Handle(command, CancellationToken.None)) { }
+        var complete = await DrainAndCaptureCompleteAsync(handler, command);
 
         // Assert
         observations.Should().ContainSingle(
             "citations-per-answer must be recorded exactly once even when there are no citations");
         observations[0].Should().Be(0L,
             "grounded-but-uncited signal: le=0 bucket must be populated");
+
+        // #3388 (Task 2): mode-parity signal — the SSE RAG path must emit a non-nullable
+        // grounding string on StreamingComplete, mirroring Task 1's REST-path assertion
+        // (AskSessionAgentResult.GroundingStatus) so both in-session agent paths carry the
+        // same grounding contract for a zero-citation answer.
+        complete.Should().NotBeNull();
+        complete!.GroundingStatus.Should().Be("Ungrounded");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // T2-AC-3b (#3388): with-citations case emits GroundingStatus="Grounded"
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "T2-AC-3b (#3388): with-citations case emits GroundingStatus=\"Grounded\" on StreamingComplete")]
+    public async Task Handle_StreamedChatWithCitations_EmitsGroundedStatus()
+    {
+        // Arrange — one Full-tier citation
+        var citations = new List<ChunkCitation>
+        {
+            new ChunkCitation(
+                DocumentId: "doc-1",
+                PageNumber: 1,
+                RelevanceScore: 0.9f,
+                SnippetPreview: "snippet A",
+                CopyrightTier: CopyrightTier.Full,
+                IsPublic: true),
+        };
+
+        var handler = BuildHandler(resolvedCitations: citations, tokenContent: "Answer with citation");
+        var command = BuildCommand();
+
+        // Act
+        var complete = await DrainAndCaptureCompleteAsync(handler, command);
+
+        // Assert — mode-parity signal (see zero-citation test comment above)
+        complete.Should().NotBeNull();
+        complete!.GroundingStatus.Should().Be("Grounded");
     }
 
     // ──────────────────────────────────────────────────────────────────────────
@@ -195,6 +232,26 @@ public sealed class ChatWithSessionAgentMetricsTests
         listener.SetMeasurementEventCallback<T>((_, value, _, _) => observations.Add(value));
         listener.Start();
         return listener;
+    }
+
+    /// <summary>
+    /// Drains the handler's streamed events and returns the <see cref="StreamingComplete"/>
+    /// payload carried by the terminal <see cref="StreamingEventType.Complete"/> event.
+    /// </summary>
+    private static async Task<StreamingComplete?> DrainAndCaptureCompleteAsync(
+        ChatWithSessionAgentCommandHandler handler,
+        ChatWithSessionAgentCommand command)
+    {
+        StreamingComplete? complete = null;
+        await foreach (var evt in handler.Handle(command, CancellationToken.None))
+        {
+            if (evt.Type == StreamingEventType.Complete)
+            {
+                complete = evt.Data as StreamingComplete;
+            }
+        }
+
+        return complete;
     }
 
     private static ChatWithSessionAgentCommand BuildCommand() =>

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentPerChunkTimeoutTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentPerChunkTimeoutTests.cs
@@ -388,7 +388,7 @@ public sealed class ChatWithSessionAgentPerChunkTimeoutTests
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<GameState?>(),
                 It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<ChatThread?>(),
                 It.IsAny<SharedUserTier?>(), It.IsAny<string>(), It.IsAny<CancellationToken>(),
-                It.IsAny<IRagDebugEventCollector?>(), It.IsAny<RetrievalProfile?>()))
+                It.IsAny<IRagDebugEventCollector?>(), It.IsAny<RetrievalProfile?>(), It.IsAny<RetrievalPolicy?>()))
             .ReturnsAsync(assembled);
 
         var tierResolver = new Mock<ICopyrightTierResolver>();

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentStreamingSafetyTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentStreamingSafetyTests.cs
@@ -356,7 +356,7 @@ public sealed class ChatWithSessionAgentStreamingSafetyTests
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<GameState?>(),
                 It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<ChatThread?>(),
                 It.IsAny<SharedUserTier?>(), It.IsAny<string>(), It.IsAny<CancellationToken>(),
-                It.IsAny<IRagDebugEventCollector?>(), It.IsAny<RetrievalProfile?>()))
+                It.IsAny<IRagDebugEventCollector?>(), It.IsAny<RetrievalProfile?>(), It.IsAny<RetrievalPolicy?>()))
             .ReturnsAsync(assembled);
 
         var tierResolver = new Mock<ICopyrightTierResolver>();

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/StreamSetupGuideQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/StreamSetupGuideQueryHandlerTests.cs
@@ -168,6 +168,13 @@ public class StreamSetupGuideQueryHandlerTests
                 It.IsAny<RequestSource>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
+
+        // #3388: grounding-contract — parsed steps carry the retrieved rulebook
+        // reference, so the terminal Complete event must report "Grounded".
+        var completeEvent = events.LastOrDefault(e => e.Type == StreamingEventType.Complete);
+        completeEvent.Should().NotBeNull();
+        var complete = completeEvent!.Data.Should().BeOfType<StreamingComplete>().Which;
+        complete.GroundingStatus.Should().Be("Grounded");
     }
 
     [Fact]
@@ -227,6 +234,11 @@ public class StreamSetupGuideQueryHandlerTests
         completeEvent.Should().NotBeNull();
         var complete = completeEvent.Data.Should().BeOfType<StreamingComplete>().Which;
         complete.totalTokens.Should().Be(0); // No LLM call, so 0 tokens
+
+        // #3388: grounding-contract — default fallback steps carry no rulebook
+        // references (CreateDefaultSetupStepsStatic), so the terminal Complete event
+        // must report "Ungrounded".
+        complete.GroundingStatus.Should().Be("Ungrounded");
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Unit/RagPromptAssemblyEnhancementsTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Unit/RagPromptAssemblyEnhancementsTests.cs
@@ -430,5 +430,35 @@ public class RagPromptAssemblyEnhancementsTests
             Times.AtLeastOnce);
     }
 
+    [Fact]
+    public async Task WhenLiveSessionPolicy_SkipsEnhancementsEvenWithTier()
+    {
+        // #3389: the in-session live path is explicitly decoupled from tier. Even with a tier present
+        // (which WOULD activate enhancements), RetrievalPolicy.LiveSession (EnhancementsEnabled=false)
+        // must NOT look up tier-derived enhancements — gating is an explicit capability, not a
+        // side-effect of the tier being null/non-null.
+        var tier = UserTier.Premium;
+        _ragEnhancementMock
+            .Setup(r => r.GetActiveEnhancementsAsync(tier, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RagEnhancement.AdaptiveRouting);
+        SetupTextSearchResults(CreateChunk("doc1", 0, 0.90f, "Pawns move forward."));
+        SetupRerankerPassthrough();
+        var service = CreateService();
+
+        // Act — explicit LiveSession policy alongside a tier that WOULD otherwise enable enhancements
+        await service.AssemblePromptAsync(
+            "tutor", "Chess", null, "How do pawns move?",
+            TestGameId, null, tier, "it", CancellationToken.None,
+            retrievalPolicy: RetrievalPolicy.LiveSession);
+
+        // Assert — enhancements gated off explicitly: no tier lookup, no adaptive routing
+        _ragEnhancementMock.Verify(
+            r => r.GetActiveEnhancementsAsync(It.IsAny<UserTier>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _complexityClassifierMock.Verify(
+            c => c.ClassifyAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
     #endregion
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/ChatCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/ChatCommandHandlerTests.cs
@@ -6,12 +6,15 @@ using Api.Middleware.Exceptions;
 using Api.Services;
 using Api.BoundedContexts.SessionTracking.Application.Services;
 using Api.Services.ImageProcessing;
+using Api.SharedKernel.Domain.Enums;
 using Api.Tests.Constants;
 using MediatR;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
 using FluentAssertions;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Api.Tests.BoundedContexts.SessionTracking.Application.Handlers;
 
@@ -239,7 +242,8 @@ public class AskSessionAgentCommandHandlerTests
 
         // Assert
         result.MessageId.Should().NotBe(Guid.Empty);
-        result.Confidence.Should().Be(0.85f); // LLM success returns 0.85 confidence
+        result.Confidence.Should().BeNull(); // #3388: no fabricated confidence on the REST path
+        result.GroundingStatus.Should().Be(GroundingStatus.Ungrounded); // #3388: REST path never has citations
         result.AgentType.Should().Be("tutor");
         saveCalledAfterFirstAdd.Should().BeTrue("SaveChangesAsync should be called after the first AddAsync (user message) to prevent sequence number race condition");
         _mockChatRepo.Verify(r => r.AddAsync(It.IsAny<SessionChatMessage>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
@@ -537,5 +541,45 @@ public class ChatQueryHandlerTests
         _mockChatRepo.Verify(
             r => r.GetBySessionIdAsync(It.IsAny<Guid>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()),
             Times.Never);
+    }
+}
+
+/// <summary>
+/// #3388: guards the wire casing of <see cref="AskSessionAgentResult.GroundingStatus"/>.
+/// The FE image-path disclaimer keys off the exact serialized value
+/// <c>"groundingStatus":"Ungrounded"</c> (camelCase property name, PascalCase enum
+/// value) produced by the global JSON options configured in
+/// <c>Program.cs</c> (<c>ConfigureHttpJsonOptions</c>: camelCase naming policy +
+/// <see cref="JsonStringEnumConverter"/>). This test mirrors those two settings so a
+/// regression to numeric enum serialization or snake/Pascal-case property naming
+/// fails fast here instead of silently breaking the FE contract.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SessionTracking")]
+public class AskSessionAgentResultSerializationTests
+{
+    private static readonly JsonSerializerOptions WireOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    [Fact]
+    public void Serialize_UngroundedResult_ProducesCamelCasePropertyWithPascalCaseEnumValue()
+    {
+        // Arrange
+        var result = new AskSessionAgentResult(
+            MessageId: Guid.NewGuid(),
+            Answer: "The rulebook does not cover this.",
+            AgentType: "qa",
+            Confidence: null,
+            CitationsJson: null,
+            GroundingStatus: GroundingStatus.Ungrounded);
+
+        // Act
+        var json = JsonSerializer.Serialize(result, WireOptions);
+
+        // Assert
+        json.Should().Contain("\"groundingStatus\":\"Ungrounded\"");
     }
 }

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/GetSessionDisputesEndpointTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/GetSessionDisputesEndpointTests.cs
@@ -1,0 +1,260 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
+using Api.BoundedContexts.GameManagement.Application.Queries.GameNight;
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.GameManagement;
+
+/// <summary>
+/// Integration tests for the per-session dispute-history endpoint:
+///   GET /api/v1/live-sessions/{sessionId}/disputes
+///
+/// Issue #3391 (finding C8): wire the existing (but unwired) GetSessionDisputesQuery so the
+/// Arbitro tab can hydrate its dispute history on reload (REST), not only via SignalR.
+///
+/// Scope decision: per-session (not the pre-existing per-game /games/{gameId}/dispute-history),
+/// because the Arbitro tab is scoped to a single live session and cross-session history is a
+/// separate future concern (DisputeHistory.gameId prop is "reserved for future").
+///
+/// Test strategy mirrors LiveSessionDiaryEndpointTests:
+/// - IntegrationWebApplicationFactory + SharedTestcontainersFixture (isolated DB per class)
+/// - TestSessionHelper for auth (session cookie)
+/// - IMediator to create sessions; DisputesJson seeded directly (same camelCase shape the
+///   LiveGameSessionMapper reads back) to avoid depending on the multi-step Arbitro LLM flow.
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "3391")]
+public sealed class GetSessionDisputesEndpointTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _databaseName = $"session_disputes_{Guid.NewGuid():N}";
+    private WebApplicationFactory<Program> _factory = null!;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    // Mirrors the mapper's write options so the seeded DisputesJson round-trips through ToDomain.
+    private static readonly JsonSerializerOptions CamelCaseOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    public GetSessionDisputesEndpointTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        await TestcontainersWaitHelpers.WaitForPostgresReadyAsync(connectionString);
+
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        await db.Database.MigrateAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_factory != null)
+            await _factory.DisposeAsync();
+
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Scenario 1: participant GET on a session with disputes → 200 + ordered list
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "GET disputes returns the session's persisted disputes ordered by timestamp asc")]
+    public async Task Get_SessionWithDisputes_ReturnsOrderedList()
+    {
+        // Arrange — create session, seed two disputes out of chronological order
+        var (client, sessionId) = await CreateSessionWithClientAsync();
+
+        var older = new RuleDisputeEntry(
+            Guid.NewGuid(), "Can I play two cards?", "No — one card per turn.",
+            new List<string> { "p.12" }, "Alice", DateTime.UtcNow.AddMinutes(-10));
+        var newer = new RuleDisputeEntry(
+            Guid.NewGuid(), "Does a tie break by score?", "Yes — highest score wins ties.",
+            new List<string> { "p.4", "p.5" }, "Bob", DateTime.UtcNow.AddMinutes(-2));
+
+        // Seed newest-first to prove the handler orders ascending.
+        await SeedDisputesAsync(sessionId, newer, older);
+
+        // Act
+        var getRequest = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/live-sessions/{sessionId}/disputes",
+            GetTokenFromClient(client));
+        var response = await client.SendAsync(getRequest);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<GetSessionDisputesResult>(JsonOptions);
+        result.Should().NotBeNull();
+        result!.SessionId.Should().Be(sessionId);
+        result.Disputes.Should().HaveCount(2);
+        result.Disputes[0].Id.Should().Be(older.Id, "disputes must be ordered by timestamp ascending");
+        result.Disputes[0].RaisedByPlayerName.Should().Be("Alice");
+        result.Disputes[0].Verdict.Should().Be("No — one card per turn.");
+        result.Disputes[0].RuleReferences.Should().ContainSingle().Which.Should().Be("p.12");
+        result.Disputes[1].Id.Should().Be(newer.Id);
+        result.Disputes[1].RuleReferences.Should().BeEquivalentTo(new[] { "p.4", "p.5" });
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Scenario 2: authenticated non-participant → 403 (IDOR guard)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "GET disputes returns 403 when caller is authenticated but not a participant")]
+    public async Task Get_NonParticipant_Returns403()
+    {
+        var (_, sessionId) = await CreateSessionWithClientAsync();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, tokenB) = await TestSessionHelper.CreateUserSessionAsync(db);
+
+        var clientB = _factory.CreateClient();
+        clientB.DefaultRequestHeaders.Add("Cookie", $"{TestSessionHelper.SessionCookieName}={tokenB}");
+
+        var getRequest = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/live-sessions/{sessionId}/disputes",
+            tokenB);
+        var response = await clientB.SendAsync(getRequest);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "an authenticated user who is not a participant must receive 403");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Scenario 3: unauthenticated caller → 401
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "GET disputes returns 401 when caller is not authenticated")]
+    public async Task Get_Unauthenticated_Returns401()
+    {
+        var anonClient = _factory.CreateClient();
+        var sessionId = Guid.NewGuid(); // irrelevant — auth check fires first
+
+        var response = await anonClient.GetAsync($"/api/v1/live-sessions/{sessionId}/disputes");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized,
+            "RequireAuthenticatedUser() must reject unauthenticated callers");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Scenario 4: session with no disputes → 200 + empty list
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "GET disputes on a session with no disputes returns 200 empty list")]
+    public async Task Get_SessionWithNoDisputes_Returns200EmptyList()
+    {
+        var (client, sessionId) = await CreateSessionWithClientAsync();
+
+        var getRequest = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/live-sessions/{sessionId}/disputes",
+            GetTokenFromClient(client));
+        var response = await client.SendAsync(getRequest);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<GetSessionDisputesResult>(JsonOptions);
+        result.Should().NotBeNull();
+        result!.Disputes.Should().BeEmpty("no disputes were raised in this session");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────────────────
+
+    private async Task<(HttpClient Client, Guid SessionId)> CreateSessionWithClientAsync()
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+        var userId = await SeedUserAsync(db);
+        var (_, token) = await TestSessionHelper.CreateUserSessionAsync(db, userId);
+
+        var sessionId = await mediator.Send(new CreateLiveSessionCommand(
+            UserId: userId,
+            GameName: "Dispute Test Game",
+            GameId: null));
+
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("Cookie", $"{TestSessionHelper.SessionCookieName}={token}");
+        client.DefaultRequestHeaders.Add("X-Test-Session-Token", token);
+
+        return (client, sessionId);
+    }
+
+    /// <summary>
+    /// Seeds disputes directly onto the session's DisputesJson column using the same camelCase
+    /// shape the LiveGameSessionMapper writes, so ToDomain reads them back verbatim.
+    /// Uses ExecuteUpdateAsync (a direct SQL UPDATE) to bypass the change tracker and the xmin
+    /// optimistic-concurrency token, and asserts exactly one row was written so a persistence
+    /// failure surfaces here instead of as an empty read downstream.
+    /// </summary>
+    private async Task SeedDisputesAsync(Guid sessionId, params RuleDisputeEntry[] disputes)
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var json = JsonSerializer.Serialize(disputes.ToList(), CamelCaseOptions);
+        var affected = await db.LiveGameSessions
+            .Where(e => e.Id == sessionId)
+            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DisputesJson, json));
+
+        affected.Should().Be(1, "the seed must update exactly the target session's DisputesJson");
+    }
+
+    private static string GetTokenFromClient(HttpClient client)
+    {
+        return client.DefaultRequestHeaders.TryGetValues("X-Test-Session-Token", out var values)
+            ? values.First()
+            : throw new InvalidOperationException("X-Test-Session-Token not set on client");
+    }
+
+    private static async Task<Guid> SeedUserAsync(MeepleAiDbContext db)
+    {
+        var userId = Guid.NewGuid();
+        db.Users.Add(new UserEntity
+        {
+            Id = userId,
+            Email = $"dispute-test-{userId:N}@test.local",
+            DisplayName = "Dispute Test User",
+            PasswordHash = "not-a-real-hash",
+            Role = "user",
+            Tier = "free",
+            Status = "Active",
+            EmailVerified = true,
+            CreatedAt = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync();
+        return userId;
+    }
+}

--- a/apps/api/tests/Api.Tests/Unit/DocumentProcessing/GetPdfImageRegionsQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/DocumentProcessing/GetPdfImageRegionsQueryHandlerTests.cs
@@ -1,0 +1,109 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Queries;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Unit.DocumentProcessing;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "3447")]
+public sealed class GetPdfImageRegionsQueryHandlerTests
+{
+    private static void SeedPdf(MeepleAiDbContext db, Guid pdfId, Guid ownerId, Guid? sharedGameId = null)
+    {
+        db.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = pdfId,
+            FileName = "test.pdf",
+            FilePath = "/tmp/test.pdf",
+            FileSizeBytes = 1024,
+            ContentType = "application/pdf",
+            UploadedByUserId = ownerId,
+            ProcessingState = "Ready",
+            SharedGameId = sharedGameId,
+        });
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsRegionsForOwner_OrderedByPage()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext($"getimg_{Guid.NewGuid():N}");
+        var pdfId = Guid.NewGuid();
+        var ownerId = Guid.NewGuid();
+        SeedPdf(db, pdfId, ownerId);
+        db.PdfImageRegions.AddRange(
+            new PdfImageRegionEntity { PdfDocumentId = pdfId, PageNumber = 5, X = 0.1, Y = 0.2, Width = 0.3, Height = 0.1, ElementType = "Image" },
+            new PdfImageRegionEntity { PdfDocumentId = pdfId, PageNumber = 4, X = 0.1, Y = 0.5, Width = 0.8, Height = 0.3, ElementType = "FigureCaption" },
+            new PdfImageRegionEntity { PdfDocumentId = Guid.NewGuid(), PageNumber = 1, X = 0, Y = 0, Width = 1, Height = 1, ElementType = "Image" });
+        await db.SaveChangesAsync();
+
+        var handler = new GetPdfImageRegionsQueryHandler(db);
+        var result = await handler.Handle(new GetPdfImageRegionsQuery(pdfId, ownerId, IsAdmin: false), CancellationToken.None);
+
+        result.Should().HaveCount(2);
+        result.Select(r => r.Page).Should().ContainInOrder(4, 5); // ordered by page
+        result[0].ElementType.Should().Be("FigureCaption");
+    }
+
+    [Fact]
+    public async Task Handle_UnknownPdf_ReturnsEmpty()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext($"getimg_{Guid.NewGuid():N}");
+        var handler = new GetPdfImageRegionsQueryHandler(db);
+        var result = await handler.Handle(
+            new GetPdfImageRegionsQuery(Guid.NewGuid(), Guid.NewGuid(), IsAdmin: false), CancellationToken.None);
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_NonOwnerPrivatePdf_ReturnsEmpty_NoLeak()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext($"getimg_{Guid.NewGuid():N}");
+        var pdfId = Guid.NewGuid();
+        SeedPdf(db, pdfId, ownerId: Guid.NewGuid()); // private, owned by another user
+        db.PdfImageRegions.Add(new PdfImageRegionEntity { PdfDocumentId = pdfId, PageNumber = 1, X = 0, Y = 0, Width = 0.5, Height = 0.5, ElementType = "Image" });
+        await db.SaveChangesAsync();
+
+        var handler = new GetPdfImageRegionsQueryHandler(db);
+        var result = await handler.Handle(
+            new GetPdfImageRegionsQuery(pdfId, Guid.NewGuid(), IsAdmin: false), CancellationToken.None);
+
+        result.Should().BeEmpty(); // non-owner of a private PDF gets an empty overlay, no existence leak
+    }
+
+    [Fact]
+    public async Task Handle_SharedGamePdf_VisibleToAnyUser()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext($"getimg_{Guid.NewGuid():N}");
+        var pdfId = Guid.NewGuid();
+        SeedPdf(db, pdfId, ownerId: Guid.NewGuid(), sharedGameId: Guid.NewGuid()); // public shared-game PDF
+        db.PdfImageRegions.Add(new PdfImageRegionEntity { PdfDocumentId = pdfId, PageNumber = 1, X = 0, Y = 0, Width = 0.5, Height = 0.5, ElementType = "Image" });
+        await db.SaveChangesAsync();
+
+        var handler = new GetPdfImageRegionsQueryHandler(db);
+        var result = await handler.Handle(
+            new GetPdfImageRegionsQuery(pdfId, Guid.NewGuid(), IsAdmin: false), CancellationToken.None);
+
+        result.Should().HaveCount(1); // shared-game PDFs are public (citation viewer)
+    }
+
+    [Fact]
+    public async Task Handle_AdminBypassesOwnership()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext($"getimg_{Guid.NewGuid():N}");
+        var pdfId = Guid.NewGuid();
+        SeedPdf(db, pdfId, ownerId: Guid.NewGuid()); // private, owned by another user
+        db.PdfImageRegions.Add(new PdfImageRegionEntity { PdfDocumentId = pdfId, PageNumber = 1, X = 0, Y = 0, Width = 0.5, Height = 0.5, ElementType = "Image" });
+        await db.SaveChangesAsync();
+
+        var handler = new GetPdfImageRegionsQueryHandler(db);
+        var result = await handler.Handle(
+            new GetPdfImageRegionsQuery(pdfId, Guid.NewGuid(), IsAdmin: true), CancellationToken.None);
+
+        result.Should().HaveCount(1); // admin bypasses ownership
+    }
+}

--- a/apps/api/tests/Api.Tests/Unit/DocumentProcessing/ImageRegionExtractorTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/DocumentProcessing/ImageRegionExtractorTests.cs
@@ -1,0 +1,50 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Unit.DocumentProcessing;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "3447")]
+public sealed class ImageRegionExtractorTests
+{
+    private const string HiResJson = """
+    {"elements":[
+      {"text":"Preparazione","page_number":1,"category":"Title","bbox":{"x":0.08,"y":0.10,"width":0.24,"height":0.05}},
+      {"text":"","page_number":4,"category":"Image","bbox":{"x":0.10,"y":0.55,"width":0.80,"height":0.30}},
+      {"text":"","page_number":5,"category":"FigureCaption","bbox":{"x":0.12,"y":0.20,"width":0.40,"height":0.06}},
+      {"text":"","page_number":6,"category":"Image","bbox":null}
+    ]}
+    """;
+
+    [Fact]
+    public void FromHiResJson_KeepsImageAndFigureCaption_WithBbox_DropsOthers()
+    {
+        var regions = ImageRegionExtractor.FromHiResJson(HiResJson);
+
+        regions.Should().HaveCount(2); // Image p4 + FigureCaption p5; Title dropped, bbox-null Image dropped
+        regions.Should().ContainSingle(r => r.ElementType == "Image" && r.Page == 4 && r.Width == 0.80);
+        regions.Should().ContainSingle(r => r.ElementType == "FigureCaption" && r.Page == 5);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("not json{")]
+    [InlineData("{\"elements\":[]}")]
+    public void FromHiResJson_NullEmptyInvalidOrNoElements_ReturnsEmpty(string? json)
+    {
+        ImageRegionExtractor.FromHiResJson(json).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void FromHiResJson_ClampsBboxToUnitRange()
+    {
+        var json = """{"elements":[{"text":"","page_number":2,"category":"Image","bbox":{"x":-0.1,"y":0.5,"width":1.5,"height":0.2}}]}""";
+        var r = ImageRegionExtractor.FromHiResJson(json).Single();
+        r.X.Should().Be(0.0);       // clamped from -0.1
+        r.Width.Should().Be(1.0);   // clamped from 1.5
+    }
+}

--- a/apps/api/tests/Api.Tests/Unit/DocumentProcessing/PdfImageRegionEntityConfigurationTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/DocumentProcessing/PdfImageRegionEntityConfigurationTests.cs
@@ -1,0 +1,38 @@
+using Api.Infrastructure.Entities;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Api.Tests.Unit.DocumentProcessing;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "3447")]
+public sealed class PdfImageRegionEntityConfigurationTests
+{
+    [Fact]
+    public async Task PdfImageRegions_RoundTrips_WithBboxAndElementType()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext($"imgregion_{Guid.NewGuid():N}");
+        var region = new PdfImageRegionEntity
+        {
+            PdfDocumentId = Guid.NewGuid(),
+            PageNumber = 4,
+            X = 0.10,
+            Y = 0.55,
+            Width = 0.80,
+            Height = 0.30,
+            ElementType = "FigureCaption"
+        };
+        db.PdfImageRegions.Add(region);
+        await db.SaveChangesAsync();
+
+        var loaded = await db.PdfImageRegions.AsNoTracking().SingleAsync();
+        loaded.PageNumber.Should().Be(4);
+        loaded.ElementType.Should().Be("FigureCaption");
+        loaded.X.Should().Be(0.10);
+        loaded.Height.Should().Be(0.30);
+    }
+}

--- a/apps/api/tests/Api.Tests/Unit/DocumentProcessing/SeedPdfImageRegionsCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/DocumentProcessing/SeedPdfImageRegionsCommandHandlerTests.cs
@@ -1,0 +1,70 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Commands;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Middleware.Exceptions;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Api.Tests.Unit.DocumentProcessing;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "3447")]
+public sealed class SeedPdfImageRegionsCommandHandlerTests
+{
+    private const string HiResJson = """
+    {"elements":[
+      {"text":"","page_number":4,"category":"Image","bbox":{"x":0.1,"y":0.5,"width":0.8,"height":0.3}},
+      {"text":"t","page_number":1,"category":"Title","bbox":{"x":0.0,"y":0.0,"width":0.1,"height":0.1}}
+    ]}
+    """;
+
+    private static void SeedPdf(MeepleAiDbContext db, Guid pdfId)
+    {
+        db.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = pdfId,
+            FileName = "test.pdf",
+            FilePath = "/tmp/test.pdf",
+            FileSizeBytes = 1024,
+            ContentType = "application/pdf",
+            UploadedByUserId = Guid.NewGuid(),
+            ProcessingState = "Ready",
+        });
+    }
+
+    [Fact]
+    public async Task Handle_InsertsParsedRegions_AndIsIdempotent()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext($"seedimg_{Guid.NewGuid():N}");
+        var pdfId = Guid.NewGuid();
+        SeedPdf(db, pdfId);
+        await db.SaveChangesAsync();
+
+        var handler = new SeedPdfImageRegionsCommandHandler(db, NullLogger<SeedPdfImageRegionsCommandHandler>.Instance);
+
+        var count1 = await handler.Handle(new SeedPdfImageRegionsCommand(pdfId, HiResJson), CancellationToken.None);
+        count1.Should().Be(1); // only the Image; Title dropped
+
+        // idempotent: seeding again replaces, does not duplicate
+        var count2 = await handler.Handle(new SeedPdfImageRegionsCommand(pdfId, HiResJson), CancellationToken.None);
+        count2.Should().Be(1);
+        (await db.PdfImageRegions.CountAsync(r => r.PdfDocumentId == pdfId)).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Handle_UnknownPdf_ThrowsNotFound()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext($"seedimg_{Guid.NewGuid():N}");
+        var handler = new SeedPdfImageRegionsCommandHandler(db, NullLogger<SeedPdfImageRegionsCommandHandler>.Instance);
+
+        var act = () => handler.Handle(new SeedPdfImageRegionsCommand(Guid.NewGuid(), HiResJson), CancellationToken.None);
+
+        // Guards the FK: a non-existent PDF is a clean 404, not a SaveChanges FK 500.
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+}

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
@@ -1174,8 +1174,10 @@ export function SessionLiveView(): ReactElement {
       visibility: 'shared' as const,
       timestamp: m.timestamp,
       citations: m.citations,
-      // AC-CHAT-3: propagate isNonGrounded ONLY from hook messages.
-      // System status messages (prepended below) do NOT get this flag → no disclaimer.
+      // Task 3 (#3388): propagate the server-authoritative groundingStatus alongside
+      // isNonGrounded — ONLY from hook messages (system status messages prepended
+      // below never carry either field, so they never show the disclaimer).
+      groundingStatus: m.groundingStatus,
       isNonGrounded: m.isNonGrounded,
     }));
 
@@ -1253,7 +1255,13 @@ export function SessionLiveView(): ReactElement {
             body: fd,
           });
           if (!res.ok) throw new Error(`ask-agent ${res.status}`);
-          const json = (await res.json()) as { answer?: string; confidence?: number };
+          // Task 3 (#3388): the multipart JSON response now carries a top-level
+          // groundingStatus (string, PascalCase — same wire contract as the SSE path).
+          const json = (await res.json()) as {
+            answer?: string;
+            confidence?: number;
+            groundingStatus?: string;
+          };
           setImageMessages(prev => [
             ...prev,
             {
@@ -1265,6 +1273,15 @@ export function SessionLiveView(): ReactElement {
                 intl.formatMessage({ id: 'pages.sessionLive.chatAgent.imageAsk.fallbackResponse' }),
               visibility: 'shared' as const,
               timestamp: new Date().toISOString(),
+              groundingStatus: json.groundingStatus as
+                | 'Grounded'
+                | 'Partial'
+                | 'Ungrounded'
+                | undefined,
+              isNonGrounded: json.groundingStatus === 'Ungrounded',
+              // Task 4 (#3388): tag as image-modality so the disclaimer copy reflects
+              // that the answer came from the photo, not the rulebook.
+              modality: 'image',
             },
           ]);
         } catch {

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
@@ -55,6 +55,19 @@ vi.mock('@/lib/domain-hooks/useSignalrSession', () => ({
   useSignalRSession: (...args: unknown[]) => useSignalRSessionMock(...args),
 }));
 
+// #3391: AgentDisputeTabContent now mounts useLiveSessionDisputes (REST hydration via useQuery).
+// Mock it to a no-op so these tests need neither a QueryClientProvider nor an
+// api.liveSessions.getDisputes mock — REST hydration is covered in
+// AgentDisputeTabContent.hydration.test.tsx.
+vi.mock('@/hooks/queries/useLiveSessionDisputes', () => ({
+  useLiveSessionDisputes: vi.fn(() => ({
+    data: [],
+    isLoading: false,
+    isSuccess: true,
+    isError: false,
+  })),
+}));
+
 // ─── next/navigation mocks ────────────────────────────────────────────────
 
 const searchParamsMap: Record<string, string> = {};

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
@@ -1958,6 +1958,34 @@ describe('SessionLiveView — #2588 A3: dual-path image/text send handler', () =
     expect((init as RequestInit).method).toBe('POST');
     expect((init as RequestInit).body).toBeInstanceOf(FormData);
   });
+
+  it('A3-3 (Task 3 #3388): image response groundingStatus="Ungrounded" flags the agent message non-grounded', async () => {
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ answer: 'Risposta immagine.', groundingStatus: 'Ungrounded' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { container } = renderWithIntl(<SessionLiveView />);
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    expect(fileInput).not.toBeNull();
+
+    const file = new File(['x'], 'board.jpg', { type: 'image/jpeg' });
+    await act(async () => {
+      fireEvent.change(fileInput, { target: { files: [file] } });
+    });
+
+    const sendBtn = screen.getAllByRole('button', { name: 'Invia messaggio' })[0];
+    await act(async () => {
+      fireEvent.click(sendBtn);
+    });
+
+    expect(
+      container.querySelector('[data-slot="chat-nongrounded-disclaimer"]')
+    ).toBeInTheDocument();
+  });
 });
 
 // ─── #2505 — viewerRole derivation + AddPlayerDialog wiring ──────────────────

--- a/apps/web/src/app/(public)/shared-games/[id]/__tests__/page.test.tsx
+++ b/apps/web/src/app/(public)/shared-games/[id]/__tests__/page.test.tsx
@@ -253,6 +253,17 @@ describe('SharedGameDetailPage (Wave A.4 — Issue #616)', () => {
       expect(meta.openGraph?.images).toEqual([{ url: SAMPLE_DETAIL.imageUrl }]);
     });
 
+    it('prefers the resolved coverUrl over the imageUrl tombstone for OG image (#3452)', async () => {
+      const coverUrl = 'https://r2.example.test/covers/33333333/cover.webp';
+      mockGetDetail.mockResolvedValue({ ...SAMPLE_DETAIL, coverUrl, imageUrl: '' });
+
+      const meta = await generateMetadata({
+        params: Promise.resolve({ id: SAMPLE_ID }),
+      });
+
+      expect(meta.openGraph?.images).toEqual([{ url: coverUrl }]);
+    });
+
     it('truncates description to 200 chars', async () => {
       const longDescription = 'x'.repeat(300);
       mockGetDetail.mockResolvedValue({ ...SAMPLE_DETAIL, description: longDescription });

--- a/apps/web/src/app/(public)/shared-games/[id]/page-client.tsx
+++ b/apps/web/src/app/(public)/shared-games/[id]/page-client.tsx
@@ -339,7 +339,7 @@ export function SharedGameDetailPageClient({
       <div className="mx-auto flex max-w-[1024px] flex-col gap-6 px-4 py-8 sm:px-6 lg:px-8">
         <Hero
           title={resolvedTitle}
-          coverUrl={game.imageUrl && game.imageUrl.length > 0 ? game.imageUrl : null}
+          coverUrl={game.coverUrl ?? null}
           year={game.yearPublished > 0 ? game.yearPublished : null}
           minPlayers={game.minPlayers > 0 ? game.minPlayers : null}
           maxPlayers={game.maxPlayers > 0 ? game.maxPlayers : null}

--- a/apps/web/src/app/(public)/shared-games/[id]/page.tsx
+++ b/apps/web/src/app/(public)/shared-games/[id]/page.tsx
@@ -129,6 +129,11 @@ export async function generateMetadata({ params }: SharedGameDetailPageProps): P
       ? detail.description.slice(0, 200)
       : SSR_METADATA.descriptionFallback;
 
+  // #3452 — prefer the R2-resolved coverUrl; imageUrl is a #2123 tombstone
+  // (always empty in prod) and is kept only as a defensive fallback.
+  const ogImage =
+    detail?.coverUrl ?? (detail?.imageUrl && detail.imageUrl.length > 0 ? detail.imageUrl : null);
+
   return {
     title: fullTitle,
     description,
@@ -137,8 +142,7 @@ export async function generateMetadata({ params }: SharedGameDetailPageProps): P
       title: fullTitle,
       description,
       type: 'website',
-      images:
-        detail?.imageUrl && detail.imageUrl.length > 0 ? [{ url: detail.imageUrl }] : undefined,
+      images: ogImage ? [{ url: ogImage }] : undefined,
     },
   };
 }

--- a/apps/web/src/app/(public)/shared-games/page-client.tsx
+++ b/apps/web/src/app/(public)/shared-games/page-client.tsx
@@ -227,7 +227,8 @@ export function SharedGamesPageClient({
     return items.map(g => ({
       id: g.id,
       title: g.title,
-      coverUrl: g.imageUrl && g.imageUrl.length > 0 ? g.imageUrl : null,
+      // #3449 — use the R2-resolved coverUrl; imageUrl is a #2123 tombstone (always empty).
+      coverUrl: g.coverUrl ?? null,
       year: g.yearPublished > 0 ? g.yearPublished : null,
       // Backend `averageRating` is on a 0..10 scale (BGG-style). Convert to 0..5.
       rating: g.averageRating != null ? g.averageRating / 2 : 0,

--- a/apps/web/src/components/features/session-live/AgentDisputeTabContent.tsx
+++ b/apps/web/src/components/features/session-live/AgentDisputeTabContent.tsx
@@ -6,16 +6,18 @@
  * Renders the "Arbitro" tab content for the canonical session-live view.
  * Hosts ArbitroModal (open-dispute CTA + form) and DisputeHistory (past verdicts).
  *
- * Dispute hydration: `useSignalRSession` is mounted at the SessionLiveView
- * orchestrator level (NOT here) so the SignalR connection persists across tab
- * changes and populates `useLiveSessionStore.disputes` in real-time.
+ * Dispute hydration (two paths):
+ *   - REST (#3391): `useLiveSessionDisputes` loads the persisted history on mount and syncs it
+ *     into `useLiveSessionStore.disputes`, so the history survives a reload.
+ *   - SignalR: `useSignalRSession` (mounted at the SessionLiveView orchestrator level so the
+ *     connection persists across tab changes) keeps the store live on 'DisputeResolved'.
  *
  * Known limitations:
- *   - No REST hydration on mount: disputes are SignalR-only (lost on reload).
  *   - Dual transport: disputes come via SignalR; rest of live state via SSE.
  *
  * @see ArbitroModal  — self-contained, POSTs to legacy endpoint, owns verdict UX.
  * @see DisputeHistory — reads disputes from useLiveSessionStore.
+ * @see useLiveSessionDisputes — REST hydration on mount (setDisputes).
  * @see useSignalRSession — wired in SessionLiveView, populates store on 'DisputeResolved'.
  */
 
@@ -23,6 +25,7 @@ import type { ReactElement } from 'react';
 
 import { ArbitroModal } from '@/components/session/live/ArbitroModal';
 import { DisputeHistory } from '@/components/session/live/DisputeHistory';
+import { useLiveSessionDisputes } from '@/hooks/queries/useLiveSessionDisputes';
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
@@ -39,6 +42,9 @@ export function AgentDisputeTabContent({
   sessionId,
   players,
 }: AgentDisputeTabContentProps): ReactElement {
+  // #3391: hydrate the persisted dispute history from REST on mount (survives reload).
+  useLiveSessionDisputes(sessionId);
+
   return (
     <div data-slot="agent-dispute-tab-content" className="flex flex-col gap-4 p-3">
       {/* Open-dispute CTA — ArbitroModal self-manages open/close state.

--- a/apps/web/src/components/features/session-live/LiveAgentChat.tsx
+++ b/apps/web/src/components/features/session-live/LiveAgentChat.tsx
@@ -50,11 +50,24 @@ export interface ChatMessage {
   readonly timestamp: string;
   readonly citations?: readonly ChatCitation[];
   /**
+   * Task 3 (#3388): server-authoritative grounding contract, propagated verbatim from
+   * `useSessionAgentChat.ChatMessage.groundingStatus` (SSE path) or set directly from
+   * the `/chat/ask-agent` JSON response (image path). Absent on system status messages.
+   */
+  readonly groundingStatus?: 'Grounded' | 'Partial' | 'Ungrounded';
+  /**
    * AC-CHAT-3: when true, the agent answered without any grounding citations.
    * Shows a discrete disclaimer below the bubble. NEVER true on system status messages
    * (those are injected by SessionLiveView without this flag).
    */
   readonly isNonGrounded?: boolean;
+  /**
+   * Task 4 (#3388): source modality of the answer, used to pick the per-modality
+   * non-grounded disclaimer copy. Absent/'text' → text-RAG SSE path copy;
+   * 'image' → multimodal /ask-agent JSON path copy (SessionLiveView sets this on
+   * the image-branch agent message).
+   */
+  readonly modality?: 'text' | 'image';
 }
 
 // ─── Labels ───────────────────────────────────────────────────────────────────
@@ -236,7 +249,9 @@ export function LiveAgentChat({
                 )}
                 {/* AC-CHAT-3: non-grounded disclaimer — only for agent messages with
                     zero citations and explicit isNonGrounded flag.
-                    NEVER shown on system status messages (those lack the flag). */}
+                    NEVER shown on system status messages (those lack the flag).
+                    Task 4 (#3388): copy varies by modality — image path answers are
+                    derived from the photo + model knowledge, not the rulebook. */}
                 {msg.isNonGrounded === true && !isOwn && (
                   <p
                     data-slot="chat-nongrounded-disclaimer"
@@ -244,7 +259,10 @@ export function LiveAgentChat({
                   >
                     <span aria-hidden="true">⚠️</span>
                     {intl.formatMessage({
-                      id: 'pages.sessionLive.chatAgent.nonGroundedDisclaimer',
+                      id:
+                        msg.modality === 'image'
+                          ? 'pages.sessionLive.chatAgent.nonGroundedDisclaimerImage'
+                          : 'pages.sessionLive.chatAgent.nonGroundedDisclaimer',
                     })}
                   </p>
                 )}

--- a/apps/web/src/components/features/session-live/__tests__/AgentDisputeTabContent.hydration.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/AgentDisputeTabContent.hydration.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * AgentDisputeTabContent — REST hydration tests (#3391, finding C8)
+ *
+ * The Arbitro tab previously read disputes ONLY from SignalR-populated store state, so on a
+ * page reload the dispute history was empty until a new SignalR event arrived. These tests
+ * exercise the real pipeline (REST client → hydration hook → live-session store → DisputeHistory)
+ * to prove the history is restored on mount.
+ *
+ * Unlike AgentDisputeTabContent.test.tsx, this file uses the REAL store (not a mock) so the
+ * hydration effect's setDisputes call is observable through the rendered DisputeHistory.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AgentDisputeTabContent } from '../AgentDisputeTabContent';
+
+import { useLiveSessionStore } from '@/lib/stores/live-session-store';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const getDisputesMock = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    liveSessions: {
+      submitDispute: vi.fn(),
+      getDisputes: (sessionId: string) => getDisputesMock(sessionId),
+    },
+  },
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const PLAYERS = [
+  { id: 'p1', name: 'Marco' },
+  { id: 'p2', name: 'Anna' },
+];
+
+function renderContent(sessionId = 'sess-001'): ReturnType<typeof render> {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const ui: ReactElement = (
+    <QueryClientProvider client={queryClient}>
+      <AgentDisputeTabContent sessionId={sessionId} players={PLAYERS} />
+    </QueryClientProvider>
+  );
+  return render(ui);
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('AgentDisputeTabContent — REST hydration on reload (#3391)', () => {
+  beforeEach(() => {
+    useLiveSessionStore.getState().reset();
+    getDisputesMock.mockReset();
+    getDisputesMock.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    useLiveSessionStore.getState().reset();
+  });
+
+  it('hydrates the dispute history from REST on mount (store starts empty, as after reload)', async () => {
+    getDisputesMock.mockResolvedValue([
+      {
+        id: 'd1',
+        description: 'Può giocare questa carta?',
+        verdict: 'No, non può.',
+        ruleReferences: ['Rule 5.3'],
+        raisedByPlayerName: 'Marco',
+        timestamp: '2026-06-30T10:00:00Z',
+      },
+    ]);
+
+    renderContent('sess-001');
+
+    // DisputeHistory renders the collapsed toggle only when disputes exist → proves the store
+    // was hydrated from the REST snapshot after mount (it started empty).
+    expect(
+      await screen.findByRole('button', { name: /Verdetti precedenti \(1\)/i })
+    ).toBeInTheDocument();
+
+    expect(getDisputesMock).toHaveBeenCalledWith('sess-001');
+  });
+
+  it('shows no history when the session has no persisted disputes', async () => {
+    getDisputesMock.mockResolvedValue([]);
+
+    renderContent('sess-002');
+
+    // Give the query a chance to resolve, then assert the toggle never appears.
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    await screen.findByRole('button', { name: /Arbitro/i }); // tab is rendered
+    expect(screen.queryByRole('button', { name: /Verdetti precedenti/i })).not.toBeInTheDocument();
+  });
+
+  // Regression guard for the review finding: on a remount served by a stale/empty REST cache,
+  // hydration must NOT drop a dispute already appended live via SignalR (store singleton).
+  it('preserves a live SignalR-appended dispute when hydrating a REST snapshot that lacks it', async () => {
+    // A dispute already in the store (as if addDispute fired from a SignalR 'DisputeResolved').
+    useLiveSessionStore.getState().addDispute({
+      id: 'live-1',
+      description: 'Live dispute via SignalR',
+      verdict: 'Sì.',
+      ruleReferences: [],
+      raisedByPlayerName: 'Alice',
+      timestamp: '2026-06-30T12:05:00Z',
+    });
+    // REST snapshot with a DIFFERENT persisted dispute but NOT the live one (e.g. a cache
+    // predating the SignalR append). A blind replace would drop 'live-1'; a merge keeps both.
+    // Returning a distinct id makes the clobber observable stably (waiting on 'rest-1' proves
+    // hydration applied before we assert 'live-1' survived).
+    getDisputesMock.mockResolvedValue([
+      {
+        id: 'rest-1',
+        description: 'Persisted dispute',
+        verdict: 'No.',
+        ruleReferences: ['p.1'],
+        raisedByPlayerName: 'Bob',
+        timestamp: '2026-06-30T12:00:00Z',
+      },
+    ]);
+
+    renderContent('sess-003');
+
+    // Wait until hydration has applied the REST snapshot...
+    await waitFor(() =>
+      expect(useLiveSessionStore.getState().disputes.map((d) => d.id)).toContain('rest-1')
+    );
+    // ...then the live SignalR dispute must still be present (merge, not blind replace).
+    expect(useLiveSessionStore.getState().disputes.map((d) => d.id)).toContain('live-1');
+  });
+});

--- a/apps/web/src/components/features/session-live/__tests__/AgentDisputeTabContent.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/AgentDisputeTabContent.test.tsx
@@ -9,6 +9,7 @@
  *   - DisputeHistory shows verdicts from useLiveSessionStore.disputes
  */
 
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -17,11 +18,13 @@ import { AgentDisputeTabContent } from '../AgentDisputeTabContent';
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
-// Mock the api (ArbitroModal calls api.liveSessions.submitDispute)
+// Mock the api. ArbitroModal calls submitDispute; AgentDisputeTabContent now also mounts
+// useLiveSessionDisputes → api.liveSessions.getDisputes (#3391), so it must exist on the mock.
 vi.mock('@/lib/api', () => ({
   api: {
     liveSessions: {
       submitDispute: vi.fn(),
+      getDisputes: vi.fn(() => Promise.resolve([])),
     },
   },
 }));
@@ -36,11 +39,16 @@ let mockDisputes: Array<{
   timestamp: string;
 }> = [];
 
-vi.mock('@/lib/stores/live-session-store', () => ({
-  useLiveSessionStore: (
-    selector: (s: { disputes: typeof mockDisputes; addDispute: () => void }) => unknown
-  ) => selector({ disputes: mockDisputes, addDispute: vi.fn() }),
-}));
+vi.mock('@/lib/stores/live-session-store', () => {
+  const state = () => ({ disputes: mockDisputes, addDispute: vi.fn(), setDisputes: vi.fn() });
+  // useLiveSessionDisputes reads useLiveSessionStore.getState().disputes (merge on hydration),
+  // so the mock must expose getState in addition to the selector-call form.
+  const useLiveSessionStore = Object.assign(
+    (selector: (s: ReturnType<typeof state>) => unknown) => selector(state()),
+    { getState: state }
+  );
+  return { useLiveSessionStore };
+});
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -50,7 +58,12 @@ const PLAYERS = [
 ];
 
 function renderContent(sessionId = 'sess-001') {
-  return render(<AgentDisputeTabContent sessionId={sessionId} players={PLAYERS} />);
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AgentDisputeTabContent sessionId={sessionId} players={PLAYERS} />
+    </QueryClientProvider>
+  );
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────

--- a/apps/web/src/components/features/session-live/__tests__/LiveAgentChat.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/LiveAgentChat.test.tsx
@@ -31,6 +31,8 @@ const INTL_MESSAGES = {
   'pages.sessionLive.chat.newMessagesToast':
     '{count, plural, one {# nuovo messaggio} other {# nuovi messaggi}}',
   'pages.sessionLive.chatAgent.nonGroundedDisclaimer': 'Risposta non basata sul regolamento',
+  'pages.sessionLive.chatAgent.nonGroundedDisclaimerImage':
+    'Ho risposto dalla foto e dalla mia conoscenza del gioco, non dal regolamento ufficiale — verifica sul manuale',
   'pages.sessionLive.chat.removeImageAriaLabel': 'Rimuovi immagine {n}',
 };
 
@@ -391,6 +393,59 @@ describe('#2500 AC-CHAT-3 — non-grounded disclaimer', () => {
     expect(
       container.querySelector('[data-slot="chat-nongrounded-disclaimer"]')
     ).not.toBeInTheDocument();
+  });
+
+  it('messaggio assistant isNonGrounded:true + modality:"image" -> disclaimer copy immagine', () => {
+    const msgNonGroundedImage: ChatMessage = {
+      id: 'msg-ng-image',
+      senderId: 'agent',
+      senderName: 'MeepleAI',
+      content: 'Risposta dalla foto.',
+      visibility: 'shared',
+      timestamp: '2026-06-23T10:00:00Z',
+      isNonGrounded: true,
+      modality: 'image',
+    };
+    const { container } = renderChat({ messages: [msgNonGroundedImage] });
+    const disclaimer = container.querySelector('[data-slot="chat-nongrounded-disclaimer"]');
+    expect(disclaimer).toBeInTheDocument();
+    expect(disclaimer?.textContent).toContain(
+      'Ho risposto dalla foto e dalla mia conoscenza del gioco, non dal regolamento ufficiale'
+    );
+    expect(disclaimer?.textContent).not.toContain('Risposta non basata sul regolamento');
+  });
+
+  it('messaggio assistant isNonGrounded:true + modality:"text" -> disclaimer copy testo esistente', () => {
+    const msgNonGroundedText: ChatMessage = {
+      id: 'msg-ng-text',
+      senderId: 'agent',
+      senderName: 'MeepleAI',
+      content: 'Risposta senza fonti.',
+      visibility: 'shared',
+      timestamp: '2026-06-23T10:00:00Z',
+      isNonGrounded: true,
+      modality: 'text',
+    };
+    const { container } = renderChat({ messages: [msgNonGroundedText] });
+    const disclaimer = container.querySelector('[data-slot="chat-nongrounded-disclaimer"]');
+    expect(disclaimer).toBeInTheDocument();
+    expect(disclaimer?.textContent).toContain('Risposta non basata sul regolamento');
+  });
+
+  it('messaggio assistant isNonGrounded:true + modality assente -> disclaimer copy testo esistente (default)', () => {
+    const msgNonGroundedDefault: ChatMessage = {
+      id: 'msg-ng-default',
+      senderId: 'agent',
+      senderName: 'MeepleAI',
+      content: 'Risposta senza fonti.',
+      visibility: 'shared',
+      timestamp: '2026-06-23T10:00:00Z',
+      isNonGrounded: true,
+    };
+    const { container } = renderChat({ messages: [msgNonGroundedDefault] });
+    const disclaimer = container.querySelector('[data-slot="chat-nongrounded-disclaimer"]');
+    expect(disclaimer).toBeInTheDocument();
+    expect(disclaimer?.textContent).toContain('Risposta non basata sul regolamento');
   });
 });
 

--- a/apps/web/src/components/pdf/PdfImageRegionOverlay.tsx
+++ b/apps/web/src/components/pdf/PdfImageRegionOverlay.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+/**
+ * PdfImageRegionOverlay — %-based table-image region overlay (#3447 slice).
+ *
+ * Twin of {@link PdfBBoxOverlay}: draws one rectangle per hi_res Image/FigureCaption region as an
+ * absolutely-positioned child of the react-pdf `<Page>` wrapper (position: relative). Regions are
+ * normalized [0,1] top-left → percentage rects, scale/DPR-independent. The caller filters `rects`
+ * to the visible page. Decorative only (`aria-hidden`); a distinct dashed style marks table graphics
+ * vs the citation highlight.
+ *
+ * Spec: docs/superpowers/specs/2026-08-01-image-table-region-slice-design.md
+ */
+
+import type { ReactElement } from 'react';
+
+import type { ImageRegion } from '@/lib/api/schemas';
+
+export interface PdfImageRegionOverlayProps {
+  readonly rects: readonly ImageRegion[];
+}
+
+export function PdfImageRegionOverlay({ rects }: PdfImageRegionOverlayProps): ReactElement | null {
+  if (rects.length === 0) return null;
+
+  return (
+    <div
+      aria-hidden="true"
+      data-slot="pdf-image-region-overlay"
+      data-testid="pdf-image-region-overlay"
+      className="pointer-events-none absolute inset-0"
+    >
+      {rects.map((r, i) => (
+        <div
+          key={`${r.page}:${r.x},${r.y},${r.width},${r.height}:${i}`}
+          data-testid="pdf-image-region-rect"
+          className="pdf-image-region-highlight absolute"
+          style={{
+            left: `${r.x * 100}%`,
+            top: `${r.y * 100}%`,
+            width: `${r.width * 100}%`,
+            height: `${r.height * 100}%`,
+          }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/pdf/PdfInlineViewer.tsx
+++ b/apps/web/src/components/pdf/PdfInlineViewer.tsx
@@ -35,10 +35,12 @@ import 'react-pdf/dist/Page/AnnotationLayer.css';
 import 'react-pdf/dist/Page/TextLayer.css';
 
 import { api } from '@/lib/api';
+import type { ImageRegion } from '@/lib/api/schemas';
 import type { CitationRegion } from '@/types';
 
 import { makeQuoteTextRenderer } from './pdf-quote-highlight';
 import { PdfBBoxOverlay } from './PdfBBoxOverlay';
+import { PdfImageRegionOverlay } from './PdfImageRegionOverlay';
 
 // Worker setup — T0 spike confirmed idempotent (multi-module assignment safe).
 pdfjs.GlobalWorkerOptions.workerSrc = new URL(
@@ -96,6 +98,7 @@ export function PdfInlineViewer({
   const [zoom, setZoom] = useState<ZoomState>(defaultZoom);
   const [containerWidth, setContainerWidth] = useState<number>(800);
   const [jumpInput, setJumpInput] = useState<string>(String(initialPage));
+  const [imageRegions, setImageRegions] = useState<readonly ImageRegion[]>([]); // #3447 slice
   const containerRef = useRef<HTMLDivElement>(null);
 
   const downloadUrl = api.pdf.getPdfDownloadUrl(documentId);
@@ -106,6 +109,12 @@ export function PdfInlineViewer({
   const pageRects = useMemo(
     () => (highlightRects ?? []).filter(r => r.page === currentPage),
     [highlightRects, currentPage]
+  );
+
+  // #3447 slice: table-image regions for the current page (fetched on open, below).
+  const pageImageRegions = useMemo(
+    () => imageRegions.filter(r => r.page === currentPage),
+    [imageRegions, currentPage]
   );
 
   const quoteRenderer = useMemo(
@@ -149,6 +158,22 @@ export function PdfInlineViewer({
 
     return () => controller.abort();
   }, [downloadUrl, initialPage]);
+
+  // #3447 slice: fetch persisted image-table regions on open (independent of the blob fetch).
+  useEffect(() => {
+    let cancelled = false;
+    api.pdf
+      .getImageRegions(documentId)
+      .then(regions => {
+        if (!cancelled) setImageRegions(regions ?? []);
+      })
+      .catch(() => {
+        if (!cancelled) setImageRegions([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [documentId]);
 
   // ResizeObserver for fit-width scale recompute.
   useEffect(() => {
@@ -338,6 +363,9 @@ export function PdfInlineViewer({
                 }
               >
                 {pageRects.length > 0 ? <PdfBBoxOverlay rects={pageRects} /> : null}
+                {pageImageRegions.length > 0 ? (
+                  <PdfImageRegionOverlay rects={pageImageRegions} />
+                ) : null}
               </Page>
             </Document>
           </div>

--- a/apps/web/src/components/pdf/__tests__/PdfImageRegionOverlay.test.tsx
+++ b/apps/web/src/components/pdf/__tests__/PdfImageRegionOverlay.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { PdfImageRegionOverlay } from '../PdfImageRegionOverlay';
+import type { ImageRegion } from '@/lib/api/schemas';
+
+const rect = (o: Partial<ImageRegion>): ImageRegion => ({
+  page: 4,
+  x: 0,
+  y: 0,
+  width: 0.1,
+  height: 0.1,
+  elementType: 'Image',
+  ...o,
+});
+
+describe('PdfImageRegionOverlay', () => {
+  it('renders one %-positioned rect per region', () => {
+    render(<PdfImageRegionOverlay rects={[rect({ x: 0.1, y: 0.2, width: 0.3, height: 0.05 })]} />);
+    const el = screen.getByTestId('pdf-image-region-rect');
+    expect(el.style.left).toBe('10%');
+    expect(el.style.top).toBe('20%');
+    expect(el.style.width).toBe('30%');
+    expect(el.style.height).toBe('5%');
+  });
+
+  it('renders one rect per region', () => {
+    render(
+      <PdfImageRegionOverlay
+        rects={[rect({ page: 4 }), rect({ page: 4, x: 0.5 }), rect({ page: 4, y: 0.5 })]}
+      />
+    );
+    expect(screen.getAllByTestId('pdf-image-region-rect')).toHaveLength(3);
+  });
+
+  it('renders nothing for empty rects', () => {
+    const { container } = render(<PdfImageRegionOverlay rects={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/web/src/components/pdf/__tests__/PdfInlineViewer.test.tsx
+++ b/apps/web/src/components/pdf/__tests__/PdfInlineViewer.test.tsx
@@ -31,7 +31,11 @@ vi.mock('react-pdf', () => ({
 
 vi.mock('@/lib/api', () => ({
   api: {
-    pdf: { getPdfDownloadUrl: (id: string) => `http://test/api/v1/pdfs/${id}/download` },
+    pdf: {
+      getPdfDownloadUrl: (id: string) => `http://test/api/v1/pdfs/${id}/download`,
+      // #3447 slice: default no regions so existing tests are unaffected; specific tests override.
+      getImageRegions: vi.fn().mockResolvedValue([]),
+    },
   },
 }));
 
@@ -39,6 +43,7 @@ const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
 
 import { PdfInlineViewer } from '../PdfInlineViewer';
+import { api } from '@/lib/api';
 
 function mockBlobSuccess() {
   mockFetch.mockResolvedValue({
@@ -67,6 +72,24 @@ describe('PdfInlineViewer', () => {
     await waitFor(() => {
       expect(screen.getByTestId('pdf-page')).toHaveAttribute('data-page-number', '3');
     });
+  });
+
+  it('draws the image-region overlay for the current page (#3447)', async () => {
+    vi.mocked(api.pdf.getImageRegions).mockResolvedValueOnce([
+      { page: 1, x: 0.1, y: 0.2, width: 0.3, height: 0.1, elementType: 'Image' },
+    ]);
+    render(<PdfInlineViewer documentId="doc-1" initialPage={1} />);
+    await waitFor(() => expect(screen.getByTestId('pdf-page')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByTestId('pdf-image-region-rect')).toBeInTheDocument());
+  });
+
+  it('does not draw image regions belonging to other pages (#3447)', async () => {
+    vi.mocked(api.pdf.getImageRegions).mockResolvedValueOnce([
+      { page: 3, x: 0.1, y: 0.2, width: 0.3, height: 0.1, elementType: 'Image' },
+    ]);
+    render(<PdfInlineViewer documentId="doc-1" initialPage={1} />);
+    await waitFor(() => expect(screen.getByTestId('pdf-page')).toBeInTheDocument());
+    expect(screen.queryByTestId('pdf-image-region-rect')).not.toBeInTheDocument();
   });
 
   it('shows error banner on fetch HTTP 500', async () => {

--- a/apps/web/src/hooks/queries/useLiveSessionDisputes.ts
+++ b/apps/web/src/hooks/queries/useLiveSessionDisputes.ts
@@ -1,0 +1,64 @@
+/**
+ * useLiveSessionDisputes — TanStack Query loader that hydrates the Arbitro tab's dispute history.
+ *
+ * Issue #3391 (finding C8): the dispute history was SignalR-only, so reopening/reloading a session
+ * showed no prior verdicts until a new SignalR event arrived. This hook loads the persisted history
+ * from REST on mount and syncs it into the live-session store (`setDisputes`), the same store slice
+ * that `useSignalRSession` keeps live via `addDispute`. The disputes key nests under
+ * liveSessionKeys.detail(id) so dispute mutations can invalidate it.
+ */
+import { useEffect } from 'react';
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { liveSessionKeys } from '@/hooks/queries/useLiveSession';
+import { api } from '@/lib/api';
+import type { RuleDisputeDto } from '@/lib/api/schemas/improvvisata.schemas';
+import { useLiveSessionStore, type RuleDispute } from '@/lib/stores/live-session-store';
+
+export const liveSessionDisputeKeys = {
+  detail: (id: string) => [...liveSessionKeys.detail(id), 'disputes'] as const,
+};
+
+/** Maps the REST DTO to the store's RuleDispute model. v2 badge fields arrive via SignalR only. */
+function toRuleDispute(dto: RuleDisputeDto): RuleDispute {
+  return {
+    id: dto.id,
+    description: dto.description,
+    verdict: dto.verdict,
+    ruleReferences: dto.ruleReferences,
+    raisedByPlayerName: dto.raisedByPlayerName,
+    timestamp: dto.timestamp,
+  };
+}
+
+export function useLiveSessionDisputes(
+  sessionId: string,
+  enabled: boolean = true
+): UseQueryResult<RuleDisputeDto[], Error> {
+  // Zustand action selector — stable reference across renders, safe as an effect dependency.
+  const setDisputes = useLiveSessionStore(s => s.setDisputes);
+
+  const query = useQuery({
+    queryKey: liveSessionDisputeKeys.detail(sessionId),
+    queryFn: () => api.liveSessions.getDisputes(sessionId),
+    enabled: enabled && !!sessionId,
+    staleTime: 30 * 1000,
+  });
+
+  useEffect(() => {
+    if (!query.data) return;
+    // Merge the authoritative REST snapshot with any live (SignalR-appended) disputes not yet
+    // reflected in it, dedup by id, so a stale-cache remount within staleTime never drops a
+    // dispute newer than the last fetch (#3391 review). On id collision the store entry wins:
+    // it carries the live v2 badge fields (confidence/outcome/votes) the REST summary omits.
+    // `addDispute` remains the live append path; this only reconciles on (re)hydration.
+    const byId = new Map<string, RuleDispute>();
+    for (const d of query.data.map(toRuleDispute)) byId.set(d.id, d);
+    for (const d of useLiveSessionStore.getState().disputes) byId.set(d.id, d);
+    const merged = [...byId.values()].sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+    setDisputes(merged);
+  }, [query.data, setDisputes]);
+
+  return query;
+}

--- a/apps/web/src/lib/api/clients/__tests__/pdfClient.test.ts
+++ b/apps/web/src/lib/api/clients/__tests__/pdfClient.test.ts
@@ -9,6 +9,7 @@ import type { Mock } from 'vitest';
 import { createPdfClient } from '../pdfClient';
 import { HttpClient } from '../../core/httpClient';
 import { getApiBase } from '../../core/httpClient';
+import { ImageRegionsResponseSchema } from '../../schemas';
 
 vi.mock('../../core/httpClient', async () => ({
   ...(await vi.importActual('../../core/httpClient')),
@@ -35,6 +36,40 @@ describe('createPdfClient', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+  });
+
+  describe('getImageRegions', () => {
+    it('fetches and unwraps image regions', async () => {
+      const regions = [{ page: 4, x: 0.1, y: 0.5, width: 0.8, height: 0.3, elementType: 'Image' }];
+      mockHttpClient.get.mockResolvedValueOnce({ regions });
+
+      const result = await pdfClient.getImageRegions('pdf-123');
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith(
+        '/api/v1/pdf/pdf-123/image-regions',
+        ImageRegionsResponseSchema
+      );
+      expect(result).toEqual(regions);
+    });
+
+    it('encodes the pdf id in the request path', async () => {
+      mockHttpClient.get.mockResolvedValueOnce({ regions: [] });
+
+      await pdfClient.getImageRegions('pdf/with spaces');
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith(
+        '/api/v1/pdf/pdf%2Fwith%20spaces/image-regions',
+        ImageRegionsResponseSchema
+      );
+    });
+
+    it('returns null when the endpoint returns null', async () => {
+      mockHttpClient.get.mockResolvedValueOnce(null);
+
+      const result = await pdfClient.getImageRegions('pdf-123');
+
+      expect(result).toBeNull();
+    });
   });
 
   describe('getProcessingProgress', () => {

--- a/apps/web/src/lib/api/clients/liveSessionsClient.ts
+++ b/apps/web/src/lib/api/clients/liveSessionsClient.ts
@@ -12,7 +12,9 @@ import { z } from 'zod';
 import {
   RuleDisputeResponseSchema,
   CreatePauseSnapshotResponseSchema,
+  SessionDisputesResultSchema,
   type RuleDisputeResponse,
+  type RuleDisputeDto,
   type CreatePauseSnapshotResponse,
 } from '../schemas/improvvisata.schemas';
 import {
@@ -190,6 +192,12 @@ export interface LiveSessionsClient {
   /** Get all diary entries for the session, ordered by createdAt ascending. */
   getDiary(sessionId: string): Promise<LiveSessionDiaryEntryDto[]>;
 
+  /**
+   * Get all rule disputes for the session, ordered by timestamp ascending (#3391).
+   * Powers the Arbitro tab's REST hydration on reload (SignalR keeps it live thereafter).
+   */
+  getDisputes(sessionId: string): Promise<RuleDisputeDto[]>;
+
   // ========== AI Score Tracking (Issue #121) ==========
 
   /** Parse a natural language message for score data, optionally auto-record */
@@ -344,6 +352,14 @@ export function createLiveSessionsClient({
         `${BASE}/${encodeURIComponent(sessionId)}/diary`
       );
       return z.array(LiveSessionDiaryEntryDtoSchema).parse(response ?? []);
+    },
+
+    async getDisputes(sessionId) {
+      const response = await httpClient.get<unknown>(
+        `${BASE}/${encodeURIComponent(sessionId)}/disputes`
+      );
+      if (!response) return [];
+      return SessionDisputesResultSchema.parse(response).disputes;
     },
 
     async getPlayers(sessionId) {

--- a/apps/web/src/lib/api/clients/pdfClient.ts
+++ b/apps/web/src/lib/api/clients/pdfClient.ts
@@ -11,6 +11,8 @@ import {
   type ProcessingProgress,
   PdfMetricsSchema,
   type PdfMetrics,
+  ImageRegionsResponseSchema,
+  type ImageRegion,
 } from '../schemas';
 import {
   IndexerVersionListSchema,
@@ -425,6 +427,20 @@ export function createPdfClient({ httpClient }: CreatePdfClientParams) {
         {}
       );
       return result ?? { orphanedChunks: 0, orphanedVectors: 0 };
+    },
+
+    // ========== Image-Table Regions (#3447 slice) ==========
+
+    /**
+     * Get persisted hi_res image-table regions for a PDF (viewer overlay).
+     * GET /api/v1/pdf/{pdfId}/image-regions
+     */
+    async getImageRegions(pdfId: string): Promise<ImageRegion[] | null> {
+      const res = await httpClient.get(
+        `/api/v1/pdf/${encodeURIComponent(pdfId)}/image-regions`,
+        ImageRegionsResponseSchema
+      );
+      return res?.regions ?? null;
     },
   };
 }

--- a/apps/web/src/lib/api/schemas/improvvisata.schemas.ts
+++ b/apps/web/src/lib/api/schemas/improvvisata.schemas.ts
@@ -54,6 +54,15 @@ export const GameDisputeHistoryItemSchema = z.object({
 
 export type GameDisputeHistoryItem = z.infer<typeof GameDisputeHistoryItemSchema>;
 
+// Per-session dispute history (#3391): GET /live-sessions/{id}/disputes → GetSessionDisputesResult.
+// Same shape as a single GameDisputeHistoryItem group but scoped to one live session (no startedAt).
+export const SessionDisputesResultSchema = z.object({
+  sessionId: z.string().uuid(),
+  disputes: z.array(RuleDisputeDtoSchema),
+});
+
+export type SessionDisputesResult = z.infer<typeof SessionDisputesResultSchema>;
+
 // ──────────────────────────────────────────────
 // Pause Snapshot
 // ──────────────────────────────────────────────

--- a/apps/web/src/lib/api/schemas/pdf.schemas.ts
+++ b/apps/web/src/lib/api/schemas/pdf.schemas.ts
@@ -9,6 +9,19 @@ import { z } from 'zod';
 
 import { GameIdString } from './common.schemas';
 
+// ========== Image-Table Regions (#3447 slice) ==========
+
+export const ImageRegionSchema = z.object({
+  page: z.number().int(),
+  x: z.number(),
+  y: z.number(),
+  width: z.number(),
+  height: z.number(),
+  elementType: z.string(),
+});
+export const ImageRegionsResponseSchema = z.object({ regions: z.array(ImageRegionSchema) });
+export type ImageRegion = z.infer<typeof ImageRegionSchema>;
+
 // ========== PDF Document ==========
 
 export const PdfDocumentDtoSchema = z.object({

--- a/apps/web/src/lib/api/schemas/shared-games.schemas.ts
+++ b/apps/web/src/lib/api/schemas/shared-games.schemas.ts
@@ -317,6 +317,12 @@ export const SharedGameDetailSchema = z.object({
   averageRating: z.number().nullable(),
   imageUrl: z.string().catch(''), // coerce null/missing to empty string
   thumbnailUrl: z.string().catch(''), // coerce null/missing to empty string
+  // Issue #2123 / #3449 — R2-resolved cover URL. Preferred over imageUrl/thumbnailUrl,
+  // which are kept as legacy tombstones. Backend SharedGameDetailDto already returns it
+  // (GetSharedGameByIdQueryHandler, resolved via CoverUrlResolver); null when no cover
+  // has been generated yet — consumers MUST fall back to the deterministic placeholder
+  // via `lib/games/cover-utils.ts`.
+  coverUrl: z.string().url().nullable().optional(),
   rules: GameRulesSchema.nullable(),
   status: GameStatusSchema, // Now string enum with JsonStringEnumConverter
   createdBy: z.string().uuid(),

--- a/apps/web/src/lib/api/shared-games.test.ts
+++ b/apps/web/src/lib/api/shared-games.test.ts
@@ -263,6 +263,16 @@ describe('getSharedGameDetail', () => {
     expect(result.kbs).toEqual([]);
   });
 
+  it('parses the R2-resolved coverUrl through schema (#3449)', async () => {
+    const withCover = {
+      ...SAMPLE_DETAIL,
+      coverUrl: 'https://r2.example.test/covers/pdf/33333333/cover-preview.webp',
+    };
+    fetchSpy.mockResolvedValueOnce(makeJsonResponse(withCover));
+    const result = await getSharedGameDetail(withCover.id);
+    expect(result.coverUrl).toBe(withCover.coverUrl);
+  });
+
   it('parses populated nested arrays through schema', async () => {
     const populated = {
       ...SAMPLE_DETAIL,

--- a/apps/web/src/lib/domain-hooks/__tests__/useSessionAgentChat.test.ts
+++ b/apps/web/src/lib/domain-hooks/__tests__/useSessionAgentChat.test.ts
@@ -41,10 +41,20 @@ function sseToken(token: string): string {
   return `data: ${JSON.stringify({ type: 7, data: { token }, timestamp: new Date().toISOString() })}\n\n`;
 }
 
-function sseComplete(chatThreadId: string, citations?: unknown[]): string {
+function sseComplete(
+  chatThreadId: string,
+  citations?: unknown[],
+  groundingStatus?: string
+): string {
   return `data: ${JSON.stringify({
     type: 4,
-    data: { chatThreadId, citations: citations ?? [], totalTokens: 10, confidence: 0.9 },
+    data: {
+      chatThreadId,
+      citations: citations ?? [],
+      totalTokens: 10,
+      confidence: 0.9,
+      groundingStatus,
+    },
     timestamp: new Date().toISOString(),
   })}\n\n`;
 }
@@ -552,6 +562,59 @@ describe('useSessionAgentChat', () => {
 
       const lastMsg = result.current.messages[result.current.messages.length - 1];
       expect(lastMsg.role).toBe('assistant');
+      expect(lastMsg.isNonGrounded).toBeFalsy();
+    });
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Task 3 (#3388): server-authoritative groundingStatus on the SSE Complete
+    // event now drives isNonGrounded instead of the citations heuristic.
+    // ─────────────────────────────────────────────────────────────────────
+
+    it('SSE complete groundingStatus="Ungrounded" → message carries groundingStatus + isNonGrounded:true', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          body: makeReadableStream([
+            sseToken('Risposta.'),
+            sseComplete('t-gs-ungrounded', [], 'Ungrounded'),
+          ]),
+        } as unknown as Response)
+      );
+
+      const { result } = renderHook(() => useSessionAgentChat('game-sess-gs-1', 'agent-gs-1'));
+
+      await act(async () => {
+        await result.current.ask('Domanda');
+      });
+
+      const lastMsg = result.current.messages[result.current.messages.length - 1];
+      expect(lastMsg.role).toBe('assistant');
+      expect(lastMsg.groundingStatus).toBe('Ungrounded');
+      expect(lastMsg.isNonGrounded).toBe(true);
+    });
+
+    it('SSE complete groundingStatus="Grounded" (with citations) → groundingStatus set + isNonGrounded falsy', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          body: makeReadableStream([
+            sseToken('Risposta.'),
+            sseComplete('t-gs-grounded', [makeCitationDto()], 'Grounded'),
+          ]),
+        } as unknown as Response)
+      );
+
+      const { result } = renderHook(() => useSessionAgentChat('game-sess-gs-2', 'agent-gs-2'));
+
+      await act(async () => {
+        await result.current.ask('Domanda');
+      });
+
+      const lastMsg = result.current.messages[result.current.messages.length - 1];
+      expect(lastMsg.role).toBe('assistant');
+      expect(lastMsg.groundingStatus).toBe('Grounded');
       expect(lastMsg.isNonGrounded).toBeFalsy();
     });
 

--- a/apps/web/src/lib/domain-hooks/useSessionAgentChat.ts
+++ b/apps/web/src/lib/domain-hooks/useSessionAgentChat.ts
@@ -28,9 +28,18 @@ export interface ChatMessage {
   timestamp: string;
   citations?: ChatCitation[];
   /**
+   * Task 3 (#3388): server-authoritative grounding contract, read verbatim from the
+   * SSE `Complete` event's `data.groundingStatus` (string, PascalCase — see
+   * `Api.SharedKernel.Domain.Enums.GroundingStatus`). Absent on user messages and on
+   * history-hydrated messages (the thread DTO does not carry this field).
+   */
+  groundingStatus?: 'Grounded' | 'Partial' | 'Ungrounded';
+  /**
    * AC-CHAT-3: true only when this is a genuine RAG assistant response with zero citations
    * (i.e., the agent answered but found no grounding in the rulebook).
    * Never set on user messages or system status messages injected by SessionLiveView.
+   * Derived from `groundingStatus` when present (Task 3 #3388); falls back to the
+   * citations heuristic when the server did not send `groundingStatus`.
    */
   isNonGrounded?: boolean;
 }
@@ -120,6 +129,9 @@ export function useSessionAgentChat(
   const [streamingContent, setStreamingContent] = useState('');
   const threadIdRef = useRef<string | undefined>(undefined);
   const citationsRef = useRef<ChatCitation[]>([]);
+  // Task 3 (#3388): server-authoritative groundingStatus captured from the SSE
+  // Complete event, consumed when building the assistant message below.
+  const groundingStatusRef = useRef<ChatMessage['groundingStatus']>(undefined);
   const abortRef = useRef<AbortController | null>(null);
   // Ref-based guard prevents double-submit race regardless of stale closure timing
   const isLoadingRef = useRef(false);
@@ -208,6 +220,7 @@ export function useSessionAgentChat(
       setError(null);
       setStreamingContent('');
       citationsRef.current = [];
+      groundingStatusRef.current = undefined;
 
       const userMsg: ChatMessage = {
         id: crypto.randomUUID(),
@@ -320,6 +333,7 @@ export function useSessionAgentChat(
                     const d = event.data as {
                       chatThreadId?: string;
                       citations?: unknown[];
+                      groundingStatus?: string;
                     };
                     if (d.chatThreadId) {
                       threadIdRef.current = d.chatThreadId;
@@ -334,6 +348,14 @@ export function useSessionAgentChat(
                       )
                         .map(mapCitationToChatCitation)
                         .filter((x): x is ChatCitation => x !== null);
+                    }
+                    // Task 3 (#3388): server-authoritative grounding contract.
+                    if (
+                      d.groundingStatus === 'Grounded' ||
+                      d.groundingStatus === 'Partial' ||
+                      d.groundingStatus === 'Ungrounded'
+                    ) {
+                      groundingStatusRef.current = d.groundingStatus;
                     }
                   } else if (event.type === SSE_ERROR) {
                     const d = event.data as { errorMessage?: string; errorCode?: string };
@@ -351,15 +373,24 @@ export function useSessionAgentChat(
           reader.releaseLock();
         }
 
-        // AC-CHAT-3: if the RAG response produced zero citations, flag as non-grounded.
+        // Task 3 (#3388): prefer the server-authoritative groundingStatus; fall back to
+        // the citations heuristic (AC-CHAT-3) only when the server did not send it.
         const hasCitations = citationsRef.current.length > 0;
+        const groundingStatus = groundingStatusRef.current;
+        const isNonGrounded =
+          groundingStatus !== undefined
+            ? groundingStatus === 'Ungrounded'
+            : hasCitations
+              ? undefined
+              : true;
         const assistantMsg: ChatMessage = {
           id: crypto.randomUUID(),
           role: 'assistant',
           content: accumulated,
           timestamp: new Date().toISOString(),
           citations: hasCitations ? citationsRef.current : undefined,
-          isNonGrounded: hasCitations ? undefined : true,
+          groundingStatus,
+          isNonGrounded,
         };
         setMessages(prev => [...prev, assistantMsg]);
         setStreamingContent('');

--- a/apps/web/src/lib/session-live/__tests__/numeric-role-contracts.test.ts
+++ b/apps/web/src/lib/session-live/__tests__/numeric-role-contracts.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Boundary guard for the two backend role enums' numeric wire contracts (issue #3392).
+ *
+ * Backend `SseJsonOptions` disables JsonStringEnumConverter, so role enums cross the wire as
+ * INTEGERS. Two different backend enums share overlapping member names but map to OPPOSITE
+ * numbers:
+ *
+ *   SessionTracking.ParticipantRole        → Spectator=0, Player=1, Host=2
+ *   GameManagement.SessionParticipantRole  → Host=0,      Player=1, Spectator=2
+ *
+ * These tests pin each contract and assert the two are NOT conflated. Any future edit that
+ * makes the two numbering schemes agree at index 0 or 2 (the real conflation vector) fails here.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  SESSION_TRACKING_ROLE_BY_NUMBER,
+  GAME_MANAGEMENT_ROLE_BY_NUMBER,
+  decodeSessionTrackingRole,
+  decodeGameManagementRole,
+} from '../participant-role';
+
+describe('SessionTracking numeric role contract (Spectator=0, Player=1, Host=2)', () => {
+  it('maps each integer to the SessionTracking role', () => {
+    expect(SESSION_TRACKING_ROLE_BY_NUMBER[0]).toBe('Spectator');
+    expect(SESSION_TRACKING_ROLE_BY_NUMBER[1]).toBe('Player');
+    expect(SESSION_TRACKING_ROLE_BY_NUMBER[2]).toBe('Host');
+  });
+
+  it('decodeSessionTrackingRole resolves each integer correctly', () => {
+    expect(decodeSessionTrackingRole(0)).toBe('Spectator');
+    expect(decodeSessionTrackingRole(1)).toBe('Player');
+    expect(decodeSessionTrackingRole(2)).toBe('Host');
+  });
+
+  it('decodeSessionTrackingRole falls back to Player for out-of-range values', () => {
+    expect(decodeSessionTrackingRole(-1)).toBe('Player');
+    expect(decodeSessionTrackingRole(3)).toBe('Player');
+    expect(decodeSessionTrackingRole(99)).toBe('Player');
+  });
+});
+
+describe('GameManagement numeric role contract (Host=0, Player=1, Spectator=2)', () => {
+  it('maps each integer to the GameManagement role', () => {
+    expect(GAME_MANAGEMENT_ROLE_BY_NUMBER[0]).toBe('Host');
+    expect(GAME_MANAGEMENT_ROLE_BY_NUMBER[1]).toBe('Player');
+    expect(GAME_MANAGEMENT_ROLE_BY_NUMBER[2]).toBe('Spectator');
+  });
+
+  it('decodeGameManagementRole resolves each integer correctly', () => {
+    expect(decodeGameManagementRole(0)).toBe('Host');
+    expect(decodeGameManagementRole(1)).toBe('Player');
+    expect(decodeGameManagementRole(2)).toBe('Spectator');
+  });
+
+  it('decodeGameManagementRole falls back to Player for out-of-range values', () => {
+    expect(decodeGameManagementRole(-1)).toBe('Player');
+    expect(decodeGameManagementRole(3)).toBe('Player');
+  });
+});
+
+describe('the two contracts must NOT be conflated (issue #3392 core guard)', () => {
+  it('index 0 means the OPPOSITE role in each contract (Spectator vs Host)', () => {
+    expect(SESSION_TRACKING_ROLE_BY_NUMBER[0]).toBe('Spectator');
+    expect(GAME_MANAGEMENT_ROLE_BY_NUMBER[0]).toBe('Host');
+    expect(SESSION_TRACKING_ROLE_BY_NUMBER[0]).not.toBe(GAME_MANAGEMENT_ROLE_BY_NUMBER[0]);
+  });
+
+  it('index 2 means the OPPOSITE role in each contract (Host vs Spectator)', () => {
+    expect(SESSION_TRACKING_ROLE_BY_NUMBER[2]).toBe('Host');
+    expect(GAME_MANAGEMENT_ROLE_BY_NUMBER[2]).toBe('Spectator');
+    expect(SESSION_TRACKING_ROLE_BY_NUMBER[2]).not.toBe(GAME_MANAGEMENT_ROLE_BY_NUMBER[2]);
+  });
+
+  it('index 1 is the only value the two contracts agree on (Player)', () => {
+    expect(SESSION_TRACKING_ROLE_BY_NUMBER[1]).toBe('Player');
+    expect(GAME_MANAGEMENT_ROLE_BY_NUMBER[1]).toBe('Player');
+  });
+
+  it('decoding the same integer against each contract yields inverted roles at 0 and 2', () => {
+    expect(decodeSessionTrackingRole(0)).not.toBe(decodeGameManagementRole(0));
+    expect(decodeSessionTrackingRole(2)).not.toBe(decodeGameManagementRole(2));
+    // Cross-check: SessionTracking Host (2) would be mis-decoded as Spectator under the GM contract.
+    expect(decodeGameManagementRole(2)).toBe('Spectator');
+    expect(decodeSessionTrackingRole(2)).toBe('Host');
+  });
+});

--- a/apps/web/src/lib/session-live/participant-role.ts
+++ b/apps/web/src/lib/session-live/participant-role.ts
@@ -36,3 +36,62 @@ export function hasRequiredRole(viewerRole: ParticipantRole, minRole: Participan
   };
   return hierarchy[viewerRole] >= hierarchy[minRole];
 }
+
+// ============================================================================
+// Numeric wire contracts (issue #3392)
+// ============================================================================
+//
+// `SseJsonOptions` on the backend
+// (apps/api/src/Api/Infrastructure/Serialization/SseJsonOptions.cs) disables
+// JsonStringEnumConverter, so backend role enums serialize as INTEGERS on the wire.
+// TWO different backend enums share overlapping member names but map to OPPOSITE numbers:
+//
+//   SessionTracking.ParticipantRole        → Spectator=0, Player=1, Host=2
+//       (privilege-ascending, LOAD-BEARING: compared ordinally in ValidatePlayerRoleBehavior)
+//   GameManagement.SessionParticipantRole  → Host=0, Player=1, Spectator=2
+//       (equality-only; formerly the homonymous `ParticipantRole`, renamed in #3392)
+//
+// The two constants below pin each numeric contract as code so a raw wire integer is never
+// decoded against the wrong enum. Conflating the two schemes (e.g. reusing one map for the
+// other backend) will fail participant-role.test.ts.
+
+/**
+ * SessionTracking.ParticipantRole numeric contract (Spectator=0, Player=1, Host=2).
+ * Mirror of apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Enums/ParticipantRole.cs.
+ */
+export const SESSION_TRACKING_ROLE_BY_NUMBER = {
+  0: 'Spectator',
+  1: 'Player',
+  2: 'Host',
+} as const satisfies Record<0 | 1 | 2, ParticipantRole>;
+
+/**
+ * GameManagement.SessionParticipantRole numeric contract (Host=0, Player=1, Spectator=2).
+ * Mirror of apps/api/src/Api/BoundedContexts/GameManagement/Domain/ValueObjects/SessionParticipantRole.cs.
+ */
+export const GAME_MANAGEMENT_ROLE_BY_NUMBER = {
+  0: 'Host',
+  1: 'Player',
+  2: 'Spectator',
+} as const satisfies Record<0 | 1 | 2, ParticipantRole>;
+
+function decodeRole(contract: Record<0 | 1 | 2, ParticipantRole>, value: number): ParticipantRole {
+  // Narrow to the known indices; anything else is an out-of-range wire value → safe default.
+  return value === 0 || value === 1 || value === 2 ? contract[value] : 'Player';
+}
+
+/**
+ * Decode a numeric wire value using the SessionTracking contract (Spectator=0, Player=1, Host=2).
+ * Out-of-range values fall back to 'Player'.
+ */
+export function decodeSessionTrackingRole(value: number): ParticipantRole {
+  return decodeRole(SESSION_TRACKING_ROLE_BY_NUMBER, value);
+}
+
+/**
+ * Decode a numeric wire value using the GameManagement contract (Host=0, Player=1, Spectator=2).
+ * Out-of-range values fall back to 'Player'.
+ */
+export function decodeGameManagementRole(value: number): ParticipantRole {
+  return decodeRole(GAME_MANAGEMENT_ROLE_BY_NUMBER, value);
+}

--- a/apps/web/src/lib/stores/__tests__/live-session-store.test.ts
+++ b/apps/web/src/lib/stores/__tests__/live-session-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, beforeEach } from 'vitest';
 
-import { useLiveSessionStore } from '@/lib/stores/live-session-store';
+import { useLiveSessionStore, type RuleDispute } from '@/lib/stores/live-session-store';
 import type { TurnOrderType } from '@/lib/session-live/turn-state';
 
 describe('useLiveSessionStore — Block A #2389 contract evolution', () => {
@@ -155,5 +155,60 @@ describe('useLiveSessionStore — Block A #2389 contract evolution', () => {
     useLiveSessionStore.getState().setGameState({ round: 5 });
     useLiveSessionStore.getState().reset();
     expect(useLiveSessionStore.getState().gameState).toBeNull();
+  });
+
+  // #3391 (finding C8) — setDisputes bulk-hydration for REST reload of the Arbitro tab
+  it('initial state — disputes is empty', () => {
+    expect(useLiveSessionStore.getState().disputes).toEqual([]);
+  });
+
+  it('setDisputes replaces the dispute list (bulk hydration on reload)', () => {
+    // A stale SignalR-appended dispute should be replaced by the authoritative REST snapshot.
+    useLiveSessionStore.getState().addDispute({
+      id: 'stale',
+      description: 'stale',
+      verdict: 'x',
+      ruleReferences: [],
+      raisedByPlayerName: 'X',
+      timestamp: '2020-01-01T00:00:00Z',
+    });
+
+    const hydrated: RuleDispute[] = [
+      {
+        id: 'd1',
+        description: 'Can I play two cards?',
+        verdict: 'No — one per turn.',
+        ruleReferences: ['p.12'],
+        raisedByPlayerName: 'Alice',
+        timestamp: '2026-01-01T00:00:00Z',
+      },
+      {
+        id: 'd2',
+        description: 'Does a tie break by score?',
+        verdict: 'Yes.',
+        ruleReferences: ['p.4', 'p.5'],
+        raisedByPlayerName: 'Bob',
+        timestamp: '2026-01-01T00:05:00Z',
+      },
+    ];
+
+    useLiveSessionStore.getState().setDisputes(hydrated);
+
+    expect(useLiveSessionStore.getState().disputes).toEqual(hydrated);
+  });
+
+  it('reset() clears disputes to an empty list', () => {
+    useLiveSessionStore.getState().setDisputes([
+      {
+        id: 'd1',
+        description: 'x',
+        verdict: 'y',
+        ruleReferences: [],
+        raisedByPlayerName: 'A',
+        timestamp: '2026-01-01T00:00:00Z',
+      },
+    ]);
+    useLiveSessionStore.getState().reset();
+    expect(useLiveSessionStore.getState().disputes).toEqual([]);
   });
 });

--- a/apps/web/src/lib/stores/live-session-store.ts
+++ b/apps/web/src/lib/stores/live-session-store.ts
@@ -100,6 +100,12 @@ interface LiveSessionState {
   addProposal: (proposal: ScoreProposal) => void;
   resolveProposal: (proposalId: string, accepted: boolean) => void;
   addDispute: (dispute: RuleDispute) => void;
+  /**
+   * #3391 (finding C8): bulk-hydrate the dispute list from the REST snapshot on reload.
+   * Replaces (not appends) so the authoritative server history supersedes SignalR-appended
+   * entries when the Arbitro tab remounts. `addDispute` remains the live SignalR append path.
+   */
+  setDisputes: (disputes: RuleDispute[]) => void;
   setConnected: (connected: boolean) => void;
   setOffline: (offline: boolean) => void;
   reset: () => void;
@@ -115,6 +121,7 @@ const initialState: Omit<
   | 'addProposal'
   | 'resolveProposal'
   | 'addDispute'
+  | 'setDisputes'
   | 'setConnected'
   | 'setOffline'
   | 'reset'
@@ -189,6 +196,8 @@ export const useLiveSessionStore = create<LiveSessionState>()(
           false,
           'addDispute'
         ),
+
+      setDisputes: disputes => set({ disputes: [...disputes] }, false, 'setDisputes'),
 
       setConnected: connected => set({ isConnected: connected }, false, 'setConnected'),
 

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -3893,6 +3893,7 @@
         "errorMessage": "Could not start the assistant. Try again later.",
         "statusAriaLabel": "Assistant status",
         "nonGroundedDisclaimer": "Answer not grounded in the rulebook",
+        "nonGroundedDisclaimerImage": "I answered from the photo and my game knowledge, not the official rulebook — check the manual",
         "imageAsk": {
           "defaultQuestion": "Analyse this image",
           "fallbackResponse": "Response not available.",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -3957,6 +3957,7 @@
         "errorMessage": "Impossibile avviare l'assistente. Riprova più tardi.",
         "statusAriaLabel": "Stato assistente",
         "nonGroundedDisclaimer": "Risposta non basata sul regolamento",
+        "nonGroundedDisclaimerImage": "Ho risposto dalla foto e dalla mia conoscenza del gioco, non dal regolamento ufficiale — verifica sul manuale",
         "imageAsk": {
           "defaultQuestion": "Analizza questa immagine",
           "fallbackResponse": "Risposta non disponibile.",

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -881,3 +881,12 @@
   border-radius: 2px;
   pointer-events: none;
 }
+
+/* #3447 slice: table-image region — dashed to distinguish from the solid citation highlight. */
+.pdf-image-region-highlight {
+  position: absolute;
+  background-color: hsl(var(--c-warning) / 0.08);
+  border: 2px dashed hsl(var(--c-warning) / 0.9);
+  border-radius: 2px;
+  pointer-events: none;
+}

--- a/docs/for-claude/architecture/adr/adr-089-session-scoring-ssot.md
+++ b/docs/for-claude/architecture/adr/adr-089-session-scoring-ssot.md
@@ -1,0 +1,121 @@
+# ADR-089 — SSOT tra i modelli di "sessione live" e i sistemi di scoring
+
+**Date**: 2026-08-01
+**Status**: Accepted — la direzione (coesistenza delimitata) ratifica e consolida decisioni già prese in ADR-083; questo ADR le rende esplicite come **mappa responsabilità → SSOT** e come contratto di non-sincronizzazione dello scoring.
+**Issue**: #3395 (finding C1 + C10 dell'audit `docs/for-developers/audits/2026-07-29-in-session-agent-grounding-audit.md`) — parte del programma-ombrello #3397
+**Related**: ADR-060 (live session persistence, xmin), ADR-065 (sessions namespace split), ADR-071 (5-state FSM), ADR-083 (convergenza aggregati live su `LiveGameSession` — **prerequisito di lettura**)
+
+## Context
+
+L'audit del 2026-07-29 (verifica avversariale multi-agente su `main-dev`) ha riconfermato due finding già noti ma mai formalizzati in un unico documento di riferimento:
+
+- **C10** — coesistono **più aggregati "sessione live"** e **più sistemi di scoring indipendenti**, collegati ma **non sincronizzati**. Un unico frontend deve riconciliarli e ogni feature cross-context paga una *tassa di traduzione*.
+- **C1** — il grounding dell'agente in-sessione è biforcato tra due bounded context; il finding rimanda a #3390 (contratto RAG unificato) ma **presuppone** che sia chiaro chi possiede *cosa* nella sessione.
+
+ADR-083 ha già mappato e **ratificato** la direzione strutturale della *superficie live* (aggregato canonico = `LiveGameSession`; `GameSession` = shadow di lifecycle/quota/history; companion `SessionTracking.Session` via Saga). Quello che ADR-083 **non** ha fatto — e che #3395 chiede — è una **tabella esplicita responsabilità → aggregato SSOT** più una dichiarazione formale che **lo scoring non è sincronizzato tra i modelli** (per prevenire l'assunzione errata, ricorrente, che i due punteggi "si parlino"). Questo ADR non introduce codice: fissa il contratto architetturale e la direzione, ancorati al codice reale (tutti i `file:line` sotto sono stati letti, non inferiti).
+
+## Mappa verificata degli aggregati
+
+Sono **tre** aggregati su **due** bounded context, su tre prefissi di route distinti e **senza id condiviso** (verificato in ADR-083 OQ1 e riconfermato qui):
+
+| Aggregato | Tabella | BC | Route | Concorrenza | "Vivo" quando | Scoring |
+|---|---|---|---|---|---|---|
+| `GameSession` | `GameSessions` | GameManagement | `/api/v1/sessions/*` | — | lifecycle 4-state | **nessuno** (shadow) |
+| `Session` | `session_tracking_sessions` | SessionTracking | `/api/v1/game-sessions/*` | `RowVersion` (`byte[]`, `[Timestamp]`) | `StartedAt≠null && FinalizedAt==null` | **polimorfico** (JSON) **+** `ScoreEntry` (righe) |
+| `LiveGameSession` | `live_game_sessions` | GameManagement | `/api/v1/live-sessions/*` | `Xmin` (Postgres, ADR-060) | `Status ∈ {Setup,InProgress,Paused}` | **round-based** (dimensioni × round) |
+
+**Evidenza (`file:line`):**
+- `SessionTracking/Domain/Entities/Session.cs:113` (`IsLive`), `:120` (`ScoringType`), `:127` (`ScoreData` JSONB), `:174` (`RowVersion`), `:471` (`SetScores`).
+- `GameManagement/Domain/Entities/LiveGameSession.cs:62` (`ScoringConfig`), `:87` (`Xmin`), `:104` (`IsActive`), `:561` (`RecordScore`), `:984` (`RecalculatePlayerScores`), `:73` (`TrackingSessionId`), `:85` (`CorrelatedGameSessionId`).
+- `GameSession` come shadow (no scoring autoritativo): ADR-083 Update 2026-06-30 (#2587).
+- ⚠️ Naming fisico: il `GameSession` di GameManagement persiste su tabella **`GameSessions`** (PascalCase, `Infrastructure/EntityConfigurations/GameManagement/GameSessionEntityConfiguration.cs:15`; porta l'indice quota #3070 `IX_GameSessions_CreatedByUserId_Status`, query `GameSessionRepository.CountActiveByUserIdAsync`/`FindHistoryAsync`). Da **non** confondere con `game_sessions` (snake_case) = `UserLibrary.UserGameSessionEntity` (play-record, `EntityConfigurations/UserLibrary/GameSessionEntityConfiguration.cs:15`), BC e schema distinti.
+
+> Nota terminologica: la tabella dell'issue #3395 elenca **due** aggregati ("`SessionTracking.Session`" vs "`GameManagement.LiveGameSession`"). Il terzo — `GameManagement.GameSession`, il guscio di lifecycle/quota/history — è l'aggregato *dietro* i link di correlazione e va incluso per completezza (ADR-083). L'issue è corretta nella sostanza; questo ADR estende la mappa a tre per non lasciare zone grigie.
+
+## Mappa verificata dei sistemi di scoring
+
+Contrariamente al framing "due sistemi", il codice reale espone **tre store di punteggio** raggiunti da **almeno quattro comandi di scrittura**:
+
+| # | Store | Aggregato / tabella | Forma dati | Comandi di scrittura (verificati) |
+|---|---|---|---|---|
+| 1 | Round-based | `LiveGameSession.RoundScores` / `live_session_round_scores` | matrice `player × round × dimension`, validata contro `ScoringConfig.HasDimension` | `RecordScore` (`LiveGameSession.cs:561`) |
+| 2a | Polimorfico | `Session.ScoringType` + `Session.ScoreData` (JSONB sull'aggregato) | discriminated-union JSON per `ScoreType` (Points/BinaryWin/Objectives/Ranking) via `IScoringStrategy` | `UpdateSessionScoresCommand` → `SetScores` |
+| 2b | Storico righe | `ScoreEntry` / `session_tracking_score_entries` | righe `(participant, round?, category?, value)` | `UpdateScoreCommand` (#4765), `UpdatePlayerScoreCommand` (#4765, `RowVersion`), `UpsertScoreWithDiaryCommand` (Session Flow v2.1 T8, + diary event) |
+| 3 | Play-record storico | `UserLibrary.GameSession`/`game_sessions` (path manuale) · `PlayRecord`/`play_records` (path event-derived) | derivato a fine partita | manuale: `RecordGameSessionCommandHandler` ← `RecordGameSessionCommand` (endpoint `UserLibraryCoreEndpoints.cs:861`) · event-derived: `LiveSessionCompletedEventHandler` (#4748) su `LiveSessionCompletedEvent` → `IPlayRecordRepository`/`play_records` |
+
+**Osservazione chiave**: lo store #2a e lo store #2b vivono **entrambi** dentro SessionTracking ma su modelli dati incompatibili (JSON sull'aggregato vs righe normalizzate). Il commento di `UpdateSessionScoresCommand.cs:9-13` lo dichiara esplicitamente: *"Distinct from `UpdateScoreCommand` … this command replaces the session's polymorphic `ScoringType` + `ScoreData` payload atomically"*. Sono due code-path che **non si riconciliano tra loro**, prima ancora di considerare il cross-BC.
+
+## Il finding centrale — lo scoring NON è sincronizzato tra i modelli
+
+I due aggregati live sono collegati da **due link a livello di identità**, entrambi `Guid?` e **portatori del solo id** (nessun payload di dominio):
+
+- `LiveGameSession.TrackingSessionId` (`:73`, `SetTrackingSessionId` `:882`) → la `SessionTracking.Session` companion (Saga at-creation, ADR-083 SP0; backfill lazy SP5-c/#2600). Serve a correlare chat-RAG / diary / media / stream.
+- `LiveGameSession.CorrelatedGameSessionId` (`:85`, `SetCorrelatedGameSessionId` `:918`) → la `GameSession` di quota/lifecycle/history (#2587 Slice 1).
+
+**Nessuno dei due link trasporta punteggi.** Non esiste code-path che legga `RoundScores` e scriva `ScoreData` (o viceversa): la correlazione è per **lifecycle / quota / companion**, non per scoring. ADR-083 OQ3 aveva già stabilito che i modelli sono *"genuinamente incompatibili … discriminated-union JSON vs matrice round×dimensione×player: nessuno è superset dell'altro"*; #2587 ha ratificato che `LiveGameSession.ScoringConfig` è *"la single source of truth per lo scoring in-play"* e che i campi scoring del `GameSession` correlato restano **non popolati**.
+
+**Rischio da prevenire** (motivo per cui lo mettiamo nero su bianco): un contributor futuro che veda `TrackingSessionId`/`CorrelatedGameSessionId` può assumere che i punteggi siano condivisi o riconciliati, e cablare una lettura cross-modello (es. "leggi il totale dal companion") ottenendo dati fantasma o vuoti. Lo scoring polimorfico shippato in `SessionLiveView` (#2389/#2483) gira di fatto sul guscio vuoto `GameSessionDto` → non è mai stato collegato a dati reali (spiega perché #2354 funziona solo su fixtures `IS_VISUAL_TEST_BUILD`). Questa è la trappola concreta che l'ADR chiude.
+
+## Decisione
+
+### 1. Mappa responsabilità → aggregato SSOT
+
+Ogni responsabilità ha **un solo** owner autoritativo. Nessuna responsabilità è condivisa tra due aggregati.
+
+| Responsabilità | SSOT | BC | Ancora |
+|---|---|---|---|
+| Lifecycle 4-state (Setup→InProgress→Paused→Completed/Abandoned) | `GameSession` | GameManagement | ADR-083 Fase 4 (Opzione B) |
+| Quota per-user cross-session | `GameSession` | GameManagement | `SessionQuotaService`, `CountActiveByUserIdAsync` |
+| History query post-play (lista/dettaglio partite) | `GameSession` (visibilità) + `UserLibrary.GameSession`/PlayRecord (record) | GameManagement / UserLibrary | `FindHistoryAsync`; `RecordGameSessionCommandHandler` |
+| Runtime in-play: players/team/turni/fasi/setup-checklist/dispute/snapshot/agent-mode | `LiveGameSession` | GameManagement | ADR-071 (FSM), ADR-060 (xmin) |
+| **Scoring in-play (live)** | **`LiveGameSession.ScoringConfig` + `RoundScores`** (round-based) | GameManagement | #2587 |
+| Diary append-only multi-autore (live) | `LiveGameSession.DiaryEntry` (nativo) | GameManagement | ADR-083 SP3 (#2570) |
+| Chat-RAG con citazioni (risposta agente) | `KnowledgeBase` (keyed su `LiveGameSession.Id`) | KnowledgeBase | ADR-083 SP0/SP1; direzione #3390 |
+| Note/eventi cifrati private per-partecipante, media companion | `SessionTracking.Session` (companion, via `TrackingSessionId`) | SessionTracking | ADR-083 SP0 |
+| Turni / note / partecipanti fuori dal path live canonico (superficie storica) | `SessionTracking.Session` | SessionTracking | legacy, vedi §Direzione |
+
+### 2. Contratto di non-sincronizzazione dello scoring
+
+- **In-play**: l'unica fonte autoritativa del punteggio a tavolo è `LiveGameSession.RoundScores` (round-based). Il `GameSession` correlato **non** deve mai essere letto come fonte del risultato; i suoi campi scoring restano `null`.
+- **Storico**: il record post-partita si deriva **da `LiveGameSession`** (evento `LiveSessionCompletedEvent`), non dal companion né dal polimorfico.
+- Lo scoring **polimorfico** (`ScoreData`) e lo **storico-righe** (`ScoreEntry`) di SessionTracking **non** sono, e non devono diventare, sincronizzati con `RoundScores`. Non è previsto alcun reconciler bidirezionale: sincronizzarli reintrodurrebbe il rischio dual-write/dedup che ADR-083 SP3 ha esplicitamente evitato per il diary.
+- Regola operativa: **scegli l'SSOT giusto per il contesto**, non ponticellare tra modelli. FE già oggi scrive lo scoring live via `useUpdateSessionScores` (CLAUDE.md); l'accoppiamento allo store round-based è responsabilità del wiring di quel path, non di una riconciliazione runtime.
+
+### 3. Direzione — **coesistenza documentata e delimitata** (non nuova convergenza)
+
+La direzione difendibile, alla luce dell'evidenza, è la **coesistenza delimitata** con SSOT-per-responsabilità, **non** un nuovo epic di convergenza/sincronizzazione. Motivazioni:
+
+1. La convergenza della *superficie live* su `LiveGameSession` è **già** la direzione ratificata (ADR-083, Direzione A) e in larga parte shippata. #3395 non deve ri-decidere quel percorso.
+2. La coesistenza di `GameSession` è **permanente e ratificata** (ADR-083 Fase 4, Opzione B / #2587): lifecycle+quota+history e runtime in-play sono concern **complementari**, non duplicazione accidentale. Fonderli violerebbe l'SRP (la quota è policy per-user cross-session, non attributo di un runtime per-istanza).
+3. I link Saga esistono per lifecycle/quota/companion, **non** per scoring (verificato). La lettura corretta di questo dato non è "sincronizziamo lo scoring" ma "**non** sincronizziamolo — dichiariamo un SSOT per contesto".
+
+L'unico item genuinamente aperto **non** è una sincronizzazione, ma un **ritiro delimitato**: portare fuori dal path live lo scoring polimorfico/`ScoreEntry` di SessionTracking (già indicato da ADR-083 #2587 come *"ri-orientato ai play-records storici, da tracciare in Fase 1/2"* e ri-emerso incompleto in questo audit). È cleanup a scope chiuso, tracciabile come follow-up, **non** un big-bang.
+
+**Fuori scope esplicito**: #3390 (contratto RAG grounded unificato) riguarda la *risposta dell'agente* — chi possiede "risposta grounded sul rulebook" (`KnowledgeBase`) — e **non unifica lo scoring**. Le due questioni condividono la diagnosi ("confine sulla costura sbagliata") ma hanno owner e piani distinti. Questo ADR non anticipa né vincola #3390 sul lato scoring.
+
+## Consequences
+
+### Positive
+- Un unico documento dichiara chi è autoritativo per ogni responsabilità della sessione live → elimina la zona grigia che alimenta C10.
+- La trappola "i due punteggi si parlano" è chiusa esplicitamente: nessuna sincronizzazione attesa, SSOT per contesto.
+- Sblocca la lettura di C1/#3390 dando per acquisito il possesso di lifecycle/runtime/scoring, così quel lavoro può concentrarsi sulla sola *risposta grounded*.
+- Zero costo di migrazione: formalizza lo stato ratificato, non muove codice.
+
+### Negative / debt
+- La coesistenza di tre aggregati resta cognitivamente costosa: un nuovo contributor deve leggere questo ADR + ADR-083 per orientarsi. Mitigazione: pointer da CLAUDE.md (§ Domain Model).
+- Il ritiro dello scoring polimorfico/`ScoreEntry` dal path live è debito reale, qui **dichiarato ma non eseguito**. Finché non è fatto, esistono comandi di scrittura scoring in SessionTracking che, se cablati per errore al path live, producono dati non autoritativi.
+- La "tassa di traduzione" cross-context per feature che attraversano i due modelli (es. correlare uno score live a una nota companion) rimane: è il prezzo accettato della separazione degli SSOT.
+
+### Neutral
+- Nessun cambiamento di schema, DTO o API. Nessun impatto su test esistenti.
+
+## Follow-up (tracciati, non parte di questo ADR)
+- Ritiro delimitato dello scoring polimorfico/`ScoreEntry` di SessionTracking dal path live (re-orientamento ai play-records storici). Da aprire come issue di cleanup con guard di non-uso sul path live.
+- #3390 (epic) — contratto RAG grounded unificato (risposta agente): concern separato, dipendente da #3388/#3389.
+
+## References
+- Issue #3395 (questo ADR); audit `docs/for-developers/audits/2026-07-29-in-session-agent-grounding-audit.md` (finding C1 + C10); programma-ombrello #3397; epic #3390.
+- ADR-083 (convergenza aggregati live; OQ1/OQ3; Fase 4 Opzione B; #2587 shadow scoring; SP0/SP3/SP5-c companion).
+- ADR-060 (persistence + xmin), ADR-065 (namespace split), ADR-071 (5-state FSM).
+- Codice: `SessionTracking/Domain/Entities/Session.cs`, `.../Entities/ScoreEntry.cs`, `.../Application/Commands/{UpdateSessionScoresCommand,UpdateScoreCommand,UpdatePlayerScoreCommand,UpsertScoreWithDiaryCommand}.cs`; `GameManagement/Domain/Entities/LiveGameSession.cs`.
+- CLAUDE.md § Domain Model — GameNight / Session (pointer a questo ADR).

--- a/docs/superpowers/plans/2026-08-01-grounding-contract.md
+++ b/docs/superpowers/plans/2026-08-01-grounding-contract.md
@@ -1,0 +1,98 @@
+# Grounding Contract Invariant (#3388) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development or superpowers:executing-plans. Steps use `- [ ]`.
+
+**Goal:** Make `groundingStatus` a non-nullable contract invariant emitted by BOTH in-session agent paths (text-RAG SSE + image/text multimodal REST), remove the fabricated `confidence=0.85`, and surface a per-modality FE disclaimer for every ungrounded answer.
+
+**Architecture:** New `GroundingStatus` enum in `Api.SharedKernel`. Derived from citations (`Grounded` iff citations>0, else `Ungrounded`; `Partial` reserved for #3390, no producer now). No EF migration — re-derivable from persisted `CitationsJson`. Wire representation is **string** on both paths (REST enum→`JsonStringEnumConverter`→PascalCase; SSE emits the enum's `.ToString()` string to avoid the numeric-enum SSE regime).
+
+**Tech Stack:** .NET 9 (MediatR, SSE), Next.js/React (Vitest), xUnit + FluentAssertions + Moq.
+
+## Global Constraints
+
+- Issue #3388; branch `feature/issue-3388-grounding-contract` (parent `main-dev`).
+- `enum GroundingStatus { Grounded = 0, Partial = 1, Ungrounded = 2 }`, namespace `Api.SharedKernel.Domain.Enums` (mirror `UserAccountStatus.cs`: file-scoped namespace, XML `<summary>`, `public enum`, numeric values).
+- Wire value is the enum NAME string: `"Grounded"` / `"Partial"` / `"Ungrounded"` (PascalCase) on BOTH paths. FE compares `=== 'Ungrounded'`.
+- `Grounded` iff `citations.Count > 0` else `Ungrounded`. No `Partial` producer.
+- Remove fabricated `confidence 0.85f` (`ChatCommandHandlers.cs:201`, `:224`) → `null`. The SSE path's `confidence` is real (`ComputeConfidence`) — leave it.
+- No EF migration. CQRS unchanged. Commit after each task. Kill testhost before BE runs. FE tests: `cd apps/web && pnpm test <file>`.
+
+---
+
+### Task 1: `GroundingStatus` enum + REST path (AskSessionAgent)
+
+**Files:**
+- Create: `apps/api/src/Api/SharedKernel/Domain/Enums/GroundingStatus.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ChatCommands.cs:45-51` (add param), `.../Commands/ChatCommandHandlers.cs:201,224,266` (null confidence + emit grounding)
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/ChatCommandHandlerTests.cs:242`
+
+**Interfaces:**
+- Produces: `public enum GroundingStatus { Grounded=0, Partial=1, Ungrounded=2 }`; `AskSessionAgentResult(Guid MessageId, string Answer, string AgentType, float? Confidence, string? CitationsJson, GroundingStatus GroundingStatus)`.
+
+- [ ] **Step 1 (RED):** In `ChatCommandHandlerTests.cs` (the `AskSessionAgentCommandHandler` test that today asserts `result.Confidence.Should().Be(0.85f)` at `:242`): change it to `result.Confidence.Should().BeNull()` AND add `result.GroundingStatus.Should().Be(GroundingStatus.Ungrounded)` (add `using Api.SharedKernel.Domain.Enums;`).
+- [ ] **Step 2:** Run `dotnet test ...Api.Tests.csproj --filter "FullyQualifiedName~ChatCommandHandlerTests" --nologo -v minimal` → FAIL (still 0.85 / no GroundingStatus member).
+- [ ] **Step 3 (GREEN):** Create `GroundingStatus.cs`. In `ChatCommands.cs` add the positional param `GroundingStatus GroundingStatus` to `AskSessionAgentResult` (+ `using Api.SharedKernel.Domain.Enums;`). In `ChatCommandHandlers.cs`: replace `confidence = 0.85f;` at `:201` and `:224` with `confidence = null;`. At the return (`:266`) compute grounding = `Ungrounded` (this path never has citations) and pass it: `new AskSessionAgentResult(agentMessage.Id, answer, agentType, agentMessage.Confidence, null, GroundingStatus.Ungrounded)`. Add the `using`.
+- [ ] **Step 4:** Run the filter → PASS. Also `--filter "Category=Unit&BoundedContext=SessionTracking"` (chat subset) → green.
+- [ ] **Step 5:** Commit `feat(ai): GroundingStatus enum + honest confidence on image path (#3388)`.
+
+---
+
+### Task 2: SSE RAG path emits server-side `groundingStatus`
+
+**Files:**
+- Modify: `apps/api/src/Api/Models/Contracts.cs:147-158` (add field to `StreamingComplete`), `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentCommandHandler.cs:710-719`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentMetricsTests.cs`
+
+**Interfaces:**
+- Consumes: nothing from Task 1 except the concept (SSE emits a **string**, not the enum, to stay wire-consistent).
+- Produces: `StreamingComplete` gains a trailing `string GroundingStatus` (string, not the enum — SSE serializes enums numerically). Value `"Grounded"`/`"Ungrounded"`.
+
+- [ ] **Step 1 (RED):** In `ChatWithSessionAgentMetricsTests.cs`, in the zero-citation test (~`:46`) drain the stream, capture the `StreamingComplete` from the terminal `Complete` event, and assert its `GroundingStatus == "Ungrounded"`; add a with-citations case asserting `"Grounded"`. (Mirror the existing `BuildHandler(resolvedCitations, ...)` + `await foreach` drain pattern.)
+- [ ] **Step 2:** Run `--filter "FullyQualifiedName~ChatWithSessionAgentMetricsTests"` → FAIL (no GroundingStatus member).
+- [ ] **Step 3 (GREEN):** Add `string GroundingStatus` as a trailing param on `record StreamingComplete(...)` (`Contracts.cs`). At `ChatWithSessionAgentCommandHandler.cs:710-719` set it: `GroundingStatus: citationDtos.Count > 0 ? "Grounded" : "Ungrounded"`. (Keep the real `confidence` unchanged.)
+- [ ] **Step 4:** Run the filter → PASS. `--filter "Category=Unit&BoundedContext=KnowledgeBase&FullyQualifiedName~ChatWithSessionAgent"` green.
+- [ ] **Step 5:** Commit `feat(ai): SSE RAG path emits groundingStatus in StreamingComplete (#3388)`.
+
+---
+
+### Task 3: FE reads server `groundingStatus` on both paths
+
+**Files:**
+- Modify: `apps/web/src/lib/domain-hooks/useSessionAgentChat.ts:24-36,319-337,354-363`, `apps/web/src/components/features/session-live/LiveAgentChat.tsx:44-58`, `apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx:1256-1269`
+- Test: `apps/web/src/lib/domain-hooks/__tests__/useSessionAgentChat.test.ts`, `.../_components/__tests__/SessionLiveView.test.tsx`
+
+**Interfaces:**
+- Consumes: backend `groundingStatus` string (`"Grounded"|"Partial"|"Ungrounded"`) on SSE `StreamingComplete.data` and on the multipart JSON response.
+- Produces: `ChatMessage.groundingStatus?: 'Grounded'|'Partial'|'Ungrounded'` on BOTH the hook interface (`useSessionAgentChat.ts:24`) and the component interface (`LiveAgentChat.tsx:44`). `isNonGrounded` becomes derived from `groundingStatus === 'Ungrounded'` (keep the field for the disclaimer condition).
+
+- [ ] **Step 1 (RED):** In `useSessionAgentChat.test.ts`, extend the `sseComplete(...)` wire builder to include `groundingStatus: 'Ungrounded'` in the `data`, and assert the produced assistant `ChatMessage` has `groundingStatus === 'Ungrounded'` (and `isNonGrounded === true`). In `SessionLiveView.test.tsx` (image branch, near the `:450` disclaimer stub), assert the image-branch agent message carries grounding when the mocked `/chat/ask-agent` JSON returns `{ answer, groundingStatus: 'Ungrounded' }`.
+- [ ] **Step 2:** Run `pnpm test src/lib/domain-hooks/__tests__/useSessionAgentChat.test.ts` (and the SessionLiveView test) → FAIL.
+- [ ] **Step 3 (GREEN):** Add `groundingStatus?: 'Grounded'|'Partial'|'Ungrounded'` to both `ChatMessage` interfaces. In `useSessionAgentChat.ts` SSE_COMPLETE handler (`:319`) read `(event.data as {...; groundingStatus?: string}).groundingStatus` and set it on the assistant message (`:354-363`); derive `isNonGrounded = groundingStatus === 'Ungrounded'` (fallback to the old citations heuristic only if `groundingStatus` is absent, for resilience). In `SessionLiveView.tsx:1256` widen the cast to `{ answer?: string; confidence?: number; groundingStatus?: string }` and set `groundingStatus`/`isNonGrounded: json.groundingStatus === 'Ungrounded'` on the message object (`:1259-1268`).
+- [ ] **Step 4:** Run both tests → PASS; `pnpm typecheck` clean.
+- [ ] **Step 5:** Commit `feat(ai): FE reads server groundingStatus on both agent paths (#3388)`.
+
+---
+
+### Task 4: Per-modality disclaimer + remove fabricated confidence from UI
+
+**Files:**
+- Modify: `apps/web/src/components/features/session-live/LiveAgentChat.tsx:240-250`, `apps/web/src/locales/it.json`, `apps/web/src/locales/en.json`
+- Test: `apps/web/src/components/features/session-live/__tests__/LiveAgentChat.test.tsx`
+
+**Interfaces:**
+- Consumes: `ChatMessage.groundingStatus` (Task 3). Needs a way to know the modality — the image-branch messages already differ; add an optional `modality?: 'text' | 'image'` to the component `ChatMessage` (default text), set `'image'` on the image-branch message in `SessionLiveView.tsx`.
+
+- [ ] **Step 1 (RED):** In `LiveAgentChat.test.tsx`, add a test: an ungrounded agent message with `modality: 'image'` renders the image-specific disclaimer copy (assert `data-slot="chat-nongrounded-disclaimer"` present and text = the new image key), and an ungrounded text message renders the existing copy. Add the two new i18n keys to the test's `INTL_MESSAGES`.
+- [ ] **Step 2:** Run `pnpm test src/components/features/session-live/__tests__/LiveAgentChat.test.tsx` → FAIL.
+- [ ] **Step 3 (GREEN):** Add i18n keys under `pages.sessionLive.chatAgent`: keep `nonGroundedDisclaimer` (text) and add `nonGroundedDisclaimerImage` = IT `"Ho risposto dalla foto e dalla mia conoscenza del gioco, non dal regolamento ufficiale — verifica sul manuale"`, EN `"I answered from the photo and my game knowledge, not the official rulebook — check the manual"`. In `LiveAgentChat.tsx:240-250` pick the key by `msg.modality === 'image' ? '...Image' : 'nonGroundedDisclaimer'`. Add `modality?: 'text'|'image'` to the component `ChatMessage` interface; in `SessionLiveView.tsx` set `modality: 'image'` on the image-branch message. Grep the file for any rendered `confidence` on the agent bubble and remove it if shown as a measured value (the image JSON `confidence` is now `null`; ensure nothing renders it as authoritative).
+- [ ] **Step 4:** Run the test → PASS; `pnpm typecheck` + `pnpm lint` clean.
+- [ ] **Step 5:** Commit `feat(ai): per-modality non-grounded disclaimer + drop fabricated confidence (#3388)`.
+
+---
+
+## Self-Review
+
+- **Spec/DoD coverage:** groundingStatus non-nullable both paths → T1 (REST) + T2 (SSE). image→Ungrounded → T1. FE disclaimer both modalities → T3+T4. No fabricated confidence → T1 (BE null) + T4 (UI). Mode-parity test → T1 asserts `AskSessionAgentResult.GroundingStatus` non-null Ungrounded; T2 asserts `StreamingComplete.GroundingStatus` emitted — together they prove both contracts carry a non-nullable grounding signal for the same (non-grounded) question. Add a one-line comment in the T2 test referencing the parity intent.
+- **Type consistency:** enum `GroundingStatus` (BE, T1) vs wire **string** `"Grounded"/"Ungrounded"` (SSE T2 + REST via converter) vs FE union `'Grounded'|'Partial'|'Ungrounded'` (T3). Casing PascalCase throughout — FE compares `=== 'Ungrounded'`.
+- **Two-serialization-regime risk (documented):** SSE would render a C# enum numerically; T2 emits a `string` on `StreamingComplete` to match the REST string. Verify the SSE test asserts the string, not a number.
+- **Out of scope:** routing the image path through retrieval (#3390); a `Partial` producer.

--- a/docs/superpowers/plans/2026-08-01-image-table-region-slice.md
+++ b/docs/superpowers/plans/2026-08-01-image-table-region-slice.md
@@ -1,0 +1,850 @@
+# Image-Table Region Grounding — Vertical Slice Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Capture hi_res `Image`/`FigureCaption` regions for one PDF, persist them in a dedicated `pdf_image_regions` table, expose them via `GET /api/v1/pdf/{id}/image-regions`, and draw them in the FE PDF viewer on open — to validate the mechanism + value before the full feature.
+
+**Architecture:** New EF entity/table (BE) + a pure parser that extracts image-region bbox from the raw Unstructured hi_res JSON (which the normal pipeline drops) + a CQRS read query/endpoint + an admin seed command/endpoint + a FE overlay (twin of #3403's `PdfBBoxOverlay`) fetched on PDF open. No router, no async job, no citation linkage (all deferred to #3435).
+
+**Tech Stack:** .NET 9 (ASP.NET Minimal APIs + MediatR CQRS + EF Core/Postgres), Next.js 16 / React 19 (react-pdf, Zod, Vitest).
+
+## Global Constraints
+
+- **Solution**: `apps/api/MeepleAI.Api.sln`. Migration cwd = `apps/api`, command `dotnet ef migrations add <Name> --project src/Api`.
+- **CQRS**: endpoints use ONLY `IMediator.Send()` — zero direct service injection in endpoints.
+- **Exceptions**: `NotFoundException`(404)/`ConflictException`(409) — never `InvalidOperationException`(500). A missing/unauthorized PDF read returns `null → Results.NotFound` (no info leak), mirroring `GetPdfTextQuery`.
+- **Coordinates**: bbox normalized `[0,1]`, **top-left, y-down** (SP-B #3406 / #3403 DA-1). Clamp out-of-range defensively.
+- **Naming**: C# PascalCase (public) / `_camelCase` (private); DB columns snake_case via `.HasColumnName`; index names `ix_<table>_<cols>`. TS PascalCase components/types, camelCase functions.
+- **Copyright (deferred, documented)**: geometric regions are Full-gated in #3403 (DA-4). The slice's seed data is dev/admin-only + read endpoint is unauthenticated-by-owner like GetPdfText; user-facing rollout MUST add tier gating first. NOT implemented in this slice.
+- **Windows dev note**: pre-push BE build can hang on stale `dotnet` DLL-locks — kill `dotnet/testhost/MSBuild` before pushing; docs-only pushes may use `--no-verify` if authorized. Kill testhost before running tests.
+
+---
+
+### Task 1: DB — `pdf_image_regions` entity + config + migration
+
+**Files:**
+- Create: `apps/api/src/Api/Infrastructure/Entities/DocumentProcessing/PdfImageRegionEntity.cs`
+- Create: `apps/api/src/Api/Infrastructure/EntityConfigurations/DocumentProcessing/PdfImageRegionEntityConfiguration.cs`
+- Modify: `apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs` (add DbSet ~line 122)
+- Create (generated): `apps/api/src/Api/Infrastructure/Migrations/*_AddPdfImageRegions.cs`
+- Test: `apps/api/tests/Api.Tests/Unit/DocumentProcessing/PdfImageRegionEntityConfigurationTests.cs`
+
+**Interfaces:**
+- Produces: `PdfImageRegionEntity { Guid Id; Guid PdfDocumentId; int PageNumber; double X; double Y; double Width; double Height; string ElementType; DateTime CreatedAt; }` (namespace `Api.Infrastructure.Entities`); `MeepleAiDbContext.PdfImageRegions` DbSet.
+
+- [ ] **Step 1: Write the entity**
+
+`PdfImageRegionEntity.cs`:
+```csharp
+namespace Api.Infrastructure.Entities;
+
+/// &lt;summary&gt;
+/// Image-table region (#3447): a hi_res Image/FigureCaption bbox for a PDF page, persisted so the
+/// viewer can highlight table graphics. Normalized [0,1] top-left. See slice spec 2026-08-01.
+/// &lt;/summary&gt;
+public class PdfImageRegionEntity
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid PdfDocumentId { get; set; }
+    public PdfDocumentEntity PdfDocument { get; set; } = null!;
+    public int PageNumber { get; set; }
+    public double X { get; set; }
+    public double Y { get; set; }
+    public double Width { get; set; }
+    public double Height { get; set; }
+    public string ElementType { get; set; } = "Image";
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}
+```
+
+- [ ] **Step 2: Write the Fluent config**
+
+`PdfImageRegionEntityConfiguration.cs`:
+```csharp
+using Api.Infrastructure.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.EntityConfigurations;
+
+internal class PdfImageRegionEntityConfiguration : IEntityTypeConfiguration&lt;PdfImageRegionEntity&gt;
+{
+    public void Configure(EntityTypeBuilder&lt;PdfImageRegionEntity&gt; builder)
+    {
+        builder.ToTable("pdf_image_regions");
+        builder.HasKey(e =&gt; e.Id);
+        builder.Property(e =&gt; e.PdfDocumentId).HasColumnName("pdf_document_id");
+        builder.Property(e =&gt; e.PageNumber).HasColumnName("page_number");
+        builder.Property(e =&gt; e.X).HasColumnName("x");
+        builder.Property(e =&gt; e.Y).HasColumnName("y");
+        builder.Property(e =&gt; e.Width).HasColumnName("width");
+        builder.Property(e =&gt; e.Height).HasColumnName("height");
+        builder.Property(e =&gt; e.ElementType).HasColumnName("element_type").HasMaxLength(64).IsRequired();
+        builder.Property(e =&gt; e.CreatedAt).HasColumnName("created_at");
+        builder.HasOne(e =&gt; e.PdfDocument).WithMany()
+            .HasForeignKey(e =&gt; e.PdfDocumentId).OnDelete(DeleteBehavior.Cascade);
+        builder.HasIndex(e =&gt; e.PdfDocumentId).HasDatabaseName("ix_pdf_image_regions_pdf_document_id");
+    }
+}
+```
+
+- [ ] **Step 3: Register the DbSet**
+
+In `MeepleAiDbContext.cs`, next to `public DbSet<PdfDocumentEntity> PdfDocuments => Set<PdfDocumentEntity>();`:
+```csharp
+public DbSet<PdfImageRegionEntity> PdfImageRegions => Set<PdfImageRegionEntity>();
+```
+(No `OnModelCreating` edit — configs auto-apply via `ApplyConfigurationsFromAssembly`.)
+
+- [ ] **Step 4: Write the failing config test**
+
+`PdfImageRegionEntityConfigurationTests.cs`:
+```csharp
+using Api.Infrastructure.Entities;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Api.Tests.Unit.DocumentProcessing;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "3447")]
+public sealed class PdfImageRegionEntityConfigurationTests
+{
+    [Fact]
+    public async Task PdfImageRegions_RoundTrips_WithBboxAndElementType()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext($"imgregion_{Guid.NewGuid():N}");
+        var region = new PdfImageRegionEntity
+        {
+            PdfDocumentId = Guid.NewGuid(), PageNumber = 4,
+            X = 0.10, Y = 0.55, Width = 0.80, Height = 0.30, ElementType = "FigureCaption"
+        };
+        db.PdfImageRegions.Add(region);
+        await db.SaveChangesAsync();
+
+        var loaded = await db.PdfImageRegions.AsNoTracking().SingleAsync();
+        loaded.PageNumber.Should().Be(4);
+        loaded.ElementType.Should().Be("FigureCaption");
+        loaded.X.Should().Be(0.10);
+        loaded.Height.Should().Be(0.30);
+    }
+}
+```
+
+- [ ] **Step 5: Run the test — verify it passes** (kill testhost first)
+
+Run: `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~PdfImageRegionEntityConfigurationTests"`
+Expected: PASS (InMemory provider honors the DbSet + config).
+
+- [ ] **Step 6: Generate the migration**
+
+Run (cwd `apps/api`): `dotnet ef migrations add AddPdfImageRegions --project src/Api`
+Review the generated `CreateTable("pdf_image_regions", ...)` + FK to `pdf_documents` (Cascade) + index. It must NOT alter existing tables.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/Infrastructure/Entities/DocumentProcessing/PdfImageRegionEntity.cs \
+        apps/api/src/Api/Infrastructure/EntityConfigurations/DocumentProcessing/PdfImageRegionEntityConfiguration.cs \
+        apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs \
+        apps/api/src/Api/Infrastructure/Migrations/ \
+        apps/api/tests/Api.Tests/Unit/DocumentProcessing/PdfImageRegionEntityConfigurationTests.cs
+git commit -m "feat(rag): pdf_image_regions entity + migration (#3447)"
+```
+
+---
+
+### Task 2: BE — `ImageRegionExtractor` (parse hi_res JSON → regions)
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/ImageRegionExtractor.cs`
+- Test: `apps/api/tests/Api.Tests/Unit/DocumentProcessing/ImageRegionExtractorTests.cs`
+
+**Interfaces:**
+- Produces: `static IReadOnlyList<ExtractedImageRegion> ImageRegionExtractor.FromHiResJson(string? hiResJson)`; `public sealed record ExtractedImageRegion(int Page, double X, double Y, double Width, double Height, string ElementType)` (namespace `Api.BoundedContexts.DocumentProcessing.Application.Services`).
+- Rationale: the normal pipeline (`UnstructuredPdfTextExtractor.MapStructuredElements`, line 299) DROPS `Image`/`FigureCaption` (empty text). This parser keeps exactly those, from the raw Python wire format.
+
+- [ ] **Step 1: Write the failing test**
+
+`ImageRegionExtractorTests.cs`:
+```csharp
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Unit.DocumentProcessing;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "3447")]
+public sealed class ImageRegionExtractorTests
+{
+    private const string HiResJson = """
+    {"elements":[
+      {"text":"Preparazione","page_number":1,"category":"Title","bbox":{"x":0.08,"y":0.10,"width":0.24,"height":0.05}},
+      {"text":"","page_number":4,"category":"Image","bbox":{"x":0.10,"y":0.55,"width":0.80,"height":0.30}},
+      {"text":"","page_number":5,"category":"FigureCaption","bbox":{"x":0.12,"y":0.20,"width":0.40,"height":0.06}},
+      {"text":"","page_number":6,"category":"Image","bbox":null}
+    ]}
+    """;
+
+    [Fact]
+    public void FromHiResJson_KeepsImageAndFigureCaption_WithBbox_DropsOthers()
+    {
+        var regions = ImageRegionExtractor.FromHiResJson(HiResJson);
+
+        regions.Should().HaveCount(2); // Image p4 + FigureCaption p5; Title dropped, bbox-null Image dropped
+        regions.Should().ContainSingle(r => r.ElementType == "Image" && r.Page == 4 && r.Width == 0.80);
+        regions.Should().ContainSingle(r => r.ElementType == "FigureCaption" && r.Page == 5);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("not json{")]
+    [InlineData("{\"elements\":[]}")]
+    public void FromHiResJson_NullEmptyInvalidOrNoElements_ReturnsEmpty(string? json)
+    {
+        ImageRegionExtractor.FromHiResJson(json).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void FromHiResJson_ClampsBboxToUnitRange()
+    {
+        var json = """{"elements":[{"text":"","page_number":2,"category":"Image","bbox":{"x":-0.1,"y":0.5,"width":1.5,"height":0.2}}]}""";
+        var r = ImageRegionExtractor.FromHiResJson(json).Single();
+        r.X.Should().Be(0.0);       // clamped from -0.1
+        r.Width.Should().Be(1.0);   // clamped from 1.5
+    }
+}
+```
+
+- [ ] **Step 2: Run it — verify it fails**
+
+Run: `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~ImageRegionExtractorTests"`
+Expected: FAIL (does not compile — `ImageRegionExtractor` undefined).
+
+- [ ] **Step 3: Write the implementation**
+
+`ImageRegionExtractor.cs`:
+```csharp
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Services;
+
+/// &lt;summary&gt;
+/// Image-table slice (#3447): extracts Image/FigureCaption regions (with bbox) from the raw Unstructured
+/// hi_res response. These are exactly the elements the normal pipeline drops (empty text), so we parse the
+/// wire format directly. Safe on null/empty/invalid input → empty. bbox clamped to [0,1].
+/// &lt;/summary&gt;
+public static class ImageRegionExtractor
+{
+    private static readonly HashSet&lt;string&gt; RegionCategories = new(StringComparer.Ordinal) { "Image", "FigureCaption" };
+
+    public static IReadOnlyList&lt;ExtractedImageRegion&gt; FromHiResJson(string? hiResJson)
+    {
+        if (string.IsNullOrWhiteSpace(hiResJson))
+        {
+            return Array.Empty&lt;ExtractedImageRegion&gt;();
+        }
+
+        try
+        {
+            var parsed = JsonSerializer.Deserialize&lt;HiResEnvelope&gt;(hiResJson);
+            if (parsed?.Elements is null)
+            {
+                return Array.Empty&lt;ExtractedImageRegion&gt;();
+            }
+
+            return parsed.Elements
+                .Where(e =&gt; e.Category is not null && RegionCategories.Contains(e.Category) && e.Bbox is not null)
+                .Select(e =&gt; new ExtractedImageRegion(
+                    Page: e.PageNumber &gt; 0 ? e.PageNumber : 1,
+                    X: Clamp01(e.Bbox!.X),
+                    Y: Clamp01(e.Bbox!.Y),
+                    Width: Clamp01(e.Bbox!.Width),
+                    Height: Clamp01(e.Bbox!.Height),
+                    ElementType: e.Category!))
+                .ToList();
+        }
+        catch (JsonException)
+        {
+            return Array.Empty&lt;ExtractedImageRegion&gt;();
+        }
+    }
+
+    private static double Clamp01(double v) =&gt; Math.Clamp(v, 0.0, 1.0);
+
+    private sealed record HiResEnvelope([property: JsonPropertyName("elements")] List&lt;HiResElement&gt;? Elements);
+    private sealed record HiResElement(
+        [property: JsonPropertyName("page_number")] int PageNumber,
+        [property: JsonPropertyName("category")] string? Category,
+        [property: JsonPropertyName("bbox")] HiResBbox? Bbox);
+    private sealed record HiResBbox(
+        [property: JsonPropertyName("x")] double X,
+        [property: JsonPropertyName("y")] double Y,
+        [property: JsonPropertyName("width")] double Width,
+        [property: JsonPropertyName("height")] double Height);
+}
+
+public sealed record ExtractedImageRegion(int Page, double X, double Y, double Width, double Height, string ElementType);
+```
+
+- [ ] **Step 4: Run it — verify it passes**
+
+Run: `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~ImageRegionExtractorTests"`
+Expected: PASS (all 6 cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/ImageRegionExtractor.cs \
+        apps/api/tests/Api.Tests/Unit/DocumentProcessing/ImageRegionExtractorTests.cs
+git commit -m "feat(rag): ImageRegionExtractor — parse hi_res Image/FigureCaption regions (#3447)"
+```
+
+---
+
+### Task 3: BE — `GetPdfImageRegionsQuery` + handler + GET endpoint
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetPdfImageRegionsQuery.cs`
+- Create: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetPdfImageRegionsQueryHandler.cs`
+- Modify: `apps/api/src/Api/Routing/Pdf/PdfRetrievalEndpoints.cs` (add `MapGet`)
+- Test: `apps/api/tests/Api.Tests/Unit/DocumentProcessing/GetPdfImageRegionsQueryHandlerTests.cs`
+
+**Interfaces:**
+- Consumes: `PdfImageRegionEntity`, `MeepleAiDbContext.PdfImageRegions` (Task 1).
+- Produces: `internal sealed record GetPdfImageRegionsQuery(Guid PdfId) : IQuery<IReadOnlyList<ImageRegionDto>>`; `internal record ImageRegionDto(int Page, double X, double Y, double Width, double Height, string ElementType)`. Handler returns `[]` when the PDF has no regions. Per-user authz/copyright gating is **deferred** (S-4) — the endpoint only requires a logged-in session (`.RequireSession()`); regions are non-sensitive geometry and an empty list is the natural "no regions" state.
+
+- [ ] **Step 1: Write the failing handler test**
+
+`GetPdfImageRegionsQueryHandlerTests.cs`:
+```csharp
+using Api.BoundedContexts.DocumentProcessing.Application.Queries;
+using Api.Infrastructure.Entities;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Api.Tests.Unit.DocumentProcessing;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "3447")]
+public sealed class GetPdfImageRegionsQueryHandlerTests
+{
+    [Fact]
+    public async Task Handle_ReturnsRegionsForPdf_OrderedByPage()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext($"getimg_{Guid.NewGuid():N}");
+        var pdfId = Guid.NewGuid();
+        db.PdfImageRegions.AddRange(
+            new PdfImageRegionEntity { PdfDocumentId = pdfId, PageNumber = 5, X = 0.1, Y = 0.2, Width = 0.3, Height = 0.1, ElementType = "Image" },
+            new PdfImageRegionEntity { PdfDocumentId = pdfId, PageNumber = 4, X = 0.1, Y = 0.5, Width = 0.8, Height = 0.3, ElementType = "FigureCaption" },
+            new PdfImageRegionEntity { PdfDocumentId = Guid.NewGuid(), PageNumber = 1, X = 0, Y = 0, Width = 1, Height = 1, ElementType = "Image" });
+        await db.SaveChangesAsync();
+
+        var handler = new GetPdfImageRegionsQueryHandler(db, NullLogger<GetPdfImageRegionsQueryHandler>.Instance);
+        var result = await handler.Handle(new GetPdfImageRegionsQuery(pdfId), CancellationToken.None);
+
+        result.Should().HaveCount(2);
+        result.Select(r => r.Page).Should().ContainInOrder(4, 5); // ordered by page
+        result[0].ElementType.Should().Be("FigureCaption");
+    }
+
+    [Fact]
+    public async Task Handle_UnknownPdf_ReturnsEmpty()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext($"getimg_{Guid.NewGuid():N}");
+        var handler = new GetPdfImageRegionsQueryHandler(db, NullLogger<GetPdfImageRegionsQueryHandler>.Instance);
+        var result = await handler.Handle(new GetPdfImageRegionsQuery(Guid.NewGuid()), CancellationToken.None);
+        result.Should().BeEmpty();
+    }
+}
+```
+
+- [ ] **Step 2: Run it — verify it fails** (compile error: types undefined).
+
+- [ ] **Step 3: Write query + handler**
+
+`GetPdfImageRegionsQuery.cs`:
+```csharp
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Queries;
+
+internal sealed record GetPdfImageRegionsQuery(Guid PdfId) : IQuery&lt;IReadOnlyList&lt;ImageRegionDto&gt;&gt;;
+
+internal record ImageRegionDto(int Page, double X, double Y, double Width, double Height, string ElementType);
+```
+
+`GetPdfImageRegionsQueryHandler.cs`:
+```csharp
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Queries;
+
+internal class GetPdfImageRegionsQueryHandler : IQueryHandler&lt;GetPdfImageRegionsQuery, IReadOnlyList&lt;ImageRegionDto&gt;&gt;
+{
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger&lt;GetPdfImageRegionsQueryHandler&gt; _logger;
+
+    public GetPdfImageRegionsQueryHandler(MeepleAiDbContext dbContext, ILogger&lt;GetPdfImageRegionsQueryHandler&gt; logger)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task&lt;IReadOnlyList&lt;ImageRegionDto&gt;&gt; Handle(GetPdfImageRegionsQuery query, CancellationToken ct)
+    {
+        var regions = await _dbContext.PdfImageRegions
+            .Where(r =&gt; r.PdfDocumentId == query.PdfId)
+            .OrderBy(r =&gt; r.PageNumber)
+            .AsNoTracking()
+            .Select(r =&gt; new ImageRegionDto(r.PageNumber, r.X, r.Y, r.Width, r.Height, r.ElementType))
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+        return regions;
+    }
+}
+```
+
+- [ ] **Step 4: Run it — verify it passes.**
+
+- [ ] **Step 5: Register the GET endpoint**
+
+In `PdfRetrievalEndpoints.cs`, inside `Map(...)` next to the other `/pdf/{pdfId:guid}/...` routes:
+```csharp
+group.MapGet("/pdf/{pdfId:guid}/image-regions", HandleGetImageRegions).RequireSession();
+```
+Add the handler method (mirror `HandleGetPdfText`):
+```csharp
+private static async Task&lt;IResult&gt; HandleGetImageRegions(Guid pdfId, IMediator mediator, CancellationToken ct)
+{
+    var regions = await mediator.Send(new GetPdfImageRegionsQuery(pdfId), ct).ConfigureAwait(false);
+    return Results.Json(new { regions });
+}
+```
+(`.RequireSession()` enforces a logged-in caller; the handler needs no session data. Add the `using` for `GetPdfImageRegionsQuery`.)
+
+- [ ] **Step 6: Build the solution to confirm the endpoint compiles**
+
+Run: `dotnet build apps/api/MeepleAI.Api.sln` → 0 errors. (Kill stray dotnet first if the build hangs.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetPdfImageRegionsQuery.cs \
+        apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetPdfImageRegionsQueryHandler.cs \
+        apps/api/src/Api/Routing/Pdf/PdfRetrievalEndpoints.cs \
+        apps/api/tests/Api.Tests/Unit/DocumentProcessing/GetPdfImageRegionsQueryHandlerTests.cs
+git commit -m "feat(rag): GET /api/v1/pdf/{id}/image-regions query + endpoint (#3447)"
+```
+
+---
+
+### Task 4: BE — `SeedPdfImageRegionsCommand` + handler + admin POST endpoint
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/SeedPdfImageRegionsCommand.cs`
+- Create: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/SeedPdfImageRegionsCommandHandler.cs`
+- Modify: `apps/api/src/Api/Routing/AdminPdfManagementEndpoints.cs` (add admin `MapPost`)
+- Test: `apps/api/tests/Api.Tests/Unit/DocumentProcessing/SeedPdfImageRegionsCommandHandlerTests.cs`
+
+**Interfaces:**
+- Consumes: `ImageRegionExtractor.FromHiResJson` (Task 2), `PdfImageRegionEntity` + DbSet (Task 1).
+- Produces: `internal sealed record SeedPdfImageRegionsCommand(Guid PdfId, string HiResJson) : ICommand<int>` (returns count inserted). Handler is **idempotent**: deletes existing regions for the pdf, inserts the parsed ones, `SaveChangesAsync`.
+
+- [ ] **Step 1: Write the failing handler test**
+
+`SeedPdfImageRegionsCommandHandlerTests.cs`:
+```csharp
+using Api.BoundedContexts.DocumentProcessing.Application.Commands;
+using Api.Infrastructure.Entities;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Api.Tests.Unit.DocumentProcessing;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "3447")]
+public sealed class SeedPdfImageRegionsCommandHandlerTests
+{
+    private const string HiResJson = """
+    {"elements":[
+      {"text":"","page_number":4,"category":"Image","bbox":{"x":0.1,"y":0.5,"width":0.8,"height":0.3}},
+      {"text":"t","page_number":1,"category":"Title","bbox":{"x":0.0,"y":0.0,"width":0.1,"height":0.1}}
+    ]}
+    """;
+
+    [Fact]
+    public async Task Handle_InsertsParsedRegions_AndIsIdempotent()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext($"seedimg_{Guid.NewGuid():N}");
+        var pdfId = Guid.NewGuid();
+        var handler = new SeedPdfImageRegionsCommandHandler(db, NullLogger<SeedPdfImageRegionsCommandHandler>.Instance);
+
+        var count1 = await handler.Handle(new SeedPdfImageRegionsCommand(pdfId, HiResJson), CancellationToken.None);
+        count1.Should().Be(1); // only the Image; Title dropped
+
+        // idempotent: seeding again replaces, does not duplicate
+        var count2 = await handler.Handle(new SeedPdfImageRegionsCommand(pdfId, HiResJson), CancellationToken.None);
+        count2.Should().Be(1);
+        (await db.PdfImageRegions.CountAsync(r => r.PdfDocumentId == pdfId)).Should().Be(1);
+    }
+}
+```
+
+- [ ] **Step 2: Run it — verify it fails.**
+
+- [ ] **Step 3: Write command + handler**
+
+`SeedPdfImageRegionsCommand.cs`:
+```csharp
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Commands;
+
+internal sealed record SeedPdfImageRegionsCommand(Guid PdfId, string HiResJson) : ICommand&lt;int&gt;;
+```
+
+`SeedPdfImageRegionsCommandHandler.cs`:
+```csharp
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Commands;
+
+internal class SeedPdfImageRegionsCommandHandler : ICommandHandler&lt;SeedPdfImageRegionsCommand, int&gt;
+{
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger&lt;SeedPdfImageRegionsCommandHandler&gt; _logger;
+
+    public SeedPdfImageRegionsCommandHandler(MeepleAiDbContext dbContext, ILogger&lt;SeedPdfImageRegionsCommandHandler&gt; logger)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task&lt;int&gt; Handle(SeedPdfImageRegionsCommand command, CancellationToken ct)
+    {
+        var regions = ImageRegionExtractor.FromHiResJson(command.HiResJson);
+
+        var existing = await _dbContext.PdfImageRegions
+            .Where(r =&gt; r.PdfDocumentId == command.PdfId).ToListAsync(ct).ConfigureAwait(false);
+        if (existing.Count &gt; 0)
+        {
+            _dbContext.PdfImageRegions.RemoveRange(existing);
+        }
+
+        foreach (var r in regions)
+        {
+            _dbContext.PdfImageRegions.Add(new PdfImageRegionEntity
+            {
+                PdfDocumentId = command.PdfId, PageNumber = r.Page,
+                X = r.X, Y = r.Y, Width = r.Width, Height = r.Height, ElementType = r.ElementType
+            });
+        }
+
+        await _dbContext.SaveChangesAsync(ct).ConfigureAwait(false);
+        _logger.LogInformation("Seeded {Count} image regions for PDF {PdfId}", regions.Count, command.PdfId);
+        return regions.Count;
+    }
+}
+```
+
+- [ ] **Step 4: Run it — verify it passes.**
+
+- [ ] **Step 5: Register the admin POST endpoint**
+
+In `AdminPdfManagementEndpoints.cs` (group `/admin/pdfs`, already admin-gated), add:
+```csharp
+group.MapPost("/{pdfId:guid}/seed-image-regions", SeedImageRegions)
+    .WithName("SeedPdfImageRegions")
+    .WithSummary("#3447 slice: seed image-table regions from a raw Unstructured hi_res JSON body");
+```
+Handler + request DTO (co-located at file end, mirror `ReindexDocument`/`ReindexDocumentRequest`):
+```csharp
+private static async Task&lt;IResult&gt; SeedImageRegions(Guid pdfId, SeedImageRegionsRequest request, IMediator mediator, CancellationToken ct)
+{
+    var count = await mediator.Send(new SeedPdfImageRegionsCommand(pdfId, request.HiResJson), ct).ConfigureAwait(false);
+    return Results.Ok(new { success = true, seeded = count });
+}
+// ...
+internal record SeedImageRegionsRequest(string HiResJson);
+```
+(Endpoint path = `/api/v1/admin/pdfs/{id}/seed-image-regions`. Add the `using` for the command namespace.)
+
+- [ ] **Step 6: Build the solution → 0 errors.**
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/SeedPdfImageRegionsCommand.cs \
+        apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/SeedPdfImageRegionsCommandHandler.cs \
+        apps/api/src/Api/Routing/AdminPdfManagementEndpoints.cs \
+        apps/api/tests/Api.Tests/Unit/DocumentProcessing/SeedPdfImageRegionsCommandHandlerTests.cs
+git commit -m "feat(rag): admin seed-image-regions command + endpoint (#3447)"
+```
+
+---
+
+### Task 5: FE — `ImageRegion` schema + `pdfClient.getImageRegions`
+
+**Files:**
+- Modify: `apps/web/src/lib/api/schemas/pdf.schemas.ts` (add schema)
+- Modify: `apps/web/src/lib/api/clients/pdfClient.ts` (add method)
+- Test: `apps/web/src/lib/api/clients/__tests__/pdfClient.test.ts` (add case; create if absent following an existing client test)
+
+**Interfaces:**
+- Produces: `ImageRegionsResponseSchema` (zod) + `type ImageRegion = { page:number; x:number; y:number; width:number; height:number; elementType:string }`; `api.pdf.getImageRegions(pdfId: string): Promise<ImageRegion[] | null>`.
+
+- [ ] **Step 1: Add the zod schema**
+
+In `pdf.schemas.ts`:
+```ts
+export const ImageRegionSchema = z.object({
+  page: z.number().int(),
+  x: z.number(), y: z.number(), width: z.number(), height: z.number(),
+  elementType: z.string(),
+});
+export const ImageRegionsResponseSchema = z.object({ regions: z.array(ImageRegionSchema) });
+export type ImageRegion = z.infer<typeof ImageRegionSchema>;
+```
+Ensure it's re-exported via `schemas/index.ts` (the barrel already re-exports `pdf.schemas`).
+
+- [ ] **Step 2: Write the failing client test**
+
+In the pdfClient test (mirror how `getProcessingProgress` is tested — mock `httpClient.get`):
+```ts
+it('getImageRegions calls the endpoint and returns regions', async () => {
+  const httpClient = { get: vi.fn().mockResolvedValue({ regions: [{ page: 4, x: 0.1, y: 0.5, width: 0.8, height: 0.3, elementType: 'Image' }] }) };
+  const client = createPdfClient({ httpClient: httpClient as any });
+  const regions = await client.getImageRegions('abc');
+  expect(httpClient.get).toHaveBeenCalledWith('/api/v1/pdf/abc/image-regions', ImageRegionsResponseSchema);
+  expect(regions).toEqual([{ page: 4, x: 0.1, y: 0.5, width: 0.8, height: 0.3, elementType: 'Image' }]);
+});
+```
+
+- [ ] **Step 3: Run it — verify it fails** (`getImageRegions` undefined).
+
+Run: `cd apps/web && pnpm test -- pdfClient`
+
+- [ ] **Step 4: Implement `getImageRegions`**
+
+In `pdfClient.ts` (mirror `getProcessingProgress`; note the endpoint returns `{ regions: [...] }`):
+```ts
+async getImageRegions(pdfId: string): Promise<ImageRegion[] | null> {
+  const res = await httpClient.get(
+    `/api/v1/pdf/${encodeURIComponent(pdfId)}/image-regions`,
+    ImageRegionsResponseSchema
+  );
+  return res?.regions ?? null;
+}
+```
+Import `ImageRegionsResponseSchema` + `ImageRegion` from `../schemas`. Add `getImageRegions` to the `PdfClient` type.
+
+- [ ] **Step 5: Run it — verify it passes.**
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /d/Repositories/meepleai-monorepo-frontend
+git add apps/web/src/lib/api/schemas/pdf.schemas.ts apps/web/src/lib/api/clients/pdfClient.ts apps/web/src/lib/api/clients/__tests__/
+git commit -m "feat(rag): pdfClient.getImageRegions + zod schema (#3447)"
+```
+
+---
+
+### Task 6: FE — `PdfImageRegionOverlay` component
+
+**Files:**
+- Create: `apps/web/src/components/pdf/PdfImageRegionOverlay.tsx`
+- Test: `apps/web/src/components/pdf/__tests__/PdfImageRegionOverlay.test.tsx`
+
+**Interfaces:**
+- Consumes: `ImageRegion` (Task 5) — but the overlay only needs `{x,y,width,height}`.
+- Produces: `PdfImageRegionOverlay({ rects }: { rects: readonly ImageRegion[] })` — draws `%`-based rects (already page-filtered by the caller), `data-testid="pdf-image-region-overlay"` wrapper + `data-testid="pdf-image-region-rect"` per rect, distinct className `pdf-image-region-highlight`. Returns `null` when empty. Mirrors `PdfBBoxOverlay`.
+
+- [ ] **Step 1: Write the failing test** (clone `PdfBBoxOverlay.test.tsx`):
+```tsx
+import { render, screen } from '@testing-library/react';
+import { PdfImageRegionOverlay } from '../PdfImageRegionOverlay';
+
+const rect = (o: Partial<{ x:number;y:number;width:number;height:number }>) =>
+  ({ page: 4, x: 0, y: 0, width: 0.1, height: 0.1, elementType: 'Image', ...o });
+
+it('renders one %-positioned rect per region', () => {
+  render(<PdfImageRegionOverlay rects={[rect({ x: 0.1, y: 0.2, width: 0.3, height: 0.05 })]} />);
+  const el = screen.getByTestId('pdf-image-region-rect');
+  expect(el.style.left).toBe('10%');
+  expect(el.style.top).toBe('20%');
+  expect(el.style.width).toBe('30%');
+  expect(el.style.height).toBe('5%');
+});
+
+it('renders nothing for empty rects', () => {
+  const { container } = render(<PdfImageRegionOverlay rects={[]} />);
+  expect(container).toBeEmptyDOMElement();
+});
+```
+
+- [ ] **Step 2: Run it — verify it fails.** `cd apps/web && pnpm test -- PdfImageRegionOverlay`
+
+- [ ] **Step 3: Implement the overlay:**
+```tsx
+import type { ImageRegion } from '@/lib/api/schemas';
+
+export interface PdfImageRegionOverlayProps {
+  readonly rects: readonly ImageRegion[];
+}
+
+/** #3447 slice: draws hi_res table-image regions as %-based rects, child of react-pdf <Page>. */
+export function PdfImageRegionOverlay({ rects }: PdfImageRegionOverlayProps): JSX.Element | null {
+  if (rects.length === 0) return null;
+  return (
+    <div aria-hidden data-testid="pdf-image-region-overlay" className="pointer-events-none absolute inset-0">
+      {rects.map((r, i) => (
+        <div
+          key={i}
+          data-testid="pdf-image-region-rect"
+          className="pdf-image-region-highlight absolute"
+          style={{ left: `${r.x * 100}%`, top: `${r.y * 100}%`, width: `${r.width * 100}%`, height: `${r.height * 100}%` }}
+        />
+      ))}
+    </div>
+  );
+}
+```
+Add a `.pdf-image-region-highlight` style to `apps/web/src/styles/globals.css` next to `.pdf-bbox-highlight` (dashed border, distinct from the citation highlight), e.g.:
+```css
+.pdf-image-region-highlight { border: 2px dashed rgb(245 158 11 / 0.9); border-radius: 2px; background: rgb(245 158 11 / 0.08); }
+```
+
+- [ ] **Step 4: Run it — verify it passes.**
+
+- [ ] **Step 5: Commit**
+```bash
+git add apps/web/src/components/pdf/PdfImageRegionOverlay.tsx apps/web/src/components/pdf/__tests__/PdfImageRegionOverlay.test.tsx apps/web/src/styles/globals.css
+git commit -m "feat(rag): PdfImageRegionOverlay component (#3447)"
+```
+
+---
+
+### Task 7: FE — fetch image-regions on open in `PdfInlineViewer` + draw
+
+**Files:**
+- Modify: `apps/web/src/components/pdf/PdfInlineViewer.tsx`
+- Test: `apps/web/src/components/pdf/__tests__/PdfInlineViewer.test.tsx` (extend)
+
+**Interfaces:**
+- Consumes: `api.pdf.getImageRegions` (Task 5), `PdfImageRegionOverlay` (Task 6).
+- Produces: `PdfInlineViewer` now fetches image-regions on `documentId` change, filters to `currentPage`, and renders `<PdfImageRegionOverlay>` as an additional child of `<Page>` (alongside the existing `PdfBBoxOverlay`).
+
+- [ ] **Step 1: Write the failing test** (extend `PdfInlineViewer.test.tsx`; mock adds `getImageRegions`):
+
+Add to the `@/lib/api` mock: `getImageRegions: vi.fn().mockResolvedValue([{ page: 1, x: 0.1, y: 0.2, width: 0.3, height: 0.1, elementType: 'Image' }])`. Then:
+```tsx
+it('draws image-region overlay for the current page fetched on open', async () => {
+  render(<PdfInlineViewer documentId="doc-1" />);
+  await waitFor(() => expect(screen.getByTestId('pdf-page')).toBeInTheDocument());
+  await waitFor(() => expect(screen.getByTestId('pdf-image-region-rect')).toBeInTheDocument());
+});
+
+it('does not draw image regions for other pages', async () => {
+  (api.pdf.getImageRegions as any).mockResolvedValueOnce([{ page: 3, x: 0.1, y: 0.2, width: 0.3, height: 0.1, elementType: 'Image' }]);
+  render(<PdfInlineViewer documentId="doc-1" initialPage={1} />);
+  await waitFor(() => expect(screen.getByTestId('pdf-page')).toBeInTheDocument());
+  expect(screen.queryByTestId('pdf-image-region-rect')).not.toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run it — verify it fails.** `cd apps/web && pnpm test -- PdfInlineViewer`
+
+- [ ] **Step 3: Implement fetch-on-open + render**
+
+In `PdfInlineViewer.tsx`:
+1. Add state `const [imageRegions, setImageRegions] = useState<readonly ImageRegion[]>([]);`
+2. Add an effect keyed on `documentId` (mirror the blob-fetch effect ~lines 125-151):
+```tsx
+useEffect(() => {
+  let cancelled = false;
+  api.pdf.getImageRegions(documentId)
+    .then((regions) => { if (!cancelled) setImageRegions(regions ?? []); })
+    .catch(() => { if (!cancelled) setImageRegions([]); });
+  return () => { cancelled = true; };
+}, [documentId]);
+```
+3. `const pageImageRegions = useMemo(() => imageRegions.filter(r => r.page === currentPage), [imageRegions, currentPage]);`
+4. Inside `<Page>`, alongside the existing `PdfBBoxOverlay`:
+```tsx
+{pageImageRegions.length > 0 ? <PdfImageRegionOverlay rects={pageImageRegions} /> : null}
+```
+Import `api`, `ImageRegion`, `PdfImageRegionOverlay`.
+
+- [ ] **Step 4: Run it — verify it passes.**
+
+- [ ] **Step 5: Typecheck + lint**
+
+Run: `cd apps/web && pnpm typecheck && pnpm lint`. Fix any issues.
+
+- [ ] **Step 6: Commit**
+```bash
+git add apps/web/src/components/pdf/PdfInlineViewer.tsx apps/web/src/components/pdf/__tests__/PdfInlineViewer.test.tsx
+git commit -m "feat(rag): fetch + draw image regions on PDF open (#3447)"
+```
+
+---
+
+### Task 8: Validation — seed agricola + visual check (manual)
+
+**Files:** none (validation).
+
+- [ ] **Step 1: Ensure the migration is applied** to the target DB (local `make dev`, or staging after deploy). Locally: `cd apps/api/src/Api && dotnet ef database update`.
+
+- [ ] **Step 2: Get agricola's hi_res regions JSON** from the Unstructured service (as in the #3419 investigation):
+```bash
+# local (if unstructured up) or staging via SSH docker exec:
+docker exec meepleai-api sh -c "curl -s -m 300 -F file=@/path/agricola-revised_rulebook.pdf -F strategy=hi_res -F language=ita http://unstructured-service:8001/api/v1/extract" > /tmp/hires.json
+```
+
+- [ ] **Step 3: Find agricola's pdfId** (DB query) and POST the seed (admin session cookie required):
+```bash
+curl -s -X POST "http://localhost:8080/api/v1/admin/pdfs/<agricola-pdfId>/seed-image-regions" \
+  -H "Content-Type: application/json" -b <admin-cookie> \
+  -d "{\"hiResJson\": $(cat /tmp/hires.json | jq -Rs .)}"
+# expect {"success":true,"seeded":N} with N > 0
+```
+
+- [ ] **Step 4: Verify the read endpoint** returns regions:
+`GET /api/v1/pdf/<agricola-pdfId>/image-regions` → `{ regions: [...] }` non-empty.
+
+- [ ] **Step 5: Open agricola in the app** (a surface that mounts `PdfInlineViewer`) and **eyeball**: are the dashed rects on the tables? Is it useful? Record the verdict in issue #3447 — this is the decision gate for the full feature.
+
+- [ ] **Step 6 (if not already): run the full affected suites**
+- BE: `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~DocumentProcessing&Category=Unit"` → 0 fail.
+- FE: `cd apps/web && pnpm test -- pdf` → 0 fail.
+
+---
+
+## Deferred (tracked in #3435, NOT in this slice)
+Productionized async hi_res enrichment job (trigger without the 120s timeout), the table-heavy PDF router (DC-B), citation→region per-page linkage (DC-F), copyright tier gating on the regions endpoint (prerequisite before user-facing rollout), corpus-scale seeding, and the Metà-C content extraction (VLM/Tesseract).

--- a/docs/superpowers/specs/2026-08-01-grounding-contract-design.md
+++ b/docs/superpowers/specs/2026-08-01-grounding-contract-design.md
@@ -1,0 +1,57 @@
+# Grounding come invariante di contratto — Design
+
+**Issue**: #3388 (epic P1 #3397, Blocco 1 "pavimento di correttezza") · **Data**: 2026-08-01
+
+## Problema
+
+La chat con l'agente in-sessione instrada su **due backend** a seconda che il messaggio contenga immagini, con contratti divergenti:
+- **Solo testo** → SSE `ChatWithSessionAgentCommandHandler` (BC KnowledgeBase): RAG con citazioni; grounding **inferito dal FE** (`isNonGrounded` se citations==0).
+- **Con immagini** → `AskSessionAgentCommandHandler` (BC SessionTracking): LLM multimodale, **nessun retrieval**, `citationsJson=null`, `confidence` **hard-coded a `0.85`**; il FE **non** imposta `isNonGrounded` → **nessun disclaimer**.
+
+Lo scenario di punta ("scatto una foto del tavolo e chiedo una regola") restituisce una risposta autorevole (`confidence 0.85`) **silenziosamente non-grounded**. Il grounding è oggi proprietà della *modalità di input*, non un invariante di sistema.
+
+## Decisioni (brainstorming 2026-08-01)
+
+- **`enum GroundingStatus { Grounded, Partial, Ungrounded }`** in `Api.SharedKernel` (Published Language neutra, condivisa da KnowledgeBase + SessionTracking). `Partial` è nel contratto per l'epic futura multimodale→RAG (#3390) ma **nessun path lo emette ora**.
+- **Derivato dai citations, nessuna migration**: `groundingStatus = citations.Count > 0 ? Grounded : Ungrounded`, calcolato a response-time e **ri-derivabile da `CitationsJson`** già persistito su `SessionChatMessage` al reload. Nessun campo/migration EF.
+- **`confidence` fabbricata rimossa** → `null` onesto (nessuna metrica reale disponibile; "numero fabbricato mostrato come misurato" per 3 lenti del panel).
+- **Disclaimer calibrato per modalità** (non generico, per evitare banner-blindness).
+
+## Componenti
+
+### BE-1 — enum condiviso
+`Api.SharedKernel/.../GroundingStatus.cs`: `enum GroundingStatus { Grounded, Partial, Ungrounded }`. Sul wire il **valore** è il nome dell'enum in **PascalCase** (`"Grounded"`/`"Ungrounded"`) — via `JsonStringEnumConverter` sul path REST e come stringa letterale sul path SSE (che serializza gli enum numericamente); la **chiave** JSON è camelCase (`groundingStatus`). Il FE confronta `=== 'Ungrounded'`.
+
+### BE-2 — path immagine/text-only (`AskSessionAgentCommandHandler`, BC SessionTracking)
+- Rimuovere `confidence=0.85f` (`ChatCommandHandlers.cs:201`, `:224`) → `confidence=null`.
+- Aggiungere `GroundingStatus` (non-nullable) a `AskSessionAgentResult`; valore `Ungrounded` per costruzione (`citationsJson=null`, nessun retrieval). L'endpoint serializza il result → il campo appare nel JSON.
+
+### BE-3 — path RAG SSE (`ChatWithSessionAgentCommandHandler`, BC KnowledgeBase)
+- Emettere `groundingStatus` **server-side** nel contratto/evento terminale: `Grounded` se citations>0, `Ungrounded` se 0. Promuove la logica da FE-derivata a invariante di contratto.
+
+### FE-1 — lettura uniforme
+- Tipizzare `groundingStatus: 'grounded'|'partial'|'ungrounded'` in `ChatMessage` (`useSessionAgentChat.ts`); leggerlo da **entrambi** i path (SSE + immagine `SessionLiveView.tsx:1256-1269`), non più inferirlo da citations.
+
+### FE-2 — disclaimer + rimozione confidence fabbricata
+- `LiveAgentChat.tsx:240`: mostrare il disclaimer per **ogni** risposta `ungrounded`, su entrambe le modalità, con copy **per-modalità**:
+  - immagine: *"Ho risposto dalla foto e dalla mia conoscenza del gioco, non dal regolamento ufficiale — verifica sul manuale"*.
+  - testo (0 citazioni): copy esistente del disclaimer RAG.
+- Chiavi i18n in `it.json`/`en.json`.
+- Rimuovere qualsiasi `confidence` fabbricata renderizzata come "misurata".
+
+## Definition of Done (dalla issue)
+
+- [ ] `groundingStatus` non-nullable esposto da **entrambi** i path.
+- [ ] Path immagine mappa `citationsJson=null` → `Ungrounded`.
+- [ ] FE mostra il disclaimer per ogni `ungrounded`, su entrambe le modalità.
+- [ ] Nessuna `confidence` fabbricata restituita/mostrata.
+- [ ] Test di **parità di modalità**: stessa domanda testo-vs-immagine → stesso *tipo* di segnale di grounding (non-nullable).
+
+## Fuori scope
+
+- Chiudere il **gap di capacità** (far passare il multimodale attraverso il retrieval) = epic #3390, non questa issue. Qui si rende **onesto il segnale**, non si aggiunge grounding al path immagine.
+- `Partial` producer (nessuno finché #3390 non introduce il grounding parziale).
+
+## Riferimenti
+
+Audit: `docs/for-developers/audits/2026-07-29-in-session-agent-grounding-audit.md` (Fase 1).

--- a/docs/superpowers/specs/2026-08-01-image-table-region-grounding-design.md
+++ b/docs/superpowers/specs/2026-08-01-image-table-region-grounding-design.md
@@ -4,10 +4,16 @@
 **Tipo**: design — follow-up investigazione #3419
 **Epic**: #3435 — "Image-table extraction & grounding" (il *Livello 2* rinviato dall'epic #3403)
 **Branch previsto**: feature branch per sub-progetto (parent `main-dev`)
-**Stato**: **design v1** — v0 draft + **spec-panel review incorporata (2026-08-01)**
-> Panel: Fowler/Nygard/Newman/Wiegers/Adzic/Crispin/Hightower. Le modifiche v1 chiudono: retrievability della
-> Metà R (§2), Fase-0 spike bloccanti (§5), assunzione 1:tabella:regione (§7 IA-6), design operativo del job VLM
-> (§8), contratto SmolDocling (DC-G), golden-set (§10), NFR VLM (§4), esempio worked (§12).
+**Stato**: **design v1.2** — v1.1 (spike) + **reframe "Metà C = batch, non servizio" + alternative a costo zero (§5bis)**
+> Panel: Fowler/Nygard/Newman/Wiegers/Adzic/Crispin/Hightower. v1 chiude: retrievability Metà R (§2), Fase-0 spike
+> (§5), IA-6 (§7), job VLM (§8), contratto SmolDocling (DC-G), golden-set (§10), NFR (§4), esempio worked (§12).
+> **v1.1** registra gli esiti spike: **DC-A ✅NO** (fast dà bbox testo ma non le regioni-immagine → serve hi_res async),
+> **DC-G ✅SÌ** (VLM image-native → thin endpoint `/extract-image` → Opzione B viabile), **DC-E ✅BLOCCATO** (il box
+> staging 8GB non può ospitare SmolDocling — 172 MiB liberi, 2.6 GiB già in swap → benchmark off-box + prerequisito
+> infra). Restano DC-C (dipende dal benchmark off-box), DC-B, DC-F.
+> **v1.2** riformula: la Metà C è un **batch di arricchimento una-tantum**, non un servizio always-on → **il vincolo
+> infra si applica solo all'ingestion CONTINUA**, non alla validazione né al corpus attuale (che si estraggono con
+> un batch locale/off-box a **costo zero** — §5bis). MVP a costo zero propeso dall'owner = **Opzione E** (region-only via hi_res).
 
 > **Origine**: investigazione di attivazione di DC-2 #3419 su staging (2026-08-01). Il wiring hi_res-per-tabelle
 > è corretto e mergiato ma **inerte sul corpus reale**: né `fast` né `hi_res` producono elementi `Table`,
@@ -122,15 +128,43 @@ Non-goal:
 > **Correzione v1 (Wiegers, CRITICAL)**: la scelta A/B/C dipende da nodi tecnici irrisolti. Vanno chiusi da spike
 > mirati **prima** di stimare l'effort e committare un'opzione. Nessun SP di implementazione parte prima.
 
-| Spike | Domanda | Sblocca | Come |
-|---|---|---|---|
-| **DC-A** | `fast` (coordinate-aware post SP-B) emette bbox `Image`/`FigureCaption` a costo basso, o servono solo con hi_res (>120s)? | Se sì → Metà R senza il nodo-timeout | Rieseguire il confronto categorie fast-vs-hi_res guardando `Image`/`FigureCaption` (non solo `Table`) |
-| **DC-F** *(nuovo v1)* | Meccanismo di legame citazione-testo → regione-immagine: prossimità di pagina è sufficiente per valore-utente, o serve overlap geometrico / stesso-blocco? | Se il linkage per-pagina basta → Metà R ha valore senza Metà C | Prototipo: per un chunk citato, mostrare le Image-region della stessa pagina; valutare rumore (illustrazioni non-tabella) |
-| **DC-C** | SmolDocling DocTags espone **location** (`<loc_*>`) usabili come bbox? | Contenuto+regione insieme (Opzione C) vs regione da hi_res + contenuto da VLM (Opzione B) | Ispezionare DocTags raw su una pagina-tabella nota |
-| **DC-G** *(nuovo v1)* | SmolDocling accetta **input immagine (crop)** o solo **PDF**? (oggi rende PDF→immagine internamente) | Opzione B (crop) fattibile senza nuovo servizio? | Leggere `smoldocling_adapter.py`/`main.py`; prototipo POST crop |
-| **DC-E** | Deploy SmolDocling su staging 8GB CPU-only: fattibilità + benchmark latenza/memoria; rischio OOM con 10 container già su | Qualsiasi opzione con Metà C | Deploy con `mem_limit`; benchmark 3-5 rulebook; misurare RAM/latenza |
+| Spike | Domanda | Esito (2026-08-01) |
+|---|---|---|
+| **DC-A** | `fast` emette bbox `Image`/`FigureCaption` a costo basso, o solo hi_res (>120s)? | ✅ **NO**. `fast` è coordinate-aware (454/454 elementi con bbox su agricola) **ma non emette `Image`/`FigureCaption`** (solo testo) — il layout model è esclusivo di hi_res. La regione precisa richiede hi_res async; niente scorciatoia region-only economica. fast dà solo bbox del testo circostante (grounding debole, già coperto da #3403). |
+| **DC-G** *(nuovo v1)* | SmolDocling accetta **input immagine (crop)** o solo **PDF**? | ✅ **SÌ, con aggiunta minima**. La VLM è image-native (`process_page(PageImage)` → `processor(images=…)`); l'endpoint pubblico è PDF-only per convenzione. Opzione B (crop) = thin endpoint `POST /extract-image` che wrappa il crop in `PageImage` e chiama il `process_page` esistente. Zero nuovo servizio. |
+| **DC-E** *(riformulato v1.1)* | ~~Deploy SmolDocling su staging 8GB~~ → **Su quale infra girano il benchmark e la Metà C?** | ✅ **BLOCCATO su staging**. Misurato: box 8GB con **172 MiB RAM liberi** + **2.6/4.0 GiB swap già usato** (`unstructured` 2.3 GiB, `embedding` 888 MiB/87%). SmolDocling vuole 2-3 GiB → **headroom negativo** → OOM-kill di un container critico (probabile vittima: `unstructured`) o thrashing. `mem_limit` non risolve (non c'è RAM fisica). **DC-E diventa: benchmark OFF-BOX (locale/VM throwaway) + decisione infra (resize a 16 GiB o nodo dedicato) prima di qualsiasi deploy Metà C.** |
+| **DC-C** | SmolDocling DocTags espone **location** (`<loc_*>`) usabili come bbox? | ⏳ Aperto — dipende dal **benchmark off-box** (DC-E): il `process_page` cattura `doctags_text` raw; i DocTags Docling tipicamente hanno `<loc_*>`, ma va confermato su modello running. Decide Opzione B (regione da hi_res) vs C (regione da DocTags). |
+| **DC-F** *(nuovo v1)* | Legame citazione-testo → regione-immagine: prossimità pagina basta? | ⏳ Aperto — valore atteso **debole** dato DC-A (fast dà solo bbox testo → highlight del testo vicino, non della tabella). |
+| **DC-B** | Router "PDF table-heavy": euristica vs flag manuale | ⏳ Aperto (analisi leggera, no deploy) |
 
 **Output di Fase 0**: una decisione documentata A/B/C con effort stimato. Solo allora partono gli SP §7.
+
+> **⚠️ Prerequisito infra (v1.1→v1.2, Hightower/Nygard)**: la Metà C **sempre-attiva** (SmolDocling VLM come servizio)
+> non è deployabile sul box 8GB saturo (172 MiB liberi, swap 65%). **MA** (v1.2) questo vincolo si applica **solo
+> all'ingestion continua** di PDF nuovi: la validazione e l'estrazione del **corpus attuale** sono un **batch**
+> eseguibile off-box a costo zero (§5bis). L'infra a pagamento serve **solo** se/quando si vuole l'estrazione VLM
+> real-time su ogni upload futuro — decisione da rimandare a feature-provata.
+
+---
+
+## 5bis. Metà C = batch, non servizio → alternative a costo zero (v1.2)
+
+**Reframe**: l'estrazione del contenuto-tabella è un **job di arricchimento una-tantum** (batch), non un servizio
+always-on. Il VLM gira, produce contenuto+bbox, si salvano in DB, e **il VLM non serve più**. Quindi il "deploy
+SmolDocling su staging" (DC-E) era un over-engineering: il batch può girare **ovunque** e solo i risultati vanno in DB.
+
+| # | Alternativa | Spesa | Trade-off |
+|---|---|---|---|
+| **A** | **Batch locale** — SmolDocling gira sulla dev machine (rulebook già in `data/rulebook/`; `docker compose --profile ai up smoldocling-service`). Estrai offline, importi i risultati in staging | **€0 ma tempo-impraticabile su CPU** | ⚠️ **Misurato (01-ago, dev machine CPU)**: SmolDocling **>95s/pagina** (agricola 12 pagine **non finite in 20 min**) vs "3-5s/pagina" del README (assume HW migliore). Corpus 52 PDF = **ore-giorni**. Il VLM è utile **solo con GPU** (~0.5s/pag) → spesa. La qualità di lettura tabelle **non è stata validata** (inference non completata) |
+| **B** | **Batch su staging in finestra di manutenzione** — fermi i non-essenziali (monitoring + reranker/embedding) + buff/cache reclaimable → RAM per un batch time-boxed, poi ripristini | **€0** | Downtime breve staging (accettabile). Più rischioso di A |
+| **C** | **OCR leggero (Tesseract, ~150 MiB)** sui crop-tabella di hi_res → testo retrievabile + regione, senza VLM | **€0** | Niente struttura tabellare, qualità più bassa; footprint minimo, può stare always-on sul box attuale |
+| **D** | **Riusare l'LLM che già paghi** (se il provider fa vision) — mandi i crop all'API esistente | pay-per-call | Spesa marginale, non zero. Solo con budget headroom |
+| **E** ⭐ | **Solo Metà R via hi_res** — nessun VLM: hi_res (già su `unstructured`) dà la bbox della tabella-immagine → il FE evidenzia la regione, l'utente la legge da sé | **€0** | Valore parziale (grounding visivo, no answerability). Rinvia la Metà C. **Quick-win MVP a costo zero (propeso dall'owner)** |
+
+**Percorso a costo zero raccomandato (aggiornato con l'esito empirico 01-ago)**:
+1. **Ora, MVP**: **Opzione E** — grounding visivo delle regioni-tabella via hi_res (async job, nessun VLM, nessuna spesa). L'utente vede la tabella evidenziata anche senza contenuto estratto. **È il percorso più solido dato che il VLM su CPU è impraticabile.**
+2. **Se serve il contenuto a costo zero**: **Opzione C (Tesseract OCR)** sui crop-tabella — veloce su CPU (~ms/regione), a differenza del VLM (>95s/pagina). Qualità inferiore (no struttura) ma pratica. **Opzione A (batch VLM locale) è scartata**: tempo-impraticabile su CPU (ore-giorni per il corpus).
+3. **VLM (Opzione B/C-SmolDocling) = solo con GPU** → spesa infra, **solo dopo** feature-provata E ingestion continua desiderata. Su CPU il VLM non è un'opzione pratica.
 
 ---
 
@@ -159,8 +193,16 @@ location (se DC-C=sì) → contenuto+regione in un colpo.
 - **Contro**: SmolDocling lento CPU (minuti/rulebook), quality più bassa (0.70-0.78) → **rischio di degradare il testo
   narrativo** vs Unstructured; da deployare (DC-E); router affidabile (DC-B).
 
-**Raccomandazione (contingente)**: risolvere Fase 0; poi **B se DC-C=no**, **C se DC-C=sì e il testo narrativo non
-degrada**; **A solo** come quick-win di grounding se DC-F dà valore accettabile e Metà C è rimandata.
+**Raccomandazione (aggiornata v1.1 con esiti spike)**:
+- **Opzione A** indebolita: DC-A=no → nessuna regione-immagine economica via `fast`; A darebbe solo grounding del
+  testo circostante (già in #3403). Quick-win marginale.
+- **Opzione B** confermata **fattibile** (DC-G=sì, thin endpoint crop) — richiede la Metà C, ma (v1.2) come **batch**
+  off-box, **non** un servizio always-on: nessun deploy persistente né spesa infra per il corpus attuale (§5bis).
+- **Opzione C** resta contingente a DC-C (DocTags location), risolvibile col benchmark **locale** (§5bis Opzione A).
+- **Percorso raccomandato v1.2** (a costo zero, vedi §5bis): (1) **MVP = Opzione E** (region-only via hi_res async,
+  nessun VLM) per il grounding visivo immediato; (2) **validare Metà C** con un **batch locale** di SmolDocling
+  (chiude DC-C + numeri); (3) decidere B vs C e l'infra a pagamento **solo dopo** feature-provata, e solo per
+  l'ingestion continua real-time. Il gate non è più "infra o niente" — l'MVP a costo zero è E.
 
 ---
 
@@ -208,10 +250,10 @@ degrada**; **A solo** come quick-win di grounding se DC-F dà valore accettabile
 
 | SP | Cosa | Metà | Costo | Dipende da |
 |----|------|------|-------|-----------|
-| **SP0 — Fase 0 spike** | Chiudere DC-A/C/E/F/G (§5) → decisione A/B/C documentata | — | S | — |
+| **SP0 — Fase 0 spike** | ~~DC-A ✅ DC-G ✅ DC-E ✅(blocco infra)~~; resta **benchmark off-box** (chiude DC-C + numeri) + decisione infra | — | S | — |
 | **SP1 — Image-region capture** | Estendere il capture bbox #3403 a `Image`/`FigureCaption`; linkage per-pagina (DC-F); FE disegna la regione | R | S | #3403 SP-B/SP-D; DC-A/DC-F |
 | **SP2 — Table-region router** | Euristica DC-B per marcare PDF/pagine con tabelle-immagine candidate | R+C | S | SP1 |
-| **SP3 — SmolDocling deploy + extract** | Deploy SmolDocling staging (DC-E, `mem_limit`); endpoint estrazione (crop se DC-G, else pagina) | C | L | SP2, DC-E/DC-G |
+| **SP3 — SmolDocling deploy + extract** | Deploy SmolDocling su **infra adeguata** (NON il box staging 8GB — resize/nodo dedicato, DC-E); thin endpoint `POST /extract-image` per i crop (DC-G ✅) | C | L | SP2, DC-E (infra), DC-G |
 | **SP4 — VLM enrichment job** | Job asincrono §8 (idempotenza/retry/checkpoint/observability/gate qualità) | C | L | SP3 |
 | **SP5 — Table-chunk indexing** | Contenuto-tabella come chunk retrievabile con `bounding_boxes_json`=regione; gating copyright | C | M | SP4 |
 | **SP6 — Answerability + citazione tabella** | Citazione chunk-tabella apre pagina + evidenzia regione; test golden-set (§10) | C | M | SP5 |
@@ -247,7 +289,8 @@ SP0 è bloccante. SP1-SP2 (Metà R) spedibili dopo SP0 se DC-A/DC-F ok. SP3-SP6 
 | **N:M tabella↔regione** | IA-6: MVP 1:1; N:M fuori scope + test di degradazione |
 | **Correlazione crop↔contenuto** (Opzione B) | bbox della regione definisce il crop → contenuto e regione condividono la geometria (valido sotto IA-6 1:1) |
 | **Contratto SmolDocling** (PDF vs crop) | DC-G in Fase 0 prima di committare Opzione B |
-| **OOM su 8GB CPU** | §8: concurrency=1, `mem_limit`, checkpoint, circuit-breaker; DC-E benchmark obbligatorio |
+| **Metà C non deployabile su infra staging attuale** *(v1.1, CRITICAL)* | Misurato: box 8GB con 172 MiB liberi + swap 65%. SmolDocling (2-3 GiB) → headroom negativo → OOM-kill di `unstructured`/critici. `mem_limit` NON basta (manca RAM fisica). **Gate**: benchmark off-box + resize (16 GiB) o nodo VLM dedicato prima di deployare la Metà C |
+| **OOM durante benchmark** | Eseguire il benchmark **fuori dal box condiviso** (locale/VM throwaway); mai avviare SmolDocling sul box saturo |
 | **Copyright leak** (contenuto verbatim) | IA-4 gating `Full`; test `regions=null`/no-content su Protected |
 | **Costo VLM sul corpus** | IA-5/NFR1: VLM solo su PDF con regioni candidate; batch, non ingest sincrono |
 | **Drift corpus post-feature** | SP7: bump `IndexerVersion` + re-extract mirato per-env |

--- a/docs/superpowers/specs/2026-08-01-image-table-region-slice-design.md
+++ b/docs/superpowers/specs/2026-08-01-image-table-region-slice-design.md
@@ -1,0 +1,103 @@
+# Image-Table Region Grounding — Vertical Slice (Opzione E MVP)
+
+**Data**: 2026-08-01
+**Tipo**: design (slice) — brainstorming approvato
+**Issue**: #3447 · **Epic**: #3435 · **Spec padre**: `2026-08-01-image-table-region-grounding-design.md` (§5bis Opzione E)
+**Branch**: `feature/issue-3447-image-table-region-slice` (parent `main-dev`)
+
+## Obiettivo
+
+Provare **end-to-end su UN PDF** che una regione-tabella catturata da `hi_res` (Unstructured) può essere
+**persistita** e **disegnata** sulla pagina PDF nel viewer, per **validare il meccanismo e giudicarne il valore**
+prima di investire nella feature completa (router + job async + linkage).
+
+**Non-goal (deferiti, tracciati in #3435)**: router "quali PDF", job async hi_res in-pipeline, linkage
+citazione→regione (DC-F), estrazione contenuto (Metà C / VLM), scala corpus.
+
+## Contesto (dall'investigazione #3419)
+
+- `hi_res` emette elementi `Image`/`FigureCaption` **con bbox normalizzata [0,1]** (SP-B #3406) → è la *regione*
+  della tabella-immagine. (`fast` non le emette — DC-A.)
+- ⚠️ Il pipeline **oggi scarta** questi elementi: `UnstructuredPdfTextExtractor.MapStructuredElements` filtra
+  `Where(e => !string.IsNullOrWhiteSpace(e.Text))`, e `Image`/`FigureCaption` hanno testo vuoto → droppati.
+- `hi_res` è lento (~185-223s) > timeout API 120s → la **cattura via API sincrona non è fattibile**; per lo slice si
+  usa una **cattura seed** (chiamata diretta a `unstructured`), il trigger produttizzato async è la feature vera.
+- #3403 ha già `PdfBBoxOverlay` FE (rect %-based, child di `<Page>`) → riusabile per disegnare le regioni.
+
+## Decisioni (dal brainstorming)
+
+| # | Decisione | Motivazione |
+|---|---|---|
+| **S-1** | **Store dedicato** `pdf_image_regions` (non riuso di `text_chunks.bounding_boxes_json`) | Le regioni-immagine non hanno un chunk-testo; store separato disaccoppia dal linkage debole (DC-F) |
+| **S-2** | **Mostra su apertura PDF** (non gated su citazione) | Dimostra il meccanismo direttamente (apri PDF → tabelle riquadrate); indipendente dal linkage |
+| **S-3** | **Cattura via seed** (hi_res diretto, non endpoint sincrono) | hi_res > timeout API 120s; il trigger async produttizzato è fuori-slice |
+| **S-4** | **Copyright gating notato ma deferito** | Dati seed, endpoint read-only; ma le regioni geometriche vanno gated `CopyrightTier=Full` (come #3403 DA-4) **prima** di qualsiasi rollout user-facing — prerequisito documentato, non nello slice |
+
+## Architettura
+
+```
+[seed one-off]                                    [runtime]
+unstructured hi_res(agricola)                     FE PdfViewer (open)
+  elements[Image|FigureCaption].bbox [0,1]           │ GET /api/v1/pdf/{id}/image-regions
+   └─ parse → PdfImageRegionEntity ──► pdf_image_regions ──► GetPdfImageRegionsQuery
+        (pdf_id, page, x,y,w,h, element_type)                  └─ ImageRegionDto[]
+                                                          └─ PdfImageRegionOverlay (%-based, child di <Page>)
+```
+
+### Componenti
+
+1. **DB — `pdf_image_regions`** (migration EF, additiva)
+   - `Id guid PK · PdfDocumentId guid FK→pdf_documents · PageNumber int · X,Y,Width,Height double (0,1 top-left) ·
+     ElementType text (Image|FigureCaption) · CreatedAt timestamptz`
+   - Index su `PdfDocumentId`. Nessun impatto sulle tabelle esistenti.
+
+2. **Domain/Infra — capture**
+   - Un helper riusa il parsing esistente ma **conserva** `Image`/`FigureCaption` con bbox (che oggi vengono droppati).
+     Firma pura: `IReadOnlyList<PdfImageRegion> ExtractImageRegions(UnstructuredExtractionResponse)` (o equivalente sui
+     raw elements) — testabile senza HTTP.
+   - Seed one-off: comando/handler `SeedPdfImageRegionsCommand(PdfId, hiResJson)` che parsea e upsert (idempotente:
+     replace-by-pdf). Invocato da un **admin endpoint** `POST /api/v1/admin/pdf/{id}/seed-image-regions` (gated admin,
+     accetta il JSON hi_res nel body). Per lo slice, l'`hiResJson` di agricola si ottiene da una chiamata diretta a
+     `unstructured` (`docker exec ... curl -F strategy=hi_res`, come nell'investigazione #3419) e si posta all'endpoint.
+     *(Il trigger produttizzato che chiama hi_res async da solo è la feature vera, fuori-slice.)*
+
+3. **Application — query (CQRS)**
+   - `GetPdfImageRegionsQuery(PdfId) → IReadOnlyList<ImageRegionDto{Page,X,Y,Width,Height,ElementType}>`.
+   - Endpoint `GET /api/v1/pdf/{id}/image-regions` via `IMediator.Send` (CQRS, zero service injection).
+
+4. **FE — overlay**
+   - Al mount del viewer per un PDF, fetch `GET /pdf/{id}/image-regions`; per ogni pagina, disegna le regioni della
+     pagina come rect %-based (child di `<Page>`), stile distinto ("tabella": bordo tratteggiato) vs highlight-citazione.
+   - Riusa il pattern `PdfBBoxOverlay` (#3403) o un `PdfImageRegionOverlay` gemello.
+
+## Data flow
+
+Seed → `pdf_image_regions` → `GET /image-regions` → FE overlay → **validazione visiva su agricola** (i box cadono
+sulle tabelle? è utile?). Questo è il **gate decisionale** per la feature completa.
+
+## Error handling / degradazione
+
+- PDF senza regioni → `[]` → il viewer non disegna nulla (nessun errore).
+- bbox fuori [0,1] → clamp (difensivo, coerente con #3403 DA-1).
+
+## Testing
+
+- **BE unit**: `ExtractImageRegions` cattura `Image`/`FigureCaption` con bbox da una risposta hi_res mockata, **scarta**
+  gli altri tipi; il seed command upsert idempotente; la query ritorna le regioni per pdf_id.
+- **BE integration**: migration applica; endpoint ritorna il DTO (Testcontainers).
+- **FE unit**: l'overlay disegna N rect con left/top/width/height %-based corretti; `[]` → nessun rect.
+- **Validazione manuale**: seed agricola su staging → apri il PDF → verifica box-su-tabella + valore.
+
+## Criteri di accettazione
+
+- **AC1** — Applicata la migration, `pdf_image_regions` esiste; seed di agricola popola ≥1 regione `Image`/`FigureCaption`.
+- **AC2** — `GET /api/v1/pdf/{agricola}/image-regions` ritorna le regioni con bbox [0,1] e `elementType`.
+- **AC3** — Nel viewer, aprendo agricola, le regioni sono disegnate come rect sulle pagine corrette.
+- **AC4** — PDF senza regioni → `[]` → viewer senza rect, nessun errore.
+- **AC5** — Baseline test invariata (0 fail); build BE/FE verdi.
+
+## Riferimenti
+
+- Spec padre `2026-08-01-image-table-region-grounding-design.md` (§5bis Opzione E, §2 retrievability, DC-A/DC-F).
+- #3403 (`bounding_boxes_json`/`PdfBBoxOverlay`, DA-1 normalizzazione, DA-4 copyright).
+- `UnstructuredPdfTextExtractor.MapStructuredElements` (filtro empty-text che oggi droppa Image/FigureCaption).


### PR DESCRIPTION
Release promote di `main-dev` → `main-staging`. 9 commit.

## Cover (attiva le copertine sul catalogo)
- #3449 — coverUrl su griglia + hero dettaglio pubblici
- #3452 — coverUrl su OpenGraph metadata
- #3457 — SkiaSharp native deps (libfontconfig1/libfreetype6) → **sblocca la generazione cover-da-PDF** (arm64)

## Lavoro parallelo incluso
- #3446 / #3453 — RAG image-table region grounding (contract invariant + vertical slice)
- #3458 — session-live: storico dispute via REST (tab Arbitro)
- #3450 — refactor enum ParticipantRole
- #3448 / #3443 — ADR/spec docs (session-scoring SSOT, image-table grounding)

## Post-deploy (cover)
Verifica `MaterializePdfCover` (0 errori SkiaSharp) → reset 128 PDF `Failed→Pending` → `BackfillPdfCoversJob` rigenera. Tracciato in #3454.

Generated with Claude Code