### PR TITLE
feat(catalog): context-aware cover resolver (#3470 Slice 1c-1)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CoverAssignmentSourceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CoverAssignmentSourceExtensions.cs
@@ -1,0 +1,26 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.SharedKernel.Domain.Covers;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
+
+/// <summary>
+/// Epic #3470 — bridges the domain-facing <see cref="CoverAssignmentSource"/>
+/// (what an admin pins) to the infrastructure storage-key <see cref="CoverKind"/>
+/// (how <see cref="CoverKeyBuilder"/> composes the R2 key). The two enums DO NOT
+/// share numeric values (<c>Source.Pdf=0</c> vs <c>Kind.Pdf=1</c>; <c>Kind.User=0</c>
+/// has no <c>Source</c> counterpart because L3 is per-user, never a catalog
+/// assignment), so a numeric <c>(CoverKind)(int)source</c> cast is silently wrong
+/// (a PDF assignment would resolve as the user-custom cover). This explicit,
+/// value-by-value switch is the ONLY sanctioned conversion.
+/// </summary>
+internal static class CoverAssignmentSourceExtensions
+{
+    public static CoverKind ToCoverKind(this CoverAssignmentSource source) => source switch
+    {
+        CoverAssignmentSource.Pdf => CoverKind.Pdf,
+        CoverAssignmentSource.Bgg => CoverKind.Bgg,
+        CoverAssignmentSource.Wikidata => CoverKind.Wikidata,
+        CoverAssignmentSource.Manual => CoverKind.Manual,
+        _ => throw new ArgumentOutOfRangeException(nameof(source), source, "Unknown cover assignment source."),
+    };
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolver.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolver.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.Infrastructure.Entities.SharedGameCatalog;
 using Api.Infrastructure.Entities.UserLibrary;
 using Api.Observability;
@@ -129,6 +130,113 @@ internal static class CoverUrlResolver
         EmitResolution("placeholder");
         return null;
     }
+
+    /// <summary>
+    /// Epic #3470 (Slice 1c) — context-aware resolution. When the admin has pinned
+    /// a <see cref="GameCoverAssignmentEntity"/> for <paramref name="context"/>, that
+    /// override wins: first the rendered per-context crop (<c>GeneratedR2Key</c>),
+    /// then the pinned source's base cover key (via <see cref="CoverKeyBuilder"/>).
+    /// If neither resolves (crop stale AND base key absent/unreachable) the call
+    /// FALLS THROUGH to the implicit precedence of <see cref="ResolvePublicAsync"/>
+    /// — never a placeholder while another layer could still serve a cover.
+    ///
+    /// The override sits BELOW the L3 user-custom cover (SD3): this method is the
+    /// public/no-user context path, mirroring <see cref="ResolvePublicAsync"/>; the
+    /// per-user layering stays in <see cref="ResolveForUserAsync"/>.
+    ///
+    /// Metric invariant (Issue #2123): exactly one <see cref="MeepleAiMetrics.CoverResolution"/>
+    /// event per call — the override emits its pinned-source tag on a win; on a
+    /// fall-through the single event comes from <see cref="ResolvePublicAsync"/>.
+    /// </summary>
+    public static async Task<string?> ResolveForContextAsync(
+        SharedGameEntity sharedGame,
+        CoverContext context,
+        IBlobStorageService blobStorage)
+    {
+        ArgumentNullException.ThrowIfNull(sharedGame);
+        ArgumentNullException.ThrowIfNull(blobStorage);
+
+        var assignment = sharedGame.CoverAssignments?
+            .FirstOrDefault(a => a.Context == context);
+
+        if (assignment is not null)
+        {
+            var overrideUrl = await ResolveAssignmentAsync(sharedGame, assignment, blobStorage)
+                .ConfigureAwait(false);
+            if (overrideUrl is not null)
+            {
+                EmitResolution(SourceTagFor(assignment.Source));
+                return overrideUrl;
+            }
+            // Override present but unresolvable (crop stale AND base key
+            // absent/unreachable). Intentionally NO metric emission here — the
+            // ResolvePublicAsync call below emits exactly one CoverResolution event
+            // for the winning implicit layer (or "placeholder"), preserving the
+            // one-event-per-call invariant.
+        }
+
+        return await ResolvePublicAsync(sharedGame, blobStorage).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Resolves a single admin assignment to a presigned URL, or null when it
+    /// cannot serve a cover: the rendered per-context crop first, then the pinned
+    /// source's base cover key. Returns null WITHOUT emitting a metric so the caller
+    /// can fall through to the implicit precedence.
+    /// </summary>
+    private static async Task<string?> ResolveAssignmentAsync(
+        SharedGameEntity sharedGame,
+        GameCoverAssignmentEntity assignment,
+        IBlobStorageService blobStorage)
+    {
+        // 1) The rendered per-context WebP crop (produced with the focal point) is
+        //    a full physical R2 key — resolve it verbatim.
+        if (!string.IsNullOrWhiteSpace(assignment.GeneratedR2Key))
+        {
+            var cropUrl = await blobStorage
+                .GetPresignedUrlForRawKeyAsync(assignment.GeneratedR2Key)
+                .ConfigureAwait(false);
+            if (cropUrl is not null)
+            {
+                return cropUrl;
+            }
+        }
+
+        // 2) Fall back to the pinned source's base cover key. The source→kind map
+        //    is explicit (the enums do not share numeric values); the base DB key
+        //    lives on the entity column for that source.
+        var kind = assignment.Source.ToCoverKind();
+        var baseKey = SourceDbKey(sharedGame, kind);
+        if (string.IsNullOrWhiteSpace(baseKey))
+        {
+            return null;
+        }
+
+        return await blobStorage
+            .GetPresignedUrlForRawKeyAsync(CoverKeyBuilder.PhysicalKeyFor(kind, baseKey))
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>Selects the entity column holding the base (suffix-free) DB key for a source kind.</summary>
+    private static string? SourceDbKey(SharedGameEntity sharedGame, CoverKind kind) => kind switch
+    {
+        CoverKind.Pdf => sharedGame.PdfCoverR2Key,
+        CoverKind.Bgg => sharedGame.BggCoverR2Key,
+        CoverKind.Wikidata => sharedGame.WikidataCoverR2Key,
+        CoverKind.Manual => sharedGame.ManualCoverR2Key,
+        // CoverKind.User (L3) is per-user and never a catalog assignment source.
+        _ => null,
+    };
+
+    /// <summary>Maps a pinned source to its <c>source</c> metric tag (mirrors the implicit-layer tags).</summary>
+    private static string SourceTagFor(CoverAssignmentSource source) => source switch
+    {
+        CoverAssignmentSource.Pdf => "r2_pdf",
+        CoverAssignmentSource.Bgg => "r2_bgg",
+        CoverAssignmentSource.Wikidata => "r2_wikidata",
+        CoverAssignmentSource.Manual => "r2_manual",
+        _ => throw new ArgumentOutOfRangeException(nameof(source), source, "Unknown cover assignment source."),
+    };
 
     private static void EmitResolution(string source)
     {

--- a/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.CatalogCovers.cs
+++ b/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.CatalogCovers.cs
@@ -15,6 +15,8 @@ internal static partial class MeepleAiMetrics
     ///   <item><c>r2_pdf</c>: PDF-derived cover from rulebook page 1 (L4)</item>
     ///   <item><c>r2_bgg</c>: BGG cover re-uploaded server-side via the admin pipeline (L2.5)</item>
     ///   <item><c>r2_wikidata</c>: Wikidata/Wikimedia Commons cover (L2)</item>
+    ///   <item><c>r2_manual</c>: admin manual-URL cover re-hosted on R2 (epic #3470); only
+    ///     wins as an explicit per-context admin override, never in the implicit chain</item>
     ///   <item><c>placeholder</c>: no cover available, FE renders deterministic placeholder</item>
     /// </list>
     ///

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/CoverAssignmentSourceExtensionsTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/CoverAssignmentSourceExtensionsTests.cs
@@ -1,0 +1,67 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.SharedKernel.Domain.Covers;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Services;
+
+/// <summary>
+/// Epic #3470 Slice 1c (item #1) — the domain-facing <see cref="CoverAssignmentSource"/>
+/// and the storage-key <see cref="CoverKind"/> DO NOT share numeric values
+/// (Source.Pdf=0 vs Kind.Pdf=1), so a naive <c>(CoverKind)(int)source</c> cast is
+/// silently wrong. This pins the explicit, value-by-value mapping.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class CoverAssignmentSourceExtensionsTests
+{
+    [Fact]
+    public void ToCoverKind_MapsPdfToPdf()
+    {
+        CoverAssignmentSource.Pdf.ToCoverKind().Should().Be(CoverKind.Pdf);
+    }
+
+    [Fact]
+    public void ToCoverKind_MapsBggToBgg()
+    {
+        CoverAssignmentSource.Bgg.ToCoverKind().Should().Be(CoverKind.Bgg);
+    }
+
+    [Fact]
+    public void ToCoverKind_MapsWikidataToWikidata()
+    {
+        CoverAssignmentSource.Wikidata.ToCoverKind().Should().Be(CoverKind.Wikidata);
+    }
+
+    [Fact]
+    public void ToCoverKind_MapsManualToManual()
+    {
+        CoverAssignmentSource.Manual.ToCoverKind().Should().Be(CoverKind.Manual);
+    }
+
+    [Fact]
+    public void ToCoverKind_IsNotTheNaiveIntCast_ForPdf()
+    {
+        // The trap this mapping exists to prevent: Source.Pdf=0 and Kind.User=0,
+        // so the numeric cast would resolve a PDF assignment to the user-custom key.
+        ((int)CoverAssignmentSource.Pdf).Should().Be(0);
+        ((int)CoverKind.Pdf).Should().Be(1);
+
+        CoverAssignmentSource.Pdf.ToCoverKind().Should().Be(CoverKind.Pdf);
+        CoverAssignmentSource.Pdf.ToCoverKind().Should().NotBe((CoverKind)(int)CoverAssignmentSource.Pdf);
+    }
+
+    [Fact]
+    public void ToCoverKind_MapsEveryDefinedSource_WithoutThrowing()
+    {
+        // Exhaustiveness guard: a new CoverAssignmentSource value with no mapping
+        // arm must fail this test (ArgumentOutOfRangeException) rather than slip
+        // through as a silent miscast.
+        foreach (CoverAssignmentSource source in Enum.GetValues<CoverAssignmentSource>())
+        {
+            var act = () => source.ToCoverKind();
+            act.Should().NotThrow($"every defined CoverAssignmentSource must map to a CoverKind ({source})");
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolverTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolverTests.cs
@@ -1,10 +1,12 @@
 using System.Collections.Concurrent;
 using System.Diagnostics.Metrics;
 using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.Infrastructure.Entities.SharedGameCatalog;
 using Api.Infrastructure.Entities.UserLibrary;
 using Api.Observability;
 using Api.Services.Pdf;
+using Api.SharedKernel.Domain.Covers;
 using FluentAssertions;
 using Moq;
 using Xunit;
@@ -342,5 +344,250 @@ public class CoverUrlResolverTests
             .ToList();
         emissions.Should().HaveCount(1);
         emissions[0].Tags["source"].Should().Be("placeholder");
+    }
+
+    // ----- Epic #3470 Slice 1c: context-aware admin override -----------------
+
+    private static GameCoverAssignmentEntity Assignment(
+        CoverContext context,
+        CoverAssignmentSource source,
+        string? generatedR2Key = null) =>
+        new()
+        {
+            Context = context,
+            Source = source,
+            GeneratedR2Key = generatedR2Key,
+        };
+
+    [Fact]
+    public async Task ResolveForContextAsync_GeneratedCropResolves_WinsOverImplicitPrecedence()
+    {
+        // PDF would win the implicit chain, but the admin pinned a per-context
+        // crop for Card — the rendered crop key wins.
+        var sg = new SharedGameEntity
+        {
+            PdfCoverR2Key = "pdf-key",
+            WikidataCoverR2Key = "wiki-key",
+            CoverAssignments = new List<GameCoverAssignmentEntity>
+            {
+                Assignment(CoverContext.Card, CoverAssignmentSource.Wikidata, "covers/card/crop.webp"),
+            },
+        };
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("covers/card/crop.webp", null))
+             .ReturnsAsync("https://r2/card-crop.webp");
+
+        var url = await CoverUrlResolver.ResolveForContextAsync(sg, CoverContext.Card, _blob.Object);
+
+        url.Should().Be("https://r2/card-crop.webp");
+        // The implicit PDF layer must NOT have been consulted.
+        _blob.Verify(b => b.GetPresignedUrlForRawKeyAsync("pdf-key-preview.webp", It.IsAny<int?>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ResolveForContextAsync_NoGeneratedCrop_UsesPinnedSourceBaseKey()
+    {
+        // No crop rendered yet: the assignment still pins Wikidata, which must win
+        // over the implicit PDF cover (PDF is higher in the implicit chain).
+        var sg = new SharedGameEntity
+        {
+            PdfCoverR2Key = "pdf-key",
+            WikidataCoverR2Key = "wiki-key",
+            CoverAssignments = new List<GameCoverAssignmentEntity>
+            {
+                Assignment(CoverContext.Card, CoverAssignmentSource.Wikidata),
+            },
+        };
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("wiki-key.webp", null))
+             .ReturnsAsync("https://r2/wiki.webp");
+
+        var url = await CoverUrlResolver.ResolveForContextAsync(sg, CoverContext.Card, _blob.Object);
+
+        url.Should().Be("https://r2/wiki.webp");
+        _blob.Verify(b => b.GetPresignedUrlForRawKeyAsync("pdf-key-preview.webp", It.IsAny<int?>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ResolveForContextAsync_ManualSource_UsesManualBaseKey()
+    {
+        var sg = new SharedGameEntity
+        {
+            ManualCoverR2Key = "covers/manual/game/cover",
+            CoverAssignments = new List<GameCoverAssignmentEntity>
+            {
+                Assignment(CoverContext.Hero, CoverAssignmentSource.Manual),
+            },
+        };
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("covers/manual/game/cover.webp", null))
+             .ReturnsAsync("https://r2/manual.webp");
+
+        var url = await CoverUrlResolver.ResolveForContextAsync(sg, CoverContext.Hero, _blob.Object);
+
+        url.Should().Be("https://r2/manual.webp");
+    }
+
+    [Fact]
+    public async Task ResolveForContextAsync_StaleGeneratedCrop_FallsBackToPinnedSourceBaseKey()
+    {
+        // The rendered crop key is stale (blob returns null) but the pinned source
+        // is still resolvable — the assignment still wins via its base key, it does
+        // NOT drop to the implicit chain.
+        var sg = new SharedGameEntity
+        {
+            PdfCoverR2Key = "pdf-key",
+            WikidataCoverR2Key = "wiki-key",
+            CoverAssignments = new List<GameCoverAssignmentEntity>
+            {
+                Assignment(CoverContext.Card, CoverAssignmentSource.Wikidata, "covers/card/stale.webp"),
+            },
+        };
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("covers/card/stale.webp", null))
+             .ReturnsAsync((string?)null);
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("wiki-key.webp", null))
+             .ReturnsAsync("https://r2/wiki.webp");
+
+        var url = await CoverUrlResolver.ResolveForContextAsync(sg, CoverContext.Card, _blob.Object);
+
+        url.Should().Be("https://r2/wiki.webp");
+    }
+
+    [Fact]
+    public async Task ResolveForContextAsync_PinnedSourceKeyAbsent_FallsThroughToImplicit_NotPlaceholder()
+    {
+        // The assignment pins Manual but no manual cover exists on the entity —
+        // resolution must fall through to the implicit precedence (PDF here), NOT
+        // return a placeholder.
+        var sg = new SharedGameEntity
+        {
+            PdfCoverR2Key = "pdf-key",
+            CoverAssignments = new List<GameCoverAssignmentEntity>
+            {
+                Assignment(CoverContext.Card, CoverAssignmentSource.Manual),
+            },
+        };
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("pdf-key-preview.webp", null))
+             .ReturnsAsync("https://r2/pdf.webp");
+
+        var url = await CoverUrlResolver.ResolveForContextAsync(sg, CoverContext.Card, _blob.Object);
+
+        url.Should().Be("https://r2/pdf.webp");
+    }
+
+    [Fact]
+    public async Task ResolveForContextAsync_PinnedSourceBlobUnreachable_FallsThroughToImplicit()
+    {
+        // Assignment pins Manual and the manual key exists, but the blob is
+        // unreachable — fall through to the implicit Wikidata layer.
+        var sg = new SharedGameEntity
+        {
+            WikidataCoverR2Key = "wiki-key",
+            ManualCoverR2Key = "manual-key",
+            CoverAssignments = new List<GameCoverAssignmentEntity>
+            {
+                Assignment(CoverContext.Card, CoverAssignmentSource.Manual),
+            },
+        };
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("manual-key.webp", null))
+             .ReturnsAsync((string?)null);
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("wiki-key.webp", null))
+             .ReturnsAsync("https://r2/wiki.webp");
+
+        var url = await CoverUrlResolver.ResolveForContextAsync(sg, CoverContext.Card, _blob.Object);
+
+        url.Should().Be("https://r2/wiki.webp");
+    }
+
+    [Fact]
+    public async Task ResolveForContextAsync_NoAssignmentForContext_UsesImplicitPrecedence()
+    {
+        // A Hero assignment exists but we resolve Card — the Card path is purely
+        // implicit (per-context isolation).
+        var sg = new SharedGameEntity
+        {
+            PdfCoverR2Key = "pdf-key",
+            CoverAssignments = new List<GameCoverAssignmentEntity>
+            {
+                Assignment(CoverContext.Hero, CoverAssignmentSource.Wikidata, "covers/hero/crop.webp"),
+            },
+        };
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("pdf-key-preview.webp", null))
+             .ReturnsAsync("https://r2/pdf.webp");
+
+        var url = await CoverUrlResolver.ResolveForContextAsync(sg, CoverContext.Card, _blob.Object);
+
+        url.Should().Be("https://r2/pdf.webp");
+        _blob.Verify(b => b.GetPresignedUrlForRawKeyAsync("covers/hero/crop.webp", It.IsAny<int?>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ResolveForContextAsync_PerContextIsolation_EachContextResolvesItsOwnAssignment()
+    {
+        var sg = new SharedGameEntity
+        {
+            PdfCoverR2Key = "pdf-key",
+            CoverAssignments = new List<GameCoverAssignmentEntity>
+            {
+                Assignment(CoverContext.Card, CoverAssignmentSource.Wikidata, "covers/card/crop.webp"),
+                Assignment(CoverContext.Hero, CoverAssignmentSource.Manual, "covers/hero/crop.webp"),
+            },
+        };
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("covers/card/crop.webp", null))
+             .ReturnsAsync("https://r2/card.webp");
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("covers/hero/crop.webp", null))
+             .ReturnsAsync("https://r2/hero.webp");
+
+        (await CoverUrlResolver.ResolveForContextAsync(sg, CoverContext.Card, _blob.Object))
+            .Should().Be("https://r2/card.webp");
+        (await CoverUrlResolver.ResolveForContextAsync(sg, CoverContext.Hero, _blob.Object))
+            .Should().Be("https://r2/hero.webp");
+    }
+
+    [Fact]
+    public async Task ResolveForContextAsync_OverrideWins_EmitsSingleMetricTaggedWithPinnedSource()
+    {
+        using var capture = new CoverMetricsCapture();
+        var sg = new SharedGameEntity
+        {
+            ManualCoverR2Key = "manual-key",
+            CoverAssignments = new List<GameCoverAssignmentEntity>
+            {
+                Assignment(CoverContext.Card, CoverAssignmentSource.Manual),
+            },
+        };
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("manual-key.webp", null))
+             .ReturnsAsync("https://r2/manual.webp");
+
+        await CoverUrlResolver.ResolveForContextAsync(sg, CoverContext.Card, _blob.Object);
+
+        capture.LongMeasurements
+            .Where(m => m.Name == "meepleai.cover.resolution.total")
+            .Should().ContainSingle()
+            .Which.Tags["source"].Should().Be("r2_manual");
+    }
+
+    [Fact]
+    public async Task ResolveForContextAsync_FallThrough_EmitsExactlyOneImplicitMetric()
+    {
+        // Defense against double-counting: an override that misses and drops to the
+        // implicit chain must emit exactly ONE metric, tagged with the winning
+        // implicit layer — never the (unresolved) pinned source.
+        using var capture = new CoverMetricsCapture();
+        var sg = new SharedGameEntity
+        {
+            PdfCoverR2Key = "pdf-key",
+            CoverAssignments = new List<GameCoverAssignmentEntity>
+            {
+                Assignment(CoverContext.Card, CoverAssignmentSource.Manual),
+            },
+        };
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("pdf-key-preview.webp", null))
+             .ReturnsAsync("https://r2/pdf.webp");
+
+        await CoverUrlResolver.ResolveForContextAsync(sg, CoverContext.Card, _blob.Object);
+
+        var emissions = capture.LongMeasurements
+            .Where(m => m.Name == "meepleai.cover.resolution.total")
+            .ToList();
+        emissions.Should().HaveCount(1);
+        emissions[0].Tags["source"].Should().Be("r2_pdf");
     }
 }


### PR DESCRIPTION
## Epic #3470 — Slice 1c-1 (Application core)

Pure-application core of the admin per-context cover editor. No DB/migration, no query-handler wiring yet (that's 1c-2/1c-3) — this lands the resolver + mapping foundation.

### What
- **`CoverAssignmentSource.ToCoverKind()`** — explicit `source→kind` switch. The two enums intentionally do NOT share numeric values (`Source.Pdf=0` vs `Kind.Pdf=1`; `Kind.User=0` has no `Source`), so a naive `(CoverKind)(int)source` cast silently miscasts a PDF assignment to the user-custom key. This is the only sanctioned conversion (exhaustive; throws on undefined).
- **`CoverUrlResolver.ResolveForContextAsync(entity, context, blob)`** — when the admin pinned a `GameCoverAssignment` for the context, the override wins: rendered per-context crop (`GeneratedR2Key`, a full physical R2 key) first, then the pinned source's base key via `CoverKeyBuilder.PhysicalKeyFor(kind, dbKey)`. If neither resolves (crop stale AND base key absent/unreachable) it **falls through** to the implicit precedence of `ResolvePublicAsync` — never a placeholder while another layer could serve a cover. Sits **below** L3 user-custom (SD3).
- **Metric taxonomy** — `r2_manual` added to the `source` tag docs; the Issue #2123 one-event-per-call invariant is preserved (override emits its pinned-source tag on a win; a fall-through gets its single event from `ResolvePublicAsync`).

### Why
Design spec §4.2 + SD1/SD2/SD3 (contract-locked 2026-08-02). Groundwork so 1c-2 (aggregate + repository reconcile) and 1c-3 (candidate read-DTO) can wire this into the 6 CoverUrl call-sites.

### Testing (TDD)
- New `CoverAssignmentSourceExtensionsTests` (mapping correctness + int-cast-trap guard + exhaustiveness).
- Extended `CoverUrlResolverTests`: override wins over implicit; no-crop→base key; stale crop→base key; pinned key absent→fall-through **not** placeholder; blob unreachable→fall-through; per-context isolation; single-metric on win and on fall-through (real `MeterListener`, not mocked counters).
- **61 cover-related tests green**; Release build clean (SonarAnalyzer/warnings-as-errors).
- Adversarial code review: no high-confidence issues.

### DoD
- [x] TDD (red→green), tests assert real behavior
- [x] Release build clean (warnings-as-errors)
- [x] No metric-invariant regression
- [x] No consumer breakage (method added, no signature changes to existing resolver methods)
- [ ] Merged to `main-dev`

Part of epic #3470. Follow-ups: 1c-2 (aggregate `CoverAssignments` + repository reconcile), 1c-3 (candidate read-DTO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
