### PR TITLE
fix(kb): rimuovi SelectedDocumentIds dal contratto config (#3394)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/UpdateAgentConfigurationCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/UpdateAgentConfigurationCommand.cs
@@ -12,14 +12,16 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Commands;
 /// <remarks>
 /// Only non-null fields are applied; missing fields preserve the current value (mirror
 /// of the <c>UpdateUserAgentCommand</c> partial-update contract from PR #695).
-/// SelectedDocumentIds is accepted on the wire to align with the frontend request shape but
-/// not yet persisted (KB linking deferred to a follow-up — same MVP scope as PR #695).
+/// Scope: this command owns ONLY the LLM configuration (model/temperature/maxTokens).
+/// Per-agent KB linking (selected documents) is a separate concern owned by the
+/// <c>AgentConfiguration</c> aggregate (#2391) and its <c>updateSelectedDocuments</c> endpoint;
+/// it is intentionally NOT part of this contract. Issue #3394 removed the previously
+/// accepted-and-discarded <c>SelectedDocumentIds</c> field to eliminate the silent no-op.
 /// Returns <c>null</c> when the agent ID is not found (endpoint maps to 404).
 /// </remarks>
 internal sealed record UpdateAgentConfigurationCommand(
     Guid AgentId,
     string? ModelId = null,
     decimal? Temperature = null,
-    int? MaxTokens = null,
-    IReadOnlyList<Guid>? SelectedDocumentIds = null
+    int? MaxTokens = null
 ) : IRequest<AgentConfigurationDto?>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/UpdateAgentConfigurationCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/UpdateAgentConfigurationCommandHandler.cs
@@ -19,7 +19,9 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Commands;
 /// explicitly to persist.
 /// Range validation is delegated to <see cref="AgentDefinitionConfig.Create"/>; invalid
 /// inputs surface as <see cref="ArgumentException"/> which the route maps to <c>400</c>.
-/// SelectedDocumentIds is accepted on the wire but not persisted in MVP (same as PR #695).
+/// Scope: LLM config only (model/temperature/maxTokens). Per-agent KB linking is owned by the
+/// <c>AgentConfiguration</c> aggregate (#2391) / <c>updateSelectedDocuments</c> endpoint, not this
+/// handler (Issue #3394 removed the accepted-and-discarded SelectedDocumentIds field).
 /// </remarks>
 internal sealed class UpdateAgentConfigurationCommandHandler
     : IRequestHandler<UpdateAgentConfigurationCommand, AgentConfigurationDto?>

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/AgentConfigurationDto.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/AgentConfigurationDto.cs
@@ -1,7 +1,11 @@
 namespace Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 
 /// <summary>
-/// DTO representing the current LLM configuration of an agent.
+/// DTO representing the current LLM configuration of an agent
+/// (model/provider/temperature/maxTokens). Per-agent KB linking (selected documents) is NOT
+/// part of this contract — it is owned by the <c>AgentConfiguration</c> aggregate (#2391) and
+/// its <c>updateSelectedDocuments</c> endpoint (Issue #3394 removed the previously exposed,
+/// always-empty <c>SelectedDocumentIds</c> field).
 /// </summary>
 public record AgentConfigurationDto(
     Guid Id,
@@ -10,6 +14,5 @@ public record AgentConfigurationDto(
     string LlmProvider,
     decimal Temperature,
     int MaxTokens,
-    IReadOnlyList<Guid> SelectedDocumentIds,
     bool IsCurrent,
     DateTime CreatedAt);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetAgentConfigurationQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetAgentConfigurationQueryHandler.cs
@@ -14,7 +14,8 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Queries;
 /// <list type="bullet">
 ///   <item><c>Id</c> mirrors <c>AgentId</c> (no separate AgentConfiguration aggregate exposed).</item>
 ///   <item><c>LlmProvider</c> is heuristically derived from the model name prefix.</item>
-///   <item><c>SelectedDocumentIds</c> is empty (KB linking deferred — same as PR #695).</item>
+///   <item>Per-agent KB linking is out of scope — owned by the <c>AgentConfiguration</c> aggregate
+///   (#2391) / <c>updateSelectedDocuments</c> endpoint (Issue #3394 removed the SelectedDocumentIds field).</item>
 ///   <item><c>IsCurrent</c> is always <c>true</c> (single config per agent in MVP).</item>
 /// </list>
 /// Returns <c>null</c> when no agent matches the supplied id (route surfaces 404).
@@ -58,7 +59,6 @@ internal sealed class GetAgentConfigurationQueryHandler
             LlmProvider: InferProvider(agent.Config.Model),
             Temperature: (decimal)agent.Config.Temperature,
             MaxTokens: agent.Config.MaxTokens,
-            SelectedDocumentIds: Array.Empty<Guid>(),
             IsCurrent: true,
             CreatedAt: agent.CreatedAt);
     }

--- a/apps/api/src/Api/Routing/AgentsEndpoints.cs
+++ b/apps/api/src/Api/Routing/AgentsEndpoints.cs
@@ -120,8 +120,7 @@ internal static class AgentsEndpoints
     private sealed record UpdateAgentConfigurationRequest(
         string? ModelId = null,
         decimal? Temperature = null,
-        int? MaxTokens = null,
-        List<Guid>? SelectedDocumentIds = null
+        int? MaxTokens = null
     );
 
     private static void MapGetAgentsEndpoint(RouteGroupBuilder group)
@@ -494,7 +493,7 @@ internal static class AgentsEndpoints
         .Produces(404)
         .WithTags("Agents")
         .WithSummary("Get agent LLM configuration")
-        .WithDescription("Returns the current LLM configuration view (model, provider, temperature, maxTokens, selectedDocumentIds). LlmProvider is heuristically inferred from the model name; SelectedDocumentIds is empty in MVP (KB linking deferred). Issue #657.")
+        .WithDescription("Returns the current LLM configuration view (model, provider, temperature, maxTokens). LlmProvider is heuristically inferred from the model name. Per-agent KB linking is owned by the AgentConfiguration aggregate / updateSelectedDocuments endpoint (#2391), not this contract (#3394). Issue #657.")
         .WithOpenApi();
     }
 
@@ -516,8 +515,7 @@ internal static class AgentsEndpoints
                     AgentId: id,
                     ModelId: request.ModelId,
                     Temperature: request.Temperature,
-                    MaxTokens: request.MaxTokens,
-                    SelectedDocumentIds: request.SelectedDocumentIds);
+                    MaxTokens: request.MaxTokens);
 
                 var dto = await mediator.Send(command, ct).ConfigureAwait(false);
                 return dto is null ? Results.NotFound() : Results.Ok(dto);
@@ -534,7 +532,7 @@ internal static class AgentsEndpoints
         .Produces(404)
         .WithTags("Agents")
         .WithSummary("Update agent LLM configuration")
-        .WithDescription("Partial update (PATCH) of agent LLM configuration: modelId, temperature, maxTokens. Range validation delegated to AgentDefinitionConfig.Create (temperature 0.0-2.0, maxTokens 100-32000). SelectedDocumentIds accepted but not persisted (KB linking deferred). Issue #658.")
+        .WithDescription("Partial update (PATCH) of agent LLM configuration: modelId, temperature, maxTokens. Range validation delegated to AgentDefinitionConfig.Create (temperature 0.0-2.0, maxTokens 100-32000). Per-agent KB linking is owned by the AgentConfiguration aggregate / updateSelectedDocuments endpoint (#2391), not this contract (#3394). Issue #658.")
         .WithOpenApi();
     }
 

--- a/apps/api/tests/Api.Tests/Integration/Agents/AgentsEndpointsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Agents/AgentsEndpointsIntegrationTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
 using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
@@ -876,7 +877,13 @@ public sealed class AgentsEndpointsIntegrationTests : IAsyncLifetime
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var dto = await response.Content.ReadFromJsonAsync<AgentConfigurationDto>();
+        var json = await response.Content.ReadAsStringAsync();
+        // #3394: the LLM-config contract no longer exposes SelectedDocumentIds. Per-agent KB
+        // linking is owned by the AgentConfiguration aggregate (#2391) / updateSelectedDocuments.
+        json.Should().NotContainEquivalentOf("selectedDocumentIds");
+        var dto = JsonSerializer.Deserialize<AgentConfigurationDto>(
+            json,
+            new JsonSerializerOptions(JsonSerializerDefaults.Web));
         dto.Should().NotBeNull();
         dto!.AgentId.Should().Be(seededId);
         dto.LlmModel.Should().Be("gpt-4");
@@ -884,7 +891,6 @@ public sealed class AgentsEndpointsIntegrationTests : IAsyncLifetime
         dto.MaxTokens.Should().Be(1000);
         dto.Temperature.Should().BeApproximately(0.7m, 0.001m);
         dto.IsCurrent.Should().BeTrue();
-        dto.SelectedDocumentIds.Should().BeEmpty();
     }
 
     // -------------------------------------------------------------------------

--- a/apps/web/src/components/agent/settings/__tests__/AgentSettingsDrawer.test.tsx
+++ b/apps/web/src/components/agent/settings/__tests__/AgentSettingsDrawer.test.tsx
@@ -74,6 +74,8 @@ const PREMIUM_MODELS = [
   },
 ];
 
+// #3394: config contract no longer exposes selectedDocumentIds (KB linking is a separate
+// flow owned by the AgentConfiguration aggregate / updateSelectedDocuments endpoint).
 const MOCK_AGENT_CONFIG = {
   id: 'config-1',
   agentId: 'agent-123',
@@ -81,7 +83,6 @@ const MOCK_AGENT_CONFIG = {
   llmProvider: 'openrouter',
   temperature: 0.3,
   maxTokens: 2048,
-  selectedDocumentIds: [],
   isCurrent: true,
   createdAt: '2026-01-01T00:00:00Z',
 };
@@ -104,7 +105,11 @@ vi.mock('@/lib/api', () => ({
 }));
 
 // Import mocked modules for dynamic control
-import { useAvailableModels, useAgentConfiguration, useUpdateAgentConfiguration } from '@/hooks/queries/useModels';
+import {
+  useAvailableModels,
+  useAgentConfiguration,
+  useUpdateAgentConfiguration,
+} from '@/hooks/queries/useModels';
 
 const mockUseAvailableModels = vi.mocked(useAvailableModels);
 const mockUseAgentConfiguration = vi.mocked(useAgentConfiguration);
@@ -137,7 +142,11 @@ const defaultProps = {
   onNameUpdated: vi.fn(),
 };
 
-function setupMocks(options?: { models?: typeof FREE_MODELS; config?: typeof MOCK_AGENT_CONFIG | null; loading?: boolean }) {
+function setupMocks(options?: {
+  models?: typeof FREE_MODELS;
+  config?: typeof MOCK_AGENT_CONFIG | null;
+  loading?: boolean;
+}) {
   const models = options?.models ?? FREE_MODELS;
   const config = options?.config !== undefined ? options.config : MOCK_AGENT_CONFIG;
   const loading = options?.loading ?? false;

--- a/apps/web/src/lib/api/schemas/agent-config.schemas.ts
+++ b/apps/web/src/lib/api/schemas/agent-config.schemas.ts
@@ -174,7 +174,15 @@ export interface GetModelsResponse {
   models: BackendModelDto[];
 }
 
-/** AgentConfigurationDto from PATCH/GET /api/v1/agents/:id/configuration */
+/**
+ * AgentConfigurationDto from PATCH/GET /api/v1/agents/:id/configuration.
+ *
+ * LLM configuration only (model/provider/temperature/maxTokens). Per-agent KB linking
+ * (selected documents) is NOT part of this contract — it is a separate flow owned by the
+ * backend AgentConfiguration aggregate (#2391) and exposed via
+ * `api.agentDocuments.updateSelectedDocuments` (see useGameAgentDocuments). Issue #3394
+ * removed the previously accepted-and-discarded `selectedDocumentIds` field.
+ */
 export interface BackendAgentConfigurationDto {
   id: string;
   agentId: string;
@@ -182,17 +190,18 @@ export interface BackendAgentConfigurationDto {
   llmProvider: string;
   temperature: number;
   maxTokens: number;
-  selectedDocumentIds: string[];
   isCurrent: boolean;
   createdAt: string;
 }
 
-/** Request body for PATCH /api/v1/agents/:id/configuration */
+/**
+ * Request body for PATCH /api/v1/agents/:id/configuration.
+ * LLM config only — see BackendAgentConfigurationDto note re: KB linking (#3394).
+ */
 export interface UpdateAgentConfigurationRequest {
   modelId?: string;
   temperature?: number;
   maxTokens?: number;
-  selectedDocumentIds?: string[];
 }
 
 /**


### PR DESCRIPTION
## Contesto (finding C7, epic #3397)

Il PATCH/GET `/agents/{id}/configuration` **accettava ed esponeva** `SelectedDocumentIds` ma l'handler lo **scartava** e la GET ritornava sempre `Array.Empty` — un campo **accettato-e-scartato in silenzio** (deferral MVP non più tracciato dopo la chiusura di #657/#658).

## Decisione: RIMUOVERE dal contratto (opzione B della DoD)

Il KB linking per-agente è **già di proprietà dell'aggregate `AgentConfiguration` (#2391)** e del suo endpoint `updateSelectedDocuments` (FE `useGameAgentDocuments`). Il contratto LLM-config (model/tokens/temp) non ne è owner. Verificato: il FE **non** inviava né leggeva `SelectedDocumentIds` da questo contratto.

- **BE**: rimosso da `UpdateAgentConfigurationCommand`, dal request DTO dell'endpoint, da `AgentConfigurationDto` e dal `BuildViewDto`. Descrizioni OpenAPI GET/PATCH aggiornate con l'ownership corretta (#2391).
- **FE**: rimosso da `agent-config.schemas` (`BackendAgentConfigurationDto` + request).

## DoD
- [x] `SelectedDocumentIds` rimosso dal contratto (nessun round-trip fantasma).
- [x] Nessun campo accettato-e-scartato in silenzio.
- [x] Ownership KB-linking documentata (→ `AgentConfiguration` #2391).

## Test
BE **102/102** (`AgentConfiguration`/`AgentsEndpoints`, ambiente Testcontainers isolato) · FE **25/25** (`AgentSettingsDrawer`) + agentsClient · typecheck + eslint verdi.

Closes #3394

🤖 Generated with [Claude Code](https://claude.com/claude-code)