### PR TITLE
fix(session-live): rimuovi affordance decorative FE (#3393)

### DIFF
--- a/apps/web/__tests__/session-live-chat-agent-g3-axe.test.tsx
+++ b/apps/web/__tests__/session-live-chat-agent-g3-axe.test.tsx
@@ -24,8 +24,6 @@ const messages = {
 const labels = {
   title: 'ChatAgent',
   agentNameAriaLabel: 'Agent name MeepleAI',
-  onlineLabel: 'Online',
-  latencyAriaLabel: 'Latency 42ms',
   chatPanelLabels: {
     title: 'Chat',
     inputAriaLabel: 'Write a message',
@@ -66,7 +64,6 @@ function renderPanel(collapsed: boolean) {
         onSendMessage={() => {}}
         agentName="MeepleAI"
         agentEmoji="🤖"
-        latencyMs={42}
         collapsed={collapsed}
         onHeaderClick={() => {}}
         labels={labels}

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
@@ -693,9 +693,10 @@ export function SessionLiveView(): ReactElement {
 
   const handleAddNote = useCallback(
     // #2575: repointed off the legacy raw fetch to /game-sessions/{id}/diary onto the SP3
-    // text-only endpoint via useAddDiaryEntry. `visibility` stays a FE-only affordance (the SP3
-    // command is text-only) — the onAddNote(content, visibility) signature is kept unchanged.
-    async (content: string, _visibility: 'private' | 'shared'): Promise<void> => {
+    // text-only endpoint via useAddDiaryEntry.
+    // #3393 (finding C6): the visibility param was dropped — the SP3 diary command is
+    // text-only, so the private/shared distinction was a FE-only decorative affordance.
+    async (content: string): Promise<void> => {
       if (sessionId == null) return;
 
       try {
@@ -1030,8 +1031,6 @@ export function SessionLiveView(): ReactElement {
     (): ChatAgentPanelLabels => ({
       title: t('pages.sessionLive.chatAgent.title'),
       agentNameAriaLabel: t('pages.sessionLive.chatAgent.agentNameAriaLabel', { name: 'MeepleAI' }),
-      onlineLabel: t('pages.sessionLive.chatAgent.onlineLabel'),
-      latencyAriaLabel: t('pages.sessionLive.chatAgent.latencyAriaLabel', { ms: 42 }),
       chatPanelLabels: chatLabels,
     }),
     [t, chatLabels]
@@ -1042,8 +1041,6 @@ export function SessionLiveView(): ReactElement {
       title: t('pages.sessionLive.notes.title'),
       inputAriaLabel: t('pages.sessionLive.notes.inputAriaLabel'),
       addAriaLabel: t('pages.sessionLive.notes.addAriaLabel'),
-      visibilityPrivate: t('pages.sessionLive.notes.visibilityPrivate'),
-      visibilityShared: t('pages.sessionLive.notes.visibilityShared'),
       emptyMessage: t('pages.sessionLive.notes.emptyMessage'),
     }),
     [t]
@@ -1320,7 +1317,6 @@ export function SessionLiveView(): ReactElement {
         authorId: e.authorName,
         authorName: e.authorName,
         content: e.content,
-        visibility: 'shared' as const,
         timestamp: e.timestamp,
       }));
   }, [activeSession]);
@@ -1356,7 +1352,6 @@ export function SessionLiveView(): ReactElement {
           onSendMessage={handleAgentSendMessage}
           agentName="MeepleAI"
           agentEmoji="🤖"
-          latencyMs={42}
           collapsed={mobileChatCollapsed}
           onHeaderClick={handleMobileChatHeaderClick}
           labels={chatAgentLabels}
@@ -1588,7 +1583,6 @@ export function SessionLiveView(): ReactElement {
         onSendMessage={handleAgentSendMessage}
         agentName="MeepleAI"
         agentEmoji="🤖"
-        latencyMs={42}
         collapsed={chatCollapsed}
         onHeaderClick={handleChatHeaderClick}
         labels={chatAgentLabels}

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
@@ -453,8 +453,6 @@ const MESSAGES: Record<string, string> = {
   // ChatAgentPanel labels (G1 #2374 T3 — composite header)
   'pages.sessionLive.chatAgent.title': 'ChatAgent',
   'pages.sessionLive.chatAgent.agentNameAriaLabel': 'Nome agente {name}',
-  'pages.sessionLive.chatAgent.onlineLabel': 'Online',
-  'pages.sessionLive.chatAgent.latencyAriaLabel': 'Latenza {ms}ms',
   // Agent launch status feedback messages (#2500 Task 4-FE R-FINDING-5)
   'pages.sessionLive.chatAgent.launchingMessage': "Avvio dell'assistente di gioco…",
   'pages.sessionLive.chatAgent.noAgentMessage': 'Nessun assistente disponibile per questo gioco.',
@@ -481,8 +479,6 @@ const MESSAGES: Record<string, string> = {
   'pages.sessionLive.notes.title': 'Note',
   'pages.sessionLive.notes.inputAriaLabel': 'Scrivi una nota',
   'pages.sessionLive.notes.addAriaLabel': 'Aggiungi nota',
-  'pages.sessionLive.notes.visibilityPrivate': 'Privata',
-  'pages.sessionLive.notes.visibilityShared': 'Condivisa',
   'pages.sessionLive.notes.emptyMessage': 'Nessuna nota ancora.',
   // SP5-a Task 3 (finding #16): diary write response-ack toast key
   'pages.sessionLive.notes.addNoteErrorToast': 'Impossibile salvare la nota. Riprova.',

--- a/apps/web/src/components/agent/AgentSelector.tsx
+++ b/apps/web/src/components/agent/AgentSelector.tsx
@@ -3,17 +3,17 @@
  *
  * Features:
  * - Dropdown selector for Tutor, Arbitro, Stratega, Narratore, Orchestrator (auto)
- * - Agent status indicators (online/offline/busy)
  * - Agent descriptions and icons
  * - Selection persistence per conversation
- * - Real-time status updates
+ *
+ * #3393 (finding C9c): the hardcoded "online" status indicators and the no-op
+ * 30s poll (which only ever re-set every agent to 'online') were removed — no
+ * real per-agent online/offline signal exists in the backend.
  */
 
 'use client';
 
-import { useState, useEffect } from 'react';
-
-import { Bot, Sparkles, Shield, Zap, Circle, BookOpen, Target } from 'lucide-react';
+import { Bot, Sparkles, Shield, Zap, BookOpen, Target } from 'lucide-react';
 
 import { Badge } from '@/components/ui/data-display/badge';
 import {
@@ -30,14 +30,12 @@ import { cn } from '@/lib/utils';
 // ============================================================================
 
 export type AgentType = 'auto' | 'tutor' | 'arbitro' | 'stratega' | 'narratore';
-export type AgentStatus = 'online' | 'offline' | 'busy';
 
 export interface Agent {
   id: AgentType;
   name: string;
   description: string;
   icon: typeof Bot;
-  status: AgentStatus;
 }
 
 export interface AgentSelectorProps {
@@ -63,7 +61,7 @@ export const AGENT_NAMES: Record<AgentType, string> = {
   narratore: 'Narratore',
 };
 
-const AGENTS: Record<AgentType, Omit<Agent, 'status'>> = {
+const AGENTS: Record<AgentType, Agent> = {
   auto: {
     id: 'auto',
     name: 'Auto (Orchestrator)',
@@ -96,51 +94,11 @@ const AGENTS: Record<AgentType, Omit<Agent, 'status'>> = {
   },
 };
 
-const STATUS_COLORS: Record<AgentStatus, string> = {
-  online: 'bg-green-500',
-  offline: 'bg-gray-400',
-  busy: 'bg-amber-500',
-};
-
-const STATUS_LABELS: Record<AgentStatus, string> = {
-  online: 'Online',
-  offline: 'Offline',
-  busy: 'Busy',
-};
-
 // ============================================================================
 // Main Component
 // ============================================================================
 
 export function AgentSelector({ value, onChange, className, disabled }: AgentSelectorProps) {
-  const [_agentStatuses, setAgentStatuses] = useState<Record<AgentType, AgentStatus>>({
-    auto: 'online',
-    tutor: 'online',
-    arbitro: 'online',
-    stratega: 'online',
-    narratore: 'online',
-  });
-
-  // Fetch agent statuses from API (real implementation would poll or use WebSocket)
-  useEffect(() => {
-    const fetchStatuses = async () => {
-      // In POC, assume all online
-      // Real implementation: await api.agents.getAll() and check status
-      setAgentStatuses({
-        auto: 'online',
-        tutor: 'online',
-        arbitro: 'online',
-        stratega: 'online',
-        narratore: 'online',
-      });
-    };
-
-    fetchStatuses();
-    // Poll every 30s for status updates
-    const interval = setInterval(fetchStatuses, 30000);
-    return () => clearInterval(interval);
-  }, []);
-
   return (
     <div className={cn('flex items-center gap-3', className)}>
       <span className="text-sm text-muted-foreground font-nunito">Agent:</span>
@@ -151,7 +109,6 @@ export function AgentSelector({ value, onChange, className, disabled }: AgentSel
         <SelectContent>
           {(Object.keys(AGENTS) as AgentType[]).map(agentId => {
             const agent = AGENTS[agentId];
-            const status = _agentStatuses[agentId];
             const Icon = agent.icon;
 
             return (
@@ -164,16 +121,7 @@ export function AgentSelector({ value, onChange, className, disabled }: AgentSel
 
                   {/* Name & Description */}
                   <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2">
-                      <span className="font-medium text-sm">{agent.name}</span>
-                      {/* Status Indicator */}
-                      <div className="flex items-center gap-1">
-                        <Circle className={cn('h-2 w-2 fill-current', STATUS_COLORS[status])} />
-                        <span className="text-xs text-muted-foreground">
-                          {STATUS_LABELS[status]}
-                        </span>
-                      </div>
-                    </div>
+                    <span className="font-medium text-sm">{agent.name}</span>
                     <p className="text-xs text-muted-foreground truncate">{agent.description}</p>
                   </div>
                 </div>

--- a/apps/web/src/components/agent/__tests__/AgentSelector.test.tsx
+++ b/apps/web/src/components/agent/__tests__/AgentSelector.test.tsx
@@ -52,17 +52,20 @@ describe('AgentSelector', () => {
     });
   });
 
-  it('shows status indicators for each agent', async () => {
+  it('does NOT show fabricated "online" status indicators (#3393)', async () => {
     render(<AgentSelector {...defaultProps} />);
 
     const trigger = screen.getByRole('combobox');
     fireEvent.click(trigger);
 
+    // Options render (descriptions confirm the dropdown opened) ...
     await waitFor(() => {
-      // Should show "Online" status for all agents in POC
-      const statusLabels = screen.getAllByText('Online');
-      expect(statusLabels.length).toBeGreaterThan(0);
+      const autoDesc = screen.getAllByText(/Automatically routes to best agent/i);
+      expect(autoDesc.length).toBeGreaterThan(0);
     });
+
+    // ... but the hardcoded "Online" status pill is gone.
+    expect(screen.queryByText('Online')).not.toBeInTheDocument();
   });
 
   it('calls onChange when agent is selected', async () => {

--- a/apps/web/src/components/features/session-live/ChatAgentPanel.tsx
+++ b/apps/web/src/components/features/session-live/ChatAgentPanel.tsx
@@ -5,8 +5,12 @@
  * Extended by Issue #2588 A3: forwards optional images param from LiveAgentChat.
  *
  * Wrapper primitive around `LiveAgentChat` that adds the mockup's
- * "magnet" header (emoji avatar + Online pip + agent name + latency +
- * ChatAgent pill) and an accordion-style collapsed semantic.
+ * "magnet" header (emoji avatar + agent name + ChatAgent pill) and an
+ * accordion-style collapsed semantic.
+ *
+ * #3393 (finding C9a/C9b): the fabricated "42ms" latency indicator and the
+ * static "Online" pip were removed — the AI agent has no real online/offline
+ * state and latency was never measured. Decorative-only affordances go.
  *
  * Body delegates to `<LiveAgentChat />` — no duplication of chat logic.
  *
@@ -45,10 +49,6 @@ export interface ChatAgentPanelLabels {
   readonly title: string;
   /** Pre-resolved (Gate A): aria-label for the agent name span. */
   readonly agentNameAriaLabel: string;
-  /** Label for the Online pulse pip — typically "Online". */
-  readonly onlineLabel: string;
-  /** Pre-resolved (Gate A): aria-label for latency indicator. e.g. "Latenza 42ms". */
-  readonly latencyAriaLabel: string;
   /** Labels forwarded to the inner `<LiveAgentChat />`. */
   readonly chatPanelLabels: LiveAgentChatLabels;
 }
@@ -74,7 +74,6 @@ export interface ChatAgentPanelProps {
   readonly agentName: string;
   /** Default '🤖'. */
   readonly agentEmoji?: string;
-  readonly latencyMs: number;
   /** Default false; G3 controls. When true, body unmounts. */
   readonly collapsed?: boolean;
   /** G3 wires the accordion FSM. When provided, header becomes a button. */
@@ -94,7 +93,6 @@ export function ChatAgentPanel({
   onSendMessage,
   agentName,
   agentEmoji = '🤖',
-  latencyMs,
   collapsed = false,
   onHeaderClick,
   compact = false,
@@ -115,35 +113,22 @@ export function ChatAgentPanel({
   // ─── Header content (identical for both <button> and <div> wrappers) ──────
   const headerContent = (
     <>
-      {/* Emoji avatar with pulse pip */}
+      {/* Emoji avatar */}
       <span
         aria-hidden="true"
-        className="relative flex h-9 w-9 shrink-0 items-center justify-center
+        className="flex h-9 w-9 shrink-0 items-center justify-center
           rounded-full bg-entity-agent/20 text-base"
       >
         {agentEmoji}
-        {/* Online pulse pip — aria-label exposes "Online" text to AT */}
-        <span
-          aria-label={labels.onlineLabel}
-          role="status"
-          className="absolute -bottom-0.5 -right-0.5 inline-block h-2.5 w-2.5
-            rounded-full border-2 border-card bg-emerald-500 animate-pulse"
-        />
       </span>
 
-      {/* Agent name + latency */}
+      {/* Agent name */}
       <span className="flex min-w-0 flex-1 flex-col gap-0.5 text-left">
         <span
           aria-label={labels.agentNameAriaLabel}
           className="truncate text-sm font-semibold text-foreground"
         >
           {agentName}
-        </span>
-        <span
-          aria-label={labels.latencyAriaLabel}
-          className="text-xs font-medium text-foreground/70"
-        >
-          {latencyMs}ms
         </span>
       </span>
 

--- a/apps/web/src/components/features/session-live/LiveSessionNotes.tsx
+++ b/apps/web/src/components/features/session-live/LiveSessionNotes.tsx
@@ -7,7 +7,11 @@
  *
  * Role variants:
  *   Spectator: read-only notes list, add-note form hidden entirely.
- *   Player+Host: full form with visibility toggle (private/shared).
+ *   Player+Host: full form (plain text-only note input).
+ *
+ * #3393 (finding C6): the private/shared visibility toggle and the "private"
+ * badge were removed — the SP3 diary endpoint is text-only, so visibility was a
+ * FE-only affordance promising a persistence behaviour the backend never had.
  *
  * Gate C: DIVERGES from MeepleCard — notes panel, not a card pattern.
  *
@@ -28,7 +32,6 @@ export interface NoteEntry {
   readonly authorId: string;
   readonly authorName: string;
   readonly content: string;
-  readonly visibility: 'private' | 'shared';
   readonly timestamp: string;
 }
 
@@ -38,8 +41,6 @@ export interface LiveSessionNotesLabels {
   readonly title: string;
   readonly inputAriaLabel: string;
   readonly addAriaLabel: string;
-  readonly visibilityPrivate: string;
-  readonly visibilityShared: string;
   readonly emptyMessage: string;
 }
 
@@ -49,7 +50,7 @@ export interface LiveSessionNotesProps {
   readonly notes: ReadonlyArray<NoteEntry>;
   readonly viewerRole: ParticipantRole;
   readonly viewerId: string;
-  readonly onAddNote: (content: string, visibility: 'private' | 'shared') => void;
+  readonly onAddNote: (content: string) => void;
   readonly labels: LiveSessionNotesLabels;
   readonly className?: string;
 }
@@ -65,7 +66,6 @@ export function LiveSessionNotes({
   className,
 }: LiveSessionNotesProps): ReactElement {
   const [inputValue, setInputValue] = useState('');
-  const [visibility, setVisibility] = useState<'private' | 'shared'>('shared');
 
   const isSpectator = viewerRole === 'Spectator';
 
@@ -73,7 +73,7 @@ export function LiveSessionNotes({
     e.preventDefault();
     const trimmed = inputValue.trim();
     if (!trimmed) return;
-    onAddNote(trimmed, visibility);
+    onAddNote(trimmed);
     setInputValue('');
   };
 
@@ -95,27 +95,18 @@ export function LiveSessionNotes({
         ) : (
           notes.map(note => {
             const isOwn = note.authorId === viewerId;
-            const isPrivate = note.visibility === 'private';
             return (
               <article
                 key={note.id}
                 data-note-id={note.id}
-                data-visibility={note.visibility}
-                className={`rounded-lg border p-3 text-sm ${
-                  isPrivate
-                    ? 'border-amber-700/30 bg-amber-900/10'
-                    : 'border-border/40 bg-card'
-                }`}
+                className="rounded-lg border border-border/40 bg-card p-3 text-sm"
               >
-                <header className="mb-1 flex items-center justify-between gap-2">
+                <header className="mb-1 flex items-center gap-2">
                   <span
                     className={`text-xs font-medium ${isOwn ? 'text-foreground' : 'text-muted-foreground'}`}
                   >
                     {note.authorName}
                   </span>
-                  {isPrivate && (
-                    <span className="text-xs text-amber-400/70">{labels.visibilityPrivate}</span>
-                  )}
                 </header>
                 <p className="text-foreground">{note.content}</p>
               </article>
@@ -127,34 +118,6 @@ export function LiveSessionNotes({
       {/* Add note form — hidden for Spectator */}
       {!isSpectator && (
         <form onSubmit={handleSubmit} className="flex shrink-0 flex-col gap-2">
-          {/* Visibility toggle */}
-          <div className="flex gap-2" role="group" aria-label="Visibilità nota">
-            <button
-              type="button"
-              aria-pressed={visibility === 'shared'}
-              onClick={() => setVisibility('shared')}
-              className={`rounded-md px-2 py-1 text-xs font-medium transition-colors ${
-                visibility === 'shared'
-                  ? 'bg-muted text-foreground'
-                  : 'text-muted-foreground hover:text-foreground'
-              }`}
-            >
-              {labels.visibilityShared}
-            </button>
-            <button
-              type="button"
-              aria-pressed={visibility === 'private'}
-              onClick={() => setVisibility('private')}
-              className={`rounded-md px-2 py-1 text-xs font-medium transition-colors ${
-                visibility === 'private'
-                  ? 'bg-amber-700/60 text-amber-100'
-                  : 'text-muted-foreground hover:text-foreground'
-              }`}
-            >
-              {labels.visibilityPrivate}
-            </button>
-          </div>
-
           <div className="flex gap-2">
             <textarea
               value={inputValue}

--- a/apps/web/src/components/features/session-live/__tests__/ChatAgentPanel.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/ChatAgentPanel.test.tsx
@@ -3,7 +3,7 @@
  *
  * Coverage (per plan §4 T3):
  * 1. data-slot="chat-agent-panel" regression hook
- * 2. header shows agent name + emoji + Online pip + latency
+ * 2. header shows agent name + emoji (no online pip / no fabricated latency — #3393)
  * 3. header has "ChatAgent" pill (mockup magnet semantic)
  * 4. body renders LiveAgentChat (data-slot="live-agent-chat")
  * 5. collapsed=true unmounts body + aria-expanded=false
@@ -51,8 +51,6 @@ const CHAT_PANEL_LABELS: LiveAgentChatLabels = {
 const LABELS: ChatAgentPanelLabels = {
   title: 'ChatAgent',
   agentNameAriaLabel: 'Nome agente Meeple',
-  onlineLabel: 'Online',
-  latencyAriaLabel: 'Latenza 42ms',
   chatPanelLabels: CHAT_PANEL_LABELS,
 };
 
@@ -76,7 +74,6 @@ function renderPanel(overrides: Partial<ChatAgentPanelProps> = {}) {
     viewerId: 'viewer-id',
     onSendMessage,
     agentName: 'Meeple',
-    latencyMs: 42,
     labels: LABELS,
     onHeaderClick,
     ...overrides,
@@ -114,17 +111,16 @@ describe('ChatAgentPanel — render shape', () => {
     expect(root).not.toBeNull();
   });
 
-  it('header shows agent name + emoji + Online pip + latency', () => {
-    renderPanel({ agentName: 'Meeple', agentEmoji: '🤖', latencyMs: 42 });
+  it('header shows agent name + emoji, without online pip or fabricated latency (#3393)', () => {
+    renderPanel({ agentName: 'Meeple', agentEmoji: '🤖' });
     // Agent name visible
     expect(screen.getByText('Meeple')).toBeInTheDocument();
     // Emoji avatar present (default 🤖)
     expect(screen.getByText('🤖')).toBeInTheDocument();
-    // Online pip — aria-label matches labels.onlineLabel
-    expect(screen.getByLabelText(LABELS.onlineLabel)).toBeInTheDocument();
-    // Latency indicator — aria-label matches labels.latencyAriaLabel + text shows ms
-    expect(screen.getByLabelText(LABELS.latencyAriaLabel)).toBeInTheDocument();
-    expect(screen.getByText(/42ms/)).toBeInTheDocument();
+    // C9b: the static "Online" pip is gone — nothing exposes it to AT
+    expect(screen.queryByLabelText('Online')).not.toBeInTheDocument();
+    // C9a: the fabricated "42ms" latency indicator is gone — no "<n>ms" text
+    expect(screen.queryByText(/\d+\s*ms/)).not.toBeInTheDocument();
   });
 
   it('header has "ChatAgent" pill (mockup magnet semantic)', () => {
@@ -179,7 +175,6 @@ describe('ChatAgentPanel — header interactions', () => {
         viewerId="viewer-id"
         onSendMessage={vi.fn()}
         agentName="Meeple"
-        latencyMs={42}
         labels={LABELS}
       />
     );

--- a/apps/web/src/components/features/session-live/__tests__/LiveSessionNotes.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/LiveSessionNotes.test.tsx
@@ -4,9 +4,9 @@
  * Coverage:
  * - Render shape (data-slot, notes list, empty state)
  * - Role variant: Spectator = read-only (no add form)
- * - Player+Host: add form visible with visibility toggle
- * - onAddNote fires with correct content + visibility
- * - aria-pressed on visibility toggle buttons
+ * - Player+Host: text-only add form (no visibility toggle — #3393)
+ * - onAddNote fires with content only
+ * - #3393: no private/shared visibility toggle, no "private" badge
  */
 
 import { render, screen } from '@testing-library/react';
@@ -22,8 +22,6 @@ const LABELS: LiveSessionNotesLabels = {
   title: 'Note di Sessione',
   inputAriaLabel: 'Scrivi una nota',
   addAriaLabel: 'Aggiungi nota',
-  visibilityPrivate: 'Privata',
-  visibilityShared: 'Condivisa',
   emptyMessage: 'Nessuna nota',
 };
 
@@ -33,7 +31,6 @@ const NOTES: ReadonlyArray<NoteEntry> = [
     authorId: 'user-a',
     authorName: 'Alice',
     content: 'Prima nota',
-    visibility: 'shared',
     timestamp: '2026-05-06T10:00:00Z',
   },
   {
@@ -41,7 +38,6 @@ const NOTES: ReadonlyArray<NoteEntry> = [
     authorId: 'viewer-id',
     authorName: 'Me',
     content: 'Nota privata',
-    visibility: 'private',
     timestamp: '2026-05-06T10:01:00Z',
   },
 ];
@@ -117,15 +113,19 @@ describe('LiveSessionNotes — role variant: Player + Host', () => {
     expect(screen.getByRole('button', { name: 'Aggiungi nota' })).toBeInTheDocument();
   });
 
-  it.each(['Player', 'Host'] as const)('shows visibility toggle for %s', role => {
-    renderNotes({ viewerRole: role });
-    expect(screen.getByRole('button', { name: /Privata/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Condivisa/i })).toBeInTheDocument();
-  });
+  it.each(['Player', 'Host'] as const)(
+    'does NOT show a private/shared visibility toggle for %s (#3393)',
+    role => {
+      renderNotes({ viewerRole: role });
+      expect(screen.queryByRole('button', { name: /Privata/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /Condivisa/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('group', { name: /Visibilità/i })).not.toBeInTheDocument();
+    }
+  );
 });
 
 describe('LiveSessionNotes — onAddNote', () => {
-  it('calls onAddNote with content and "shared"', async () => {
+  it('calls onAddNote with content only (no visibility arg — #3393)', async () => {
     const user = userEvent.setup();
     const { onAddNote } = renderNotes({ viewerRole: 'Player' });
 
@@ -133,18 +133,7 @@ describe('LiveSessionNotes — onAddNote', () => {
     await user.click(screen.getByRole('button', { name: 'Aggiungi nota' }));
 
     expect(onAddNote).toHaveBeenCalledOnce();
-    expect(onAddNote).toHaveBeenCalledWith('My note', 'shared');
-  });
-
-  it('calls onAddNote with "private" when switched', async () => {
-    const user = userEvent.setup();
-    const { onAddNote } = renderNotes({ viewerRole: 'Player' });
-
-    await user.click(screen.getByRole('button', { name: /Privata/i }));
-    await user.type(screen.getByRole('textbox', { name: 'Scrivi una nota' }), 'Private note');
-    await user.click(screen.getByRole('button', { name: 'Aggiungi nota' }));
-
-    expect(onAddNote).toHaveBeenCalledWith('Private note', 'private');
+    expect(onAddNote).toHaveBeenCalledWith('My note');
   });
 
   it('does not call onAddNote when input is empty', async () => {
@@ -167,19 +156,13 @@ describe('LiveSessionNotes — onAddNote', () => {
   });
 });
 
-describe('LiveSessionNotes — aria', () => {
-  it('aria-pressed reflects current visibility selection', async () => {
-    const user = userEvent.setup();
-    renderNotes({ viewerRole: 'Player' });
-
-    const sharedBtn = screen.getByRole('button', { name: /Condivisa/i });
-    expect(sharedBtn).toHaveAttribute('aria-pressed', 'true');
-
-    await user.click(screen.getByRole('button', { name: /Privata/i }));
-    expect(screen.getByRole('button', { name: /Privata/i })).toHaveAttribute(
-      'aria-pressed',
-      'true'
-    );
-    expect(sharedBtn).toHaveAttribute('aria-pressed', 'false');
+describe('LiveSessionNotes — #3393 removed affordances', () => {
+  it('does not render a "private" visibility badge on notes', () => {
+    renderNotes({ notes: NOTES });
+    // Note content still renders, but no decorative private/shared badge appears.
+    expect(screen.getByText('Prima nota')).toBeInTheDocument();
+    expect(screen.getByText('Nota privata')).toBeInTheDocument();
+    expect(screen.queryByText('Privata')).not.toBeInTheDocument();
+    expect(screen.queryByText('Condivisa')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -3883,8 +3883,6 @@
       },
       "chatAgent": {
         "title": "ChatAgent",
-        "onlineLabel": "Online",
-        "latencyAriaLabel": "Latency {ms}ms",
         "agentNameAriaLabel": "Agent name {name}",
         "collapsedAriaLabel": "ChatAgent collapsed — click to expand",
         "expandedAriaLabel": "ChatAgent expanded — click to collapse",
@@ -3910,8 +3908,6 @@
         "title": "Notes",
         "inputAriaLabel": "Write a note",
         "addAriaLabel": "Add note",
-        "visibilityPrivate": "Private",
-        "visibilityShared": "Shared",
         "emptyMessage": "No notes yet.",
         "addNoteErrorToast": "Failed to save note. Please try again."
       },

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -3947,8 +3947,6 @@
       },
       "chatAgent": {
         "title": "ChatAgent",
-        "onlineLabel": "Online",
-        "latencyAriaLabel": "Latenza {ms}ms",
         "agentNameAriaLabel": "Nome agente {name}",
         "collapsedAriaLabel": "ChatAgent collassato — clic per espandere",
         "expandedAriaLabel": "ChatAgent espanso — clic per collassare",
@@ -3974,8 +3972,6 @@
         "title": "Note",
         "inputAriaLabel": "Scrivi una nota",
         "addAriaLabel": "Aggiungi nota",
-        "visibilityPrivate": "Privata",
-        "visibilityShared": "Condivisa",
         "emptyMessage": "Nessuna nota ancora.",
         "addNoteErrorToast": "Impossibile salvare la nota. Riprova."
       },


### PR DESCRIPTION
## Contesto (finding C6+C9, epic #3397)

Rimosse 3 affordance FE che promettevano comportamenti non implementati (**segnali fabbricati mostrati come reali**):

- **C9a — latenza "42ms"** (`ChatAgentPanel`): numero fabbricato mostrato come misurato → rimosso (prop `latencyMs` + label + i passaggi `42` in `SessionLiveView`).
- **C9b — pip "Online" statico** dell'agente (`animate-pulse`) → rimosso (l'agente AI non ha uno stato online/offline reale).
- **C9c — AgentSelector** status "online" hardcoded + poll no-op 30s → rimossi (state, interval, status indicator, consts/tipi inutilizzati).
- **C6 — note visibility private/shared** (`LiveSessionNotes`): il POST `/diary` è text-only → rimosso il toggle, il campo `visibility` da `NoteEntry` e il badge "private". `SessionLiveView.noteEntries` hardcoda `visibility: 'shared'`, quindi il ramo private era **dead code decorativo**.

`onAddNote` semplificato a `(content)`. Rimosse le chiavi i18n inutilizzate.

## DoD
- [x] Nessuna affordance FE che promette comportamento non implementato.
- [x] Segnali di stato reali o assenti (non simulati).

## Test
Typecheck pulito · vitest **155/155** (verifica indipendente) su ChatAgentPanel/LiveSessionNotes/AgentSelector/SessionLiveView + consumer + axe · eslint 0 errori (rimossi anche alcuni colori hardcoded pre-esistenti). Diff netto: **+65/−209**.

Closes #3393

🤖 Generated with [Claude Code](https://claude.com/claude-code)