### PR TITLE
fix(docprocessing): pin SkiaSharp Linux native to v119 (#3454)

### DIFF
--- a/apps/api/src/Api/Api.csproj
+++ b/apps/api/src/Api/Api.csproj
@@ -116,6 +116,16 @@
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="9.1.0" />
     <PackageReference Include="SkiaSharp" Version="3.119.2" />
+    <!--
+      #3454 — pin the Linux native lib to match the managed SkiaSharp (3.119.2).
+      Without this, ScottPlot 5.0.47 → SkiaSharp.HarfBuzz 2.88.9 transitively
+      pins SkiaSharp.NativeAssets.Linux.NoDependencies 2.88.9, so on Linux the
+      published libSkiaSharp.so is v88.1 while the managed SkiaSharp is 3.119.2
+      → SKObject static init throws "native libSkiaSharp (88.1) incompatible
+      … range [119.0, 120.0)" and PDF cover generation fails. Windows dev is
+      unaffected (Win32 native already resolves to 3.119.2).
+    -->
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.2" />
     <PackageReference Include="SlackNet" Version="0.17.10" />
     <PackageReference Include="StackExchange.Redis" Version="2.10.1" />
     <PackageReference Include="System.Drawing.Common" Version="10.0.8" />


### PR DESCRIPTION
Parte di #3454 (Fase 1, correzione). Segue #3457 (fontconfig), che era **necessario ma non sufficiente**.

## Problema (post-deploy)

Dopo il deploy di #3457, il reset degli 86 PDF a Pending + backfill produce ancora 0 cover. Log staging:
\`\`\`
System.InvalidOperationException: The version of the native libSkiaSharp library (88.1)
is incompatible with this version of SkiaSharp. Supported versions ... [119.0, 120.0).
\`\`\`

## Root cause

`ScottPlot 5.0.47` → `SkiaSharp.HarfBuzz 2.88.9` pinna transitivamente `SkiaSharp.NativeAssets.Linux.NoDependencies 2.88.9`. Su **Linux** il `libSkiaSharp.so` pubblicato era **v88.1**, mentre il managed `SkiaSharp` è **3.119.2** → `SKObject` static init throw. Windows dev inalterato (Win32 native già 3.119.2), da cui l'invisibilità nei test locali fino al runtime arm64 di staging.

## Fix

`PackageReference SkiaSharp.NativeAssets.Linux.NoDependencies 3.119.2` esplicito → override del transitivo. **Verificato**: `dotnet restore` ora risolve `SkiaSharp.NativeAssets.Linux.NoDependencies/3.119.2` (era 2.88.9).

## Verifica finale
Richiede deploy staging arm64 (runtime-only). Post-deploy: reset 86 `Failed→Pending` → il backfill genera le cover. Tracciato in #3454.

Generated with Claude Code