### PR TITLE
fix(rag-eval): use canonical hybrid retrieval in eval harness (not deprecated AskAsync)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Evaluation/Commands/GenerateLabelingCandidatesCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Evaluation/Commands/GenerateLabelingCandidatesCommandHandler.cs
@@ -43,11 +43,14 @@ internal sealed class GenerateLabelingCandidatesCommandHandler
 
         foreach (var sample in dataset.Samples)
         {
-            var response = await _ragService.AskAsync(
+            // Canonical hybrid retrieval path — AskAsync's legacy vector path is deprecated and returns
+            // empty results, so labeling candidates must come from AskWithHybridSearchAsync.
+            var response = await _ragService.AskWithHybridSearchAsync(
                 sample.GameId ?? "",
                 sample.Question,
-                null,
-                false,
+                SearchMode.Hybrid,
+                language: null,
+                bypassCache: false,
                 cancellationToken).ConfigureAwait(false);
 
             var candidates = (response.snippets ?? [])

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Evaluation/Services/DatasetEvaluationService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Evaluation/Services/DatasetEvaluationService.cs
@@ -104,13 +104,16 @@ internal sealed class DatasetEvaluationService : IDatasetEvaluationService
 
         try
         {
-            // Query the RAG system
-            // Note: IRagService.AskAsync signature is (gameId, query, language, bypassCache, cancellationToken)
-            var ragResponse = await _ragService.AskAsync(
+            // Query the RAG system via the canonical hybrid retrieval path. IRagService.AskAsync's legacy
+            // vector path is deprecated and returns empty results (RagService.ExecuteRetrievalPhaseAsync),
+            // so the eval must use AskWithHybridSearchAsync to exercise the real production retrieval.
+            // bypassCache: true so each run measures fresh retrieval, not a possibly-stale cached response.
+            var ragResponse = await _ragService.AskWithHybridSearchAsync(
                 sample.GameId ?? "",
                 sample.Question,
-                null,
-                false,
+                SearchMode.Hybrid,
+                language: null,
+                bypassCache: true,
                 cancellationToken).ConfigureAwait(false);
 
             stopwatch.Stop();

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Evaluation/Commands/LabelingAssistTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Evaluation/Commands/LabelingAssistTests.cs
@@ -62,9 +62,10 @@ public class LabelingAssistTests
 
             var mockRagService = new Mock<IRagService>();
             mockRagService
-                .Setup(r => r.AskAsync(
+                .Setup(r => r.AskWithHybridSearchAsync(
                     It.IsAny<string>(),
                     It.IsAny<string>(),
+                    It.IsAny<SearchMode>(),
                     It.IsAny<string?>(),
                     It.IsAny<bool>(),
                     It.IsAny<CancellationToken>()))
@@ -89,9 +90,10 @@ public class LabelingAssistTests
             item.Candidates[1].ChunkId.Should().Be("s2");
             item.Candidates[1].Relevant.Should().BeNull();
 
-            mockRagService.Verify(r => r.AskAsync(
+            mockRagService.Verify(r => r.AskWithHybridSearchAsync(
                 "",
                 "How many players?",
+                It.IsAny<SearchMode>(),
                 null,
                 false,
                 It.IsAny<CancellationToken>()), Times.Once);
@@ -121,9 +123,10 @@ public class LabelingAssistTests
 
             var mockRagService = new Mock<IRagService>();
             mockRagService
-                .Setup(r => r.AskAsync(
+                .Setup(r => r.AskWithHybridSearchAsync(
                     It.IsAny<string>(),
                     It.IsAny<string>(),
+                    It.IsAny<SearchMode>(),
                     It.IsAny<string?>(),
                     It.IsAny<bool>(),
                     It.IsAny<CancellationToken>()))

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Evaluation/Services/DatasetEvaluationServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Evaluation/Services/DatasetEvaluationServiceTests.cs
@@ -463,11 +463,12 @@ public class DatasetEvaluationServiceTests
             new("Snippet text 2", "chunk-2", 2, 1, 0.85f)
         };
 
-        // Note: AskAsync signature is (gameId, query, language, bypassCache, cancellationToken)
+        // Note: AskWithHybridSearchAsync signature is (gameId, query, searchMode, language, bypassCache, cancellationToken)
         _mockRagService
-            .Setup(r => r.AskAsync(
+            .Setup(r => r.AskWithHybridSearchAsync(
                 It.IsAny<string>(),
                 It.IsAny<string>(),
+                It.IsAny<SearchMode>(),
                 It.IsAny<string?>(),
                 It.IsAny<bool>(),
                 It.IsAny<CancellationToken>()))
@@ -494,11 +495,12 @@ public class DatasetEvaluationServiceTests
         // Arrange
         var sample = CreateSample();
 
-        // Note: AskAsync signature is (gameId, query, language, bypassCache, cancellationToken)
+        // Note: AskWithHybridSearchAsync signature is (gameId, query, searchMode, language, bypassCache, cancellationToken)
         _mockRagService
-            .Setup(r => r.AskAsync(
+            .Setup(r => r.AskWithHybridSearchAsync(
                 It.IsAny<string>(),
                 It.IsAny<string>(),
+                It.IsAny<SearchMode>(),
                 It.IsAny<string?>(),
                 It.IsAny<bool>(),
                 It.IsAny<CancellationToken>()))
@@ -537,11 +539,12 @@ public class DatasetEvaluationServiceTests
             dataset.AddSample(CreateSample($"sample-{i}"));
         }
 
-        // Note: AskAsync signature is (gameId, query, language, bypassCache, cancellationToken)
+        // Note: AskWithHybridSearchAsync signature is (gameId, query, searchMode, language, bypassCache, cancellationToken)
         _mockRagService
-            .Setup(r => r.AskAsync(
+            .Setup(r => r.AskWithHybridSearchAsync(
                 It.IsAny<string>(),
                 It.IsAny<string>(),
+                It.IsAny<SearchMode>(),
                 It.IsAny<string?>(),
                 It.IsAny<bool>(),
                 It.IsAny<CancellationToken>()))
@@ -569,11 +572,12 @@ public class DatasetEvaluationServiceTests
             dataset.AddSample(CreateSample($"sample-{i}"));
         }
 
-        // Note: AskAsync signature is (gameId, query, language, bypassCache, cancellationToken)
+        // Note: AskWithHybridSearchAsync signature is (gameId, query, searchMode, language, bypassCache, cancellationToken)
         _mockRagService
-            .Setup(r => r.AskAsync(
+            .Setup(r => r.AskWithHybridSearchAsync(
                 It.IsAny<string>(),
                 It.IsAny<string>(),
+                It.IsAny<SearchMode>(),
                 It.IsAny<string?>(),
                 It.IsAny<bool>(),
                 It.IsAny<CancellationToken>()))
@@ -605,11 +609,12 @@ public class DatasetEvaluationServiceTests
         var callCount = 0;
         using var cts = new CancellationTokenSource();
 
-        // Note: AskAsync signature is (gameId, query, language, bypassCache, cancellationToken)
+        // Note: AskWithHybridSearchAsync signature is (gameId, query, searchMode, language, bypassCache, cancellationToken)
         _mockRagService
-            .Setup(r => r.AskAsync(
+            .Setup(r => r.AskWithHybridSearchAsync(
                 It.IsAny<string>(),
                 It.IsAny<string>(),
+                It.IsAny<SearchMode>(),
                 It.IsAny<string?>(),
                 It.IsAny<bool>(),
                 It.IsAny<CancellationToken>()))
@@ -669,11 +674,12 @@ public class DatasetEvaluationServiceTests
             new("Snippet text", "s1", 1, 1, 0.9f)
         };
 
-        // Note: AskAsync signature is (gameId, query, language, bypassCache, cancellationToken)
+        // Note: AskWithHybridSearchAsync signature is (gameId, query, searchMode, language, bypassCache, cancellationToken)
         _mockRagService
-            .Setup(r => r.AskAsync(
+            .Setup(r => r.AskWithHybridSearchAsync(
                 It.IsAny<string>(),
                 It.IsAny<string>(),
+                It.IsAny<SearchMode>(),
                 It.IsAny<string?>(),
                 It.IsAny<bool>(),
                 It.IsAny<CancellationToken>()))
@@ -700,13 +706,30 @@ public class DatasetEvaluationServiceTests
     {
         var snippet = new Snippet(text: CitablePhrase, source: source, page: page, line: 0, score: 0.9f);
         _mockRagService
-            .Setup(r => r.AskAsync(
-                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(),
+            .Setup(r => r.AskWithHybridSearchAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SearchMode>(), It.IsAny<string?>(),
                 It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new QaResponse(
                 answer: CitablePhrase,
                 snippets: new List<Snippet> { snippet },
                 confidence: 0.9));
+    }
+
+    [Fact]
+    public async Task EvaluateSample_UsesHybridSearchPath_NotLegacyAskAsync()
+    {
+        // The eval must exercise the canonical hybrid retrieval path. IRagService.AskAsync's legacy
+        // vector path is deprecated and returns empty results (RagService.ExecuteRetrievalPhaseAsync),
+        // so using it would make every eval sample retrieve nothing (degenerate citation/recall metrics).
+        SetupRagResponseCitingPage(page: 7);
+
+        await _service.EvaluateSampleAsync(CreateSample(), EvaluationOptions.Default, TestContext.Current.CancellationToken);
+
+        _mockRagService.Verify(
+            r => r.AskWithHybridSearchAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SearchMode>(),
+                It.IsAny<string?>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Endpoints/AdminEvalEndpointsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Endpoints/AdminEvalEndpointsIntegrationTests.cs
@@ -59,9 +59,10 @@ public sealed class AdminEvalEndpointsIntegrationTests : IAsyncLifetime
 
         var mockRagService = new Mock<IRagService>();
         mockRagService
-            .Setup(r => r.AskAsync(
+            .Setup(r => r.AskWithHybridSearchAsync(
                 It.IsAny<string>(),
                 It.IsAny<string>(),
+                It.IsAny<SearchMode>(),
                 It.IsAny<string?>(),
                 It.IsAny<bool>(),
                 It.IsAny<CancellationToken>()))


### PR DESCRIPTION
## Bug

L'harness della RAG evaluation suite (`DatasetEvaluationService` + `GenerateLabelingCandidatesCommandHandler`) chiamava `IRagService.AskAsync`, il cui path di **retrieval vettoriale legacy è deprecato e ritorna SEMPRE risultati vuoti** (`RagService.ExecuteRetrievalPhaseAsync` logga *"Legacy vector retrieval skipped, returning empty results"*).

**Conseguenza:** ogni sample dell'eval recuperava zero snippet → recall/citation-accuracy **degeneri a prescindere dallo stato del corpus**. L'eval-set non ha MAI potuto produrre numeri non-degeneri — scoperto eseguendo il baseline reale su staging (P95 ~0.3ms, citation_accuracy=0, log "Legacy vector retrieval skipped").

Il metric citation-accuracy di #3467 è corretto; questo fix rende l'harness a cui si aggancia effettivamente funzionante.

## Fix

Entrambi i call-site passano a **`AskWithHybridSearchAsync`** (il path canonico usato in produzione via `/agents/qa`). L'eval usa `bypassCache=true` così ogni run misura retrieval fresco (non una risposta cachata potenzialmente stale/dell'epoca-bloccata).

## Verifica

- Test aggiornati: mock `AskWithHybridSearchAsync` in `DatasetEvaluationServiceTests` / `LabelingAssistTests` / `AdminEvalEndpointsIntegrationTests`; nuovo test `EvaluateSample_UsesHybridSearchPath_NotLegacyAskAsync`.
- **64 unit + 9 integration verdi** in locale.
- Sblocca il baseline reale del gate #3390 (retrieval ora effettivo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)