### PR TITLE
feat(catalog): cover assignment EF schema + migration (#3470 Slice 1b)

### DIFF
--- a/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/GameCoverAssignmentEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/GameCoverAssignmentEntity.cs
@@ -1,0 +1,28 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.SharedKernel.Domain.Covers;
+
+namespace Api.Infrastructure.Entities.SharedGameCatalog;
+
+/// <summary>
+/// Persistence model for <see cref="GameCoverAssignment"/> (epic #3470, Slice 1b).
+/// An admin's per-context cover choice for a game: which source is pinned for a
+/// given UI context and the crop focal point. At most one row per
+/// (SharedGameId, Context). The generated per-context WebP crop key is stored
+/// once rendered.
+/// </summary>
+public class GameCoverAssignmentEntity
+{
+    public Guid Id { get; set; }
+    public Guid SharedGameId { get; set; }
+    public CoverContext Context { get; set; }
+    public CoverAssignmentSource Source { get; set; }
+    public double FocalX { get; set; }
+    public double FocalY { get; set; }
+    public string? GeneratedR2Key { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public Guid CreatedBy { get; set; }
+    public DateTime? UpdatedAt { get; set; }
+    public Guid? UpdatedBy { get; set; }
+
+    public SharedGameEntity SharedGame { get; set; } = default!;
+}

--- a/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/SharedGameEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/SharedGameEntity.cs
@@ -114,6 +114,29 @@ public class SharedGameEntity
     public string? BggCoverR2Key { get; set; }
 
     /// <summary>
+    /// Epic #3470 — admin manual-URL cover source. The URL is fetched
+    /// server-to-server, license-validated + re-encoded to WebP and re-hosted on
+    /// R2 (never hotlinked); only this R2 key is persisted. Resolved as
+    /// <c>CoverKind.Manual</c>. Null when no manual cover was set.
+    /// </summary>
+    public string? ManualCoverR2Key { get; set; }
+
+    /// <summary>License identifier the admin attested for the manual cover (whitelist-validated).</summary>
+    public string? ManualCoverLicense { get; set; }
+
+    /// <summary>Attribution string for the manual cover, shown in the attribution footer.</summary>
+    public string? ManualCoverAttribution { get; set; }
+
+    /// <summary>Original source URL of the manual cover (audit/provenance; never rendered).</summary>
+    public string? ManualCoverSourceUrl { get; set; }
+
+    /// <summary>Admin who attested the manual cover's license.</summary>
+    public Guid? ManualCoverAttestedBy { get; set; }
+
+    /// <summary>When the manual cover's license was attested.</summary>
+    public DateTime? ManualCoverAttestedAt { get; set; }
+
+    /// <summary>
     /// Issue #1929 Task C Macro 3a (DEC-B-8, DEC-C-8) — E2E test seeding scope marker.
     /// Explicit column (NOT shadow property) to avoid EF Core 9 + Npgsql null-after-save bug.
     /// Stamped on insert by SeedTestLibraryGameCommandHandler; consumed by
@@ -130,6 +153,7 @@ public class SharedGameEntity
     public ICollection<GameMechanicEntity> Mechanics { get; set; } = new List<GameMechanicEntity>();
 
     // Navigation properties (one-to-many)
+    public ICollection<GameCoverAssignmentEntity> CoverAssignments { get; set; } = new List<GameCoverAssignmentEntity>();
     public ICollection<GameFaqEntity> Faqs { get; set; } = new List<GameFaqEntity>();
     public ICollection<GameErrataEntity> Erratas { get; set; } = new List<GameErrataEntity>();
     public ICollection<SharedGameDocumentEntity> Documents { get; set; } = new List<SharedGameDocumentEntity>();

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/SharedGameCatalog/GameCoverAssignmentEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/SharedGameCatalog/GameCoverAssignmentEntityConfiguration.cs
@@ -1,0 +1,39 @@
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.EntityConfigurations.SharedGameCatalog;
+
+internal class GameCoverAssignmentEntityConfiguration : IEntityTypeConfiguration<GameCoverAssignmentEntity>
+{
+    public void Configure(EntityTypeBuilder<GameCoverAssignmentEntity> builder)
+    {
+        builder.ToTable("game_cover_assignments");
+
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id).HasColumnName("id").ValueGeneratedOnAdd();
+        builder.Property(e => e.SharedGameId).HasColumnName("shared_game_id").IsRequired();
+        builder.Property(e => e.Context).HasColumnName("context").IsRequired().HasConversion<short>();
+        builder.Property(e => e.Source).HasColumnName("source").IsRequired().HasConversion<short>();
+        builder.Property(e => e.FocalX).HasColumnName("focal_x").IsRequired().HasDefaultValue(0.5);
+        builder.Property(e => e.FocalY).HasColumnName("focal_y").IsRequired().HasDefaultValue(0.5);
+        builder.Property(e => e.GeneratedR2Key).HasColumnName("generated_r2_key");
+        builder.Property(e => e.CreatedAt).HasColumnName("created_at").IsRequired().HasDefaultValueSql("NOW()");
+        builder.Property(e => e.CreatedBy).HasColumnName("created_by").IsRequired();
+        builder.Property(e => e.UpdatedAt).HasColumnName("updated_at");
+        builder.Property(e => e.UpdatedBy).HasColumnName("updated_by");
+
+        // Optimistic concurrency via Postgres xmin (ADR-060).
+        builder.Property<uint>("xmin").HasColumnName("xmin").HasColumnType("xid").IsRowVersion();
+
+        // At most one assignment per (game, context).
+        builder.HasIndex(e => new { e.SharedGameId, e.Context })
+            .IsUnique()
+            .HasDatabaseName("ux_game_cover_assignments_game_context");
+
+        builder.HasOne(a => a.SharedGame)
+            .WithMany(g => g.CoverAssignments)
+            .HasForeignKey(a => a.SharedGameId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/SharedGameCatalog/SharedGameEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/SharedGameCatalog/SharedGameEntityConfiguration.cs
@@ -160,6 +160,35 @@ internal class SharedGameEntityConfiguration : IEntityTypeConfiguration<SharedGa
             .HasColumnName("wikidata_cover_attribution")
             .IsRequired(false);
 
+        // Epic #3470 — admin manual-URL cover (fetched + re-hosted on R2).
+        builder.Property(e => e.ManualCoverR2Key)
+            .HasMaxLength(512)
+            .HasColumnName("manual_cover_r2_key")
+            .IsRequired(false);
+
+        builder.Property(e => e.ManualCoverLicense)
+            .HasMaxLength(64)
+            .HasColumnName("manual_cover_license")
+            .IsRequired(false);
+
+        builder.Property(e => e.ManualCoverAttribution)
+            .HasMaxLength(512)
+            .HasColumnName("manual_cover_attribution")
+            .IsRequired(false);
+
+        builder.Property(e => e.ManualCoverSourceUrl)
+            .HasMaxLength(2048)
+            .HasColumnName("manual_cover_source_url")
+            .IsRequired(false);
+
+        builder.Property(e => e.ManualCoverAttestedBy)
+            .HasColumnName("manual_cover_attested_by")
+            .IsRequired(false);
+
+        builder.Property(e => e.ManualCoverAttestedAt)
+            .HasColumnName("manual_cover_attested_at")
+            .IsRequired(false);
+
         // Issue #1823 Phase B M8 — Wikidata QID resolved against shared_games
         // before the cover-enrichment orchestrator runs (ADR DEC-3a). Max 32
         // chars covers Q-numbers well past the current Wikidata range.

--- a/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+++ b/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
@@ -196,6 +196,7 @@ public class MeepleAiDbContext : DbContext
     public DbSet<GameCategoryEntity> GameCategories => Set<GameCategoryEntity>(); // ISSUE-2370: Game categories taxonomy
     public DbSet<GameMechanicEntity> GameMechanics => Set<GameMechanicEntity>(); // ISSUE-2370: Game mechanics taxonomy
     public DbSet<GameFaqEntity> GameFaqs => Set<GameFaqEntity>(); // ISSUE-2370: Game FAQs
+    public DbSet<GameCoverAssignmentEntity> GameCoverAssignments => Set<GameCoverAssignmentEntity>(); // #3470: admin per-context cover editor
     public DbSet<GameErrataEntity> GameErrata => Set<GameErrataEntity>(); // ISSUE-2370: Game errata
     public DbSet<SharedGameDeleteRequestEntity> SharedGameDeleteRequests => Set<SharedGameDeleteRequestEntity>(); // ISSUE-2370: Delete requests
     public DbSet<SharedGameDocumentEntity> SharedGameDocuments => Set<SharedGameDocumentEntity>(); // ISSUE-2391: Sprint 1 - PDF association

--- a/apps/api/src/Api/Infrastructure/Migrations/20260802103541_AddGameCoverAssignments.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260802103541_AddGameCoverAssignments.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260802103541_AddGameCoverAssignments")]
+    partial class AddGameCoverAssignments
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260802103541_AddGameCoverAssignments.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260802103541_AddGameCoverAssignments.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGameCoverAssignments : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "manual_cover_attested_at",
+                table: "shared_games",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "manual_cover_attested_by",
+                table: "shared_games",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "manual_cover_attribution",
+                table: "shared_games",
+                type: "character varying(512)",
+                maxLength: 512,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "manual_cover_license",
+                table: "shared_games",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "manual_cover_r2_key",
+                table: "shared_games",
+                type: "character varying(512)",
+                maxLength: 512,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "manual_cover_source_url",
+                table: "shared_games",
+                type: "character varying(2048)",
+                maxLength: 2048,
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "game_cover_assignments",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    shared_game_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    context = table.Column<short>(type: "smallint", nullable: false),
+                    source = table.Column<short>(type: "smallint", nullable: false),
+                    focal_x = table.Column<double>(type: "double precision", nullable: false, defaultValue: 0.5),
+                    focal_y = table.Column<double>(type: "double precision", nullable: false, defaultValue: 0.5),
+                    generated_r2_key = table.Column<string>(type: "text", nullable: true),
+                    created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "NOW()"),
+                    created_by = table.Column<Guid>(type: "uuid", nullable: false),
+                    updated_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    updated_by = table.Column<Guid>(type: "uuid", nullable: true),
+                    xmin = table.Column<uint>(type: "xid", rowVersion: true, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_game_cover_assignments", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_game_cover_assignments_shared_games_shared_game_id",
+                        column: x => x.shared_game_id,
+                        principalTable: "shared_games",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ux_game_cover_assignments_game_context",
+                table: "game_cover_assignments",
+                columns: new[] { "shared_game_id", "context" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "game_cover_assignments");
+
+            migrationBuilder.DropColumn(
+                name: "manual_cover_attested_at",
+                table: "shared_games");
+
+            migrationBuilder.DropColumn(
+                name: "manual_cover_attested_by",
+                table: "shared_games");
+
+            migrationBuilder.DropColumn(
+                name: "manual_cover_attribution",
+                table: "shared_games");
+
+            migrationBuilder.DropColumn(
+                name: "manual_cover_license",
+                table: "shared_games");
+
+            migrationBuilder.DropColumn(
+                name: "manual_cover_r2_key",
+                table: "shared_games");
+
+            migrationBuilder.DropColumn(
+                name: "manual_cover_source_url",
+                table: "shared_games");
+        }
+    }
+}


### PR DESCRIPTION
Seconda fetta di #3470 — **Infrastructure/schema** (segue Slice 1a dominio, #3473 merged).

## Contenuto
- `GameCoverAssignmentEntity` + config → tabella `game_cover_assignments` (per-(game,context) source pin + focal point + generated crop key), `UNIQUE(shared_game_id, context)`, FK cascade, **xmin** optimistic concurrency (ADR-060); enum → smallint via `HasConversion<short>`
- `SharedGameEntity`: colonne `manual_cover_*` (r2_key/license/attribution/source_url/attested_by/attested_at) per la sorgente URL manuale, a specchio delle colonne Wikidata
- `DbSet<GameCoverAssignmentEntity>` + migration `20260802103541_AddGameCoverAssignments`

## Verifica
- `dotnet ef migrations add` OK (build succeeded); migration = CreateTable + 6 AddColumn + unique index, Down pulita
- Build Api pulita + **27 test cover verdi** (nessuna regressione)

## Scope
Fetta schema-only (nessun reader/writer ancora). Seguono: Slice 1c (resolver `ResolveForContextAsync` + read-DTO candidati + mapping dominio↔entity con reconcile) + Slice 1d (FE overlay picker). Design in spec #3471, epic #3470.

Relates to #3470.

Generated with Claude Code