### PR TITLE
release: promote main-dev -> main-staging (SkiaSharp native v119 #3464 + RAG area-filter + kb/session fixes)

### DIFF
--- a/apps/api/src/Api/Api.csproj
+++ b/apps/api/src/Api/Api.csproj
@@ -116,6 +116,16 @@
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="9.1.0" />
     <PackageReference Include="SkiaSharp" Version="3.119.2" />
+    <!--
+      #3454 — pin the Linux native lib to match the managed SkiaSharp (3.119.2).
+      Without this, ScottPlot 5.0.47 → SkiaSharp.HarfBuzz 2.88.9 transitively
+      pins SkiaSharp.NativeAssets.Linux.NoDependencies 2.88.9, so on Linux the
+      published libSkiaSharp.so is v88.1 while the managed SkiaSharp is 3.119.2
+      → SKObject static init throws "native libSkiaSharp (88.1) incompatible
+      … range [119.0, 120.0)" and PDF cover generation fails. Windows dev is
+      unaffected (Win32 native already resolves to 3.119.2).
+    -->
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.2" />
     <PackageReference Include="SlackNet" Version="0.17.10" />
     <PackageReference Include="StackExchange.Redis" Version="2.10.1" />
     <PackageReference Include="System.Drawing.Common" Version="10.0.8" />

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/SeedPdfImageRegionsCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/SeedPdfImageRegionsCommand.cs
@@ -7,4 +7,4 @@ namespace Api.BoundedContexts.DocumentProcessing.Application.Commands;
 /// Idempotent (replace-by-pdf). Invoked by an admin endpoint; the productionized async trigger
 /// that runs hi_res on its own is the full feature (deferred, #3435). Returns the count inserted.
 /// </summary>
-internal sealed record SeedPdfImageRegionsCommand(Guid PdfId, string HiResJson) : ICommand<int>;
+internal sealed record SeedPdfImageRegionsCommand(Guid PdfId, string HiResJson, double? MinAreaFraction = null) : ICommand<int>;

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/SeedPdfImageRegionsCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/SeedPdfImageRegionsCommandHandler.cs
@@ -33,7 +33,9 @@ internal class SeedPdfImageRegionsCommandHandler : ICommandHandler<SeedPdfImageR
             throw new NotFoundException("PdfDocument", command.PdfId.ToString());
         }
 
-        var regions = ImageRegionExtractor.FromHiResJson(command.HiResJson);
+        var regions = ImageRegionExtractor.FromHiResJson(
+            command.HiResJson,
+            command.MinAreaFraction ?? ImageRegionExtractor.DefaultMinAreaFraction);
 
         var existing = await _dbContext.PdfImageRegions
             .Where(r => r.PdfDocumentId == command.PdfId)

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/ImageRegionExtractor.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/ImageRegionExtractor.cs
@@ -11,10 +11,16 @@ namespace Api.BoundedContexts.DocumentProcessing.Application.Services;
 /// </summary>
 public static class ImageRegionExtractor
 {
+    /// <summary>Default anti-noise threshold (#3456): keep regions whose normalized area
+    /// (Width*Height, fraction of page) is at least 3%. Filters out icons/glyphs.</summary>
+    public const double DefaultMinAreaFraction = 0.03;
+
     private static readonly HashSet<string> RegionCategories =
         new(StringComparer.Ordinal) { "Image", "FigureCaption" };
 
-    public static IReadOnlyList<ExtractedImageRegion> FromHiResJson(string? hiResJson)
+    public static IReadOnlyList<ExtractedImageRegion> FromHiResJson(
+        string? hiResJson,
+        double minAreaFraction = DefaultMinAreaFraction)
     {
         if (string.IsNullOrWhiteSpace(hiResJson))
         {
@@ -38,6 +44,9 @@ public static class ImageRegionExtractor
                     Width: Clamp01(e.Bbox!.Width),
                     Height: Clamp01(e.Bbox!.Height),
                     ElementType: e.Category!))
+                // #3456 anti-noise: drop tiny regions (icons/glyphs) below the area threshold.
+                // Area is on already-clamped values; >= keeps a region exactly at the threshold.
+                .Where(r => r.Width * r.Height >= minAreaFraction)
                 .ToList();
         }
         catch (JsonException)

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/UpdateAgentConfigurationCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/UpdateAgentConfigurationCommand.cs
@@ -12,14 +12,16 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Commands;
 /// <remarks>
 /// Only non-null fields are applied; missing fields preserve the current value (mirror
 /// of the <c>UpdateUserAgentCommand</c> partial-update contract from PR #695).
-/// SelectedDocumentIds is accepted on the wire to align with the frontend request shape but
-/// not yet persisted (KB linking deferred to a follow-up — same MVP scope as PR #695).
+/// Scope: this command owns ONLY the LLM configuration (model/temperature/maxTokens).
+/// Per-agent KB linking (selected documents) is a separate concern owned by the
+/// <c>AgentConfiguration</c> aggregate (#2391) and its <c>updateSelectedDocuments</c> endpoint;
+/// it is intentionally NOT part of this contract. Issue #3394 removed the previously
+/// accepted-and-discarded <c>SelectedDocumentIds</c> field to eliminate the silent no-op.
 /// Returns <c>null</c> when the agent ID is not found (endpoint maps to 404).
 /// </remarks>
 internal sealed record UpdateAgentConfigurationCommand(
     Guid AgentId,
     string? ModelId = null,
     decimal? Temperature = null,
-    int? MaxTokens = null,
-    IReadOnlyList<Guid>? SelectedDocumentIds = null
+    int? MaxTokens = null
 ) : IRequest<AgentConfigurationDto?>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/UpdateAgentConfigurationCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/UpdateAgentConfigurationCommandHandler.cs
@@ -19,7 +19,9 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Commands;
 /// explicitly to persist.
 /// Range validation is delegated to <see cref="AgentDefinitionConfig.Create"/>; invalid
 /// inputs surface as <see cref="ArgumentException"/> which the route maps to <c>400</c>.
-/// SelectedDocumentIds is accepted on the wire but not persisted in MVP (same as PR #695).
+/// Scope: LLM config only (model/temperature/maxTokens). Per-agent KB linking is owned by the
+/// <c>AgentConfiguration</c> aggregate (#2391) / <c>updateSelectedDocuments</c> endpoint, not this
+/// handler (Issue #3394 removed the accepted-and-discarded SelectedDocumentIds field).
 /// </remarks>
 internal sealed class UpdateAgentConfigurationCommandHandler
     : IRequestHandler<UpdateAgentConfigurationCommand, AgentConfigurationDto?>

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/AgentConfigurationDto.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/AgentConfigurationDto.cs
@@ -1,7 +1,11 @@
 namespace Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 
 /// <summary>
-/// DTO representing the current LLM configuration of an agent.
+/// DTO representing the current LLM configuration of an agent
+/// (model/provider/temperature/maxTokens). Per-agent KB linking (selected documents) is NOT
+/// part of this contract — it is owned by the <c>AgentConfiguration</c> aggregate (#2391) and
+/// its <c>updateSelectedDocuments</c> endpoint (Issue #3394 removed the previously exposed,
+/// always-empty <c>SelectedDocumentIds</c> field).
 /// </summary>
 public record AgentConfigurationDto(
     Guid Id,
@@ -10,6 +14,5 @@ public record AgentConfigurationDto(
     string LlmProvider,
     decimal Temperature,
     int MaxTokens,
-    IReadOnlyList<Guid> SelectedDocumentIds,
     bool IsCurrent,
     DateTime CreatedAt);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetAgentConfigurationQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetAgentConfigurationQueryHandler.cs
@@ -14,7 +14,8 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Queries;
 /// <list type="bullet">
 ///   <item><c>Id</c> mirrors <c>AgentId</c> (no separate AgentConfiguration aggregate exposed).</item>
 ///   <item><c>LlmProvider</c> is heuristically derived from the model name prefix.</item>
-///   <item><c>SelectedDocumentIds</c> is empty (KB linking deferred — same as PR #695).</item>
+///   <item>Per-agent KB linking is out of scope — owned by the <c>AgentConfiguration</c> aggregate
+///   (#2391) / <c>updateSelectedDocuments</c> endpoint (Issue #3394 removed the SelectedDocumentIds field).</item>
 ///   <item><c>IsCurrent</c> is always <c>true</c> (single config per agent in MVP).</item>
 /// </list>
 /// Returns <c>null</c> when no agent matches the supplied id (route surfaces 404).
@@ -58,7 +59,6 @@ internal sealed class GetAgentConfigurationQueryHandler
             LlmProvider: InferProvider(agent.Config.Model),
             Temperature: (decimal)agent.Config.Temperature,
             MaxTokens: agent.Config.MaxTokens,
-            SelectedDocumentIds: Array.Empty<Guid>(),
             IsCurrent: true,
             CreatedAt: agent.CreatedAt);
     }

--- a/apps/api/src/Api/Routing/AdminPdfManagementEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminPdfManagementEndpoints.cs
@@ -80,7 +80,7 @@ internal static class AdminPdfManagementEndpoints
         CancellationToken cancellationToken)
     {
         var count = await mediator.Send(
-            new SeedPdfImageRegionsCommand(pdfId, request.HiResJson),
+            new SeedPdfImageRegionsCommand(pdfId, request.HiResJson, request.MinAreaFraction),
             cancellationToken).ConfigureAwait(false);
         return Results.Ok(new { success = true, seeded = count });
     }
@@ -124,4 +124,4 @@ internal static class AdminPdfManagementEndpoints
 
 internal record BulkDeletePdfsRequest(List<Guid> PdfIds);
 internal record ReindexDocumentRequest(string? IndexerVersion);
-internal record SeedImageRegionsRequest(string HiResJson);
+internal record SeedImageRegionsRequest(string HiResJson, double? MinAreaFraction = null);

--- a/apps/api/src/Api/Routing/AgentsEndpoints.cs
+++ b/apps/api/src/Api/Routing/AgentsEndpoints.cs
@@ -120,8 +120,7 @@ internal static class AgentsEndpoints
     private sealed record UpdateAgentConfigurationRequest(
         string? ModelId = null,
         decimal? Temperature = null,
-        int? MaxTokens = null,
-        List<Guid>? SelectedDocumentIds = null
+        int? MaxTokens = null
     );
 
     private static void MapGetAgentsEndpoint(RouteGroupBuilder group)
@@ -494,7 +493,7 @@ internal static class AgentsEndpoints
         .Produces(404)
         .WithTags("Agents")
         .WithSummary("Get agent LLM configuration")
-        .WithDescription("Returns the current LLM configuration view (model, provider, temperature, maxTokens, selectedDocumentIds). LlmProvider is heuristically inferred from the model name; SelectedDocumentIds is empty in MVP (KB linking deferred). Issue #657.")
+        .WithDescription("Returns the current LLM configuration view (model, provider, temperature, maxTokens). LlmProvider is heuristically inferred from the model name. Per-agent KB linking is owned by the AgentConfiguration aggregate / updateSelectedDocuments endpoint (#2391), not this contract (#3394). Issue #657.")
         .WithOpenApi();
     }
 
@@ -516,8 +515,7 @@ internal static class AgentsEndpoints
                     AgentId: id,
                     ModelId: request.ModelId,
                     Temperature: request.Temperature,
-                    MaxTokens: request.MaxTokens,
-                    SelectedDocumentIds: request.SelectedDocumentIds);
+                    MaxTokens: request.MaxTokens);
 
                 var dto = await mediator.Send(command, ct).ConfigureAwait(false);
                 return dto is null ? Results.NotFound() : Results.Ok(dto);
@@ -534,7 +532,7 @@ internal static class AgentsEndpoints
         .Produces(404)
         .WithTags("Agents")
         .WithSummary("Update agent LLM configuration")
-        .WithDescription("Partial update (PATCH) of agent LLM configuration: modelId, temperature, maxTokens. Range validation delegated to AgentDefinitionConfig.Create (temperature 0.0-2.0, maxTokens 100-32000). SelectedDocumentIds accepted but not persisted (KB linking deferred). Issue #658.")
+        .WithDescription("Partial update (PATCH) of agent LLM configuration: modelId, temperature, maxTokens. Range validation delegated to AgentDefinitionConfig.Create (temperature 0.0-2.0, maxTokens 100-32000). Per-agent KB linking is owned by the AgentConfiguration aggregate / updateSelectedDocuments endpoint (#2391), not this contract (#3394). Issue #658.")
         .WithOpenApi();
     }
 

--- a/apps/api/tests/Api.Tests/Integration/Agents/AgentsEndpointsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Agents/AgentsEndpointsIntegrationTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
 using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
@@ -876,7 +877,13 @@ public sealed class AgentsEndpointsIntegrationTests : IAsyncLifetime
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var dto = await response.Content.ReadFromJsonAsync<AgentConfigurationDto>();
+        var json = await response.Content.ReadAsStringAsync();
+        // #3394: the LLM-config contract no longer exposes SelectedDocumentIds. Per-agent KB
+        // linking is owned by the AgentConfiguration aggregate (#2391) / updateSelectedDocuments.
+        json.Should().NotContainEquivalentOf("selectedDocumentIds");
+        var dto = JsonSerializer.Deserialize<AgentConfigurationDto>(
+            json,
+            new JsonSerializerOptions(JsonSerializerDefaults.Web));
         dto.Should().NotBeNull();
         dto!.AgentId.Should().Be(seededId);
         dto.LlmModel.Should().Be("gpt-4");
@@ -884,7 +891,6 @@ public sealed class AgentsEndpointsIntegrationTests : IAsyncLifetime
         dto.MaxTokens.Should().Be(1000);
         dto.Temperature.Should().BeApproximately(0.7m, 0.001m);
         dto.IsCurrent.Should().BeTrue();
-        dto.SelectedDocumentIds.Should().BeEmpty();
     }
 
     // -------------------------------------------------------------------------

--- a/apps/api/tests/Api.Tests/Unit/DocumentProcessing/ImageRegionExtractorTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/DocumentProcessing/ImageRegionExtractorTests.cs
@@ -7,26 +7,30 @@ namespace Api.Tests.Unit.DocumentProcessing;
 
 [Trait("Category", TestCategories.Unit)]
 [Trait("BoundedContext", "DocumentProcessing")]
-[Trait("Issue", "3447")]
+[Trait("Issue", "3456")]
 public sealed class ImageRegionExtractorTests
 {
     private const string HiResJson = """
     {"elements":[
       {"text":"Preparazione","page_number":1,"category":"Title","bbox":{"x":0.08,"y":0.10,"width":0.24,"height":0.05}},
       {"text":"","page_number":4,"category":"Image","bbox":{"x":0.10,"y":0.55,"width":0.80,"height":0.30}},
-      {"text":"","page_number":5,"category":"FigureCaption","bbox":{"x":0.12,"y":0.20,"width":0.40,"height":0.06}},
-      {"text":"","page_number":6,"category":"Image","bbox":null}
+      {"text":"","page_number":5,"category":"FigureCaption","bbox":{"x":0.12,"y":0.20,"width":0.40,"height":0.10}},
+      {"text":"","page_number":6,"category":"Image","bbox":null},
+      {"text":"","page_number":7,"category":"Image","bbox":{"x":0.10,"y":0.10,"width":0.05,"height":0.05}}
     ]}
     """;
 
     [Fact]
-    public void FromHiResJson_KeepsImageAndFigureCaption_WithBbox_DropsOthers()
+    public void FromHiResJson_KeepsLargeImageAndFigureCaption_DropsOtherTypesNullBboxAndTinyRegions()
     {
         var regions = ImageRegionExtractor.FromHiResJson(HiResJson);
 
-        regions.Should().HaveCount(2); // Image p4 + FigureCaption p5; Title dropped, bbox-null Image dropped
+        // Image p4 (0.80*0.30=0.24) + FigureCaption p5 (0.40*0.10=0.04) kept;
+        // Title dropped (type), bbox-null Image p6 dropped, tiny Image p7 (0.05*0.05=0.0025) dropped (area < 3%).
+        regions.Should().HaveCount(2);
         regions.Should().ContainSingle(r => r.ElementType == "Image" && r.Page == 4 && r.Width == 0.80);
         regions.Should().ContainSingle(r => r.ElementType == "FigureCaption" && r.Page == 5);
+        regions.Should().NotContain(r => r.Page == 7);
     }
 
     [Theory]
@@ -46,5 +50,44 @@ public sealed class ImageRegionExtractorTests
         var r = ImageRegionExtractor.FromHiResJson(json).Single();
         r.X.Should().Be(0.0);       // clamped from -0.1
         r.Width.Should().Be(1.0);   // clamped from 1.5
+    }
+
+    [Fact]
+    public void FromHiResJson_DefaultThreshold_IsThreePercent()
+    {
+        ImageRegionExtractor.DefaultMinAreaFraction.Should().Be(0.03);
+    }
+
+    [Fact]
+    public void FromHiResJson_DropsRegionsBelowMinArea()
+    {
+        // 0.10*0.20 = 0.02 (2%) < default 3% → dropped
+        var json = """{"elements":[{"text":"","page_number":1,"category":"Image","bbox":{"x":0.1,"y":0.1,"width":0.10,"height":0.20}}]}""";
+        ImageRegionExtractor.FromHiResJson(json).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void FromHiResJson_RespectsCustomMinArea()
+    {
+        // Image area = 0.20*0.20 = 0.04 (4%). Kept at default 3%, dropped at custom 10%.
+        var json = """{"elements":[{"text":"","page_number":1,"category":"Image","bbox":{"x":0.1,"y":0.1,"width":0.20,"height":0.20}}]}""";
+        ImageRegionExtractor.FromHiResJson(json).Should().HaveCount(1);
+        ImageRegionExtractor.FromHiResJson(json, minAreaFraction: 0.10).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void FromHiResJson_AreaExactlyAtThreshold_IsKept()
+    {
+        // area = 0.30*0.10 = 0.03 == default threshold → kept (>=)
+        var json = """{"elements":[{"text":"","page_number":1,"category":"Image","bbox":{"x":0.0,"y":0.0,"width":0.30,"height":0.10}}]}""";
+        ImageRegionExtractor.FromHiResJson(json).Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void FromHiResJson_ZeroThreshold_DisablesFilter()
+    {
+        // tiny region kept when threshold is 0
+        var json = """{"elements":[{"text":"","page_number":1,"category":"Image","bbox":{"x":0.1,"y":0.1,"width":0.01,"height":0.01}}]}""";
+        ImageRegionExtractor.FromHiResJson(json, minAreaFraction: 0.0).Should().HaveCount(1);
     }
 }

--- a/apps/api/tests/Api.Tests/Unit/DocumentProcessing/SeedPdfImageRegionsCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/DocumentProcessing/SeedPdfImageRegionsCommandHandlerTests.cs
@@ -23,6 +23,12 @@ public sealed class SeedPdfImageRegionsCommandHandlerTests
     ]}
     """;
 
+    private const string TinyRegionJson = """
+    {"elements":[
+      {"text":"","page_number":2,"category":"Image","bbox":{"x":0.1,"y":0.1,"width":0.10,"height":0.20}}
+    ]}
+    """;
+
     private static void SeedPdf(MeepleAiDbContext db, Guid pdfId)
     {
         db.PdfDocuments.Add(new PdfDocumentEntity
@@ -66,5 +72,32 @@ public sealed class SeedPdfImageRegionsCommandHandlerTests
 
         // Guards the FK: a non-existent PDF is a clean 404, not a SaveChanges FK 500.
         await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_DefaultThreshold_DropsTinyRegion()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext($"seedimg_{Guid.NewGuid():N}");
+        var pdfId = Guid.NewGuid();
+        SeedPdf(db, pdfId);
+        await db.SaveChangesAsync();
+        var handler = new SeedPdfImageRegionsCommandHandler(db, NullLogger<SeedPdfImageRegionsCommandHandler>.Instance);
+
+        // 0.10*0.20 = 0.02 (2%) < default 3% → nothing seeded
+        var count = await handler.Handle(new SeedPdfImageRegionsCommand(pdfId, TinyRegionJson), CancellationToken.None);
+        count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_CustomThresholdZero_KeepsTinyRegion()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext($"seedimg_{Guid.NewGuid():N}");
+        var pdfId = Guid.NewGuid();
+        SeedPdf(db, pdfId);
+        await db.SaveChangesAsync();
+        var handler = new SeedPdfImageRegionsCommandHandler(db, NullLogger<SeedPdfImageRegionsCommandHandler>.Instance);
+
+        var count = await handler.Handle(new SeedPdfImageRegionsCommand(pdfId, TinyRegionJson, MinAreaFraction: 0.0), CancellationToken.None);
+        count.Should().Be(1);
     }
 }

--- a/apps/web/__tests__/session-live-chat-agent-g3-axe.test.tsx
+++ b/apps/web/__tests__/session-live-chat-agent-g3-axe.test.tsx
@@ -24,8 +24,6 @@ const messages = {
 const labels = {
   title: 'ChatAgent',
   agentNameAriaLabel: 'Agent name MeepleAI',
-  onlineLabel: 'Online',
-  latencyAriaLabel: 'Latency 42ms',
   chatPanelLabels: {
     title: 'Chat',
     inputAriaLabel: 'Write a message',
@@ -66,7 +64,6 @@ function renderPanel(collapsed: boolean) {
         onSendMessage={() => {}}
         agentName="MeepleAI"
         agentEmoji="🤖"
-        latencyMs={42}
         collapsed={collapsed}
         onHeaderClick={() => {}}
         labels={labels}

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
@@ -693,9 +693,10 @@ export function SessionLiveView(): ReactElement {
 
   const handleAddNote = useCallback(
     // #2575: repointed off the legacy raw fetch to /game-sessions/{id}/diary onto the SP3
-    // text-only endpoint via useAddDiaryEntry. `visibility` stays a FE-only affordance (the SP3
-    // command is text-only) — the onAddNote(content, visibility) signature is kept unchanged.
-    async (content: string, _visibility: 'private' | 'shared'): Promise<void> => {
+    // text-only endpoint via useAddDiaryEntry.
+    // #3393 (finding C6): the visibility param was dropped — the SP3 diary command is
+    // text-only, so the private/shared distinction was a FE-only decorative affordance.
+    async (content: string): Promise<void> => {
       if (sessionId == null) return;
 
       try {
@@ -1030,8 +1031,6 @@ export function SessionLiveView(): ReactElement {
     (): ChatAgentPanelLabels => ({
       title: t('pages.sessionLive.chatAgent.title'),
       agentNameAriaLabel: t('pages.sessionLive.chatAgent.agentNameAriaLabel', { name: 'MeepleAI' }),
-      onlineLabel: t('pages.sessionLive.chatAgent.onlineLabel'),
-      latencyAriaLabel: t('pages.sessionLive.chatAgent.latencyAriaLabel', { ms: 42 }),
       chatPanelLabels: chatLabels,
     }),
     [t, chatLabels]
@@ -1042,8 +1041,6 @@ export function SessionLiveView(): ReactElement {
       title: t('pages.sessionLive.notes.title'),
       inputAriaLabel: t('pages.sessionLive.notes.inputAriaLabel'),
       addAriaLabel: t('pages.sessionLive.notes.addAriaLabel'),
-      visibilityPrivate: t('pages.sessionLive.notes.visibilityPrivate'),
-      visibilityShared: t('pages.sessionLive.notes.visibilityShared'),
       emptyMessage: t('pages.sessionLive.notes.emptyMessage'),
     }),
     [t]
@@ -1320,7 +1317,6 @@ export function SessionLiveView(): ReactElement {
         authorId: e.authorName,
         authorName: e.authorName,
         content: e.content,
-        visibility: 'shared' as const,
         timestamp: e.timestamp,
       }));
   }, [activeSession]);
@@ -1356,7 +1352,6 @@ export function SessionLiveView(): ReactElement {
           onSendMessage={handleAgentSendMessage}
           agentName="MeepleAI"
           agentEmoji="🤖"
-          latencyMs={42}
           collapsed={mobileChatCollapsed}
           onHeaderClick={handleMobileChatHeaderClick}
           labels={chatAgentLabels}
@@ -1588,7 +1583,6 @@ export function SessionLiveView(): ReactElement {
         onSendMessage={handleAgentSendMessage}
         agentName="MeepleAI"
         agentEmoji="🤖"
-        latencyMs={42}
         collapsed={chatCollapsed}
         onHeaderClick={handleChatHeaderClick}
         labels={chatAgentLabels}

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
@@ -453,8 +453,6 @@ const MESSAGES: Record<string, string> = {
   // ChatAgentPanel labels (G1 #2374 T3 — composite header)
   'pages.sessionLive.chatAgent.title': 'ChatAgent',
   'pages.sessionLive.chatAgent.agentNameAriaLabel': 'Nome agente {name}',
-  'pages.sessionLive.chatAgent.onlineLabel': 'Online',
-  'pages.sessionLive.chatAgent.latencyAriaLabel': 'Latenza {ms}ms',
   // Agent launch status feedback messages (#2500 Task 4-FE R-FINDING-5)
   'pages.sessionLive.chatAgent.launchingMessage': "Avvio dell'assistente di gioco…",
   'pages.sessionLive.chatAgent.noAgentMessage': 'Nessun assistente disponibile per questo gioco.',
@@ -481,8 +479,6 @@ const MESSAGES: Record<string, string> = {
   'pages.sessionLive.notes.title': 'Note',
   'pages.sessionLive.notes.inputAriaLabel': 'Scrivi una nota',
   'pages.sessionLive.notes.addAriaLabel': 'Aggiungi nota',
-  'pages.sessionLive.notes.visibilityPrivate': 'Privata',
-  'pages.sessionLive.notes.visibilityShared': 'Condivisa',
   'pages.sessionLive.notes.emptyMessage': 'Nessuna nota ancora.',
   // SP5-a Task 3 (finding #16): diary write response-ack toast key
   'pages.sessionLive.notes.addNoteErrorToast': 'Impossibile salvare la nota. Riprova.',

--- a/apps/web/src/components/agent/AgentSelector.tsx
+++ b/apps/web/src/components/agent/AgentSelector.tsx
@@ -3,17 +3,17 @@
  *
  * Features:
  * - Dropdown selector for Tutor, Arbitro, Stratega, Narratore, Orchestrator (auto)
- * - Agent status indicators (online/offline/busy)
  * - Agent descriptions and icons
  * - Selection persistence per conversation
- * - Real-time status updates
+ *
+ * #3393 (finding C9c): the hardcoded "online" status indicators and the no-op
+ * 30s poll (which only ever re-set every agent to 'online') were removed — no
+ * real per-agent online/offline signal exists in the backend.
  */
 
 'use client';
 
-import { useState, useEffect } from 'react';
-
-import { Bot, Sparkles, Shield, Zap, Circle, BookOpen, Target } from 'lucide-react';
+import { Bot, Sparkles, Shield, Zap, BookOpen, Target } from 'lucide-react';
 
 import { Badge } from '@/components/ui/data-display/badge';
 import {
@@ -30,14 +30,12 @@ import { cn } from '@/lib/utils';
 // ============================================================================
 
 export type AgentType = 'auto' | 'tutor' | 'arbitro' | 'stratega' | 'narratore';
-export type AgentStatus = 'online' | 'offline' | 'busy';
 
 export interface Agent {
   id: AgentType;
   name: string;
   description: string;
   icon: typeof Bot;
-  status: AgentStatus;
 }
 
 export interface AgentSelectorProps {
@@ -63,7 +61,7 @@ export const AGENT_NAMES: Record<AgentType, string> = {
   narratore: 'Narratore',
 };
 
-const AGENTS: Record<AgentType, Omit<Agent, 'status'>> = {
+const AGENTS: Record<AgentType, Agent> = {
   auto: {
     id: 'auto',
     name: 'Auto (Orchestrator)',
@@ -96,51 +94,11 @@ const AGENTS: Record<AgentType, Omit<Agent, 'status'>> = {
   },
 };
 
-const STATUS_COLORS: Record<AgentStatus, string> = {
-  online: 'bg-green-500',
-  offline: 'bg-gray-400',
-  busy: 'bg-amber-500',
-};
-
-const STATUS_LABELS: Record<AgentStatus, string> = {
-  online: 'Online',
-  offline: 'Offline',
-  busy: 'Busy',
-};
-
 // ============================================================================
 // Main Component
 // ============================================================================
 
 export function AgentSelector({ value, onChange, className, disabled }: AgentSelectorProps) {
-  const [_agentStatuses, setAgentStatuses] = useState<Record<AgentType, AgentStatus>>({
-    auto: 'online',
-    tutor: 'online',
-    arbitro: 'online',
-    stratega: 'online',
-    narratore: 'online',
-  });
-
-  // Fetch agent statuses from API (real implementation would poll or use WebSocket)
-  useEffect(() => {
-    const fetchStatuses = async () => {
-      // In POC, assume all online
-      // Real implementation: await api.agents.getAll() and check status
-      setAgentStatuses({
-        auto: 'online',
-        tutor: 'online',
-        arbitro: 'online',
-        stratega: 'online',
-        narratore: 'online',
-      });
-    };
-
-    fetchStatuses();
-    // Poll every 30s for status updates
-    const interval = setInterval(fetchStatuses, 30000);
-    return () => clearInterval(interval);
-  }, []);
-
   return (
     <div className={cn('flex items-center gap-3', className)}>
       <span className="text-sm text-muted-foreground font-nunito">Agent:</span>
@@ -151,7 +109,6 @@ export function AgentSelector({ value, onChange, className, disabled }: AgentSel
         <SelectContent>
           {(Object.keys(AGENTS) as AgentType[]).map(agentId => {
             const agent = AGENTS[agentId];
-            const status = _agentStatuses[agentId];
             const Icon = agent.icon;
 
             return (
@@ -164,16 +121,7 @@ export function AgentSelector({ value, onChange, className, disabled }: AgentSel
 
                   {/* Name & Description */}
                   <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2">
-                      <span className="font-medium text-sm">{agent.name}</span>
-                      {/* Status Indicator */}
-                      <div className="flex items-center gap-1">
-                        <Circle className={cn('h-2 w-2 fill-current', STATUS_COLORS[status])} />
-                        <span className="text-xs text-muted-foreground">
-                          {STATUS_LABELS[status]}
-                        </span>
-                      </div>
-                    </div>
+                    <span className="font-medium text-sm">{agent.name}</span>
                     <p className="text-xs text-muted-foreground truncate">{agent.description}</p>
                   </div>
                 </div>

--- a/apps/web/src/components/agent/__tests__/AgentSelector.test.tsx
+++ b/apps/web/src/components/agent/__tests__/AgentSelector.test.tsx
@@ -52,17 +52,20 @@ describe('AgentSelector', () => {
     });
   });
 
-  it('shows status indicators for each agent', async () => {
+  it('does NOT show fabricated "online" status indicators (#3393)', async () => {
     render(<AgentSelector {...defaultProps} />);
 
     const trigger = screen.getByRole('combobox');
     fireEvent.click(trigger);
 
+    // Options render (descriptions confirm the dropdown opened) ...
     await waitFor(() => {
-      // Should show "Online" status for all agents in POC
-      const statusLabels = screen.getAllByText('Online');
-      expect(statusLabels.length).toBeGreaterThan(0);
+      const autoDesc = screen.getAllByText(/Automatically routes to best agent/i);
+      expect(autoDesc.length).toBeGreaterThan(0);
     });
+
+    // ... but the hardcoded "Online" status pill is gone.
+    expect(screen.queryByText('Online')).not.toBeInTheDocument();
   });
 
   it('calls onChange when agent is selected', async () => {

--- a/apps/web/src/components/agent/settings/__tests__/AgentSettingsDrawer.test.tsx
+++ b/apps/web/src/components/agent/settings/__tests__/AgentSettingsDrawer.test.tsx
@@ -74,6 +74,8 @@ const PREMIUM_MODELS = [
   },
 ];
 
+// #3394: config contract no longer exposes selectedDocumentIds (KB linking is a separate
+// flow owned by the AgentConfiguration aggregate / updateSelectedDocuments endpoint).
 const MOCK_AGENT_CONFIG = {
   id: 'config-1',
   agentId: 'agent-123',
@@ -81,7 +83,6 @@ const MOCK_AGENT_CONFIG = {
   llmProvider: 'openrouter',
   temperature: 0.3,
   maxTokens: 2048,
-  selectedDocumentIds: [],
   isCurrent: true,
   createdAt: '2026-01-01T00:00:00Z',
 };
@@ -104,7 +105,11 @@ vi.mock('@/lib/api', () => ({
 }));
 
 // Import mocked modules for dynamic control
-import { useAvailableModels, useAgentConfiguration, useUpdateAgentConfiguration } from '@/hooks/queries/useModels';
+import {
+  useAvailableModels,
+  useAgentConfiguration,
+  useUpdateAgentConfiguration,
+} from '@/hooks/queries/useModels';
 
 const mockUseAvailableModels = vi.mocked(useAvailableModels);
 const mockUseAgentConfiguration = vi.mocked(useAgentConfiguration);
@@ -137,7 +142,11 @@ const defaultProps = {
   onNameUpdated: vi.fn(),
 };
 
-function setupMocks(options?: { models?: typeof FREE_MODELS; config?: typeof MOCK_AGENT_CONFIG | null; loading?: boolean }) {
+function setupMocks(options?: {
+  models?: typeof FREE_MODELS;
+  config?: typeof MOCK_AGENT_CONFIG | null;
+  loading?: boolean;
+}) {
   const models = options?.models ?? FREE_MODELS;
   const config = options?.config !== undefined ? options.config : MOCK_AGENT_CONFIG;
   const loading = options?.loading ?? false;

--- a/apps/web/src/components/features/session-live/ChatAgentPanel.tsx
+++ b/apps/web/src/components/features/session-live/ChatAgentPanel.tsx
@@ -5,8 +5,12 @@
  * Extended by Issue #2588 A3: forwards optional images param from LiveAgentChat.
  *
  * Wrapper primitive around `LiveAgentChat` that adds the mockup's
- * "magnet" header (emoji avatar + Online pip + agent name + latency +
- * ChatAgent pill) and an accordion-style collapsed semantic.
+ * "magnet" header (emoji avatar + agent name + ChatAgent pill) and an
+ * accordion-style collapsed semantic.
+ *
+ * #3393 (finding C9a/C9b): the fabricated "42ms" latency indicator and the
+ * static "Online" pip were removed — the AI agent has no real online/offline
+ * state and latency was never measured. Decorative-only affordances go.
  *
  * Body delegates to `<LiveAgentChat />` — no duplication of chat logic.
  *
@@ -45,10 +49,6 @@ export interface ChatAgentPanelLabels {
   readonly title: string;
   /** Pre-resolved (Gate A): aria-label for the agent name span. */
   readonly agentNameAriaLabel: string;
-  /** Label for the Online pulse pip — typically "Online". */
-  readonly onlineLabel: string;
-  /** Pre-resolved (Gate A): aria-label for latency indicator. e.g. "Latenza 42ms". */
-  readonly latencyAriaLabel: string;
   /** Labels forwarded to the inner `<LiveAgentChat />`. */
   readonly chatPanelLabels: LiveAgentChatLabels;
 }
@@ -74,7 +74,6 @@ export interface ChatAgentPanelProps {
   readonly agentName: string;
   /** Default '🤖'. */
   readonly agentEmoji?: string;
-  readonly latencyMs: number;
   /** Default false; G3 controls. When true, body unmounts. */
   readonly collapsed?: boolean;
   /** G3 wires the accordion FSM. When provided, header becomes a button. */
@@ -94,7 +93,6 @@ export function ChatAgentPanel({
   onSendMessage,
   agentName,
   agentEmoji = '🤖',
-  latencyMs,
   collapsed = false,
   onHeaderClick,
   compact = false,
@@ -115,35 +113,22 @@ export function ChatAgentPanel({
   // ─── Header content (identical for both <button> and <div> wrappers) ──────
   const headerContent = (
     <>
-      {/* Emoji avatar with pulse pip */}
+      {/* Emoji avatar */}
       <span
         aria-hidden="true"
-        className="relative flex h-9 w-9 shrink-0 items-center justify-center
+        className="flex h-9 w-9 shrink-0 items-center justify-center
           rounded-full bg-entity-agent/20 text-base"
       >
         {agentEmoji}
-        {/* Online pulse pip — aria-label exposes "Online" text to AT */}
-        <span
-          aria-label={labels.onlineLabel}
-          role="status"
-          className="absolute -bottom-0.5 -right-0.5 inline-block h-2.5 w-2.5
-            rounded-full border-2 border-card bg-emerald-500 animate-pulse"
-        />
       </span>
 
-      {/* Agent name + latency */}
+      {/* Agent name */}
       <span className="flex min-w-0 flex-1 flex-col gap-0.5 text-left">
         <span
           aria-label={labels.agentNameAriaLabel}
           className="truncate text-sm font-semibold text-foreground"
         >
           {agentName}
-        </span>
-        <span
-          aria-label={labels.latencyAriaLabel}
-          className="text-xs font-medium text-foreground/70"
-        >
-          {latencyMs}ms
         </span>
       </span>
 

--- a/apps/web/src/components/features/session-live/LiveSessionNotes.tsx
+++ b/apps/web/src/components/features/session-live/LiveSessionNotes.tsx
@@ -7,7 +7,11 @@
  *
  * Role variants:
  *   Spectator: read-only notes list, add-note form hidden entirely.
- *   Player+Host: full form with visibility toggle (private/shared).
+ *   Player+Host: full form (plain text-only note input).
+ *
+ * #3393 (finding C6): the private/shared visibility toggle and the "private"
+ * badge were removed — the SP3 diary endpoint is text-only, so visibility was a
+ * FE-only affordance promising a persistence behaviour the backend never had.
  *
  * Gate C: DIVERGES from MeepleCard — notes panel, not a card pattern.
  *
@@ -28,7 +32,6 @@ export interface NoteEntry {
   readonly authorId: string;
   readonly authorName: string;
   readonly content: string;
-  readonly visibility: 'private' | 'shared';
   readonly timestamp: string;
 }
 
@@ -38,8 +41,6 @@ export interface LiveSessionNotesLabels {
   readonly title: string;
   readonly inputAriaLabel: string;
   readonly addAriaLabel: string;
-  readonly visibilityPrivate: string;
-  readonly visibilityShared: string;
   readonly emptyMessage: string;
 }
 
@@ -49,7 +50,7 @@ export interface LiveSessionNotesProps {
   readonly notes: ReadonlyArray<NoteEntry>;
   readonly viewerRole: ParticipantRole;
   readonly viewerId: string;
-  readonly onAddNote: (content: string, visibility: 'private' | 'shared') => void;
+  readonly onAddNote: (content: string) => void;
   readonly labels: LiveSessionNotesLabels;
   readonly className?: string;
 }
@@ -65,7 +66,6 @@ export function LiveSessionNotes({
   className,
 }: LiveSessionNotesProps): ReactElement {
   const [inputValue, setInputValue] = useState('');
-  const [visibility, setVisibility] = useState<'private' | 'shared'>('shared');
 
   const isSpectator = viewerRole === 'Spectator';
 
@@ -73,7 +73,7 @@ export function LiveSessionNotes({
     e.preventDefault();
     const trimmed = inputValue.trim();
     if (!trimmed) return;
-    onAddNote(trimmed, visibility);
+    onAddNote(trimmed);
     setInputValue('');
   };
 
@@ -95,27 +95,18 @@ export function LiveSessionNotes({
         ) : (
           notes.map(note => {
             const isOwn = note.authorId === viewerId;
-            const isPrivate = note.visibility === 'private';
             return (
               <article
                 key={note.id}
                 data-note-id={note.id}
-                data-visibility={note.visibility}
-                className={`rounded-lg border p-3 text-sm ${
-                  isPrivate
-                    ? 'border-amber-700/30 bg-amber-900/10'
-                    : 'border-border/40 bg-card'
-                }`}
+                className="rounded-lg border border-border/40 bg-card p-3 text-sm"
               >
-                <header className="mb-1 flex items-center justify-between gap-2">
+                <header className="mb-1 flex items-center gap-2">
                   <span
                     className={`text-xs font-medium ${isOwn ? 'text-foreground' : 'text-muted-foreground'}`}
                   >
                     {note.authorName}
                   </span>
-                  {isPrivate && (
-                    <span className="text-xs text-amber-400/70">{labels.visibilityPrivate}</span>
-                  )}
                 </header>
                 <p className="text-foreground">{note.content}</p>
               </article>
@@ -127,34 +118,6 @@ export function LiveSessionNotes({
       {/* Add note form — hidden for Spectator */}
       {!isSpectator && (
         <form onSubmit={handleSubmit} className="flex shrink-0 flex-col gap-2">
-          {/* Visibility toggle */}
-          <div className="flex gap-2" role="group" aria-label="Visibilità nota">
-            <button
-              type="button"
-              aria-pressed={visibility === 'shared'}
-              onClick={() => setVisibility('shared')}
-              className={`rounded-md px-2 py-1 text-xs font-medium transition-colors ${
-                visibility === 'shared'
-                  ? 'bg-muted text-foreground'
-                  : 'text-muted-foreground hover:text-foreground'
-              }`}
-            >
-              {labels.visibilityShared}
-            </button>
-            <button
-              type="button"
-              aria-pressed={visibility === 'private'}
-              onClick={() => setVisibility('private')}
-              className={`rounded-md px-2 py-1 text-xs font-medium transition-colors ${
-                visibility === 'private'
-                  ? 'bg-amber-700/60 text-amber-100'
-                  : 'text-muted-foreground hover:text-foreground'
-              }`}
-            >
-              {labels.visibilityPrivate}
-            </button>
-          </div>
-
           <div className="flex gap-2">
             <textarea
               value={inputValue}

--- a/apps/web/src/components/features/session-live/__tests__/ChatAgentPanel.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/ChatAgentPanel.test.tsx
@@ -3,7 +3,7 @@
  *
  * Coverage (per plan §4 T3):
  * 1. data-slot="chat-agent-panel" regression hook
- * 2. header shows agent name + emoji + Online pip + latency
+ * 2. header shows agent name + emoji (no online pip / no fabricated latency — #3393)
  * 3. header has "ChatAgent" pill (mockup magnet semantic)
  * 4. body renders LiveAgentChat (data-slot="live-agent-chat")
  * 5. collapsed=true unmounts body + aria-expanded=false
@@ -51,8 +51,6 @@ const CHAT_PANEL_LABELS: LiveAgentChatLabels = {
 const LABELS: ChatAgentPanelLabels = {
   title: 'ChatAgent',
   agentNameAriaLabel: 'Nome agente Meeple',
-  onlineLabel: 'Online',
-  latencyAriaLabel: 'Latenza 42ms',
   chatPanelLabels: CHAT_PANEL_LABELS,
 };
 
@@ -76,7 +74,6 @@ function renderPanel(overrides: Partial<ChatAgentPanelProps> = {}) {
     viewerId: 'viewer-id',
     onSendMessage,
     agentName: 'Meeple',
-    latencyMs: 42,
     labels: LABELS,
     onHeaderClick,
     ...overrides,
@@ -114,17 +111,16 @@ describe('ChatAgentPanel — render shape', () => {
     expect(root).not.toBeNull();
   });
 
-  it('header shows agent name + emoji + Online pip + latency', () => {
-    renderPanel({ agentName: 'Meeple', agentEmoji: '🤖', latencyMs: 42 });
+  it('header shows agent name + emoji, without online pip or fabricated latency (#3393)', () => {
+    renderPanel({ agentName: 'Meeple', agentEmoji: '🤖' });
     // Agent name visible
     expect(screen.getByText('Meeple')).toBeInTheDocument();
     // Emoji avatar present (default 🤖)
     expect(screen.getByText('🤖')).toBeInTheDocument();
-    // Online pip — aria-label matches labels.onlineLabel
-    expect(screen.getByLabelText(LABELS.onlineLabel)).toBeInTheDocument();
-    // Latency indicator — aria-label matches labels.latencyAriaLabel + text shows ms
-    expect(screen.getByLabelText(LABELS.latencyAriaLabel)).toBeInTheDocument();
-    expect(screen.getByText(/42ms/)).toBeInTheDocument();
+    // C9b: the static "Online" pip is gone — nothing exposes it to AT
+    expect(screen.queryByLabelText('Online')).not.toBeInTheDocument();
+    // C9a: the fabricated "42ms" latency indicator is gone — no "<n>ms" text
+    expect(screen.queryByText(/\d+\s*ms/)).not.toBeInTheDocument();
   });
 
   it('header has "ChatAgent" pill (mockup magnet semantic)', () => {
@@ -179,7 +175,6 @@ describe('ChatAgentPanel — header interactions', () => {
         viewerId="viewer-id"
         onSendMessage={vi.fn()}
         agentName="Meeple"
-        latencyMs={42}
         labels={LABELS}
       />
     );

--- a/apps/web/src/components/features/session-live/__tests__/LiveSessionNotes.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/LiveSessionNotes.test.tsx
@@ -4,9 +4,9 @@
  * Coverage:
  * - Render shape (data-slot, notes list, empty state)
  * - Role variant: Spectator = read-only (no add form)
- * - Player+Host: add form visible with visibility toggle
- * - onAddNote fires with correct content + visibility
- * - aria-pressed on visibility toggle buttons
+ * - Player+Host: text-only add form (no visibility toggle — #3393)
+ * - onAddNote fires with content only
+ * - #3393: no private/shared visibility toggle, no "private" badge
  */
 
 import { render, screen } from '@testing-library/react';
@@ -22,8 +22,6 @@ const LABELS: LiveSessionNotesLabels = {
   title: 'Note di Sessione',
   inputAriaLabel: 'Scrivi una nota',
   addAriaLabel: 'Aggiungi nota',
-  visibilityPrivate: 'Privata',
-  visibilityShared: 'Condivisa',
   emptyMessage: 'Nessuna nota',
 };
 
@@ -33,7 +31,6 @@ const NOTES: ReadonlyArray<NoteEntry> = [
     authorId: 'user-a',
     authorName: 'Alice',
     content: 'Prima nota',
-    visibility: 'shared',
     timestamp: '2026-05-06T10:00:00Z',
   },
   {
@@ -41,7 +38,6 @@ const NOTES: ReadonlyArray<NoteEntry> = [
     authorId: 'viewer-id',
     authorName: 'Me',
     content: 'Nota privata',
-    visibility: 'private',
     timestamp: '2026-05-06T10:01:00Z',
   },
 ];
@@ -117,15 +113,19 @@ describe('LiveSessionNotes — role variant: Player + Host', () => {
     expect(screen.getByRole('button', { name: 'Aggiungi nota' })).toBeInTheDocument();
   });
 
-  it.each(['Player', 'Host'] as const)('shows visibility toggle for %s', role => {
-    renderNotes({ viewerRole: role });
-    expect(screen.getByRole('button', { name: /Privata/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Condivisa/i })).toBeInTheDocument();
-  });
+  it.each(['Player', 'Host'] as const)(
+    'does NOT show a private/shared visibility toggle for %s (#3393)',
+    role => {
+      renderNotes({ viewerRole: role });
+      expect(screen.queryByRole('button', { name: /Privata/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /Condivisa/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('group', { name: /Visibilità/i })).not.toBeInTheDocument();
+    }
+  );
 });
 
 describe('LiveSessionNotes — onAddNote', () => {
-  it('calls onAddNote with content and "shared"', async () => {
+  it('calls onAddNote with content only (no visibility arg — #3393)', async () => {
     const user = userEvent.setup();
     const { onAddNote } = renderNotes({ viewerRole: 'Player' });
 
@@ -133,18 +133,7 @@ describe('LiveSessionNotes — onAddNote', () => {
     await user.click(screen.getByRole('button', { name: 'Aggiungi nota' }));
 
     expect(onAddNote).toHaveBeenCalledOnce();
-    expect(onAddNote).toHaveBeenCalledWith('My note', 'shared');
-  });
-
-  it('calls onAddNote with "private" when switched', async () => {
-    const user = userEvent.setup();
-    const { onAddNote } = renderNotes({ viewerRole: 'Player' });
-
-    await user.click(screen.getByRole('button', { name: /Privata/i }));
-    await user.type(screen.getByRole('textbox', { name: 'Scrivi una nota' }), 'Private note');
-    await user.click(screen.getByRole('button', { name: 'Aggiungi nota' }));
-
-    expect(onAddNote).toHaveBeenCalledWith('Private note', 'private');
+    expect(onAddNote).toHaveBeenCalledWith('My note');
   });
 
   it('does not call onAddNote when input is empty', async () => {
@@ -167,19 +156,13 @@ describe('LiveSessionNotes — onAddNote', () => {
   });
 });
 
-describe('LiveSessionNotes — aria', () => {
-  it('aria-pressed reflects current visibility selection', async () => {
-    const user = userEvent.setup();
-    renderNotes({ viewerRole: 'Player' });
-
-    const sharedBtn = screen.getByRole('button', { name: /Condivisa/i });
-    expect(sharedBtn).toHaveAttribute('aria-pressed', 'true');
-
-    await user.click(screen.getByRole('button', { name: /Privata/i }));
-    expect(screen.getByRole('button', { name: /Privata/i })).toHaveAttribute(
-      'aria-pressed',
-      'true'
-    );
-    expect(sharedBtn).toHaveAttribute('aria-pressed', 'false');
+describe('LiveSessionNotes — #3393 removed affordances', () => {
+  it('does not render a "private" visibility badge on notes', () => {
+    renderNotes({ notes: NOTES });
+    // Note content still renders, but no decorative private/shared badge appears.
+    expect(screen.getByText('Prima nota')).toBeInTheDocument();
+    expect(screen.getByText('Nota privata')).toBeInTheDocument();
+    expect(screen.queryByText('Privata')).not.toBeInTheDocument();
+    expect(screen.queryByText('Condivisa')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/lib/api/schemas/agent-config.schemas.ts
+++ b/apps/web/src/lib/api/schemas/agent-config.schemas.ts
@@ -174,7 +174,15 @@ export interface GetModelsResponse {
   models: BackendModelDto[];
 }
 
-/** AgentConfigurationDto from PATCH/GET /api/v1/agents/:id/configuration */
+/**
+ * AgentConfigurationDto from PATCH/GET /api/v1/agents/:id/configuration.
+ *
+ * LLM configuration only (model/provider/temperature/maxTokens). Per-agent KB linking
+ * (selected documents) is NOT part of this contract — it is a separate flow owned by the
+ * backend AgentConfiguration aggregate (#2391) and exposed via
+ * `api.agentDocuments.updateSelectedDocuments` (see useGameAgentDocuments). Issue #3394
+ * removed the previously accepted-and-discarded `selectedDocumentIds` field.
+ */
 export interface BackendAgentConfigurationDto {
   id: string;
   agentId: string;
@@ -182,17 +190,18 @@ export interface BackendAgentConfigurationDto {
   llmProvider: string;
   temperature: number;
   maxTokens: number;
-  selectedDocumentIds: string[];
   isCurrent: boolean;
   createdAt: string;
 }
 
-/** Request body for PATCH /api/v1/agents/:id/configuration */
+/**
+ * Request body for PATCH /api/v1/agents/:id/configuration.
+ * LLM config only — see BackendAgentConfigurationDto note re: KB linking (#3394).
+ */
 export interface UpdateAgentConfigurationRequest {
   modelId?: string;
   temperature?: number;
   maxTokens?: number;
-  selectedDocumentIds?: string[];
 }
 
 /**

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -3883,8 +3883,6 @@
       },
       "chatAgent": {
         "title": "ChatAgent",
-        "onlineLabel": "Online",
-        "latencyAriaLabel": "Latency {ms}ms",
         "agentNameAriaLabel": "Agent name {name}",
         "collapsedAriaLabel": "ChatAgent collapsed — click to expand",
         "expandedAriaLabel": "ChatAgent expanded — click to collapse",
@@ -3910,8 +3908,6 @@
         "title": "Notes",
         "inputAriaLabel": "Write a note",
         "addAriaLabel": "Add note",
-        "visibilityPrivate": "Private",
-        "visibilityShared": "Shared",
         "emptyMessage": "No notes yet.",
         "addNoteErrorToast": "Failed to save note. Please try again."
       },

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -3947,8 +3947,6 @@
       },
       "chatAgent": {
         "title": "ChatAgent",
-        "onlineLabel": "Online",
-        "latencyAriaLabel": "Latenza {ms}ms",
         "agentNameAriaLabel": "Nome agente {name}",
         "collapsedAriaLabel": "ChatAgent collassato — clic per espandere",
         "expandedAriaLabel": "ChatAgent espanso — clic per collassare",
@@ -3974,8 +3972,6 @@
         "title": "Note",
         "inputAriaLabel": "Scrivi una nota",
         "addAriaLabel": "Aggiungi nota",
-        "visibilityPrivate": "Privata",
-        "visibilityShared": "Condivisa",
         "emptyMessage": "Nessuna nota ancora.",
         "addNoteErrorToast": "Impossibile salvare la nota. Riprova."
       },

--- a/docs/for-developers/operations/deploy-staging-runbook.md
+++ b/docs/for-developers/operations/deploy-staging-runbook.md
@@ -161,6 +161,30 @@ gh run watch $(gh run list --workflow "Deploy to Staging" --limit 1 --json datab
 The slow path takes ~15-25 min (CI rebuild + deploy) vs ~10 min for the image-tag path,
 but produces a clean git history. Use slow path for P2/P3, fast path for P1.
 
+## Servizi AI — rebuild immagine `unstructured-service` (#3455)
+
+Quando modifichi la **pipeline coordinate** di `unstructured-service`
+(`apps/unstructured-service/src/api/coordinates.py` o `schemas.py`, es. SP-B #3406),
+l'immagine Docker **NON** si aggiorna da sola: `partition_pdf` continua a girare sul
+codice bakeato nell'immagine.
+
+- **Staging/prod**: il job `build` (push GHCR) ricostruisce le immagini ad ogni deploy →
+  la modifica a `coordinates.py` è inclusa automaticamente una volta mergiata e deployata.
+- **Locale**: `docker compose build` **non** è automatico. Dopo aver toccato `coordinates.py`
+  ricostruisci a mano, altrimenti `POST /extract` (strategy=hi_res) restituisce elementi
+  `Image`/`FigureCaption` **senza** `bbox` (0 bbox), pur avendo la libreria le coordinate.
+
+Rebuild + verifica in locale:
+
+```bash
+cd infra && docker compose --profile ai build unstructured-service
+docker compose --profile ai up -d unstructured-service
+# conferma che l'immagine ricostruita include la pipeline #3406:
+docker exec meepleai-unstructured grep -n normalized_bbox /app/src/api/coordinates.py
+```
+
+Ref: #3455 (epic #3435 image-table grounding), slice #3447.
+
 ## Observability
 
 - Slack: notifiche via `notify-start` + `notify-end` jobs (channel configurato in repo secrets `SLACK_GITNOTIFY_WEBHOOK_URL` + `SLACK_CRITICAL_WEBHOOK_URL`)

--- a/docs/superpowers/plans/2026-08-02-image-region-area-filter.md
+++ b/docs/superpowers/plans/2026-08-02-image-region-area-filter.md
@@ -1,0 +1,383 @@
+# Image-Region Area Filter + Unstructured Refresh — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Aggiungere un filtro area-minima anti-rumore alla cattura delle regioni immagine-tabella (#3456) e ricostruire/documentare l'immagine `unstructured-service` che emette i bbox (#3455).
+
+**Architecture:** Filtro puro lato BE in `ImageRegionExtractor.FromHiResJson` (soglia `double`, default 3% via const), propagato come parametro opzionale attraverso il command/request/endpoint del seed. Per #3455 nessuna modifica al sorgente Python (già ha #3406): rebuild dell'immagine Docker + nota nel runbook di deploy.
+
+**Tech Stack:** .NET 9 (xUnit + FluentAssertions), CQRS/MediatR, Docker Compose, Python 3.11 (unstructured-service).
+
+## Global Constraints
+
+- Solution BE: `apps/api/MeepleAI.Api.sln`. Build dopo un cambio di ctor/signature: build della **solution**, non del solo progetto.
+- CQRS: endpoint usano solo `IMediator.Send` (nessuna service injection).
+- Eccezioni dominio: `NotFoundException` (404), mai `InvalidOperationException` (500) — invariante esistente, non toccata qui.
+- Naming C#: PascalCase pubblico, `_camelCase` privato.
+- Baseline unit test: 0 fail. Una PR non deve aumentare il fail count.
+- Git hooks eseguono build completa → `git commit`/`push` vanno in **timeout foreground**: eseguirli con `run_in_background` e verificare l'esito con `git log`/`git status` (exit 0 ≠ commit garantito).
+- Soglia area = frazione di pagina `Width * Height` ∈ [0,1]; default **`0.03`** (3%); confronto **`>=`** (inclusivo); area calcolata sui valori **già clampati** a [0,1].
+
+---
+
+### Task 1: Filtro area-minima in `ImageRegionExtractor` (#3456)
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/ImageRegionExtractor.cs`
+- Test: `apps/api/tests/Api.Tests/Unit/DocumentProcessing/ImageRegionExtractorTests.cs`
+
+**Interfaces:**
+- Produces: `ImageRegionExtractor.FromHiResJson(string? hiResJson, double minAreaFraction = ImageRegionExtractor.DefaultMinAreaFraction)` → `IReadOnlyList<ExtractedImageRegion>`; `public const double ImageRegionExtractor.DefaultMinAreaFraction = 0.03`.
+- Consumes: nulla (Task 1 è la base).
+
+- [ ] **Step 1: Aggiorna il fixture e aggiungi i test del filtro**
+
+In `ImageRegionExtractorTests.cs`, sostituisci il campo `HiResJson` (la `FigureCaption` passa da area 2.4% → >3% così resta "tenuta"; aggiungi una `Image` piccola sotto soglia) e aggiungi i test del filtro. Il test esistente `FromHiResJson_KeepsImageAndFigureCaption_WithBbox_DropsOthers` va aggiornato per la nuova FigureCaption e per la piccola Image droppata.
+
+```csharp
+    private const string HiResJson = """
+    {"elements":[
+      {"text":"Preparazione","page_number":1,"category":"Title","bbox":{"x":0.08,"y":0.10,"width":0.24,"height":0.05}},
+      {"text":"","page_number":4,"category":"Image","bbox":{"x":0.10,"y":0.55,"width":0.80,"height":0.30}},
+      {"text":"","page_number":5,"category":"FigureCaption","bbox":{"x":0.12,"y":0.20,"width":0.40,"height":0.10}},
+      {"text":"","page_number":6,"category":"Image","bbox":null},
+      {"text":"","page_number":7,"category":"Image","bbox":{"x":0.10,"y":0.10,"width":0.05,"height":0.05}}
+    ]}
+    """;
+
+    [Fact]
+    public void FromHiResJson_KeepsLargeImageAndFigureCaption_DropsOtherTypesNullBboxAndTinyRegions()
+    {
+        var regions = ImageRegionExtractor.FromHiResJson(HiResJson);
+
+        // Image p4 (0.80*0.30=0.24) + FigureCaption p5 (0.40*0.10=0.04) kept;
+        // Title dropped (type), bbox-null Image p6 dropped, tiny Image p7 (0.05*0.05=0.0025) dropped (area < 3%).
+        regions.Should().HaveCount(2);
+        regions.Should().ContainSingle(r => r.ElementType == "Image" && r.Page == 4 && r.Width == 0.80);
+        regions.Should().ContainSingle(r => r.ElementType == "FigureCaption" && r.Page == 5);
+        regions.Should().NotContain(r => r.Page == 7);
+    }
+
+    [Fact]
+    public void FromHiResJson_DefaultThreshold_IsThreePercent()
+    {
+        ImageRegionExtractor.DefaultMinAreaFraction.Should().Be(0.03);
+    }
+
+    [Fact]
+    public void FromHiResJson_DropsRegionsBelowMinArea()
+    {
+        // 0.10*0.20 = 0.02 (2%) < default 3% → dropped
+        var json = """{"elements":[{"text":"","page_number":1,"category":"Image","bbox":{"x":0.1,"y":0.1,"width":0.10,"height":0.20}}]}""";
+        ImageRegionExtractor.FromHiResJson(json).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void FromHiResJson_RespectsCustomMinArea()
+    {
+        // Image area = 0.20*0.20 = 0.04 (4%). Kept at default 3%, dropped at custom 10%.
+        var json = """{"elements":[{"text":"","page_number":1,"category":"Image","bbox":{"x":0.1,"y":0.1,"width":0.20,"height":0.20}}]}""";
+        ImageRegionExtractor.FromHiResJson(json).Should().HaveCount(1);
+        ImageRegionExtractor.FromHiResJson(json, minAreaFraction: 0.10).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void FromHiResJson_AreaExactlyAtThreshold_IsKept()
+    {
+        // area = 0.30*0.10 = 0.03 == default threshold → kept (>=)
+        var json = """{"elements":[{"text":"","page_number":1,"category":"Image","bbox":{"x":0.0,"y":0.0,"width":0.30,"height":0.10}}]}""";
+        ImageRegionExtractor.FromHiResJson(json).Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void FromHiResJson_ZeroThreshold_DisablesFilter()
+    {
+        // tiny region kept when threshold is 0
+        var json = """{"elements":[{"text":"","page_number":1,"category":"Image","bbox":{"x":0.1,"y":0.1,"width":0.01,"height":0.01}}]}""";
+        ImageRegionExtractor.FromHiResJson(json, minAreaFraction: 0.0).Should().HaveCount(1);
+    }
+```
+
+Il test `FromHiResJson_ClampsBboxToUnitRange` esistente usa area `1.0*0.2 = 0.2` (dopo clamp) → sopra soglia, resta verde. I test `FromHiResJson_NullEmptyInvalidOrNoElements_ReturnsEmpty` restano invariati.
+
+- [ ] **Step 2: Esegui i test e verifica che falliscano**
+
+Run: `cd apps/api && dotnet test MeepleAI.Api.sln --filter "FullyQualifiedName~ImageRegionExtractorTests" --nologo`
+Expected: FAIL (compilazione: `DefaultMinAreaFraction`/parametro `minAreaFraction` non esistono; `HaveCount(2)` vs vecchio comportamento).
+
+- [ ] **Step 3: Implementa il filtro area in `ImageRegionExtractor`**
+
+In `ImageRegionExtractor.cs`, aggiungi la const e il parametro, e inserisci il filtro area dopo la `Select` (così opera sui valori clampati). Sostituisci il corpo di `FromHiResJson`:
+
+```csharp
+public static class ImageRegionExtractor
+{
+    /// <summary>Default anti-noise threshold (#3456): keep regions whose normalized area
+    /// (Width*Height, fraction of page) is at least 3%. Filters out icons/glyphs.</summary>
+    public const double DefaultMinAreaFraction = 0.03;
+
+    private static readonly HashSet<string> RegionCategories =
+        new(StringComparer.Ordinal) { "Image", "FigureCaption" };
+
+    public static IReadOnlyList<ExtractedImageRegion> FromHiResJson(
+        string? hiResJson,
+        double minAreaFraction = DefaultMinAreaFraction)
+    {
+        if (string.IsNullOrWhiteSpace(hiResJson))
+        {
+            return Array.Empty<ExtractedImageRegion>();
+        }
+
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<HiResEnvelope>(hiResJson);
+            if (parsed?.Elements is null)
+            {
+                return Array.Empty<ExtractedImageRegion>();
+            }
+
+            return parsed.Elements
+                .Where(e => e.Category is not null && RegionCategories.Contains(e.Category) && e.Bbox is not null)
+                .Select(e => new ExtractedImageRegion(
+                    Page: e.PageNumber > 0 ? e.PageNumber : 1,
+                    X: Clamp01(e.Bbox!.X),
+                    Y: Clamp01(e.Bbox!.Y),
+                    Width: Clamp01(e.Bbox!.Width),
+                    Height: Clamp01(e.Bbox!.Height),
+                    ElementType: e.Category!))
+                // #3456 anti-noise: drop tiny regions (icons/glyphs) below the area threshold.
+                // Area is on already-clamped values; >= keeps a region exactly at the threshold.
+                .Where(r => r.Width * r.Height >= minAreaFraction)
+                .ToList();
+        }
+        catch (JsonException)
+        {
+            return Array.Empty<ExtractedImageRegion>();
+        }
+    }
+```
+
+(Il resto della classe — `Clamp01`, i record `HiResEnvelope`/`HiResElement`/`HiResBbox`, e `ExtractedImageRegion` — resta invariato.)
+
+- [ ] **Step 4: Esegui i test e verifica che passino**
+
+Run: `cd apps/api && dotnet test MeepleAI.Api.sln --filter "FullyQualifiedName~ImageRegionExtractorTests" --nologo`
+Expected: PASS (tutti).
+
+- [ ] **Step 5: Commit** (background per via degli hook — poi verifica con `git log`)
+
+```bash
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/ImageRegionExtractor.cs \
+        apps/api/tests/Api.Tests/Unit/DocumentProcessing/ImageRegionExtractorTests.cs
+git commit -m "feat(rag): area-minima anti-rumore in ImageRegionExtractor (#3456)"
+```
+
+---
+
+### Task 2: Propaga la soglia configurabile attraverso il seed (#3456)
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/SeedPdfImageRegionsCommand.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/SeedPdfImageRegionsCommandHandler.cs:36`
+- Modify: `apps/api/src/Api/Routing/AdminPdfManagementEndpoints.cs:76-86,127`
+- Test: `apps/api/tests/Api.Tests/Unit/DocumentProcessing/SeedPdfImageRegionsCommandHandlerTests.cs`
+
+**Interfaces:**
+- Consumes: `ImageRegionExtractor.FromHiResJson(hiResJson, minAreaFraction)` e `ImageRegionExtractor.DefaultMinAreaFraction` (Task 1).
+- Produces: `SeedPdfImageRegionsCommand(Guid PdfId, string HiResJson, double? MinAreaFraction = null)`; `SeedImageRegionsRequest(string HiResJson, double? MinAreaFraction = null)`.
+
+- [ ] **Step 1: Aggiungi i test dell'handler per la soglia**
+
+In `SeedPdfImageRegionsCommandHandlerTests.cs` aggiungi due test. Usano una regione piccola (area 2% < 3%) che il default scarta ma una soglia custom `0.0` conserva. Nota: la costruzione `new SeedPdfImageRegionsCommand(pdfId, json)` resta valida (il nuovo parametro è opzionale), quindi i test esistenti non cambiano.
+
+```csharp
+    private const string TinyRegionJson = """
+    {"elements":[
+      {"text":"","page_number":2,"category":"Image","bbox":{"x":0.1,"y":0.1,"width":0.10,"height":0.20}}
+    ]}
+    """;
+
+    [Fact]
+    public async Task Handle_DefaultThreshold_DropsTinyRegion()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext($"seedimg_{Guid.NewGuid():N}");
+        var pdfId = Guid.NewGuid();
+        SeedPdf(db, pdfId);
+        await db.SaveChangesAsync();
+        var handler = new SeedPdfImageRegionsCommandHandler(db, NullLogger<SeedPdfImageRegionsCommandHandler>.Instance);
+
+        // 0.10*0.20 = 0.02 (2%) < default 3% → nothing seeded
+        var count = await handler.Handle(new SeedPdfImageRegionsCommand(pdfId, TinyRegionJson), CancellationToken.None);
+        count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_CustomThresholdZero_KeepsTinyRegion()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext($"seedimg_{Guid.NewGuid():N}");
+        var pdfId = Guid.NewGuid();
+        SeedPdf(db, pdfId);
+        await db.SaveChangesAsync();
+        var handler = new SeedPdfImageRegionsCommandHandler(db, NullLogger<SeedPdfImageRegionsCommandHandler>.Instance);
+
+        var count = await handler.Handle(new SeedPdfImageRegionsCommand(pdfId, TinyRegionJson, MinAreaFraction: 0.0), CancellationToken.None);
+        count.Should().Be(1);
+    }
+```
+
+- [ ] **Step 2: Esegui i test e verifica che falliscano**
+
+Run: `cd apps/api && dotnet test MeepleAI.Api.sln --filter "FullyQualifiedName~SeedPdfImageRegionsCommandHandlerTests" --nologo`
+Expected: FAIL (compilazione: `SeedPdfImageRegionsCommand` non ha `MinAreaFraction`).
+
+- [ ] **Step 3: Aggiungi il parametro al command, request e propagalo nell'handler + endpoint**
+
+`SeedPdfImageRegionsCommand.cs` — aggiungi il parametro opzionale al record:
+
+```csharp
+internal sealed record SeedPdfImageRegionsCommand(Guid PdfId, string HiResJson, double? MinAreaFraction = null) : ICommand<int>;
+```
+
+`SeedPdfImageRegionsCommandHandler.cs` riga 36 — passa la soglia (fallback al default della slice):
+
+```csharp
+        var regions = ImageRegionExtractor.FromHiResJson(
+            command.HiResJson,
+            command.MinAreaFraction ?? ImageRegionExtractor.DefaultMinAreaFraction);
+```
+
+`AdminPdfManagementEndpoints.cs` riga 127 — aggiungi il campo opzionale al request record:
+
+```csharp
+internal record SeedImageRegionsRequest(string HiResJson, double? MinAreaFraction = null);
+```
+
+`AdminPdfManagementEndpoints.cs` righe 82-84 — propaga la soglia al command:
+
+```csharp
+        var count = await mediator.Send(
+            new SeedPdfImageRegionsCommand(pdfId, request.HiResJson, request.MinAreaFraction),
+            cancellationToken).ConfigureAwait(false);
+```
+
+- [ ] **Step 4: Esegui i test dell'handler e la build della solution**
+
+Run: `cd apps/api && dotnet test MeepleAI.Api.sln --filter "FullyQualifiedName~SeedPdfImageRegionsCommandHandlerTests" --nologo`
+Expected: PASS (vecchi + 2 nuovi).
+Run (verifica ctor call-site endpoint): `cd apps/api && dotnet build MeepleAI.Api.sln --nologo`
+Expected: Build succeeded, 0 error.
+
+- [ ] **Step 5: Commit** (background — poi verifica con `git log`)
+
+```bash
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/SeedPdfImageRegionsCommand.cs \
+        apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/SeedPdfImageRegionsCommandHandler.cs \
+        apps/api/src/Api/Routing/AdminPdfManagementEndpoints.cs \
+        apps/api/tests/Api.Tests/Unit/DocumentProcessing/SeedPdfImageRegionsCommandHandlerTests.cs
+git commit -m "feat(rag): soglia area configurabile per-seed nell'endpoint image-regions (#3456)"
+```
+
+---
+
+### Task 3: Rebuild + verifica immagine `unstructured-service` (#3455)
+
+**Files:** nessuna modifica sorgente (il sorgente ha già #3406). Task ops, nessun commit.
+
+**Interfaces:** verifica AC3 (immagine ricostruita contiene `normalized_bbox`).
+
+- [ ] **Step 1: Build dell'immagine unstructured-service dal sorgente attuale**
+
+Il build è lungo (unstructured + torch + NLTK) → eseguilo in background e attendi la notifica.
+
+Run (background): `cd infra && docker compose build unstructured-service`
+Expected: `Successfully built` / servizio buildato senza errori.
+
+- [ ] **Step 2: Avvia il servizio e verifica `#3406` dentro l'immagine ricostruita**
+
+```bash
+cd infra && docker compose up -d unstructured-service
+docker exec meepleai-unstructured grep -rn "normalized_bbox" /app/src/api/coordinates.py
+```
+Expected: la `grep` trova `bbox=normalized_bbox(el)` / `def normalized_bbox` → conferma che l'immagine ricostruita include SP-B #3406.
+
+Se il container non parte per dipendenze mancanti (rete/env `[ai]`), ripiega sulla verifica statica dal builder:
+```bash
+cd infra && docker compose run --rm --no-deps unstructured-service grep -rn "normalized_bbox" /app/src/api/coordinates.py
+```
+
+- [ ] **Step 3: (Opzionale) Smoke `/extract` se agricola è disponibile localmente**
+
+Solo se il PDF agricola è raggiungibile in locale: `curl -F file=@<agricola.pdf> -F strategy=hi_res http://localhost:8001/extract` e verifica che gli `Image`/`FigureCaption` abbiano `bbox` popolato. Altrimenti salta (Step 2 è sufficiente per AC3); la verifica su staging resta checklist SSH documentata (Task 4).
+
+---
+
+### Task 4: Documenta la dipendenza rebuild↔coordinates nel runbook (#3455)
+
+**Files:**
+- Modify: `docs/for-developers/operations/deploy-staging-runbook.md`
+
+**Interfaces:** verifica AC4.
+
+- [ ] **Step 1: Aggiungi la nota di rebuild**
+
+Trova nel runbook una sezione adatta (deploy dei servizi / build immagini). Aggiungi un blocco con questo contenuto (adatta i titoli alla struttura esistente del file):
+
+```markdown
+### ⚠️ Rebuild `unstructured-service` quando cambia la pipeline coordinate
+
+Quando modifichi `apps/unstructured-service/src/api/coordinates.py` o `schemas.py`
+(pipeline delle coordinate bbox, es. SP-B #3406), l'immagine Docker deployata **NON**
+si aggiorna da sola: `partition_pdf` continua a girare sul codice bakeato nell'immagine.
+
+Sintomo di immagine stantia: `POST /extract` (strategy=hi_res) restituisce elementi
+`Image`/`FigureCaption` **senza** `bbox` (0 bbox), pur avendo la libreria le coordinate.
+
+Rebuild + verifica:
+```bash
+cd infra && docker compose build unstructured-service && docker compose up -d unstructured-service
+docker exec meepleai-unstructured grep -n normalized_bbox /app/src/api/coordinates.py   # deve trovare #3406
+```
+
+Ref: #3455 (epic #3435), slice #3447.
+```
+
+- [ ] **Step 2: Commit** (background — poi verifica con `git log`)
+
+```bash
+git add docs/for-developers/operations/deploy-staging-runbook.md
+git commit -m "docs(ops): nota rebuild unstructured quando cambia coordinates.py (#3455)"
+```
+
+---
+
+### Task 5: Gate finale + apertura PR
+
+**Files:** nessuna modifica; verifica AC5 e apertura PR.
+
+- [ ] **Step 1: Build + suite unit DocumentProcessing verde**
+
+Run: `cd apps/api && dotnet test MeepleAI.Api.sln --filter "BoundedContext=DocumentProcessing&Category=Unit" --nologo`
+Expected: PASS, 0 fail (baseline invariata).
+
+- [ ] **Step 2: Push del branch** (background — verifica con `git status`/`git log origin/...`)
+
+```bash
+git push -u origin feature/issue-3456-image-region-area-filter
+```
+
+- [ ] **Step 3: Apri la PR verso il parent `main-dev`**
+
+```bash
+gh pr create --base main-dev --head feature/issue-3456-image-region-area-filter \
+  --title "feat(rag): filtro area anti-rumore image-regions + rebuild unstructured (#3456, #3455)" \
+  --body "Closes #3456\nCloses #3455\n\n- #3456: filtro area-minima (default 3%, configurabile per-seed) in ImageRegionExtractor.\n- #3455: rebuild immagine unstructured (sorgente già #3406) + nota runbook deploy.\n\nSpec: docs/superpowers/specs/2026-08-02-image-region-area-filter-design.md"
+```
+
+- [ ] **Step 4: Aggiorna le checkbox/DoD delle issue #3456 e #3455 su GitHub** (spuntare le azioni completate; annotare che verifica staging via SSH e smoke agricola restano ops post-merge). Chiudere via merge PR (auto-delete branch attivo).
+
+---
+
+## Note per l'esecutore
+
+- **Ordine**: Task 1 → 2 (dipendenza: 2 usa la firma/const di 1). Task 3/4 (#3455) sono indipendenti da 1/2 e possono procedere in parallelo. Task 5 chiude.
+- **Rischio Task 3**: il build dell'immagine unstructured può richiedere 10-30 min e dipendere dalla rete; se fallisce/eccede, il codice #3456 (Task 1-2) e la doc (Task 4) restano deliverable committabili — annotare l'esito del rebuild nella issue senza bloccare la PR.

--- a/docs/superpowers/specs/2026-08-02-image-region-area-filter-design.md
+++ b/docs/superpowers/specs/2026-08-02-image-region-area-filter-design.md
@@ -1,0 +1,103 @@
+# Image-Region Anti-Noise Filter + Unstructured Image Refresh
+
+**Data**: 2026-08-02
+**Tipo**: design — brainstorming approvato
+**Issue**: #3456 (F2, filtro) · #3455 (F1, immagine unstructured) · **Epic**: #3435 · **Origine**: validazione slice #3447
+**Branch**: `feature/issue-3456-image-region-area-filter` (parent `main-dev`)
+
+## Obiettivo
+
+Ridurre il rumore nella cattura delle regioni immagine-tabella (#3447) e garantire che l'immagine
+`unstructured-service` emetta i bbox necessari:
+
+- **#3456** — le 613 regioni catturate su agricola sono dominate da icone/glifi minuscoli (mediana area
+  **0.03%** pagina); solo **~32** hanno area >3% e cadono sulle vere figure/tessere/board. Introdurre un
+  **filtro area minima** lato estrazione.
+- **#3455** — `/extract` restituiva 0 bbox perché l'immagine Docker deployata **precede** SP-B #3406
+  (`bbox=normalized_bbox(el)`). Il sorgente è già a posto; serve **rebuild** dell'immagine + nota nel
+  runbook di deploy.
+
+## Contesto
+
+- `ImageRegionExtractor.FromHiResJson` (`apps/api/.../DocumentProcessing/Application/Services/`) oggi tiene
+  **tutti** gli `Image`/`FigureCaption` con bbox. L'area normalizzata di una regione è `Width * Height` ∈ [0,1]
+  (frazione di pagina). Consumatore: `SeedPdfImageRegionsCommandHandler` → `pdf_image_regions`.
+- `apps/unstructured-service/src/api/coordinates.py` contiene già `normalized_bbox` (#3406). Il difetto #3455
+  è puramente sull'**immagine Docker** buildata, non sul sorgente.
+
+## Decisioni (dal brainstorming)
+
+| # | Decisione | Motivazione |
+|---|-----------|-------------|
+| **D-1** | Filtro **lato BE estrazione** (in `FromHiResJson`), non FE resa | DB `pdf_image_regions` pulito (~32 vs 613), query/overlay semplici; ritaratura = re-seed (già idempotente replace-by-pdf) |
+| **D-2** | Soglia **configurabile per-seed**, default **3%** (`0.03`) | #3456 chiede soglia "tarata su più rulebook"; esporla nel command/request permette taratura per-rulebook senza redeploy |
+| **D-3** | **Solo area**, niente filtro per-tipo | YAGNI: l'obiettivo sono figure/tessere/board di area grande; un ramo per-tipo aggiunge complessità senza guadagno dimostrato. `FigureCaption` legittime di area >soglia restano incluse |
+| **D-4** | Area calcolata sui valori **già clampati** [0,1] | Coerente con ciò che l'overlay disegna; evita che un bbox degenere fuori-range superi la soglia |
+| **D-5** | Confronto **`>=`** (soglia inclusiva) | Determinismo su valori-limite; una regione esattamente alla soglia è "abbastanza grande" |
+| **D-6** | #3455: **rebuild immagine + doc**, nessuna modifica Python | Il sorgente ha già #3406; il valore è ricostruire l'immagine e documentare la dipendenza |
+| **D-7** | **Un branch/PR** per le due issue | Accoppiate: il filtro #3456 si valida end-to-end solo con un'immagine unstructured che emette bbox (#3455) |
+
+## Architettura / modifiche
+
+### #3456 — filtro area (BE)
+
+```
+FromHiResJson(hiResJson, minAreaFraction = 0.03)
+  parse → Where(category ∈ {Image,FigureCaption} && bbox != null)
+        → Select(clamp01 su X,Y,W,H)
+        → Where(W * H >= minAreaFraction)      ← NUOVO filtro anti-rumore
+        → ExtractedImageRegion[]
+```
+
+- **`ImageRegionExtractor.FromHiResJson`**: nuovo parametro `double minAreaFraction = 0.03`. Il filtro area
+  si applica **dopo** il clamp (D-4), con `>=` (D-5). Firma pura, testabile senza HTTP.
+- **`SeedImageRegionsRequest`** (record del body admin): nuovo campo `double? MinAreaFraction` opzionale.
+- **`SeedPdfImageRegionsCommand`**: nuovo campo `double? MinAreaFraction`.
+- **`SeedPdfImageRegionsCommandHandler`**: chiama `FromHiResJson(cmd.HiResJson, cmd.MinAreaFraction ?? 0.03)`.
+- **`AdminPdfManagementEndpoints.SeedImageRegions`**: propaga `request.MinAreaFraction` al command.
+
+### #3455 — immagine unstructured
+
+- **Rebuild**: `docker compose build unstructured-service` + `up -d`; verifica `grep normalized_bbox` dentro il
+  container conferma la presenza di #3406 nell'immagine ricostruita. Test `/extract` su agricola solo se il PDF
+  è disponibile localmente.
+- **Doc**: nota in `docs/for-developers/operations/deploy-staging-runbook.md` — l'immagine `unstructured-service`
+  va ri-buildata quando cambia la pipeline coordinate (`coordinates.py`/`schemas.py`), con comando di verifica.
+
+## Error handling / degradazione
+
+- Input null/vuoto/JSON invalido → `[]` (invariato).
+- Nessuna regione sopra soglia → `[]` → viewer senza rect, nessun errore (coerente con AC4 di #3447).
+- `minAreaFraction` fuori range non è validato lato dominio: 0 = nessun filtro (retro-compat effettiva),
+  >1 = tutto droppato; la responsabilità della taratura è del chiamante seed.
+
+## Testing
+
+- **BE unit** (`ImageRegionExtractorTests`):
+  - fixture aggiornato: `FigureCaption` area >3% resta "tenuta"; aggiunta una `Image` piccola (<3%) droppata.
+  - `FromHiResJson_DropsRegionsBelowMinArea` — regione sotto soglia scartata, sopra soglia tenuta.
+  - `FromHiResJson_RespectsCustomMinArea` — soglia custom (es. 0.10) cambia l'esito.
+  - `FromHiResJson_AreaExactlyAtThreshold_IsKept` — edge `>=`.
+  - `FromHiResJson_DefaultThreshold_IsThreePercent` — verifica default.
+  - i test null/empty/invalid e clamp restano verdi.
+- **BE unit** (handler, se necessario): il default 3% è applicato quando `MinAreaFraction` è null.
+- **Gate**: build BE verde; baseline unit invariata (0 fail).
+
+## Criteri di accettazione
+
+- **AC1** (#3456) — `FromHiResJson` con default scarta le regioni con `W*H < 0.03`, tiene le altre.
+- **AC2** (#3456) — la soglia è sovrascrivibile per-seed via `SeedImageRegionsRequest.MinAreaFraction`.
+- **AC3** (#3455) — immagine `unstructured-service` ricostruita contiene `normalized_bbox` (verifica in-container).
+- **AC4** (#3455) — `deploy-staging-runbook.md` documenta la dipendenza rebuild↔coordinates.
+- **AC5** — build BE verde; baseline test invariata.
+
+## Non-goal (deferiti a #3435)
+
+- Trigger async hi_res in-pipeline; linkage citazione→regione; estrazione contenuto; scala corpus.
+- Filtro per-tipo / privilegiare `FigureCaption` (D-3): rivalutabile se la taratura su più rulebook lo richiede.
+- Verifica immagine staging/prod via SSH: resta checklist ops documentata (non eseguibile da questa sessione).
+
+## Riferimenti
+
+- Slice #3447: `docs/superpowers/specs/2026-08-01-image-table-region-slice-design.md`.
+- SP-B #3406 (`coordinates.py`/`normalized_bbox`), #3403 (`PdfBBoxOverlay`, normalizzazione/clamp).


### PR DESCRIPTION
Release promote. 4 commit.

## Attiva le cover (fix critico)
- #3464 — SkiaSharp native Linux v119 (sblocca definitivamente la generazione cover-da-PDF; segue #3457 fontconfig)

## Lavoro parallelo incluso
- #3462 — RAG: filtro area anti-rumore image-regions + rebuild unstructured
- #3465 — kb: rimuove SelectedDocumentIds dal contratto config
- #3463 — session-live: rimuove affordance decorative FE

## Post-deploy (cover)
Ri-reset 86 PDF `Failed→Pending` → BackfillPdfCoversJob genera. Tracciato #3454.

Generated with Claude Code