### PR TITLE
feat(rag): golden eval-set + page-level citation-accuracy metric (#3467)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Evaluation/Commands/MergeLabelsCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Evaluation/Commands/MergeLabelsCommand.cs
@@ -10,5 +10,9 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Evaluation.Commands;
 /// </summary>
 /// <param name="DatasetPath">Path to the dataset JSON file to load samples from.</param>
 /// <param name="Review">The reviewed labeling candidates to merge.</param>
-internal sealed record MergeLabelsCommand(string DatasetPath, LabelingReview Review)
+/// <param name="OutputPath">
+/// Optional destination for persisting the merged dataset JSON. When null, the merge is in-memory
+/// only (backward compatible); when set, the handler writes the labeled dataset to this path.
+/// </param>
+internal sealed record MergeLabelsCommand(string DatasetPath, LabelingReview Review, string? OutputPath = null)
     : IRequest<EvaluationDataset>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Evaluation/Commands/MergeLabelsCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Evaluation/Commands/MergeLabelsCommandHandler.cs
@@ -39,7 +39,10 @@ internal sealed class MergeLabelsCommandHandler : IRequestHandler<MergeLabelsCom
                     .ToList(),
                 StringComparer.Ordinal);
 
-        var merged = EvaluationDataset.Create(dataset.Name, dataset.Description, dataset.SourceType);
+        // Preserve source metadata (Version/CreatedAt) — persisting an in-place merge must not silently
+        // downgrade the version-tracked golden dataset.
+        var merged = EvaluationDataset.Create(
+            dataset.Name, dataset.Description, dataset.SourceType, dataset.Version, dataset.CreatedAt);
 
         foreach (var sample in dataset.Samples)
         {
@@ -55,6 +58,18 @@ internal sealed class MergeLabelsCommandHandler : IRequestHandler<MergeLabelsCom
             relevantChunkIdsBySampleId.Count,
             dataset.Count,
             request.DatasetPath);
+
+        // Persistence is opt-in: when an OutputPath is supplied, write the labeled dataset back to disk
+        // (closing the labeling round-trip); otherwise the merge stays in-memory (backward compatible).
+        // Write to a temp file then move-with-overwrite so a crash/concurrent write can never truncate the
+        // (possibly in-place / version-tracked) destination file.
+        if (!string.IsNullOrWhiteSpace(request.OutputPath))
+        {
+            var tempPath = request.OutputPath + ".tmp";
+            await File.WriteAllTextAsync(tempPath, merged.ToJson(), cancellationToken).ConfigureAwait(false);
+            File.Move(tempPath, request.OutputPath, overwrite: true);
+            _logger.LogInformation("Persisted merged dataset to '{OutputPath}'", request.OutputPath);
+        }
 
         return merged;
     }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Evaluation/Services/DatasetEvaluationService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Evaluation/Services/DatasetEvaluationService.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Api.BoundedContexts.KnowledgeBase.Domain.Evaluation;
+using Api.BoundedContexts.KnowledgeBase.Domain.Services;
 using Api.Services;
 using Microsoft.Extensions.Logging;
 
@@ -13,13 +14,19 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Evaluation.Services;
 internal sealed class DatasetEvaluationService : IDatasetEvaluationService
 {
     private readonly IRagService _ragService;
+    private readonly InlineCitationMatcherService _citationMatcher;
+    private readonly ICitationValidationService _citationValidation;
     private readonly ILogger<DatasetEvaluationService> _logger;
 
     public DatasetEvaluationService(
         IRagService ragService,
+        InlineCitationMatcherService citationMatcher,
+        ICitationValidationService citationValidation,
         ILogger<DatasetEvaluationService> logger)
     {
         _ragService = ragService ?? throw new ArgumentNullException(nameof(ragService));
+        _citationMatcher = citationMatcher ?? throw new ArgumentNullException(nameof(citationMatcher));
+        _citationValidation = citationValidation ?? throw new ArgumentNullException(nameof(citationValidation));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -121,11 +128,30 @@ internal sealed class DatasetEvaluationService : IDatasetEvaluationService
             var hitAt10 = HasHitAtK(retrievedChunkIds, relevantChunkIds, 10);
             var (dcg, idealDcg) = CalculateDcgComponents(retrievedChunkIds, relevantChunkIds, 10);
 
-            // Calculate answer correctness using keyword matching
+            // Calculate answer correctness using keyword/word-overlap matching (deterministic, CI-stable;
+            // NOT an LLM-as-judge despite historical naming).
             var answerCorrectness = CalculateAnswerCorrectness(
                 sample.ExpectedAnswer,
                 ragResponse.answer ?? "",
                 sample.ExpectedKeywords);
+
+            // Citation accuracy (#3467): page-level, stable across corpus re-index. The pages the answer
+            // actually cites come from InlineCitationMatcherService (phrases in the answer grounded to
+            // snippets), compared to the sample's ExpectedCitations per its match policy. Structural
+            // validity is a separate trust floor (well-formed PDF:guid + existing doc + page in range).
+            var snippets = ragResponse.snippets ?? [];
+            var inlineMatches = _citationMatcher.Match(ragResponse.answer ?? string.Empty, snippets);
+            var actualCitationPages = inlineMatches
+                .Select(m => m.PageNumber)
+                .Distinct()
+                .OrderBy(p => p)
+                .ToList();
+            bool? citationMatched = sample.ExpectedCitations?.IsSatisfiedBy(actualCitationPages);
+            var expectedCitationPages = sample.ExpectedCitations?.PrimaryPages.ToList() ?? [];
+
+            var citationValidation = await _citationValidation
+                .ValidateCitationsAsync(snippets, sample.GameId ?? string.Empty, cancellationToken)
+                .ConfigureAwait(false);
 
             return new EvaluationSampleResult
             {
@@ -141,6 +167,10 @@ internal sealed class DatasetEvaluationService : IDatasetEvaluationService
                 DcgAt10 = dcg,
                 IdealDcgAt10 = idealDcg,
                 AnswerCorrectness = answerCorrectness,
+                ActualCitationPages = actualCitationPages,
+                ExpectedCitationPages = expectedCitationPages,
+                CitationMatched = citationMatched,
+                CitationStructuralValidity = citationValidation.ValidationAccuracy,
                 LatencyMs = stopwatch.Elapsed.TotalMilliseconds,
                 Confidence = ragResponse.confidence ?? 0.0
             };
@@ -262,6 +292,12 @@ internal sealed class DatasetEvaluationService : IDatasetEvaluationService
         return (dcg, idealDcg);
     }
 
+    /// <summary>
+    /// Deterministic answer-correctness heuristic: expected-keyword hit rate when keywords are provided,
+    /// else containment / word-overlap between expected and generated answers. This is intentionally NOT
+    /// an LLM-as-judge — it is kept keyword-based so scores are deterministic and CI-stable (a real
+    /// LLM-judge is explicitly out of scope, YAGNI).
+    /// </summary>
     private static double CalculateAnswerCorrectness(
         string expectedAnswer,
         string generatedAnswer,

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Evaluation/Services/EvaluationReportFormatter.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Evaluation/Services/EvaluationReportFormatter.cs
@@ -89,15 +89,18 @@ internal static class EvaluationReportFormatter
         AppendMetricRow(sb, "MRR", metrics.Mrr);
         AppendMetricRow(sb, "P95 Latency (ms)", metrics.P95LatencyMs);
         AppendMetricRow(sb, "Answer Correctness", metrics.AnswerCorrectness);
+        AppendMetricRow(sb, "Citation Accuracy", metrics.CitationAccuracy);
+        AppendMetricRow(sb, "Citation Structural Validity", metrics.CitationStructuralValidity);
         sb.Append("| Sample Count | ").Append(metrics.SampleCount.ToString(CultureInfo.InvariantCulture)).AppendLine(" |");
         sb.Append("| Labeled | ").Append(metrics.LabeledSampleCount.ToString(CultureInfo.InvariantCulture)).AppendLine(" |");
         sb.Append("| Unlabeled | ").Append(metrics.UnlabeledSampleCount.ToString(CultureInfo.InvariantCulture)).AppendLine(" |");
+        sb.Append("| Cited | ").Append(metrics.CitedSampleCount.ToString(CultureInfo.InvariantCulture)).AppendLine(" |");
         sb.AppendLine();
 
         sb.AppendLine("## Metrics by Language");
         sb.AppendLine();
-        sb.AppendLine("| Language | Recall@5 | Recall@10 | nDCG@10 | MRR | Answer Correctness | Labeled | Unlabeled |");
-        sb.AppendLine("| --- | --- | --- | --- | --- | --- | --- | --- |");
+        sb.AppendLine("| Language | Recall@5 | Recall@10 | nDCG@10 | MRR | Answer Correctness | Citation Accuracy | Labeled | Unlabeled |");
+        sb.AppendLine("| --- | --- | --- | --- | --- | --- | --- | --- | --- |");
 
         foreach (var (language, languageMetrics) in byLanguage.OrderBy(kvp => kvp.Key, StringComparer.Ordinal))
         {
@@ -107,6 +110,7 @@ internal static class EvaluationReportFormatter
               .Append(" | ").Append(FormatDouble(languageMetrics.NdcgAt10))
               .Append(" | ").Append(FormatDouble(languageMetrics.Mrr))
               .Append(" | ").Append(FormatDouble(languageMetrics.AnswerCorrectness))
+              .Append(" | ").Append(FormatDouble(languageMetrics.CitationAccuracy))
               .Append(" | ").Append(languageMetrics.LabeledSampleCount.ToString(CultureInfo.InvariantCulture))
               .Append(" | ").Append(languageMetrics.UnlabeledSampleCount.ToString(CultureInfo.InvariantCulture))
               .AppendLine(" |");
@@ -159,7 +163,10 @@ internal static class EvaluationReportFormatter
         AnswerCorrectness = metrics.AnswerCorrectness,
         SampleCount = metrics.SampleCount,
         LabeledSampleCount = metrics.LabeledSampleCount,
-        UnlabeledSampleCount = metrics.UnlabeledSampleCount
+        UnlabeledSampleCount = metrics.UnlabeledSampleCount,
+        CitationAccuracy = metrics.CitationAccuracy,
+        CitationStructuralValidity = metrics.CitationStructuralValidity,
+        CitedSampleCount = metrics.CitedSampleCount
     };
 
     private sealed class ReportProjection
@@ -193,6 +200,9 @@ internal static class EvaluationReportFormatter
         public int SampleCount { get; init; }
         public int LabeledSampleCount { get; init; }
         public int UnlabeledSampleCount { get; init; }
+        public double CitationAccuracy { get; init; }
+        public double CitationStructuralValidity { get; init; }
+        public int CitedSampleCount { get; init; }
     }
 
     private sealed class CoverageProjection

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Evaluation/CitationMatchPolicy.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Evaluation/CitationMatchPolicy.cs
@@ -1,0 +1,21 @@
+namespace Api.BoundedContexts.KnowledgeBase.Domain.Evaluation;
+
+/// <summary>
+/// Policy for comparing the pages a generated answer actually cites against a sample's
+/// <see cref="ExpectedCitations.PrimaryPages"/> ground truth. Mirrors the Libro-Game golden-set
+/// schema (<c>tests/llm-eval/golden-set/schema.md</c>).
+/// </summary>
+internal enum CitationMatchPolicy
+{
+    /// <summary>Actual cited pages equal the expected pages exactly (set equality, order-independent).</summary>
+    Exact,
+
+    /// <summary>Intersection of actual and expected pages is non-empty. Pragmatic default.</summary>
+    OverlapAtLeastOne,
+
+    /// <summary>Actual cited pages are a subset of expected (no extra pages cited).</summary>
+    Subset,
+
+    /// <summary>Actual cited pages are a superset of expected (all expected pages present).</summary>
+    Superset
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Evaluation/CitationMatchPolicyWire.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Evaluation/CitationMatchPolicyWire.cs
@@ -1,0 +1,36 @@
+namespace Api.BoundedContexts.KnowledgeBase.Domain.Evaluation;
+
+/// <summary>
+/// Wire-format (snake_case) mapping for <see cref="CitationMatchPolicy"/>, matching the golden-set
+/// schema (<c>tests/llm-eval/golden-set/schema.md</c>): "exact", "overlap_at_least_one", "subset",
+/// "superset". Mapping is explicit (not naming-policy-derived) to keep the JSON contract stable.
+/// </summary>
+internal static class CitationMatchPolicyWire
+{
+    /// <summary>Renders the policy as its snake_case wire value.</summary>
+    public static string ToWireValue(this CitationMatchPolicy policy) => policy switch
+    {
+        CitationMatchPolicy.Exact => "exact",
+        CitationMatchPolicy.OverlapAtLeastOne => "overlap_at_least_one",
+        CitationMatchPolicy.Subset => "subset",
+        CitationMatchPolicy.Superset => "superset",
+        _ => "overlap_at_least_one"
+    };
+
+    /// <summary>
+    /// Parses a wire value. A null/blank value (an omitted match_policy) falls back to the pragmatic
+    /// default (overlap). A non-blank UNRECOGNIZED token throws — a typo must not silently degrade to the
+    /// loosest comparison, which would weaken the citation-accuracy gate in the false-negative direction (#3467).
+    /// </summary>
+    public static CitationMatchPolicy Parse(string? wireValue) => wireValue?.Trim().ToLowerInvariant() switch
+    {
+        null or "" => CitationMatchPolicy.OverlapAtLeastOne,
+        "exact" => CitationMatchPolicy.Exact,
+        "overlap_at_least_one" => CitationMatchPolicy.OverlapAtLeastOne,
+        "subset" => CitationMatchPolicy.Subset,
+        "superset" => CitationMatchPolicy.Superset,
+        _ => throw new ArgumentException(
+            $"Unrecognized citation match_policy '{wireValue}'. Expected one of: exact, overlap_at_least_one, subset, superset.",
+            nameof(wireValue))
+    };
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Evaluation/EvaluationDataset.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Evaluation/EvaluationDataset.cs
@@ -58,16 +58,24 @@ internal sealed class EvaluationDataset
     public int Count => _samples.Count;
 
     /// <summary>
-    /// Creates an empty dataset.
+    /// Creates an empty dataset. <paramref name="version"/> and <paramref name="createdAt"/> are optional so
+    /// callers that rebuild a dataset (e.g. the label-merge handler) can preserve the source metadata instead
+    /// of silently resetting version to the default and created_at to "now".
     /// </summary>
-    public static EvaluationDataset Create(string name, string description, string sourceType = "meepleai_custom")
+    public static EvaluationDataset Create(
+        string name,
+        string description,
+        string sourceType = "meepleai_custom",
+        string? version = null,
+        DateTime? createdAt = null)
     {
         return new EvaluationDataset
         {
             Name = name,
             Description = description,
             SourceType = sourceType,
-            CreatedAt = DateTime.UtcNow
+            Version = version ?? "1.0.0",
+            CreatedAt = createdAt ?? DateTime.UtcNow
         };
     }
 
@@ -227,7 +235,14 @@ internal sealed class EvaluationDataset
                 ExpectedKeywords = s.ExpectedKeywords.ToList(),
                 RelevantChunkIds = s.RelevantChunkIds.ToList(),
                 DatasetSource = s.DatasetSource,
-                Language = s.Language
+                Language = s.Language,
+                ExpectedCitations = s.ExpectedCitations is null
+                    ? null
+                    : new ExpectedCitationsDto
+                    {
+                        PrimaryPages = s.ExpectedCitations.PrimaryPages.ToList(),
+                        MatchPolicy = s.ExpectedCitations.MatchPolicy.ToWireValue()
+                    }
             }).ToList()
         };
 
@@ -267,7 +282,14 @@ internal sealed class EvaluationDataset
                 ExpectedKeywords = sampleDto.ExpectedKeywords ?? [],
                 RelevantChunkIds = sampleDto.RelevantChunkIds ?? [],
                 DatasetSource = sampleDto.DatasetSource ?? "unknown",
-                Language = sampleDto.Language
+                Language = sampleDto.Language,
+                ExpectedCitations = sampleDto.ExpectedCitations is null
+                    ? null
+                    : new ExpectedCitations
+                    {
+                        PrimaryPages = sampleDto.ExpectedCitations.PrimaryPages ?? [],
+                        MatchPolicy = CitationMatchPolicyWire.Parse(sampleDto.ExpectedCitations.MatchPolicy)
+                    }
             };
             dataset._samples.Add(sample);
         }
@@ -300,5 +322,12 @@ internal sealed class EvaluationDataset
         public List<string>? RelevantChunkIds { get; set; }
         public string? DatasetSource { get; set; }
         public string? Language { get; set; }
+        public ExpectedCitationsDto? ExpectedCitations { get; set; }
+    }
+
+    private sealed class ExpectedCitationsDto
+    {
+        public List<int>? PrimaryPages { get; set; }
+        public string? MatchPolicy { get; set; }
     }
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Evaluation/EvaluationMetrics.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Evaluation/EvaluationMetrics.cs
@@ -32,8 +32,8 @@ internal sealed record EvaluationMetrics
     public double P95LatencyMs { get; init; }
 
     /// <summary>
-    /// Answer correctness score from LLM-as-judge evaluation.
-    /// Range: 0.0 to 1.0
+    /// Answer correctness score from deterministic keyword / word-overlap matching (NOT an LLM-as-judge;
+    /// kept keyword-based for CI stability). Range: 0.0 to 1.0.
     /// </summary>
     public double AnswerCorrectness { get; init; }
 
@@ -53,6 +53,24 @@ internal sealed record EvaluationMetrics
     public int UnlabeledSampleCount { get; init; }
 
     /// <summary>
+    /// Citation accuracy (0..1): among citation-graded samples (those with <c>ExpectedCitations</c>),
+    /// the fraction whose actual cited pages satisfy the expected pages per the sample's match policy.
+    /// Page-level, so stable across corpus re-index (#3427).
+    /// </summary>
+    public double CitationAccuracy { get; init; }
+
+    /// <summary>
+    /// Structural validity (0..1): mean fraction of well-formed citations (PDF:guid + existing document +
+    /// page in range) across successful samples. A trust floor separate from page-accuracy.
+    /// </summary>
+    public double CitationStructuralValidity { get; init; }
+
+    /// <summary>
+    /// Number of citation-graded samples (with <c>ExpectedCitations</c>) contributing to <see cref="CitationAccuracy"/>.
+    /// </summary>
+    public int CitedSampleCount { get; init; }
+
+    /// <summary>
     /// Empty metrics instance for fallback scenarios.
     /// </summary>
     public static EvaluationMetrics Empty => new()
@@ -65,7 +83,10 @@ internal sealed record EvaluationMetrics
         AnswerCorrectness = 0.0,
         SampleCount = 0,
         LabeledSampleCount = 0,
-        UnlabeledSampleCount = 0
+        UnlabeledSampleCount = 0,
+        CitationAccuracy = 0.0,
+        CitationStructuralValidity = 0.0,
+        CitedSampleCount = 0
     };
 
     /// <summary>
@@ -80,7 +101,10 @@ internal sealed record EvaluationMetrics
         double answerCorrectness,
         int sampleCount,
         int labeledSampleCount = 0,
-        int unlabeledSampleCount = 0)
+        int unlabeledSampleCount = 0,
+        double citationAccuracy = 0.0,
+        double citationStructuralValidity = 0.0,
+        int citedSampleCount = 0)
     {
         return new EvaluationMetrics
         {
@@ -92,7 +116,10 @@ internal sealed record EvaluationMetrics
             AnswerCorrectness = Math.Clamp(answerCorrectness, 0.0, 1.0),
             SampleCount = Math.Max(0, sampleCount),
             LabeledSampleCount = Math.Max(0, labeledSampleCount),
-            UnlabeledSampleCount = Math.Max(0, unlabeledSampleCount)
+            UnlabeledSampleCount = Math.Max(0, unlabeledSampleCount),
+            CitationAccuracy = Math.Clamp(citationAccuracy, 0.0, 1.0),
+            CitationStructuralValidity = Math.Clamp(citationStructuralValidity, 0.0, 1.0),
+            CitedSampleCount = Math.Max(0, citedSampleCount)
         };
     }
 
@@ -121,6 +148,16 @@ internal sealed record EvaluationMetrics
         var mrr = labeled.Count > 0 ? labeled.Average(r => r.ReciprocalRank) : 0.0;
         var answerCorrectness = successful.Average(r => r.AnswerCorrectness);
 
+        // Citation accuracy is computed only over "citation-graded" samples (those with ExpectedCitations,
+        // i.e. CitationMatched != null) so ungraded samples cannot silently pollute it — mirroring how
+        // retrieval metrics exclude unlabeled samples. Structural validity is a trust floor over ALL
+        // successful samples (a sample that cited nothing is vacuously valid, CitationStructuralValidity = 1.0).
+        var citationGraded = successful.Where(r => r.CitationMatched.HasValue).ToList();
+        var citationAccuracy = citationGraded.Count > 0
+            ? citationGraded.Average(r => r.CitationMatched!.Value ? 1.0 : 0.0)
+            : 0.0;
+        var citationStructuralValidity = successful.Average(r => r.CitationStructuralValidity);
+
         // Calculate P95 latency over all successful samples
         var latencies = successful.Select(r => r.LatencyMs).OrderBy(l => l).ToList();
         var p95Index = (int)Math.Ceiling(latencies.Count * 0.95) - 1;
@@ -135,7 +172,10 @@ internal sealed record EvaluationMetrics
             answerCorrectness: answerCorrectness,
             sampleCount: successful.Count,
             labeledSampleCount: labeled.Count,
-            unlabeledSampleCount: successful.Count - labeled.Count
+            unlabeledSampleCount: successful.Count - labeled.Count,
+            citationAccuracy: citationAccuracy,
+            citationStructuralValidity: citationStructuralValidity,
+            citedSampleCount: citationGraded.Count
         );
     }
 
@@ -155,4 +195,17 @@ internal sealed record EvaluationMetrics
     /// </summary>
     public bool MeetsPhase5Target() =>
         RecallAt10 >= 0.70 && P95LatencyMs < 1500.0;
+
+    /// <summary>
+    /// The citation-accuracy gate for the in-session live path (#3467): no enhancement wired in #3390
+    /// may regress citation accuracy below this page-level threshold.
+    /// </summary>
+    public const double CitationAccuracyTarget = 0.80;
+
+    /// <summary>
+    /// Checks if metrics meet the citation-accuracy target (<see cref="CitationAccuracyTarget"/>).
+    /// This is the per-enhancement gate #3390 must satisfy, alongside <see cref="MeetsPhase5Target"/>.
+    /// </summary>
+    public bool MeetsCitationAccuracyTarget() =>
+        CitationAccuracy >= CitationAccuracyTarget;
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Evaluation/EvaluationResult.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Evaluation/EvaluationResult.cs
@@ -64,7 +64,7 @@ internal sealed record EvaluationSampleResult
     public double IdealDcgAt10 { get; init; }
 
     /// <summary>
-    /// Answer correctness score from keyword matching or LLM judge.
+    /// Answer correctness score from the deterministic keyword / word-overlap heuristic (not an LLM judge).
     /// </summary>
     public double AnswerCorrectness { get; init; }
 
@@ -77,6 +77,29 @@ internal sealed record EvaluationSampleResult
     /// Confidence score from RAG system.
     /// </summary>
     public double Confidence { get; init; }
+
+    /// <summary>
+    /// Pages the generated answer actually cited inline (distinct, from InlineCitationMatcher).
+    /// </summary>
+    public IReadOnlyList<int> ActualCitationPages { get; init; } = [];
+
+    /// <summary>
+    /// Ground-truth expected citation pages for this sample (from <c>ExpectedCitations.PrimaryPages</c>).
+    /// </summary>
+    public IReadOnlyList<int> ExpectedCitationPages { get; init; } = [];
+
+    /// <summary>
+    /// Whether the actual cited pages satisfy the sample's expected citations per its match policy.
+    /// Null = the sample has no <c>ExpectedCitations</c> (not citation-graded; excluded from CitationAccuracy).
+    /// </summary>
+    public bool? CitationMatched { get; init; }
+
+    /// <summary>
+    /// Structural validity sub-score (0..1): fraction of the response's citations that are well-formed
+    /// (PDF:guid + existing document + page in range), via CitationValidationService. Defaults to 1.0
+    /// (vacuously valid when the response cited nothing).
+    /// </summary>
+    public double CitationStructuralValidity { get; init; } = 1.0;
 
     /// <summary>
     /// Error message if evaluation failed.

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Evaluation/EvaluationSample.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Evaluation/EvaluationSample.cs
@@ -73,6 +73,13 @@ internal sealed record EvaluationSample
     public string? Language { get; init; }
 
     /// <summary>
+    /// Page-level citation ground truth for citation-accuracy scoring. Null = the sample is not
+    /// citation-graded (excluded from the CitationAccuracy aggregate). Page-level so it survives
+    /// corpus re-index (#3427), unlike <see cref="RelevantChunkIds"/>.
+    /// </summary>
+    public ExpectedCitations? ExpectedCitations { get; init; }
+
+    /// <summary>
     /// Creates a sample for Mozilla Structured QA format.
     /// </summary>
     public static EvaluationSample FromMozilla(

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Evaluation/ExpectedCitations.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Evaluation/ExpectedCitations.cs
@@ -1,0 +1,39 @@
+namespace Api.BoundedContexts.KnowledgeBase.Domain.Evaluation;
+
+/// <summary>
+/// Page-level citation ground truth for an <see cref="EvaluationSample"/>. Page-level (not chunk-id)
+/// so it stays stable across corpus re-index (#3427). Citation-accuracy compares the pages actually
+/// cited inline in a generated answer against <see cref="PrimaryPages"/> per <see cref="MatchPolicy"/>.
+/// </summary>
+internal sealed record ExpectedCitations
+{
+    /// <summary>
+    /// Ground-truth source page(s) where the answer is found. An empty list encodes the
+    /// "no answer expected" edge case (typically paired with <see cref="CitationMatchPolicy.Exact"/>).
+    /// </summary>
+    public IReadOnlyList<int> PrimaryPages { get; init; } = [];
+
+    /// <summary>How actual cited pages are compared to <see cref="PrimaryPages"/>. Defaults to overlap.</summary>
+    public CitationMatchPolicy MatchPolicy { get; init; } = CitationMatchPolicy.OverlapAtLeastOne;
+
+    /// <summary>
+    /// Whether the pages an answer actually cited satisfy this ground truth under <see cref="MatchPolicy"/>.
+    /// Comparison is set-based (page order and duplicates are irrelevant).
+    /// </summary>
+    public bool IsSatisfiedBy(IEnumerable<int> actualPages)
+    {
+        ArgumentNullException.ThrowIfNull(actualPages);
+
+        var actual = actualPages.ToHashSet();
+        var expected = PrimaryPages.ToHashSet();
+
+        return MatchPolicy switch
+        {
+            CitationMatchPolicy.Exact => actual.SetEquals(expected),
+            CitationMatchPolicy.OverlapAtLeastOne => actual.Overlaps(expected),
+            CitationMatchPolicy.Subset => actual.IsSubsetOf(expected),
+            CitationMatchPolicy.Superset => actual.IsSupersetOf(expected),
+            _ => actual.Overlaps(expected)
+        };
+    }
+}

--- a/apps/api/src/Api/Routing/KnowledgeBase/AdminEvalEndpoints.cs
+++ b/apps/api/src/Api/Routing/KnowledgeBase/AdminEvalEndpoints.cs
@@ -30,6 +30,11 @@ internal static class AdminEvalEndpoints
             .WithName("GenerateLabelingCandidates")
             .Produces<LabelingReview>(200)
             .WithSummary("Generate AI-proposed retrieval candidates from a dataset file, awaiting human relevance review");
+
+        group.MapPost("/merge-labels", HandleMergeLabels)
+            .WithName("MergeEvaluationLabels")
+            .Produces<string>(200, contentType: "application/json")
+            .WithSummary("Merge human-reviewed labeling verdicts into a dataset and persist the labeled dataset to file");
     }
 
     private static async Task<IResult> HandleRunRetrievalEvaluation(
@@ -80,6 +85,36 @@ internal static class AdminEvalEndpoints
         return Results.Ok(review);
     }
 
+    private static async Task<IResult> HandleMergeLabels(
+        MergeLabelsRequest request,
+        IMediator mediator,
+        CancellationToken ct)
+    {
+        // NOTE: this only rejects a missing/non-existent datasetPath with a 4xx before
+        // dispatching any command. Full path sandboxing (restricting datasetPath to an
+        // allowlisted root directory) is tracked in issue #3438.
+        var pathError = ValidateDatasetPath(request.DatasetPath);
+        if (pathError is not null)
+        {
+            return pathError;
+        }
+
+        // Guard Items too: a body like {"review":{}} deserializes to a non-null Review with a null Items,
+        // which would NRE (500) when the handler enumerates it — reject it as a 400 instead.
+        if (request.Review?.Items is null)
+        {
+            return Results.BadRequest(new { error = "review with items is required" });
+        }
+
+        // OutputPath defaults to the source dataset (apply labels in-place); callers may target a
+        // separate file. Path sandboxing of the output path is deferred to #3438 alongside datasetPath.
+        var merged = await mediator.Send(
+            new MergeLabelsCommand(request.DatasetPath, request.Review, request.OutputPath ?? request.DatasetPath),
+            ct).ConfigureAwait(false);
+
+        return Results.Text(merged.ToJson(), "application/json");
+    }
+
     private static IResult? ValidateDatasetPath(string? datasetPath)
     {
         if (string.IsNullOrWhiteSpace(datasetPath))
@@ -98,3 +133,4 @@ internal static class AdminEvalEndpoints
 
 internal sealed record RunRetrievalEvaluationRequest(string DatasetPath, int? MaxSamples = null);
 internal sealed record GenerateLabelingCandidatesRequest(string DatasetPath, int? TopN = null);
+internal sealed record MergeLabelsRequest(string DatasetPath, LabelingReview Review, string? OutputPath = null);

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Evaluation/Commands/LabelingAssistTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Evaluation/Commands/LabelingAssistTests.cs
@@ -188,6 +188,132 @@ public class LabelingAssistTests
     }
 
     [Fact]
+    public async Task Merge_PreservesDatasetVersionAndCreatedAt()
+    {
+        // Arrange — a dataset carrying non-default version + created_at (the golden set is version-tracked).
+        const string json = """
+        {
+          "name": "versioned-dataset",
+          "description": "metadata-preservation regression",
+          "version": "1.1.0",
+          "source_type": "meepleai_custom",
+          "created_at": "2026-08-02T00:00:00Z",
+          "samples": [
+            { "id": "s1", "question": "Q1?", "expected_answer": "A1" }
+          ]
+        }
+        """;
+        var datasetPath = Path.GetTempFileName();
+        await File.WriteAllTextAsync(datasetPath, json);
+        var outputPath = Path.Combine(Path.GetTempPath(), $"merged-meta-{Guid.NewGuid():N}.json");
+        var original = EvaluationDataset.FromJson(json);
+
+        try
+        {
+            var handler = new MergeLabelsCommandHandler(Mock.Of<ILogger<MergeLabelsCommandHandler>>());
+            var command = new MergeLabelsCommand(datasetPath, new LabelingReview(new List<LabelingReviewItem>()), outputPath);
+
+            // Act
+            var merged = await handler.Handle(command, CancellationToken.None);
+
+            // Assert — merging must not silently downgrade version / reset created_at
+            merged.Version.Should().Be(original.Version);
+            merged.CreatedAt.Should().Be(original.CreatedAt);
+
+            var reloaded = EvaluationDataset.FromJson(await File.ReadAllTextAsync(outputPath));
+            reloaded.Version.Should().Be(original.Version);
+            reloaded.CreatedAt.Should().Be(original.CreatedAt);
+        }
+        finally
+        {
+            File.Delete(datasetPath);
+            if (File.Exists(outputPath))
+            {
+                File.Delete(outputPath);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Merge_WithOutputPath_PersistsMergedDatasetToFile()
+    {
+        // Arrange
+        var dataset = BuildSingleSampleDataset("sample-x", "What is the goal?");
+        var datasetPath = WriteDatasetToTempFile(dataset);
+        var outputPath = Path.Combine(Path.GetTempPath(), $"merged-labels-{Guid.NewGuid():N}.json");
+
+        try
+        {
+            var review = new LabelingReview(new List<LabelingReviewItem>
+            {
+                new(
+                    SampleId: "sample-x",
+                    Question: "What is the goal?",
+                    Candidates: new List<LabelingCandidate>
+                    {
+                        new(ChunkId: "s1", Page: 1, Score: 0.9f, Snippet: "text s1", Relevant: true)
+                    })
+            });
+
+            var handler = new MergeLabelsCommandHandler(Mock.Of<ILogger<MergeLabelsCommandHandler>>());
+            var command = new MergeLabelsCommand(datasetPath, review, outputPath);
+
+            // Act
+            await handler.Handle(command, CancellationToken.None);
+
+            // Assert — the merged dataset is persisted to disk with the applied labels
+            File.Exists(outputPath).Should().BeTrue();
+            var persisted = EvaluationDataset.FromJson(await File.ReadAllTextAsync(outputPath));
+            persisted.Samples.Should().ContainSingle()
+                .Which.RelevantChunkIds.Should().BeEquivalentTo(new[] { "s1" });
+        }
+        finally
+        {
+            File.Delete(datasetPath);
+            if (File.Exists(outputPath))
+            {
+                File.Delete(outputPath);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Merge_WithoutOutputPath_DoesNotWriteToDatasetPath()
+    {
+        // Arrange — capture the original file contents; a no-OutputPath merge must not overwrite it.
+        var dataset = BuildSingleSampleDataset("sample-x", "What is the goal?");
+        var datasetPath = WriteDatasetToTempFile(dataset);
+        var originalContents = await File.ReadAllTextAsync(datasetPath);
+
+        try
+        {
+            var review = new LabelingReview(new List<LabelingReviewItem>
+            {
+                new(
+                    SampleId: "sample-x",
+                    Question: "What is the goal?",
+                    Candidates: new List<LabelingCandidate>
+                    {
+                        new(ChunkId: "s1", Page: 1, Score: 0.9f, Snippet: "text s1", Relevant: true)
+                    })
+            });
+
+            var handler = new MergeLabelsCommandHandler(Mock.Of<ILogger<MergeLabelsCommandHandler>>());
+            var command = new MergeLabelsCommand(datasetPath, review);
+
+            // Act
+            await handler.Handle(command, CancellationToken.None);
+
+            // Assert — source file untouched (persistence is opt-in via OutputPath)
+            (await File.ReadAllTextAsync(datasetPath)).Should().Be(originalContents);
+        }
+        finally
+        {
+            File.Delete(datasetPath);
+        }
+    }
+
+    [Fact]
     public async Task Merge_SampleWithoutReviewItem_KeepsOriginalRelevantChunkIds()
     {
         // Arrange

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Evaluation/Services/DatasetEvaluationServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Evaluation/Services/DatasetEvaluationServiceTests.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.KnowledgeBase.Application.Evaluation.Services;
 using Api.BoundedContexts.KnowledgeBase.Domain.Evaluation;
+using Api.BoundedContexts.KnowledgeBase.Domain.Services;
 using Api.Models;
 using Api.Services;
 using Microsoft.Extensions.Logging;
@@ -18,14 +19,33 @@ namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Evaluation.Service
 public class DatasetEvaluationServiceTests
 {
     private readonly Mock<IRagService> _mockRagService;
+    private readonly Mock<ICitationValidationService> _mockCitationValidation;
+    private readonly InlineCitationMatcherService _citationMatcher;
     private readonly Mock<ILogger<DatasetEvaluationService>> _mockLogger;
     private readonly DatasetEvaluationService _service;
 
     public DatasetEvaluationServiceTests()
     {
         _mockRagService = new Mock<IRagService>();
+        _mockCitationValidation = new Mock<ICitationValidationService>();
+        _citationMatcher = new InlineCitationMatcherService();
         _mockLogger = new Mock<ILogger<DatasetEvaluationService>>();
-        _service = new DatasetEvaluationService(_mockRagService.Object, _mockLogger.Object);
+
+        // Default: citation validation reports a vacuously-valid result (no citations to validate),
+        // so structural validity defaults to 1.0 for tests that do not exercise it.
+        _mockCitationValidation
+            .Setup(v => v.ValidateCitationsAsync(It.IsAny<IReadOnlyList<Snippet>>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CitationValidationResult
+            {
+                IsValid = true,
+                TotalCitations = 0,
+                ValidCitations = 0,
+                Errors = new List<CitationValidationError>(),
+                Message = string.Empty
+            });
+
+        _service = new DatasetEvaluationService(
+            _mockRagService.Object, _citationMatcher, _mockCitationValidation.Object, _mockLogger.Object);
     }
 
     private static EvaluationSample CreateSample(
@@ -60,7 +80,25 @@ public class DatasetEvaluationServiceTests
     {
         // Act & Assert
         Action act = () =>
-            new DatasetEvaluationService(null!, _mockLogger.Object);
+            new DatasetEvaluationService(null!, _citationMatcher, _mockCitationValidation.Object, _mockLogger.Object);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Constructor_WithNullCitationMatcher_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Action act = () =>
+            new DatasetEvaluationService(_mockRagService.Object, null!, _mockCitationValidation.Object, _mockLogger.Object);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Constructor_WithNullCitationValidation_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Action act = () =>
+            new DatasetEvaluationService(_mockRagService.Object, _citationMatcher, null!, _mockLogger.Object);
         act.Should().Throw<ArgumentNullException>();
     }
 
@@ -69,7 +107,7 @@ public class DatasetEvaluationServiceTests
     {
         // Act & Assert
         Action act = () =>
-            new DatasetEvaluationService(_mockRagService.Object, null!);
+            new DatasetEvaluationService(_mockRagService.Object, _citationMatcher, _mockCitationValidation.Object, null!);
         act.Should().Throw<ArgumentNullException>();
     }
     [Fact]
@@ -650,5 +688,116 @@ public class DatasetEvaluationServiceTests
         result.Metrics.LabeledSampleCount.Should().Be(1);
         result.Metrics.UnlabeledSampleCount.Should().Be(1);
         result.Metrics.RecallAt5.Should().Be(1.0); // Labeled sample's hit only; unlabeled doesn't drag it to 0.5
+    }
+
+    // === Citation accuracy (#3467) ===
+
+    // A >5-word phrase so InlineCitationMatcherService extracts it as a significant phrase; the
+    // generated answer repeats it verbatim so the matcher yields the snippet's page as an actual citation.
+    private const string CitablePhrase = "the five resource types are brick lumber wool grain and ore";
+
+    private void SetupRagResponseCitingPage(int page, string source = "PDF:doc-1")
+    {
+        var snippet = new Snippet(text: CitablePhrase, source: source, page: page, line: 0, score: 0.9f);
+        _mockRagService
+            .Setup(r => r.AskAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(),
+                It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new QaResponse(
+                answer: CitablePhrase,
+                snippets: new List<Snippet> { snippet },
+                confidence: 0.9));
+    }
+
+    [Fact]
+    public async Task EvaluateSample_ExtractsActualCitationPages_FromInlineMatches()
+    {
+        // Arrange
+        SetupRagResponseCitingPage(page: 7);
+
+        // Act
+        var result = await _service.EvaluateSampleAsync(CreateSample(), EvaluationOptions.Default, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.ActualCitationPages.Should().Contain(7);
+    }
+
+    [Fact]
+    public async Task EvaluateSample_CitationMatched_WhenActualPageOverlapsExpected()
+    {
+        // Arrange
+        SetupRagResponseCitingPage(page: 7);
+        var sample = CreateSample() with
+        {
+            ExpectedCitations = new ExpectedCitations
+            {
+                PrimaryPages = new[] { 7 },
+                MatchPolicy = CitationMatchPolicy.OverlapAtLeastOne
+            }
+        };
+
+        // Act
+        var result = await _service.EvaluateSampleAsync(sample, EvaluationOptions.Default, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.CitationMatched.Should().BeTrue();
+        result.ExpectedCitationPages.Should().Equal(7);
+    }
+
+    [Fact]
+    public async Task EvaluateSample_CitationNotMatched_WhenActualPageMissesExpected()
+    {
+        // Arrange
+        SetupRagResponseCitingPage(page: 3); // answer cites page 3, ground truth is page 7
+        var sample = CreateSample() with
+        {
+            ExpectedCitations = new ExpectedCitations
+            {
+                PrimaryPages = new[] { 7 },
+                MatchPolicy = CitationMatchPolicy.OverlapAtLeastOne
+            }
+        };
+
+        // Act
+        var result = await _service.EvaluateSampleAsync(sample, EvaluationOptions.Default, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.CitationMatched.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task EvaluateSample_CitationMatchedNull_WhenSampleHasNoExpectedCitations()
+    {
+        // Arrange
+        SetupRagResponseCitingPage(page: 7);
+
+        // Act — sample has no ExpectedCitations, so it is not citation-graded
+        var result = await _service.EvaluateSampleAsync(CreateSample(), EvaluationOptions.Default, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.CitationMatched.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task EvaluateSample_StructuralValidity_ReflectsCitationValidation()
+    {
+        // Arrange
+        SetupRagResponseCitingPage(page: 7);
+        _mockCitationValidation
+            .Setup(v => v.ValidateCitationsAsync(It.IsAny<IReadOnlyList<Snippet>>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CitationValidationResult
+            {
+                IsValid = false,
+                TotalCitations = 4,
+                ValidCitations = 3,
+                Errors = new List<CitationValidationError>(),
+                Message = string.Empty
+            });
+
+        // Act
+        var result = await _service.EvaluateSampleAsync(CreateSample(), EvaluationOptions.Default, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.CitationStructuralValidity.Should().Be(0.75);
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Evaluation/Services/EvaluationReportFormatterTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Evaluation/Services/EvaluationReportFormatterTests.cs
@@ -191,4 +191,52 @@ public class EvaluationReportFormatterTests
         // Assert
         act.Should().NotThrow();
     }
+
+    [Fact]
+    public void ToMarkdown_IncludesCitationMetrics()
+    {
+        // Arrange
+        var sampleResults = new List<EvaluationSampleResult>
+        {
+            CreateSampleResult("s-001") with { CitationMatched = true, CitationStructuralValidity = 1.0 }
+        };
+        var result = CreateResult(sampleResults);
+        var byLanguage = new Dictionary<string, EvaluationMetrics>(StringComparer.Ordinal)
+        {
+            ["en"] = EvaluationMetrics.Compute(sampleResults)
+        };
+
+        // Act
+        var markdown = EvaluationReportFormatter.ToMarkdown(result, byLanguage);
+
+        // Assert
+        markdown.Should().Contain("Citation Accuracy");
+        markdown.Should().Contain("Citation Structural Validity");
+        markdown.Should().Contain("Cited");
+    }
+
+    [Fact]
+    public void ToJson_IncludesCitationMetrics()
+    {
+        // Arrange
+        var sampleResults = new List<EvaluationSampleResult>
+        {
+            CreateSampleResult("s-001") with { CitationMatched = true, CitationStructuralValidity = 1.0 }
+        };
+        var result = CreateResult(sampleResults);
+        var byLanguage = new Dictionary<string, EvaluationMetrics>(StringComparer.Ordinal)
+        {
+            ["en"] = EvaluationMetrics.Compute(sampleResults)
+        };
+
+        // Act
+        var json = EvaluationReportFormatter.ToJson(result, byLanguage);
+
+        // Assert
+        using var document = JsonDocument.Parse(json);
+        var metrics = document.RootElement.GetProperty("metrics");
+        metrics.TryGetProperty("citation_accuracy", out _).Should().BeTrue();
+        metrics.TryGetProperty("citation_structural_validity", out _).Should().BeTrue();
+        metrics.TryGetProperty("cited_sample_count", out _).Should().BeTrue();
+    }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Evaluation/EvaluationDatasetTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Evaluation/EvaluationDatasetTests.cs
@@ -480,6 +480,105 @@ public class EvaluationDatasetTests
     }
 
     [Fact]
+    public void ToJson_AndFromJson_RoundTripsExpectedCitations()
+    {
+        // Arrange
+        var dataset = EvaluationDataset.Create("Test Dataset", "A test dataset");
+        dataset.AddSample(new EvaluationSample
+        {
+            Id = "sample-1",
+            Question = "What is the setup?",
+            ExpectedAnswer = "Set up the board",
+            ExpectedCitations = new ExpectedCitations
+            {
+                PrimaryPages = new[] { 3, 5 },
+                MatchPolicy = CitationMatchPolicy.Subset
+            }
+        });
+
+        // Act
+        var roundTripped = EvaluationDataset.FromJson(dataset.ToJson());
+
+        // Assert
+        var restored = roundTripped.Samples[0].ExpectedCitations;
+        restored.Should().NotBeNull();
+        restored!.PrimaryPages.Should().Equal(3, 5);
+        restored.MatchPolicy.Should().Be(CitationMatchPolicy.Subset);
+    }
+
+    [Fact]
+    public void FromJson_ReadsExpectedCitations_FromSnakeCase()
+    {
+        // Arrange
+        var json = """
+        {
+            "name": "Test Dataset",
+            "description": "Test",
+            "samples": [
+                {
+                    "id": "sample-1",
+                    "question": "Q1",
+                    "expected_answer": "A1",
+                    "expected_citations": { "primary_pages": [7, 9], "match_policy": "exact" }
+                }
+            ]
+        }
+        """;
+
+        // Act
+        var dataset = EvaluationDataset.FromJson(json);
+
+        // Assert
+        var citations = dataset.Samples[0].ExpectedCitations;
+        citations.Should().NotBeNull();
+        citations!.PrimaryPages.Should().Equal(7, 9);
+        citations.MatchPolicy.Should().Be(CitationMatchPolicy.Exact);
+    }
+
+    [Fact]
+    public void FromJson_ExpectedCitationsWithoutMatchPolicy_DefaultsToOverlapAtLeastOne()
+    {
+        // Arrange
+        var json = """
+        {
+            "samples": [
+                {
+                    "id": "sample-1",
+                    "question": "Q1",
+                    "expected_answer": "A1",
+                    "expected_citations": { "primary_pages": [4] }
+                }
+            ]
+        }
+        """;
+
+        // Act
+        var dataset = EvaluationDataset.FromJson(json);
+
+        // Assert
+        dataset.Samples[0].ExpectedCitations!.MatchPolicy.Should().Be(CitationMatchPolicy.OverlapAtLeastOne);
+    }
+
+    [Fact]
+    public void FromJson_WithoutExpectedCitations_IsNull()
+    {
+        // Arrange
+        var json = """
+        {
+            "samples": [
+                { "id": "sample-1", "question": "Q1", "expected_answer": "A1" }
+            ]
+        }
+        """;
+
+        // Act
+        var dataset = EvaluationDataset.FromJson(json);
+
+        // Assert
+        dataset.Samples[0].ExpectedCitations.Should().BeNull();
+    }
+
+    [Fact]
     public void Count_ReflectsNumberOfSamples()
     {
         // Arrange

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Evaluation/EvaluationMetricsTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Evaluation/EvaluationMetricsTests.cs
@@ -293,4 +293,100 @@ public class EvaluationMetricsTests
         metrics.UnlabeledSampleCount.Should().Be(1);
         metrics.SampleCount.Should().Be(2);
     }
+
+    [Fact]
+    public void Compute_CitationAccuracy_OverCitedSamplesOnly()
+    {
+        // Arrange: one citation-graded match, one citation-graded miss, one not citation-graded (null)
+        var results = new List<EvaluationSampleResult>
+        {
+            new() { SampleId = "s-001", Question = "Q1?", ExpectedAnswer = "A1", CitationMatched = true },
+            new() { SampleId = "s-002", Question = "Q2?", ExpectedAnswer = "A2", CitationMatched = false },
+            new() { SampleId = "s-003", Question = "Q3?", ExpectedAnswer = "A3", CitationMatched = null }
+        };
+
+        // Act
+        var metrics = EvaluationMetrics.Compute(results);
+
+        // Assert: 1 of 2 citation-graded samples matched; the ungraded sample is excluded
+        metrics.CitationAccuracy.Should().Be(0.5);
+        metrics.CitedSampleCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void Compute_CitationStructuralValidity_AveragesOverSuccessfulSamples()
+    {
+        // Arrange
+        var results = new List<EvaluationSampleResult>
+        {
+            new() { SampleId = "s-001", Question = "Q1?", ExpectedAnswer = "A1", CitationStructuralValidity = 1.0 },
+            new() { SampleId = "s-002", Question = "Q2?", ExpectedAnswer = "A2", CitationStructuralValidity = 0.5 }
+        };
+
+        // Act
+        var metrics = EvaluationMetrics.Compute(results);
+
+        // Assert
+        metrics.CitationStructuralValidity.Should().Be(0.75);
+    }
+
+    [Fact]
+    public void Empty_HasZeroCitationMetrics()
+    {
+        // Arrange & Act
+        var metrics = EvaluationMetrics.Empty;
+
+        // Assert
+        metrics.CitationAccuracy.Should().Be(0.0);
+        metrics.CitationStructuralValidity.Should().Be(0.0);
+        metrics.CitedSampleCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void MeetsCitationAccuracyTarget_AtThreshold_ReturnsTrue()
+    {
+        // Arrange — citation accuracy exactly at the 0.80 target
+        var metrics = EvaluationMetrics.Create(
+            recallAt5: 0.5, recallAt10: 0.5, ndcgAt10: 0.5, mrr: 0.5,
+            p95LatencyMs: 100.0, answerCorrectness: 0.5, sampleCount: 30,
+            citationAccuracy: 0.80);
+
+        // Act & Assert
+        metrics.MeetsCitationAccuracyTarget().Should().BeTrue();
+    }
+
+    [Fact]
+    public void MeetsCitationAccuracyTarget_BelowThreshold_ReturnsFalse()
+    {
+        // Arrange — just under the 0.80 target
+        var metrics = EvaluationMetrics.Create(
+            recallAt5: 0.9, recallAt10: 0.9, ndcgAt10: 0.9, mrr: 0.9,
+            p95LatencyMs: 100.0, answerCorrectness: 0.9, sampleCount: 30,
+            citationAccuracy: 0.79);
+
+        // Act & Assert
+        metrics.MeetsCitationAccuracyTarget().Should().BeFalse();
+    }
+
+    [Fact]
+    public void Create_WithCitationMetrics_ClampsToBounds()
+    {
+        // Arrange & Act
+        var metrics = EvaluationMetrics.Create(
+            recallAt5: 0.5,
+            recallAt10: 0.5,
+            ndcgAt10: 0.5,
+            mrr: 0.5,
+            p95LatencyMs: 100.0,
+            answerCorrectness: 0.5,
+            sampleCount: 30,
+            citationAccuracy: 1.5, // clamps to 1.0
+            citationStructuralValidity: -0.2, // clamps to 0.0
+            citedSampleCount: -3); // clamps to 0
+
+        // Assert
+        metrics.CitationAccuracy.Should().Be(1.0);
+        metrics.CitationStructuralValidity.Should().Be(0.0);
+        metrics.CitedSampleCount.Should().Be(0);
+    }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Evaluation/EvaluationSeedDatasetTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Evaluation/EvaluationSeedDatasetTests.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Linq;
 using Api.BoundedContexts.KnowledgeBase.Domain.Evaluation;
 using Api.Tests.Constants;
 using FluentAssertions;
@@ -7,13 +8,16 @@ using Xunit;
 namespace Api.Tests.BoundedContexts.KnowledgeBase.Domain.Evaluation;
 
 /// <summary>
-/// Validates the EN seed evaluation dataset (Issue #3433, Task 7).
-/// The seed dataset is intentionally unlabeled (RelevantChunkIds empty) — labels are meant
-/// to be filled in later via the labeling-assist workflow (Task 5).
+/// Validates the EN golden evaluation dataset (Issue #3433 Task 7, extended by #3467).
+/// The dataset is intentionally recall-unlabeled (RelevantChunkIds empty) — chunk-id labels are
+/// filled in via the labeling-assist workflow after the #3427 re-index. Page-level expected_citations
+/// (#3467) are present now because pages are stable across re-index.
 /// </summary>
 [Trait("Category", TestCategories.Unit)]
 public class EvaluationSeedDatasetTests
 {
+    private static readonly string[] GoldenGames = ["catan", "wingspan", "dominion", "ark-nova", "7-wonders"];
+
     [Fact]
     public void EnSeed_LoadsAsValidLanguageTaggedDataset()
     {
@@ -28,9 +32,35 @@ public class EvaluationSeedDatasetTests
         var dataset = EvaluationDataset.FromJson(json);
 
         // Assert
-        dataset.Samples.Count.Should().BeGreaterThanOrEqualTo(12);
+        dataset.Samples.Count.Should().BeGreaterThanOrEqualTo(30,
+            "the golden set must meet the >=30 baseline sample requirement (#3467)");
         dataset.Samples.Should().OnlyContain(s => s.Language == "en");
-        dataset.Samples.Should().OnlyContain(s => s.RelevantChunkIds.Count == 0);
+        dataset.Samples.Should().OnlyContain(s => s.RelevantChunkIds.Count == 0,
+            "recall labeling is deferred to the labeling-assist workflow after the #3427 re-index");
+    }
+
+    [Fact]
+    public void EnSeed_CoversAllFiveGoldenGames()
+    {
+        var filePath = Path.Combine(GetEvaluationDatasetsPath(), "meepleai-en-seed.json");
+        var dataset = EvaluationDataset.FromJson(File.ReadAllText(filePath));
+
+        var games = dataset.Samples.Select(s => s.GameId).Distinct().ToList();
+        games.Should().Contain(GoldenGames);
+    }
+
+    [Fact]
+    public void EnSeed_HasNonDegenerateCitationGradedCoverage()
+    {
+        var filePath = Path.Combine(GetEvaluationDatasetsPath(), "meepleai-en-seed.json");
+        var dataset = EvaluationDataset.FromJson(File.ReadAllText(filePath));
+
+        var citationGraded = dataset.Samples.Where(s => s.ExpectedCitations is not null).ToList();
+
+        citationGraded.Should().HaveCountGreaterThanOrEqualTo(20,
+            "the golden set must expose a non-degenerate citation-accuracy signal (#3467)");
+        citationGraded.Should().OnlyContain(s => s.ExpectedCitations!.PrimaryPages.Count > 0,
+            "a citation-graded sample must name at least one expected page");
     }
 
     private static string GetEvaluationDatasetsPath()

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Evaluation/ExpectedCitationsTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Evaluation/ExpectedCitationsTests.cs
@@ -1,0 +1,82 @@
+using Api.BoundedContexts.KnowledgeBase.Domain.Evaluation;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Domain.Evaluation;
+
+/// <summary>
+/// Unit tests for the page-level citation match policies (#3467).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+public class ExpectedCitationsTests
+{
+    [Theory]
+    // Exact: set equality, order-independent
+    [InlineData("exact", new[] { 3, 5 }, new[] { 3, 5 }, true)]
+    [InlineData("exact", new[] { 3, 5 }, new[] { 5, 3 }, true)]
+    [InlineData("exact", new[] { 3, 5 }, new[] { 3 }, false)]
+    [InlineData("exact", new[] { 3, 5 }, new[] { 3, 5, 7 }, false)]
+    // OverlapAtLeastOne: non-empty intersection
+    [InlineData("overlap_at_least_one", new[] { 3, 5 }, new[] { 5, 9 }, true)]
+    [InlineData("overlap_at_least_one", new[] { 3, 5 }, new[] { 9 }, false)]
+    // Subset: actual is a subset of expected (no extra pages cited)
+    [InlineData("subset", new[] { 3, 5, 7 }, new[] { 3, 5 }, true)]
+    [InlineData("subset", new[] { 3, 5 }, new[] { 3, 9 }, false)]
+    // Superset: actual is a superset of expected (all expected pages present)
+    [InlineData("superset", new[] { 3, 5 }, new[] { 3, 5, 7 }, true)]
+    [InlineData("superset", new[] { 3, 5 }, new[] { 3 }, false)]
+    public void IsSatisfiedBy_AppliesPolicy(string policyWire, int[] expectedPages, int[] actualPages, bool expected)
+    {
+        // Arrange — policy parsed from its snake_case wire value (exercises the wire mapping too)
+        var citations = new ExpectedCitations
+        {
+            PrimaryPages = expectedPages,
+            MatchPolicy = CitationMatchPolicyWire.Parse(policyWire)
+        };
+
+        // Act & Assert
+        citations.IsSatisfiedBy(actualPages).Should().Be(expected);
+    }
+
+    [Fact]
+    public void IsSatisfiedBy_ExactWithEmptyExpected_IsTrueOnlyWhenActualEmpty()
+    {
+        // "No answer expected" edge case: the answer must cite nothing.
+        var noAnswer = new ExpectedCitations { PrimaryPages = [], MatchPolicy = CitationMatchPolicy.Exact };
+
+        noAnswer.IsSatisfiedBy([]).Should().BeTrue();
+        noAnswer.IsSatisfiedBy(new[] { 2 }).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsSatisfiedBy_IgnoresDuplicatePages()
+    {
+        var citations = new ExpectedCitations { PrimaryPages = new[] { 4 }, MatchPolicy = CitationMatchPolicy.Exact };
+
+        citations.IsSatisfiedBy(new[] { 4, 4, 4 }).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Parse_NullOrBlank_DefaultsToOverlap(string? wire)
+    {
+        // Omitted match_policy is the documented default (a sample can carry primary_pages without a policy).
+        CitationMatchPolicyWire.Parse(wire).Should().Be(CitationMatchPolicy.OverlapAtLeastOne);
+    }
+
+    [Theory]
+    [InlineData("exact_match")]
+    [InlineData("overlap")]
+    [InlineData("sub_set")]
+    [InlineData("nonsense")]
+    public void Parse_UnrecognizedToken_ThrowsInsteadOfSilentlyWeakeningTheGate(string wire)
+    {
+        // A typo'd policy must fail loud rather than silently degrade to the loosest comparison,
+        // which would weaken the citation-accuracy gate in the false-negative direction (#3467 review).
+        Action act = () => CitationMatchPolicyWire.Parse(wire);
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Endpoints/AdminEvalEndpointsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Endpoints/AdminEvalEndpointsIntegrationTests.cs
@@ -34,6 +34,7 @@ namespace Api.Tests.BoundedContexts.KnowledgeBase.Endpoints;
 public sealed class AdminEvalEndpointsIntegrationTests : IAsyncLifetime
 {
     private const string RetrievalEndpoint = "/api/v1/admin/eval/retrieval";
+    private const string MergeLabelsEndpoint = "/api/v1/admin/eval/merge-labels";
 
     private static readonly Guid TestAdminId = Guid.NewGuid();
 
@@ -44,6 +45,7 @@ public sealed class AdminEvalEndpointsIntegrationTests : IAsyncLifetime
     private string _adminSessionToken = null!;
     private string _userSessionToken = null!;
     private string _datasetPath = null!;
+    private string _mergeOutputPath = null!;
 
     public AdminEvalEndpointsIntegrationTests(SharedTestcontainersFixture fixture)
     {
@@ -103,6 +105,8 @@ public sealed class AdminEvalEndpointsIntegrationTests : IAsyncLifetime
 
         _datasetPath = Path.Combine(Path.GetTempPath(), $"eval-dataset-{Guid.NewGuid():N}.json");
         await File.WriteAllTextAsync(_datasetPath, dataset.ToJson());
+
+        _mergeOutputPath = Path.Combine(Path.GetTempPath(), $"eval-merged-{Guid.NewGuid():N}.json");
     }
 
     public async ValueTask DisposeAsync()
@@ -115,7 +119,33 @@ public sealed class AdminEvalEndpointsIntegrationTests : IAsyncLifetime
         {
             File.Delete(_datasetPath);
         }
+
+        if (File.Exists(_mergeOutputPath))
+        {
+            File.Delete(_mergeOutputPath);
+        }
     }
+
+    private static object BuildMergeReviewBody(string datasetPath, string? outputPath) => new
+    {
+        datasetPath,
+        outputPath,
+        review = new
+        {
+            items = new[]
+            {
+                new
+                {
+                    sampleId = "s1",
+                    question = "Where do I place my first settlement?",
+                    candidates = new[]
+                    {
+                        new { chunkId = "chunk-1", page = 3, score = 0.9f, snippet = "Setup rules...", relevant = true }
+                    }
+                }
+            }
+        }
+    };
 
     [Fact]
     public async Task RunRetrievalEvaluation_WithAdminAuth_Returns200WithMetricsJson()
@@ -185,6 +215,96 @@ public sealed class AdminEvalEndpointsIntegrationTests : IAsyncLifetime
         var request = new HttpRequestMessage(HttpMethod.Post, RetrievalEndpoint)
         {
             Content = JsonContent.Create(new { datasetPath = _datasetPath })
+        };
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task MergeLabels_WithAdminAuth_PersistsLabeledDatasetAndReturns200()
+    {
+        // Arrange
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            MergeLabelsEndpoint,
+            _adminSessionToken,
+            BuildMergeReviewBody(_datasetPath, _mergeOutputPath));
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        File.Exists(_mergeOutputPath).Should().BeTrue("the endpoint persists the merged dataset to the output path");
+        var persisted = EvaluationDataset.FromJson(await File.ReadAllTextAsync(_mergeOutputPath));
+        persisted.Samples.Should().ContainSingle()
+            .Which.RelevantChunkIds.Should().BeEquivalentTo(new[] { "chunk-1" });
+    }
+
+    [Fact]
+    public async Task MergeLabels_WithNonExistentDatasetPath_Returns404()
+    {
+        // Arrange
+        var missingDatasetPath = Path.Combine(Path.GetTempPath(), $"missing-dataset-{Guid.NewGuid():N}.json");
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            MergeLabelsEndpoint,
+            _adminSessionToken,
+            BuildMergeReviewBody(missingDatasetPath, _mergeOutputPath));
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task MergeLabels_WithNullReviewItems_Returns400()
+    {
+        // Arrange — a body like {"review":{}} deserializes to a non-null Review with null Items; the endpoint
+        // must reject it (400) rather than NRE (500) when the handler enumerates the items.
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            MergeLabelsEndpoint,
+            _adminSessionToken,
+            new { datasetPath = _datasetPath, outputPath = _mergeOutputPath, review = new { } });
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task MergeLabels_WithRegularUserAuth_Returns403()
+    {
+        // Arrange
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            MergeLabelsEndpoint,
+            _userSessionToken,
+            BuildMergeReviewBody(_datasetPath, _mergeOutputPath));
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task MergeLabels_WithoutAuth_Returns401()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(HttpMethod.Post, MergeLabelsEndpoint)
+        {
+            Content = JsonContent.Create(BuildMergeReviewBody(_datasetPath, _mergeOutputPath))
         };
 
         // Act

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Unit/RagPromptAssemblyEnhancementsTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Unit/RagPromptAssemblyEnhancementsTests.cs
@@ -1,6 +1,8 @@
 using Api.BoundedContexts.KnowledgeBase.Application.Services;
 using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
 using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
+using Api.BoundedContexts.KnowledgeBase.Domain.Plugins.Implementations.Evaluation;
+using Api.BoundedContexts.KnowledgeBase.Domain.Plugins.Implementations.Retrieval;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services.Enhancements;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services.Reranking;
@@ -458,6 +460,58 @@ public class RagPromptAssemblyEnhancementsTests
         _complexityClassifierMock.Verify(
             c => c.ClassifyAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);
+    }
+
+    #endregion
+
+    #region CRAG web-fallback OFF on the closed rulebook domain (#3467)
+
+    [Fact]
+    public async Task WhenLiveSessionPolicy_CragEvaluatorNeverInvoked()
+    {
+        // #3467 negative-space assertion: on the in-session live path the CRAG evaluator must NOT run —
+        // even when the user's tier would activate CRAG — because RetrievalPolicy.LiveSession gates
+        // enhancements OFF (EnhancementsEnabled=false). This is the trust-critical invariant the grounding
+        // audit (§7) flagged as invisible to CI. It guards the #3389 wiring against regression.
+        var tier = UserTier.Premium;
+        _ragEnhancementMock
+            .Setup(r => r.GetActiveEnhancementsAsync(tier, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RagEnhancement.CragEvaluation);
+        SetupTextSearchResults(CreateChunk("doc1", 0, 0.90f, "Pawns move forward."));
+        SetupRerankerPassthrough();
+        var service = CreateService();
+
+        // Act — live path alongside a tier whose enhancements include CRAG
+        await service.AssemblePromptAsync(
+            "tutor", "Chess", null, "How do pawns move?",
+            TestGameId, null, tier, "it", CancellationToken.None,
+            retrievalPolicy: RetrievalPolicy.LiveSession);
+
+        // Assert — CRAG evaluation never runs on the live path, and the tier is never even consulted
+        _relevanceEvaluatorMock.Verify(
+            e => e.EvaluateAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<ScoredChunk>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _ragEnhancementMock.Verify(
+            r => r.GetActiveEnhancementsAsync(It.IsAny<UserTier>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public void RagPromptAssemblyService_HasNoWebRetrievalDependency()
+    {
+        // #3467 negative-space assertion: the CRAG "corrective" requery on the closed rulebook domain
+        // stays internal to the corpus (ExpandQueryAsync + TryHybridSearchAsync). The forward-looking
+        // web-fallback plugins (RetrievalWebPlugin / EvaluationCragPlugin, which simulate "web_search")
+        // must NEVER be wired into the live prompt-assembly path. If #3390 later routes an action here to
+        // a web plugin, this test goes RED — forcing an explicit new flag that keeps the rulebook domain OFF.
+        var ctor = typeof(RagPromptAssemblyService).GetConstructors().Single();
+        var parameterTypes = ctor.GetParameters().Select(p => p.ParameterType).ToList();
+
+        parameterTypes.Should().NotContain(typeof(RetrievalWebPlugin));
+        parameterTypes.Should().NotContain(typeof(EvaluationCragPlugin));
+        parameterTypes.Select(t => t.Name).Should().NotContain(
+            n => n.Contains("WebPlugin", StringComparison.Ordinal),
+            "web-fallback retrieval must not be a dependency of the live prompt-assembly path");
     }
 
     #endregion

--- a/apps/api/tests/Api.Tests/Unit/KnowledgeBase/Evaluation/DatasetEvaluationServiceMetricTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/KnowledgeBase/Evaluation/DatasetEvaluationServiceMetricTests.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.KnowledgeBase.Application.Evaluation.Services;
 using Api.BoundedContexts.KnowledgeBase.Domain.Evaluation;
+using Api.BoundedContexts.KnowledgeBase.Domain.Services;
 using Api.Services;
 using Api.Tests.Constants;
 using FluentAssertions;
@@ -23,8 +24,10 @@ public sealed class DatasetEvaluationServiceMetricTests
     public DatasetEvaluationServiceMetricTests()
     {
         var ragService = new Mock<IRagService>();
+        var citationValidation = new Mock<ICitationValidationService>();
         var logger = new Mock<ILogger<DatasetEvaluationService>>();
-        _service = new DatasetEvaluationService(ragService.Object, logger.Object);
+        _service = new DatasetEvaluationService(
+            ragService.Object, new InlineCitationMatcherService(), citationValidation.Object, logger.Object);
     }
 
     #region CalculateRecallAtK Tests

--- a/docs/for-developers/testing/rag-golden-eval-set.md
+++ b/docs/for-developers/testing/rag-golden-eval-set.md
@@ -1,0 +1,99 @@
+# RAG Golden Evaluation Set (#3467)
+
+**Status**: active · **Epic**: #3397 (in-session agent grounding) · **Unblocks**: #3390 (live-path enhancement wiring)
+
+The golden evaluation set is the **gate** the in-session live retrieval path must pass before any RAG
+enhancement (AdaptiveRouting / CRAG / RAPTOR / RAG-Fusion / Graph) is wired onto it in #3390. It exists
+so grounding quality is a **measured invariant**, not an unverified side-effect of turning enhancements on.
+
+## The 5 golden games
+
+Catan · Wingspan · Dominion · Ark Nova · 7 Wonders.
+
+Dataset: [`tests/evaluation-datasets/meepleai-en-seed.json`](../../../tests/evaluation-datasets/meepleai-en-seed.json)
+(EN, ≥30 samples, all 5 games). `relevant_chunk_ids` are intentionally empty pending the #3427 re-index —
+recall labeling is applied later via the labeling-assist workflow (chunk ids churn on re-index). Page-level
+`expected_citations` are authored **now** because pages are stable across re-index.
+
+## Sample schema (citation ground truth)
+
+Each sample follows `EvaluationSample`; the citation-relevant field (mirrors
+[`tests/llm-eval/golden-set/schema.md`](../../../tests/llm-eval/golden-set/schema.md)):
+
+```jsonc
+"expected_citations": {
+  "primary_pages": [7],                 // ground-truth page(s) where the answer lives
+  "match_policy": "overlap_at_least_one" // exact | overlap_at_least_one | subset | superset
+}
+```
+
+| `match_policy` | Passes when the answer's actual cited pages… |
+| --- | --- |
+| `exact` | equal the expected set exactly (order-independent) |
+| `overlap_at_least_one` | intersect the expected set (**pragmatic default**) |
+| `subset` | are a subset of expected (no extra pages cited) |
+| `superset` | are a superset of expected (all expected pages present) |
+
+Use `exact` with an empty `primary_pages` for "no-answer expected" edge cases. A sample **without**
+`expected_citations` is not citation-graded (it is excluded from the CitationAccuracy aggregate).
+
+## Metrics
+
+Computed by `DatasetEvaluationService` → `EvaluationMetrics`, reported by `EvaluationReportFormatter`
+(Markdown + snake_case JSON: `recall_at_5/10`, `ndcg_at_10`, `mrr`, `answer_correctness`,
+`citation_accuracy`, `citation_structural_validity`, `cited_sample_count`, `p95_latency_ms`, coverage).
+
+- **Recall@5 / @10, nDCG@10, MRR** — retrieval quality over recall-labeled samples (unlabeled excluded).
+- **Citation accuracy** — page-level: actual cited pages (from `InlineCitationMatcherService`) vs
+  `expected_citations` per `match_policy`, over citation-graded samples only.
+- **Citation structural validity** — trust floor: fraction of the response's citations that are well-formed
+  (`PDF:guid` + existing document + page in range), via `CitationValidationService`.
+- **Answer correctness** — deterministic keyword / word-overlap heuristic (NOT an LLM-as-judge; kept
+  keyword-based for CI stability).
+
+## Thresholds (the #3390 per-enhancement gate)
+
+Encoded on `EvaluationMetrics` (`MeetsPhase5Target`, `MeetsCitationAccuracyTarget`). No enhancement wired
+in #3390 may regress the enhancement-free baseline below:
+
+| Gate | Threshold |
+| --- | --- |
+| Recall@10 | ≥ 0.70 |
+| Citation accuracy (`overlap_at_least_one`, page-level) | ≥ 0.80 |
+| P95 latency | < 1500 ms |
+| Web calls from the live path (rulebook domain) | **0** (permanent invariant) |
+
+> The 0.70 / 0.80 thresholds are pragmatic, aligned with the in-code Phase-5 target; confirm against the
+> first real baseline after the #3427 re-index. If the real baseline is lower, the eval-set still serves its
+> purpose: **measure** and **prevent regression**.
+
+## CRAG web-fallback is OFF on the closed rulebook domain
+
+On the closed rulebook domain, a web "corrective" fallback **worsens** fidelity. The contract:
+
+- The live path uses `RetrievalPolicy.LiveSession` (`EnhancementsEnabled = false`) → `activeEnhancements = None`
+  → the CRAG block in `RagPromptAssemblyService` **does not run**. Guarded by
+  `RagPromptAssemblyEnhancementsTests.WhenLiveSessionPolicy_CragEvaluatorNeverInvoked`.
+- When CRAG *is* active (non-live path), the "corrective" requery stays **internal** to the corpus
+  (`ExpandQueryAsync` + `TryHybridSearchAsync`); it never routes to a web plugin. The web-fallback plugins
+  (`RetrievalWebPlugin`, `EvaluationCragPlugin`, which only *simulate* `web_search`) are **not** dependencies
+  of the live prompt-assembly path. Guarded by
+  `RagPromptAssemblyEnhancementsTests.RagPromptAssemblyService_HasNoWebRetrievalDependency` — if #3390 ever
+  wires a web plugin here, that test goes RED, forcing an explicit new flag that keeps the rulebook domain OFF.
+- **Runtime kill-switch**: feature flag `rag.enhancement.crag-evaluation` (`FeatureFlagSeeder`) disables all
+  of CRAG without a redeploy (note: this also disables the harmless internal requery, not only a web fallback).
+
+## Workflow & tooling
+
+Admin-gated endpoints (CQRS via `IMediator`), plus Makefile wrappers (local ad-hoc smoke; a real staging run
+is deferred until the #3427 re-index):
+
+| Step | Endpoint | Makefile |
+| --- | --- | --- |
+| Run retrieval eval | `POST /api/v1/admin/eval/retrieval` | `make eval-retrieval DATASET=…` |
+| AI-propose labels | `POST /api/v1/admin/eval/labeling-candidates` | — |
+| Merge reviewed labels (persist) | `POST /api/v1/admin/eval/merge-labels` | `make eval-merge-labels DATASET=… REVIEW=…` |
+
+Recall labeling (`relevant_chunk_ids`) and a committed baseline report under
+`docs/for-developers/evaluation-reports/` are completed **after** the #3427 re-index (chunk ids are unstable
+before it). Path sandboxing of `datasetPath` / `outputPath` is deferred to #3438.

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -464,6 +464,24 @@ eval-retrieval: ## Run RAG retrieval evaluation via admin endpoint (DATASET=path
 		-d "{\"datasetPath\":\"$(DATASET)\",\"maxSamples\":$$max}" \
 		| (command -v jq >/dev/null 2>&1 && jq . || cat)
 
+eval-merge-labels: ## Merge a human-reviewed LabelingReview into a dataset and persist it (DATASET=path + REVIEW=path-to-review-json required; OUTPUT optional, defaults to DATASET; BASE_URL default localhost:8080; ADMIN_EMAIL/ADMIN_PASSWORD to auto-login). Recall labeling deferred until #3427 corpus re-index completes.
+	@test -n "$(DATASET)" || (echo "DATASET required: make eval-merge-labels DATASET=../tests/evaluation-datasets/meepleai-en-seed.json REVIEW=review.json" && exit 64)
+	@test -n "$(REVIEW)" || (echo "REVIEW required: path to a JSON file containing the reviewed LabelingReview ({\"items\":[...]})" && exit 64)
+	@test -f "$(REVIEW)" || (echo "REVIEW file not found: $(REVIEW)" && exit 66)
+	@cookie=$$(mktemp); trap 'rm -f "$$cookie"' EXIT; \
+	base="$(BASE_URL)"; [ -n "$$base" ] || base="http://localhost:8080"; \
+	out="$(OUTPUT)"; [ -n "$$out" ] || out="$(DATASET)"; \
+	if [ -n "$(ADMIN_EMAIL)" ] && [ -n "$(ADMIN_PASSWORD)" ]; then \
+		curl -s -o /dev/null -c "$$cookie" -X POST "$$base/api/v1/auth/login" \
+			-H 'Content-Type: application/json' \
+			-d "{\"email\":\"$(ADMIN_EMAIL)\",\"password\":\"$(ADMIN_PASSWORD)\"}"; \
+	fi; \
+	review=$$(cat "$(REVIEW)"); \
+	curl -s -b "$$cookie" -X POST "$$base/api/v1/admin/eval/merge-labels" \
+		-H 'Content-Type: application/json' \
+		-d "{\"datasetPath\":\"$(DATASET)\",\"outputPath\":\"$$out\",\"review\":$$review}" \
+		| (command -v jq >/dev/null 2>&1 && jq . || cat)
+
 .PHONY: dev dev-core dev-down \
         tunnel tunnel-stop tunnel-status integration-check integration \
         integration-down work work-stop smoke smoke-staging smoke-pg-readback staging staging-minimal staging-with-tutor staging-tutor-down staging-core staging-down prod prod-down \
@@ -477,4 +495,4 @@ eval-retrieval: ## Run RAG retrieval evaluation via admin endpoint (DATASET=path
         db-snapshot db-snapshot-sanitized db-reset-migrations db-restore-snapshot db-rollback-safetynet \
         game-reset-help game-reset-backup game-reset-mapping game-reset-relink game-reset-verify game-reset-rollback-rehearse \
         reindex-corpus reindex-corpus-help \
-        eval-retrieval
+        eval-retrieval eval-merge-labels

--- a/tests/evaluation-datasets/README.md
+++ b/tests/evaluation-datasets/README.md
@@ -6,9 +6,20 @@ Evaluation datasets for measuring MeepleAI RAG pipeline quality, as defined in A
 
 | Dataset | Source Format | Samples | Games | Difficulty Levels |
 |---------|--------------|---------|-------|-------------------|
+| `meepleai-en-seed.json` | MeepleAI Golden (EN) | 35 | 5 golden | easy, medium, hard |
 | `mozilla-boardgames.json` | Mozilla Structured QA | 25 | 6 | easy, medium, hard |
 | `meepleai-custom.json` | MeepleAI Custom | 35 | 3 | easy, medium, hard |
-| **Total** | **Combined** | **60** | **8** | **3 levels** |
+
+### `meepleai-en-seed.json` — golden evaluation set (#3467)
+
+The **golden** set for the 5 golden games (Catan, Wingspan, Dominion, Ark Nova, 7 Wonders). It unions the
+real `source_page` ground truth from the seed/mozilla/custom datasets into page-level **`expected_citations`**
+and is the gate the in-session live path must pass before enhancements are wired in #3390. See
+[`docs/for-developers/testing/rag-golden-eval-set.md`](../../docs/for-developers/testing/rag-golden-eval-set.md).
+
+- **`expected_citations`**: `{ "primary_pages": int[], "match_policy": "exact" | "overlap_at_least_one" | "subset" | "superset" }`.
+  Page-level, so stable across the #3427 re-index. A sample without it is not citation-graded.
+- `relevant_chunk_ids` are intentionally empty pending #3427 (recall labeling via the labeling-assist workflow).
 
 ## Dataset Formats
 

--- a/tests/evaluation-datasets/meepleai-en-seed.json
+++ b/tests/evaluation-datasets/meepleai-en-seed.json
@@ -1,9 +1,9 @@
 {
-  "name": "MeepleAI English Seed Evaluation Dataset",
-  "description": "English-language seed evaluation dataset for the RAG retrieval-evaluation harness. Covers the 5 golden games (Catan, Wingspan, Dominion, Ark Nova, 7 Wonders) with unlabeled samples intended to be labeled via the labeling-assist workflow.",
-  "version": "1.0.0",
+  "name": "MeepleAI English Golden Evaluation Dataset",
+  "description": "English golden evaluation dataset for the 5 golden games (Catan, Wingspan, Dominion, Ark Nova, 7 Wonders). Unions real source_page ground truth from the seed/mozilla/custom datasets into page-level expected_citations (#3467). relevant_chunk_ids are intentionally empty pending the #3427 re-index (recall labeling via the labeling-assist workflow).",
+  "version": "1.1.0",
   "source_type": "meepleai_custom",
-  "created_at": "2026-08-01T00:00:00Z",
+  "created_at": "2026-08-02T00:00:00Z",
   "samples": [
     {
       "id": "en-seed-001",
@@ -15,10 +15,22 @@
       "difficulty": "easy",
       "category": "setup",
       "game_id": "catan",
-      "expected_keywords": ["brick", "lumber", "wool", "grain", "ore"],
+      "expected_keywords": [
+        "brick",
+        "lumber",
+        "wool",
+        "grain",
+        "ore"
+      ],
       "relevant_chunk_ids": [],
       "dataset_source": "meepleai_custom",
-      "language": "en"
+      "language": "en",
+      "expected_citations": {
+        "primary_pages": [
+          2
+        ],
+        "match_policy": "overlap_at_least_one"
+      }
     },
     {
       "id": "en-seed-002",
@@ -30,10 +42,20 @@
       "difficulty": "easy",
       "category": "scoring",
       "game_id": "catan",
-      "expected_keywords": ["10", "victory points", "win"],
+      "expected_keywords": [
+        "10",
+        "victory points",
+        "win"
+      ],
       "relevant_chunk_ids": [],
       "dataset_source": "meepleai_custom",
-      "language": "en"
+      "language": "en",
+      "expected_citations": {
+        "primary_pages": [
+          12
+        ],
+        "match_policy": "overlap_at_least_one"
+      }
     },
     {
       "id": "en-seed-003",
@@ -45,10 +67,20 @@
       "difficulty": "easy",
       "category": "setup",
       "game_id": "wingspan",
-      "expected_keywords": ["5", "bird cards", "food tokens"],
+      "expected_keywords": [
+        "5",
+        "bird cards",
+        "food tokens"
+      ],
       "relevant_chunk_ids": [],
       "dataset_source": "meepleai_custom",
-      "language": "en"
+      "language": "en",
+      "expected_citations": {
+        "primary_pages": [
+          4
+        ],
+        "match_policy": "overlap_at_least_one"
+      }
     },
     {
       "id": "en-seed-004",
@@ -60,10 +92,20 @@
       "difficulty": "medium",
       "category": "gameplay",
       "game_id": "wingspan",
-      "expected_keywords": ["Forest", "Grassland", "Wetland"],
+      "expected_keywords": [
+        "Forest",
+        "Grassland",
+        "Wetland"
+      ],
       "relevant_chunk_ids": [],
       "dataset_source": "meepleai_custom",
-      "language": "en"
+      "language": "en",
+      "expected_citations": {
+        "primary_pages": [
+          6
+        ],
+        "match_policy": "overlap_at_least_one"
+      }
     },
     {
       "id": "en-seed-005",
@@ -75,10 +117,20 @@
       "difficulty": "medium",
       "category": "gameplay",
       "game_id": "dominion",
-      "expected_keywords": ["Action", "Buy", "Cleanup"],
+      "expected_keywords": [
+        "Action",
+        "Buy",
+        "Cleanup"
+      ],
       "relevant_chunk_ids": [],
       "dataset_source": "meepleai_custom",
-      "language": "en"
+      "language": "en",
+      "expected_citations": {
+        "primary_pages": [
+          3
+        ],
+        "match_policy": "overlap_at_least_one"
+      }
     },
     {
       "id": "en-seed-006",
@@ -90,10 +142,23 @@
       "difficulty": "hard",
       "category": "setup",
       "game_id": "dominion",
-      "expected_keywords": ["46", "Copper", "40", "Silver", "30", "Gold"],
+      "expected_keywords": [
+        "46",
+        "Copper",
+        "40",
+        "Silver",
+        "30",
+        "Gold"
+      ],
       "relevant_chunk_ids": [],
       "dataset_source": "meepleai_custom",
-      "language": "en"
+      "language": "en",
+      "expected_citations": {
+        "primary_pages": [
+          5
+        ],
+        "match_policy": "overlap_at_least_one"
+      }
     },
     {
       "id": "en-seed-007",
@@ -105,10 +170,20 @@
       "difficulty": "medium",
       "category": "gameplay",
       "game_id": "dominion",
-      "expected_keywords": ["discards", "5 cards", "reshuffle"],
+      "expected_keywords": [
+        "discards",
+        "5 cards",
+        "reshuffle"
+      ],
       "relevant_chunk_ids": [],
       "dataset_source": "meepleai_custom",
-      "language": "en"
+      "language": "en",
+      "expected_citations": {
+        "primary_pages": [
+          4
+        ],
+        "match_policy": "overlap_at_least_one"
+      }
     },
     {
       "id": "en-seed-008",
@@ -120,10 +195,21 @@
       "difficulty": "medium",
       "category": "gameplay",
       "game_id": "ark-nova",
-      "expected_keywords": ["Build", "Animals", "Cards", "Association"],
+      "expected_keywords": [
+        "Build",
+        "Animals",
+        "Cards",
+        "Association"
+      ],
       "relevant_chunk_ids": [],
       "dataset_source": "meepleai_custom",
-      "language": "en"
+      "language": "en",
+      "expected_citations": {
+        "primary_pages": [
+          7
+        ],
+        "match_policy": "overlap_at_least_one"
+      }
     },
     {
       "id": "en-seed-009",
@@ -135,10 +221,20 @@
       "difficulty": "hard",
       "category": "scoring",
       "game_id": "ark-nova",
-      "expected_keywords": ["reputation", "animals", "conservation"],
+      "expected_keywords": [
+        "reputation",
+        "animals",
+        "conservation"
+      ],
       "relevant_chunk_ids": [],
       "dataset_source": "meepleai_custom",
-      "language": "en"
+      "language": "en",
+      "expected_citations": {
+        "primary_pages": [
+          15
+        ],
+        "match_policy": "overlap_at_least_one"
+      }
     },
     {
       "id": "en-seed-010",
@@ -150,10 +246,20 @@
       "difficulty": "easy",
       "category": "setup",
       "game_id": "7-wonders",
-      "expected_keywords": ["3 ages", "7 cards", "draft"],
+      "expected_keywords": [
+        "3 ages",
+        "7 cards",
+        "draft"
+      ],
       "relevant_chunk_ids": [],
       "dataset_source": "meepleai_custom",
-      "language": "en"
+      "language": "en",
+      "expected_citations": {
+        "primary_pages": [
+          3
+        ],
+        "match_policy": "overlap_at_least_one"
+      }
     },
     {
       "id": "en-seed-011",
@@ -165,10 +271,20 @@
       "difficulty": "medium",
       "category": "gameplay",
       "game_id": "7-wonders",
-      "expected_keywords": ["counter-clockwise", "Age II", "right"],
+      "expected_keywords": [
+        "counter-clockwise",
+        "Age II",
+        "right"
+      ],
       "relevant_chunk_ids": [],
       "dataset_source": "meepleai_custom",
-      "language": "en"
+      "language": "en",
+      "expected_citations": {
+        "primary_pages": [
+          4
+        ],
+        "match_policy": "overlap_at_least_one"
+      }
     },
     {
       "id": "en-seed-012",
@@ -180,7 +296,527 @@
       "difficulty": "hard",
       "category": "scoring",
       "game_id": "7-wonders",
-      "expected_keywords": ["shields", "conflict token", "defeat token"],
+      "expected_keywords": [
+        "shields",
+        "conflict token",
+        "defeat token"
+      ],
+      "relevant_chunk_ids": [],
+      "dataset_source": "meepleai_custom",
+      "language": "en",
+      "expected_citations": {
+        "primary_pages": [
+          9
+        ],
+        "match_policy": "overlap_at_least_one"
+      }
+    },
+    {
+      "id": "en-seed-013",
+      "question": "How many settlement pieces does each player start with in Catan?",
+      "expected_answer": "Each player starts with 5 settlement pieces.",
+      "source": "catan-rulebook",
+      "source_page": 3,
+      "section": "Components",
+      "difficulty": "easy",
+      "category": "setup",
+      "game_id": "catan",
+      "expected_keywords": [
+        "5",
+        "settlement"
+      ],
+      "relevant_chunk_ids": [],
+      "dataset_source": "meepleai_custom",
+      "language": "en",
+      "expected_citations": {
+        "primary_pages": [
+          3
+        ],
+        "match_policy": "overlap_at_least_one"
+      }
+    },
+    {
+      "id": "en-seed-014",
+      "question": "What resource cards are needed to build a road in Catan?",
+      "expected_answer": "One brick and one lumber are needed to build a road.",
+      "source": "catan-rulebook",
+      "source_page": 7,
+      "section": "Building Costs",
+      "difficulty": "easy",
+      "category": "gameplay",
+      "game_id": "catan",
+      "expected_keywords": [
+        "brick",
+        "lumber"
+      ],
+      "relevant_chunk_ids": [],
+      "dataset_source": "meepleai_custom",
+      "language": "en",
+      "expected_citations": {
+        "primary_pages": [
+          7
+        ],
+        "match_policy": "overlap_at_least_one"
+      }
+    },
+    {
+      "id": "en-seed-015",
+      "question": "When a 7 is rolled in Catan, what happens to players with more than 7 resource cards?",
+      "expected_answer": "Players with more than 7 resource cards must discard half of their resource cards (rounded down).",
+      "source": "catan-rulebook",
+      "source_page": 8,
+      "section": "The Robber",
+      "difficulty": "medium",
+      "category": "gameplay",
+      "game_id": "catan",
+      "expected_keywords": [
+        "discard",
+        "half",
+        "7"
+      ],
+      "relevant_chunk_ids": [],
+      "dataset_source": "meepleai_custom",
+      "language": "en",
+      "expected_citations": {
+        "primary_pages": [
+          8
+        ],
+        "match_policy": "overlap_at_least_one"
+      }
+    },
+    {
+      "id": "en-seed-016",
+      "question": "How many victory points are needed to win a standard game of Catan?",
+      "expected_answer": "10 victory points are needed to win.",
+      "source": "catan-rulebook",
+      "source_page": 12,
+      "section": "Winning",
+      "difficulty": "easy",
+      "category": "scoring",
+      "game_id": "catan",
+      "expected_keywords": [
+        "10",
+        "victory"
+      ],
+      "relevant_chunk_ids": [],
+      "dataset_source": "meepleai_custom",
+      "language": "en",
+      "expected_citations": {
+        "primary_pages": [
+          12
+        ],
+        "match_policy": "overlap_at_least_one"
+      }
+    },
+    {
+      "id": "en-seed-017",
+      "question": "What is the longest road bonus in Catan and how many victory points is it worth?",
+      "expected_answer": "The Longest Road card is awarded to the first player to build a continuous road of at least 5 segments. It is worth 2 victory points.",
+      "source": "catan-rulebook",
+      "source_page": 11,
+      "section": "Special Victory Points",
+      "difficulty": "medium",
+      "category": "scoring",
+      "game_id": "catan",
+      "expected_keywords": [
+        "5",
+        "road",
+        "2",
+        "victory"
+      ],
+      "relevant_chunk_ids": [],
+      "dataset_source": "meepleai_custom",
+      "language": "en",
+      "expected_citations": {
+        "primary_pages": [
+          11
+        ],
+        "match_policy": "overlap_at_least_one"
+      }
+    },
+    {
+      "id": "en-seed-018",
+      "question": "In 7 Wonders, how many cards does each player receive in the first age?",
+      "expected_answer": "Each player receives 7 cards at the beginning of each age.",
+      "source": "7wonders-rulebook",
+      "source_page": 5,
+      "section": "Card Distribution",
+      "difficulty": "easy",
+      "category": "setup",
+      "game_id": "7-wonders",
+      "expected_keywords": [
+        "7",
+        "cards"
+      ],
+      "relevant_chunk_ids": [],
+      "dataset_source": "meepleai_custom",
+      "language": "en",
+      "expected_citations": {
+        "primary_pages": [
+          5
+        ],
+        "match_policy": "overlap_at_least_one"
+      }
+    },
+    {
+      "id": "en-seed-019",
+      "question": "How does card drafting work in 7 Wonders?",
+      "expected_answer": "Each player selects one card from their hand, plays it simultaneously, then passes the remaining cards to the next player. Direction alternates by age.",
+      "source": "7wonders-rulebook",
+      "source_page": 6,
+      "section": "Drafting",
+      "difficulty": "hard",
+      "category": "gameplay",
+      "game_id": "7-wonders",
+      "expected_keywords": [
+        "select",
+        "simultaneously",
+        "pass",
+        "direction"
+      ],
+      "relevant_chunk_ids": [],
+      "dataset_source": "meepleai_custom",
+      "language": "en",
+      "expected_citations": {
+        "primary_pages": [
+          6
+        ],
+        "match_policy": "overlap_at_least_one"
+      }
+    },
+    {
+      "id": "en-seed-020",
+      "question": "Can you trade with the bank in Catan, and at what ratio?",
+      "expected_answer": "Yes, you can trade 4 identical resource cards for 1 resource card of any type with the bank. With a harbor, the ratio can be 3:1 (general) or 2:1 (specific resource).",
+      "source": "catan-rulebook",
+      "source_page": 9,
+      "section": "Trading",
+      "difficulty": "hard",
+      "category": "gameplay",
+      "game_id": "catan",
+      "expected_keywords": [
+        "4",
+        "bank",
+        "harbor",
+        "3:1",
+        "2:1"
+      ],
+      "relevant_chunk_ids": [],
+      "dataset_source": "meepleai_custom",
+      "language": "en",
+      "expected_citations": {
+        "primary_pages": [
+          9
+        ],
+        "match_policy": "overlap_at_least_one"
+      }
+    },
+    {
+      "id": "en-seed-021",
+      "question": "How many development cards can you buy per turn in Catan?",
+      "expected_answer": "You can buy as many development cards as you can afford per turn, but you can only play one development card per turn.",
+      "source": "catan-rulebook",
+      "source_page": 10,
+      "section": "Development Cards",
+      "difficulty": "hard",
+      "category": "gameplay",
+      "game_id": "catan",
+      "expected_keywords": [
+        "buy",
+        "play",
+        "one"
+      ],
+      "relevant_chunk_ids": [],
+      "dataset_source": "meepleai_custom",
+      "language": "en",
+      "expected_citations": {
+        "primary_pages": [
+          10
+        ],
+        "match_policy": "overlap_at_least_one"
+      }
+    },
+    {
+      "id": "en-seed-022",
+      "question": "How many resource cards does each terrain hex produce when its number is rolled?",
+      "expected_answer": "Each terrain hex produces 1 resource card for every settlement adjacent to it, and 2 resource cards for every city adjacent to it.",
+      "source": "catan-rulebook",
+      "source_page": 6,
+      "section": "Resource Production",
+      "difficulty": "easy",
+      "category": "gameplay",
+      "game_id": "catan",
+      "expected_keywords": [
+        "1",
+        "settlement",
+        "2",
+        "city"
+      ],
+      "relevant_chunk_ids": [],
+      "dataset_source": "meepleai_custom",
+      "language": "en",
+      "expected_citations": {
+        "primary_pages": [
+          6
+        ],
+        "match_policy": "overlap_at_least_one"
+      }
+    },
+    {
+      "id": "en-seed-023",
+      "question": "What resources are needed to build a city in Catan?",
+      "expected_answer": "3 ore and 2 grain are needed to upgrade a settlement to a city.",
+      "source": "catan-rulebook",
+      "source_page": 7,
+      "section": "Building Costs",
+      "difficulty": "easy",
+      "category": "gameplay",
+      "game_id": "catan",
+      "expected_keywords": [
+        "3",
+        "ore",
+        "2",
+        "grain"
+      ],
+      "relevant_chunk_ids": [],
+      "dataset_source": "meepleai_custom",
+      "language": "en",
+      "expected_citations": {
+        "primary_pages": [
+          7
+        ],
+        "match_policy": "overlap_at_least_one"
+      }
+    },
+    {
+      "id": "en-seed-024",
+      "question": "What is the placement rule for settlements in Catan?",
+      "expected_answer": "Settlements must be placed on an unoccupied intersection that is at least two intersections away from any other settlement or city (the distance rule).",
+      "source": "catan-rulebook",
+      "source_page": 5,
+      "section": "Placement Rules",
+      "difficulty": "medium",
+      "category": "gameplay",
+      "game_id": "catan",
+      "expected_keywords": [
+        "intersection",
+        "two",
+        "distance"
+      ],
+      "relevant_chunk_ids": [],
+      "dataset_source": "meepleai_custom",
+      "language": "en",
+      "expected_citations": {
+        "primary_pages": [
+          5
+        ],
+        "match_policy": "overlap_at_least_one"
+      }
+    },
+    {
+      "id": "en-seed-025",
+      "question": "How do ports work in Catan?",
+      "expected_answer": "Ports allow better trade ratios with the bank. A general port allows 3:1 trades, while specific resource ports allow 2:1 trades for that resource. You must build a settlement on a port to use it.",
+      "source": "catan-rulebook",
+      "source_page": 9,
+      "section": "Maritime Trade",
+      "difficulty": "medium",
+      "category": "gameplay",
+      "game_id": "catan",
+      "expected_keywords": [
+        "3:1",
+        "2:1",
+        "settlement",
+        "port"
+      ],
+      "relevant_chunk_ids": [],
+      "dataset_source": "meepleai_custom",
+      "language": "en",
+      "expected_citations": {
+        "primary_pages": [
+          9
+        ],
+        "match_policy": "overlap_at_least_one"
+      }
+    },
+    {
+      "id": "en-seed-026",
+      "question": "What is the Knight card in Catan and how is Largest Army determined?",
+      "expected_answer": "The Knight card lets you move the robber to a new hex and steal a resource from an adjacent player. The player who plays the most Knight cards (minimum 3) receives the Largest Army card worth 2 victory points.",
+      "source": "catan-rulebook",
+      "source_page": 10,
+      "section": "Development Cards",
+      "difficulty": "hard",
+      "category": "gameplay",
+      "game_id": "catan",
+      "expected_keywords": [
+        "robber",
+        "steal",
+        "3",
+        "Largest Army",
+        "2"
+      ],
+      "relevant_chunk_ids": [],
+      "dataset_source": "meepleai_custom",
+      "language": "en",
+      "expected_citations": {
+        "primary_pages": [
+          10
+        ],
+        "match_policy": "overlap_at_least_one"
+      }
+    },
+    {
+      "id": "en-seed-027",
+      "question": "Can you play a development card on the same turn you buy it in Catan?",
+      "expected_answer": "No, you cannot play a development card on the same turn you bought it. You must wait until a subsequent turn to play it.",
+      "source": "catan-rulebook",
+      "source_page": 10,
+      "section": "Development Cards",
+      "difficulty": "hard",
+      "category": "gameplay",
+      "game_id": "catan",
+      "expected_keywords": [
+        "cannot",
+        "same",
+        "turn",
+        "subsequent"
+      ],
+      "relevant_chunk_ids": [],
+      "dataset_source": "meepleai_custom",
+      "language": "en",
+      "expected_citations": {
+        "primary_pages": [
+          10
+        ],
+        "match_policy": "overlap_at_least_one"
+      }
+    },
+    {
+      "id": "en-seed-028",
+      "question": "What happens during initial placement in Catan?",
+      "expected_answer": "Players take turns placing 1 settlement and 1 road in order, then in reverse order place a second settlement and road. The second settlement produces starting resources.",
+      "source": "catan-rulebook",
+      "source_page": 4,
+      "section": "Setup",
+      "difficulty": "medium",
+      "category": "setup",
+      "game_id": "catan",
+      "expected_keywords": [
+        "settlement",
+        "road",
+        "reverse",
+        "second",
+        "resources"
+      ],
+      "relevant_chunk_ids": [],
+      "dataset_source": "meepleai_custom",
+      "language": "en",
+      "expected_citations": {
+        "primary_pages": [
+          4
+        ],
+        "match_policy": "overlap_at_least_one"
+      }
+    },
+    {
+      "id": "en-seed-029",
+      "question": "What are the three main actions a player can take on their turn in Wingspan besides playing a bird?",
+      "expected_answer": "Gain food from the birdfeeder, lay eggs, and draw bird cards — each activated by placing an action cube in the Forest, Grassland, or Wetland row respectively.",
+      "source": "wingspan-rulebook",
+      "difficulty": "medium",
+      "category": "gameplay",
+      "game_id": "wingspan",
+      "expected_keywords": [
+        "gain food",
+        "lay eggs",
+        "draw"
+      ],
+      "relevant_chunk_ids": [],
+      "dataset_source": "meepleai_custom",
+      "language": "en"
+    },
+    {
+      "id": "en-seed-030",
+      "question": "How many rounds are played in a game of Wingspan and how do the available turns change?",
+      "expected_answer": "A game lasts 4 rounds; the number of available turns decreases each round (8, 7, 6, then 5) as cubes are set aside for end-of-round goals.",
+      "source": "wingspan-rulebook",
+      "difficulty": "medium",
+      "category": "scoring",
+      "game_id": "wingspan",
+      "expected_keywords": [
+        "4 rounds",
+        "turns",
+        "decrease"
+      ],
+      "relevant_chunk_ids": [],
+      "dataset_source": "meepleai_custom",
+      "language": "en"
+    },
+    {
+      "id": "en-seed-031",
+      "question": "How many cards make up a player's starting deck in Dominion and what are they?",
+      "expected_answer": "Each player starts with a 10-card deck: 7 Copper and 3 Estates.",
+      "source": "dominion-rulebook",
+      "difficulty": "easy",
+      "category": "setup",
+      "game_id": "dominion",
+      "expected_keywords": [
+        "10 cards",
+        "7 Copper",
+        "3 Estate"
+      ],
+      "relevant_chunk_ids": [],
+      "dataset_source": "meepleai_custom",
+      "language": "en"
+    },
+    {
+      "id": "en-seed-032",
+      "question": "What conditions end a game of Dominion?",
+      "expected_answer": "The game ends when the Province pile is empty or when any three Supply piles are empty; the player with the most victory points then wins.",
+      "source": "dominion-rulebook",
+      "difficulty": "medium",
+      "category": "scoring",
+      "game_id": "dominion",
+      "expected_keywords": [
+        "Province",
+        "three",
+        "piles empty"
+      ],
+      "relevant_chunk_ids": [],
+      "dataset_source": "meepleai_custom",
+      "language": "en"
+    },
+    {
+      "id": "en-seed-033",
+      "question": "What are the two scoring tracks in Ark Nova and how does the game end?",
+      "expected_answer": "The Appeal track and the Conservation Points track; the game ends when the two markers meet or cross on the scoring display.",
+      "source": "ark-nova-rulebook",
+      "difficulty": "hard",
+      "category": "scoring",
+      "game_id": "ark-nova",
+      "expected_keywords": [
+        "Appeal",
+        "Conservation",
+        "cross"
+      ],
+      "relevant_chunk_ids": [],
+      "dataset_source": "meepleai_custom",
+      "language": "en"
+    },
+    {
+      "id": "en-seed-034",
+      "question": "What do break icons trigger in Ark Nova?",
+      "expected_answer": "Break icons trigger the Break phase, during which the player takes a Sponsors bonus and the card display is refreshed before play continues.",
+      "source": "ark-nova-rulebook",
+      "difficulty": "medium",
+      "category": "gameplay",
+      "game_id": "ark-nova",
+      "expected_keywords": [
+        "break",
+        "phase",
+        "display"
+      ],
       "relevant_chunk_ids": [],
       "dataset_source": "meepleai_custom",
       "language": "en"


### PR DESCRIPTION
## Cosa

Prerequisito abilitante dell'epic **3397** (affidabilità agente in-sessione): aggiunge la **metrica citation-accuracy page-level** e il **golden eval-set** che diventano il gate obbligatorio prima del cablaggio degli enhancement RAG sul live path (issue **3390**). Estende lo scaffolding eval Slice 4 (3433/3441), non lo riscrive. TDD RED→GREEN su ogni slice.

Closes #3467

## Contenuto

- **`expected_citations` `{primary_pages, match_policy}`** su `EvaluationSample`: 4 policy page-level (`exact`/`overlap_at_least_one`/`subset`/`superset`), round-trip snake_case. Una policy con typo **fallisce loud** invece di degradare silenziosamente alla comparazione più permissiva.
- **Metriche** `CitationAccuracy` + `CitationStructuralValidity` + `CitedSampleCount` (accuracy solo sui sample citation-graded; riusa `InlineCitationMatcherService` + `CitationValidationService`), esposte nel report Markdown + JSON.
- **`POST /api/v1/admin/eval/merge-labels`** (admin-gated, CQRS `IMediator` only) che **persiste** il dataset etichettato in modo **atomico** (temp + move) preservando `version`/`created_at` + target `make eval-merge-labels`.
- **Guard negative-space CRAG-off**: il live path (`RetrievalPolicy.LiveSession`, `EnhancementsEnabled=false`) non esegue mai CRAG; `RagPromptAssemblyService` non ha alcuna dipendenza da plugin web (il web-fallback resta OFF sul dominio regolamenti — se 3390 cablasse un plugin web, il test reflection va RED).
- **Golden set**: 34 sample EN sui 5 giochi golden (Catan/Wingspan/Dominion/ArkNova/7Wonders), **28 citation-graded** da `source_page` reale (**zero pagine fabbricate**, union da seed/mozilla/custom). `relevant_chunk_ids` vuoti — labeling recall deferito a 3427 (chunk-id instabili al re-index).
- Gate `MeetsCitationAccuracyTarget(>=0.80)`; doc [`rag-golden-eval-set.md`](docs/for-developers/testing/rag-golden-eval-set.md); fix docstring fuorviante "LLM-as-judge" (answer correctness è euristica keyword deterministica).

## Soglie del gate 3390 (codificate qui)

Recall@10 ≥ 0.70 · CitationAccuracy ≥ 0.80 (page-level) · P95 < 1500ms · 0 chiamate web dal live path.

## Fuori scope (deferito, dichiarato)

- Labeling `relevant_chunk_ids` + baseline report su staging → gated su **3427**.
- Sandboxing `datasetPath`/`outputPath` → **3438** (non allargato qui).
- LLM-as-judge reale → YAGNI (keyword-accuracy deterministica e CI-stabile).

## Test

- **4614+ test unit KnowledgeBase verdi**, 0 regressioni (il solo fail transitorio è `ChatWithSessionAgentMetricsTests`, flake noto `MeterListener` + xUnit parallel — passa in isolamento, non toccato dal diff).
- **9/9 integration** `AdminEvalEndpointsIntegrationTests` (retrieval + merge-labels: 200/400/403/404/401, persistenza reale, metadata preservata).

## Review adversariale

Review multi-lente (6 dimensioni → verifica adversariale per finding). Completata parzialmente (session limit sulle lenti citation-correctness/crag-guards/test-quality — auto-revisionate durante il TDD). **Tutti e 4 i finding confermati sono stati risolti in questo PR**: (1) Parse fail-loud su policy typo; (2) preserva version/created_at + write atomica su merge in-place; (3) guard `review.items` null → 400; (4) rimosso sample duplicato `en-seed-022`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)