### PR TITLE
feat(catalog): cover assignment domain foundation (#3470 Slice 1a)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/CoverAssignmentSource.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/CoverAssignmentSource.cs
@@ -1,0 +1,22 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+
+/// <summary>
+/// The cover sources an admin may pin to a UI context (epic #3470, Slice 0 SD1).
+/// Excludes the per-user custom cover (L3), which is user personalization and is
+/// never set at catalog level. Maps to the internal storage-key
+/// <c>CoverKind</c> in the infrastructure layer.
+/// </summary>
+public enum CoverAssignmentSource
+{
+    /// <summary>PDF-derived cover (rulebook page).</summary>
+    Pdf = 0,
+
+    /// <summary>BGG re-uploaded cover (admin server-to-server, ADR-059 §2).</summary>
+    Bgg = 1,
+
+    /// <summary>Wikidata/Commons cover.</summary>
+    Wikidata = 2,
+
+    /// <summary>Admin manual-URL cover, fetched + re-hosted on R2 with license attestation.</summary>
+    Manual = 3,
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/GameCoverAssignment.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/GameCoverAssignment.cs
@@ -23,6 +23,7 @@ public sealed class GameCoverAssignment : Entity<Guid>
     private readonly DateTime _createdAt;
     private readonly Guid _createdBy;
     private DateTime? _updatedAt;
+    private Guid? _updatedBy;
 
     /// <summary>Gets the unique identifier of this assignment.</summary>
     public new Guid Id => _id;
@@ -54,6 +55,9 @@ public sealed class GameCoverAssignment : Entity<Guid>
     /// <summary>Gets the last update timestamp.</summary>
     public DateTime? UpdatedAt => _updatedAt;
 
+    /// <summary>Gets the id of the admin who last changed source/focal point.</summary>
+    public Guid? UpdatedBy => _updatedBy;
+
     /// <summary>Parameterless constructor for EF Core.</summary>
     private GameCoverAssignment() : base()
     {
@@ -70,7 +74,8 @@ public sealed class GameCoverAssignment : Entity<Guid>
         string? generatedR2Key,
         DateTime createdAt,
         Guid createdBy,
-        DateTime? updatedAt) : base(id)
+        DateTime? updatedAt,
+        Guid? updatedBy) : base(id)
     {
         _id = id;
         _sharedGameId = sharedGameId;
@@ -82,6 +87,7 @@ public sealed class GameCoverAssignment : Entity<Guid>
         _createdAt = createdAt;
         _createdBy = createdBy;
         _updatedAt = updatedAt;
+        _updatedBy = updatedBy;
     }
 
     /// <summary>Creates a new assignment with validation.</summary>
@@ -99,6 +105,12 @@ public sealed class GameCoverAssignment : Entity<Guid>
         if (createdBy == Guid.Empty)
             throw new ArgumentException("CreatedBy cannot be empty", nameof(createdBy));
 
+        if (!Enum.IsDefined(context))
+            throw new ArgumentException("Invalid CoverContext", nameof(context));
+
+        if (!Enum.IsDefined(source))
+            throw new ArgumentException("Invalid CoverAssignmentSource", nameof(source));
+
         EnsureFocalInRange(focalX, nameof(focalX));
         EnsureFocalInRange(focalY, nameof(focalY));
 
@@ -112,33 +124,47 @@ public sealed class GameCoverAssignment : Entity<Guid>
             generatedR2Key: null,
             DateTime.UtcNow,
             createdBy,
-            updatedAt: null);
+            updatedAt: null,
+            updatedBy: null);
     }
 
     /// <summary>Repoints the assignment at a different source; clears the stale rendered crop.</summary>
-    public void ChangeSource(CoverAssignmentSource source)
+    public void ChangeSource(CoverAssignmentSource source, Guid updatedBy)
     {
+        if (!Enum.IsDefined(source))
+            throw new ArgumentException("Invalid CoverAssignmentSource", nameof(source));
+
+        if (updatedBy == Guid.Empty)
+            throw new ArgumentException("UpdatedBy cannot be empty", nameof(updatedBy));
+
         if (_source == source)
             return;
 
         _source = source;
         _generatedR2Key = null;
-        _updatedAt = DateTime.UtcNow;
+        Touch(updatedBy);
     }
 
     /// <summary>Updates the crop focal point; clears the stale rendered crop.</summary>
-    public void SetFocalPoint(double focalX, double focalY)
+    public void SetFocalPoint(double focalX, double focalY, Guid updatedBy)
     {
         EnsureFocalInRange(focalX, nameof(focalX));
         EnsureFocalInRange(focalY, nameof(focalY));
 
+        if (updatedBy == Guid.Empty)
+            throw new ArgumentException("UpdatedBy cannot be empty", nameof(updatedBy));
+
         _focalX = focalX;
         _focalY = focalY;
         _generatedR2Key = null;
-        _updatedAt = DateTime.UtcNow;
+        Touch(updatedBy);
     }
 
-    /// <summary>Records the R2 key of the rendered per-context crop.</summary>
+    /// <summary>
+    /// Records the R2 key of the rendered per-context crop. This is a system
+    /// operation (the rendering pipeline), so it stamps the timestamp but not an
+    /// admin actor — <see cref="UpdatedBy"/> keeps the last human change.
+    /// </summary>
     public void SetGeneratedKey(string generatedR2Key)
     {
         if (string.IsNullOrWhiteSpace(generatedR2Key))
@@ -148,9 +174,15 @@ public sealed class GameCoverAssignment : Entity<Guid>
         _updatedAt = DateTime.UtcNow;
     }
 
+    private void Touch(Guid updatedBy)
+    {
+        _updatedAt = DateTime.UtcNow;
+        _updatedBy = updatedBy;
+    }
+
     private static void EnsureFocalInRange(double value, string paramName)
     {
-        if (value < 0.0 || value > 1.0)
-            throw new ArgumentOutOfRangeException(paramName, value, "Focal point must be in [0, 1].");
+        if (double.IsNaN(value) || double.IsInfinity(value) || value < 0.0 || value > 1.0)
+            throw new ArgumentOutOfRangeException(paramName, value, "Focal point must be a finite value in [0, 1].");
     }
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/GameCoverAssignment.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/GameCoverAssignment.cs
@@ -1,0 +1,156 @@
+using Api.SharedKernel.Domain.Covers;
+using Api.SharedKernel.Domain.Entities;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+
+/// <summary>
+/// An admin's per-context cover choice for a game (epic #3470). Pins which
+/// <see cref="CoverAssignmentSource"/> is used for a given <see cref="CoverContext"/>
+/// and the focal point of the crop (SD2). At most one assignment per
+/// (game, context). Absence of an assignment falls back to the resolver's
+/// implicit precedence (backward-compat). The generated per-context WebP key
+/// is set once the crop has been rendered.
+/// </summary>
+public sealed class GameCoverAssignment : Entity<Guid>
+{
+    private Guid _id;
+    private Guid _sharedGameId;
+    private readonly CoverContext _context;
+    private CoverAssignmentSource _source;
+    private double _focalX;
+    private double _focalY;
+    private string? _generatedR2Key;
+    private readonly DateTime _createdAt;
+    private readonly Guid _createdBy;
+    private DateTime? _updatedAt;
+
+    /// <summary>Gets the unique identifier of this assignment.</summary>
+    public new Guid Id => _id;
+
+    /// <summary>Gets the ID of the game this assignment belongs to.</summary>
+    public Guid SharedGameId => _sharedGameId;
+
+    /// <summary>Gets the UI context this assignment targets.</summary>
+    public CoverContext Context => _context;
+
+    /// <summary>Gets the pinned cover source.</summary>
+    public CoverAssignmentSource Source => _source;
+
+    /// <summary>Gets the crop focal point X (0..1, 0.5 = center).</summary>
+    public double FocalX => _focalX;
+
+    /// <summary>Gets the crop focal point Y (0..1, 0.5 = center).</summary>
+    public double FocalY => _focalY;
+
+    /// <summary>Gets the R2 key of the rendered per-context WebP crop, if generated.</summary>
+    public string? GeneratedR2Key => _generatedR2Key;
+
+    /// <summary>Gets the creation timestamp.</summary>
+    public DateTime CreatedAt => _createdAt;
+
+    /// <summary>Gets the id of the admin who created this assignment.</summary>
+    public Guid CreatedBy => _createdBy;
+
+    /// <summary>Gets the last update timestamp.</summary>
+    public DateTime? UpdatedAt => _updatedAt;
+
+    /// <summary>Parameterless constructor for EF Core.</summary>
+    private GameCoverAssignment() : base()
+    {
+    }
+
+    /// <summary>Internal constructor for reconstitution from persistence.</summary>
+    internal GameCoverAssignment(
+        Guid id,
+        Guid sharedGameId,
+        CoverContext context,
+        CoverAssignmentSource source,
+        double focalX,
+        double focalY,
+        string? generatedR2Key,
+        DateTime createdAt,
+        Guid createdBy,
+        DateTime? updatedAt) : base(id)
+    {
+        _id = id;
+        _sharedGameId = sharedGameId;
+        _context = context;
+        _source = source;
+        _focalX = focalX;
+        _focalY = focalY;
+        _generatedR2Key = generatedR2Key;
+        _createdAt = createdAt;
+        _createdBy = createdBy;
+        _updatedAt = updatedAt;
+    }
+
+    /// <summary>Creates a new assignment with validation.</summary>
+    public static GameCoverAssignment Create(
+        Guid sharedGameId,
+        CoverContext context,
+        CoverAssignmentSource source,
+        Guid createdBy,
+        double focalX = 0.5,
+        double focalY = 0.5)
+    {
+        if (sharedGameId == Guid.Empty)
+            throw new ArgumentException("SharedGameId cannot be empty", nameof(sharedGameId));
+
+        if (createdBy == Guid.Empty)
+            throw new ArgumentException("CreatedBy cannot be empty", nameof(createdBy));
+
+        EnsureFocalInRange(focalX, nameof(focalX));
+        EnsureFocalInRange(focalY, nameof(focalY));
+
+        return new GameCoverAssignment(
+            Guid.NewGuid(),
+            sharedGameId,
+            context,
+            source,
+            focalX,
+            focalY,
+            generatedR2Key: null,
+            DateTime.UtcNow,
+            createdBy,
+            updatedAt: null);
+    }
+
+    /// <summary>Repoints the assignment at a different source; clears the stale rendered crop.</summary>
+    public void ChangeSource(CoverAssignmentSource source)
+    {
+        if (_source == source)
+            return;
+
+        _source = source;
+        _generatedR2Key = null;
+        _updatedAt = DateTime.UtcNow;
+    }
+
+    /// <summary>Updates the crop focal point; clears the stale rendered crop.</summary>
+    public void SetFocalPoint(double focalX, double focalY)
+    {
+        EnsureFocalInRange(focalX, nameof(focalX));
+        EnsureFocalInRange(focalY, nameof(focalY));
+
+        _focalX = focalX;
+        _focalY = focalY;
+        _generatedR2Key = null;
+        _updatedAt = DateTime.UtcNow;
+    }
+
+    /// <summary>Records the R2 key of the rendered per-context crop.</summary>
+    public void SetGeneratedKey(string generatedR2Key)
+    {
+        if (string.IsNullOrWhiteSpace(generatedR2Key))
+            throw new ArgumentException("GeneratedR2Key is required", nameof(generatedR2Key));
+
+        _generatedR2Key = generatedR2Key;
+        _updatedAt = DateTime.UtcNow;
+    }
+
+    private static void EnsureFocalInRange(double value, string paramName)
+    {
+        if (value < 0.0 || value > 1.0)
+            throw new ArgumentOutOfRangeException(paramName, value, "Focal point must be in [0, 1].");
+    }
+}

--- a/apps/api/src/Api/SharedKernel/Domain/Covers/CoverContext.cs
+++ b/apps/api/src/Api/SharedKernel/Domain/Covers/CoverContext.cs
@@ -1,0 +1,19 @@
+namespace Api.SharedKernel.Domain.Covers;
+
+/// <summary>
+/// The UI surfaces for which an admin can assign a distinct game cover
+/// (epic #3470, Slice 0 SD1). Each context has a target aspect ratio; the
+/// rendered crop is produced from the chosen source with a configurable
+/// focal point (SD2).
+/// </summary>
+public enum CoverContext
+{
+    /// <summary>Portrait card ~2:3 — catalog grid, list, thumbnail.</summary>
+    Card = 0,
+
+    /// <summary>Landscape ~16:9 — detail hero, featured, hub banner.</summary>
+    Hero = 1,
+
+    /// <summary>OpenGraph social share ~1.91:1 (1200×630).</summary>
+    Social = 2,
+}

--- a/apps/api/src/Api/SharedKernel/Domain/Covers/CoverKeyBuilder.cs
+++ b/apps/api/src/Api/SharedKernel/Domain/Covers/CoverKeyBuilder.cs
@@ -20,6 +20,9 @@ internal enum CoverKind
 
     /// <summary>Wikidata/Commons cover — physical key adds <c>.webp</c>.</summary>
     Wikidata,
+
+    /// <summary>Admin manual-URL cover (epic #3470): fetched + re-hosted on R2 — physical key adds <c>.webp</c>.</summary>
+    Manual,
 }
 
 /// <summary>
@@ -54,6 +57,10 @@ internal static class CoverKeyBuilder
     /// <summary>Wikidata/Commons cover (L2): <c>covers/{gameId:D}/cover</c>.</summary>
     public static CoverKey ForWikidata(Guid gameId) =>
         Build(CoverKind.Wikidata, $"covers/{gameId:D}/cover");
+
+    /// <summary>Admin manual-URL cover (epic #3470): <c>covers/manual/{gameId:D}/cover</c>.</summary>
+    public static CoverKey ForManual(Guid gameId) =>
+        Build(CoverKind.Manual, $"covers/manual/{gameId:D}/cover");
 
     /// <summary>
     /// BGG re-uploaded cover (L2.5): <c>bgg-covers/{bggId}/cover{ext}</c>. The
@@ -104,6 +111,7 @@ internal static class CoverKeyBuilder
         CoverKind.Pdf => "-preview.webp",
         CoverKind.Bgg => string.Empty,
         CoverKind.Wikidata => ".webp",
+        CoverKind.Manual => ".webp",
         _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, "Unknown cover kind."),
     };
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Entities/GameCoverAssignmentTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Entities/GameCoverAssignmentTests.cs
@@ -14,6 +14,7 @@ public sealed class GameCoverAssignmentTests
 {
     private static readonly Guid GameId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
     private static readonly Guid AdminId = Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd");
+    private static readonly Guid Admin2Id = Guid.Parse("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee");
 
     [Fact]
     public void Create_WithDefaults_CentersFocalAndLeavesCropUnrendered()
@@ -28,6 +29,7 @@ public sealed class GameCoverAssignmentTests
         a.GeneratedR2Key.Should().BeNull();
         a.CreatedBy.Should().Be(AdminId);
         a.UpdatedAt.Should().BeNull();
+        a.UpdatedBy.Should().BeNull();
     }
 
     [Theory]
@@ -53,16 +55,41 @@ public sealed class GameCoverAssignmentTests
     }
 
     [Fact]
-    public void ChangeSource_ClearsGeneratedKeyAndStampsUpdate()
+    public void Create_RejectsNonFiniteFocalPoint()
+    {
+        var actNan = () => GameCoverAssignment.Create(
+            GameId, CoverContext.Card, CoverAssignmentSource.Pdf, AdminId, double.NaN, 0.5);
+        var actInf = () => GameCoverAssignment.Create(
+            GameId, CoverContext.Card, CoverAssignmentSource.Pdf, AdminId, 0.5, double.PositiveInfinity);
+
+        actNan.Should().Throw<ArgumentOutOfRangeException>();
+        actInf.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void Create_RejectsUndefinedEnumValues()
+    {
+        var actContext = () => GameCoverAssignment.Create(
+            GameId, (CoverContext)99, CoverAssignmentSource.Pdf, AdminId);
+        var actSource = () => GameCoverAssignment.Create(
+            GameId, CoverContext.Card, (CoverAssignmentSource)99, AdminId);
+
+        actContext.Should().Throw<ArgumentException>();
+        actSource.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void ChangeSource_ClearsGeneratedKeyAndStampsUpdater()
     {
         var a = GameCoverAssignment.Create(GameId, CoverContext.Card, CoverAssignmentSource.Pdf, AdminId);
         a.SetGeneratedKey("covers/manual/x/cover.webp");
 
-        a.ChangeSource(CoverAssignmentSource.Manual);
+        a.ChangeSource(CoverAssignmentSource.Manual, Admin2Id);
 
         a.Source.Should().Be(CoverAssignmentSource.Manual);
         a.GeneratedR2Key.Should().BeNull("changing source invalidates the stale rendered crop");
         a.UpdatedAt.Should().NotBeNull();
+        a.UpdatedBy.Should().Be(Admin2Id);
     }
 
     [Fact]
@@ -71,22 +98,36 @@ public sealed class GameCoverAssignmentTests
         var a = GameCoverAssignment.Create(GameId, CoverContext.Card, CoverAssignmentSource.Pdf, AdminId);
         a.SetGeneratedKey("k.webp");
 
-        a.ChangeSource(CoverAssignmentSource.Pdf);
+        a.ChangeSource(CoverAssignmentSource.Pdf, Admin2Id);
 
         a.GeneratedR2Key.Should().Be("k.webp", "a no-op source change must not clear the crop");
+        a.UpdatedBy.Should().BeNull("a no-op change must not stamp an updater");
     }
 
     [Fact]
-    public void SetFocalPoint_UpdatesAndClearsGeneratedKey()
+    public void ChangeSource_RejectsUndefinedSourceAndEmptyUpdater()
+    {
+        var a = GameCoverAssignment.Create(GameId, CoverContext.Card, CoverAssignmentSource.Pdf, AdminId);
+
+        var actEnum = () => a.ChangeSource((CoverAssignmentSource)99, Admin2Id);
+        var actUpdater = () => a.ChangeSource(CoverAssignmentSource.Wikidata, Guid.Empty);
+
+        actEnum.Should().Throw<ArgumentException>();
+        actUpdater.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void SetFocalPoint_UpdatesClearsGeneratedKeyAndStampsUpdater()
     {
         var a = GameCoverAssignment.Create(GameId, CoverContext.Hero, CoverAssignmentSource.Bgg, AdminId);
         a.SetGeneratedKey("k.webp");
 
-        a.SetFocalPoint(0.25, 0.75);
+        a.SetFocalPoint(0.25, 0.75, Admin2Id);
 
         a.FocalX.Should().Be(0.25);
         a.FocalY.Should().Be(0.75);
         a.GeneratedR2Key.Should().BeNull();
+        a.UpdatedBy.Should().Be(Admin2Id);
     }
 
     [Fact]
@@ -97,5 +138,16 @@ public sealed class GameCoverAssignmentTests
         var act = () => a.SetGeneratedKey("  ");
 
         act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void SetGeneratedKey_IsSystemOp_DoesNotStampUpdater()
+    {
+        var a = GameCoverAssignment.Create(GameId, CoverContext.Card, CoverAssignmentSource.Pdf, AdminId);
+
+        a.SetGeneratedKey("covers/manual/x/cover.webp");
+
+        a.UpdatedAt.Should().NotBeNull("the render pipeline still stamps the timestamp");
+        a.UpdatedBy.Should().BeNull("a system render is not attributed to an admin");
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Entities/GameCoverAssignmentTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Entities/GameCoverAssignmentTests.cs
@@ -1,0 +1,101 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.SharedKernel.Domain.Covers;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Domain.Entities;
+
+/// <summary>
+/// Domain unit tests for <see cref="GameCoverAssignment"/> (epic #3470, Slice 1a).
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class GameCoverAssignmentTests
+{
+    private static readonly Guid GameId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static readonly Guid AdminId = Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd");
+
+    [Fact]
+    public void Create_WithDefaults_CentersFocalAndLeavesCropUnrendered()
+    {
+        var a = GameCoverAssignment.Create(GameId, CoverContext.Hero, CoverAssignmentSource.Wikidata, AdminId);
+
+        a.SharedGameId.Should().Be(GameId);
+        a.Context.Should().Be(CoverContext.Hero);
+        a.Source.Should().Be(CoverAssignmentSource.Wikidata);
+        a.FocalX.Should().Be(0.5);
+        a.FocalY.Should().Be(0.5);
+        a.GeneratedR2Key.Should().BeNull();
+        a.CreatedBy.Should().Be(AdminId);
+        a.UpdatedAt.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("00000000-0000-0000-0000-000000000000", "dddddddd-dddd-dddd-dddd-dddddddddddd")]
+    [InlineData("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", "00000000-0000-0000-0000-000000000000")]
+    public void Create_RejectsEmptyIds(string gameId, string adminId)
+    {
+        var act = () => GameCoverAssignment.Create(
+            Guid.Parse(gameId), CoverContext.Card, CoverAssignmentSource.Pdf, Guid.Parse(adminId));
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Theory]
+    [InlineData(-0.01, 0.5)]
+    [InlineData(0.5, 1.01)]
+    public void Create_RejectsOutOfRangeFocalPoint(double x, double y)
+    {
+        var act = () => GameCoverAssignment.Create(
+            GameId, CoverContext.Card, CoverAssignmentSource.Pdf, AdminId, x, y);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void ChangeSource_ClearsGeneratedKeyAndStampsUpdate()
+    {
+        var a = GameCoverAssignment.Create(GameId, CoverContext.Card, CoverAssignmentSource.Pdf, AdminId);
+        a.SetGeneratedKey("covers/manual/x/cover.webp");
+
+        a.ChangeSource(CoverAssignmentSource.Manual);
+
+        a.Source.Should().Be(CoverAssignmentSource.Manual);
+        a.GeneratedR2Key.Should().BeNull("changing source invalidates the stale rendered crop");
+        a.UpdatedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ChangeSource_ToSameSource_IsNoOp()
+    {
+        var a = GameCoverAssignment.Create(GameId, CoverContext.Card, CoverAssignmentSource.Pdf, AdminId);
+        a.SetGeneratedKey("k.webp");
+
+        a.ChangeSource(CoverAssignmentSource.Pdf);
+
+        a.GeneratedR2Key.Should().Be("k.webp", "a no-op source change must not clear the crop");
+    }
+
+    [Fact]
+    public void SetFocalPoint_UpdatesAndClearsGeneratedKey()
+    {
+        var a = GameCoverAssignment.Create(GameId, CoverContext.Hero, CoverAssignmentSource.Bgg, AdminId);
+        a.SetGeneratedKey("k.webp");
+
+        a.SetFocalPoint(0.25, 0.75);
+
+        a.FocalX.Should().Be(0.25);
+        a.FocalY.Should().Be(0.75);
+        a.GeneratedR2Key.Should().BeNull();
+    }
+
+    [Fact]
+    public void SetGeneratedKey_RejectsBlank()
+    {
+        var a = GameCoverAssignment.Create(GameId, CoverContext.Card, CoverAssignmentSource.Pdf, AdminId);
+
+        var act = () => a.SetGeneratedKey("  ");
+
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/apps/api/tests/Api.Tests/SharedKernel/Domain/Covers/CoverKeyContractTests.cs
+++ b/apps/api/tests/Api.Tests/SharedKernel/Domain/Covers/CoverKeyContractTests.cs
@@ -54,6 +54,16 @@ public sealed class CoverKeyContractTests
         key.PhysicalKey.Should().Be($"covers/{GameId:D}/cover.webp");
     }
 
+    [Fact]
+    public void ForManual_MatchesProductionConvention()
+    {
+        var key = CoverKeyBuilder.ForManual(GameId);
+
+        key.Kind.Should().Be(CoverKind.Manual);
+        key.DbKey.Should().Be($"covers/manual/{GameId:D}/cover");
+        key.PhysicalKey.Should().Be($"covers/manual/{GameId:D}/cover.webp");
+    }
+
     [Theory]
     [InlineData(".jpg", "bgg-covers/13/cover.jpg")]
     [InlineData("jpg", "bgg-covers/13/cover.jpg")]    // normalizes a missing leading dot
@@ -88,6 +98,7 @@ public sealed class CoverKeyContractTests
             CoverKeyBuilder.ForUser(UserId, GameId),
             CoverKeyBuilder.ForPdf(PdfId),
             CoverKeyBuilder.ForWikidata(GameId),
+            CoverKeyBuilder.ForManual(GameId),
             CoverKeyBuilder.ForBgg(BggId, ".jpg"),
             CoverKeyBuilder.ForBgg(BggId, ".webp"),
         };


### PR DESCRIPTION
Prima fetta implementativa di #3470 (admin cover editor) — **layer Dominio** (DDD-first).

## Contenuto
- `CoverContext` enum (Card 2:3 / Hero 16:9 / Social 1.91:1) — SD1
- `CoverKind.Manual` + `CoverKeyBuilder.ForManual` + suffisso (webp re-hostato)
- `CoverAssignmentSource` enum (Pdf/Bgg/Wikidata/Manual; esclude L3 per-utente)
- `GameCoverAssignment` entity (aggregato SharedGame): pin sorgente + focal-point per (game, context); factory con validazione; `ChangeSource`/`SetFocalPoint` azzerano il crop renderizzato stale

## Test
- `CoverKeyContractTests`: `ForManual` + incluso nel round-trip write-key==read-key
- `GameCoverAssignmentTests`: create/validazione/change-source/focal/generated-key
- **23 pass**, build Api pulita (fix Sonar S2933 readonly)

## Nota scope
Fetta puramente Dominio (nessuna persistenza/uso ancora). Seguono in PR successive di Slice 1: EF+migration `game_cover_assignments` + colonne `manual_cover_*`, resolver context-aware, read-DTO candidati, overlay picker FE. Design completo nella spec (#3471) + epic #3470.

Relates to #3470.

Generated with Claude Code