### PR TITLE
docs(rag-eval): first real baseline + calibrated golden citation pages (#3467)

### DIFF
--- a/docs/for-developers/evaluation-reports/baseline-2026-08-02.md
+++ b/docs/for-developers/evaluation-reports/baseline-2026-08-02.md
@@ -1,0 +1,55 @@
+# RAG Golden Eval-Set Baseline — 2026-08-02
+
+**First real, non-degenerate baseline** of the golden evaluation set (#3467), run against the live staging
+corpus. Establishes the floor the in-session live path must beat once #3390 wires RAG enhancements.
+
+## Result (34 samples, 5 golden games, hybrid retrieval, `bypassCache=true`)
+
+| Metric | Value | Gate target (#3390) | Status |
+| --- | --- | --- | --- |
+| **Citation accuracy** (page-level, `overlap_at_least_one`) | **0.286** (8/28) | ≥ 0.80 | ⬇️ floor — enhancements must raise it |
+| **Citation structural validity** | **1.00** (100%) | — | ✅ every citation well-formed |
+| **Answer correctness** (keyword heuristic) | **0.55** | — | baseline |
+| **P95 latency** | **2529 ms** | < 1500 ms | ⬇️ above target |
+| Recall@5 / @10 / nDCG / MRR | 0 | ≥ 0.70 (recall@10) | **N/A** — see limitation |
+| Citation-graded samples | 28 / 34 | — | — |
+
+## How this was produced
+
+1. **#3467 deployed to staging** (`deploy-staging.yml`, GHCR image `staging-20260802-b470ae7`).
+2. **Corpus / infra fixes** required to make the games answerable:
+   - The staging processing queue was stuck: 3 zombie jobs held all 3 worker slots
+     (`processing_queue_config.max_concurrent_workers = 3`). Cancelling them drained the 29-job backlog.
+   - 4 broken duplicate docs (`rulebook-<game>.pdf`, 0 pages extracted) blocked the RAG for
+     Catan/7 Wonders/Ark Nova/Wingspan; soft-deleted. The real `<game>_en_rulebook.pdf` docs (Ready) remain.
+3. **Harness bug fixed (#3475)** — the eval harness called the deprecated `IRagService.AskAsync`
+   (legacy vector path that always returns empty); switched to the canonical `AskWithHybridSearchAsync`.
+   Before this fix the eval-set could never produce non-degenerate retrieval numbers.
+4. **Golden pages calibrated** against the real corpus. The seed's authored `source_page` values did not
+   match the indexed rulebook (e.g. Catan "10 VP to win" was assumed p12 but lives on p2). Each sample's
+   `expected_citations.primary_pages` was re-derived from where its `expected_keywords` co-occur in the
+   corpus. Calibration raised citation accuracy from **0.071 → 0.286**.
+
+## Reading the numbers
+
+- **Citation accuracy 0.286** is the honest floor: on the closed rulebook domain, ~29% of citation-graded
+  answers cite a page that overlaps the ground-truth page. #3390's enhancements (adaptive routing, RAPTOR,
+  fusion — CRAG web-fallback stays OFF) must raise this toward the 0.80 gate without regressing it.
+- **Structural validity 1.00** — no malformed / hallucinated citations.
+- **P95 2529 ms** exceeds the 1500 ms Phase-5 target; latency work is part of the live-path effort.
+
+## Known limitation — recall is not measurable in this harness
+
+`recall@k` is degenerate (0) by construction: the eval reads `snippet.source`, which for the per-game
+retrieval path is **document-level** (`PDF:{docId}`), not chunk-level. Every retrieved snippet from a
+game's single Ready rulebook shares the same source, so recall would be trivially 1.0 for any hit and 0
+here because `relevant_chunk_ids` are unlabelled. Meaningful recall needs a chunk-level id exposed on the
+per-game retrieval path (separate issue) plus chunk-id labelling (unstable until a corpus re-index). The
+page-level **citation accuracy** was added precisely because it is stable and measurable today.
+
+## Next steps for #3390
+
+1. Wire live-path enhancements behind the flag; measure per-enhancement against this baseline
+   (citation accuracy must not regress; target ≥ 0.80).
+2. Human-verify the auto-calibrated `expected_citations` pages (this run used keyword co-occurrence).
+3. Expose a chunk-level retrieval id for a real recall@k, then label `relevant_chunk_ids`.

--- a/tests/evaluation-datasets/meepleai-en-seed.json
+++ b/tests/evaluation-datasets/meepleai-en-seed.json
@@ -27,7 +27,8 @@
       "language": "en",
       "expected_citations": {
         "primary_pages": [
-          2
+          3,
+          6
         ],
         "match_policy": "overlap_at_least_one"
       }
@@ -52,7 +53,7 @@
       "language": "en",
       "expected_citations": {
         "primary_pages": [
-          12
+          2
         ],
         "match_policy": "overlap_at_least_one"
       }
@@ -77,7 +78,8 @@
       "language": "en",
       "expected_citations": {
         "primary_pages": [
-          4
+          1,
+          2
         ],
         "match_policy": "overlap_at_least_one"
       }
@@ -102,6 +104,7 @@
       "language": "en",
       "expected_citations": {
         "primary_pages": [
+          4,
           6
         ],
         "match_policy": "overlap_at_least_one"
@@ -127,7 +130,8 @@
       "language": "en",
       "expected_citations": {
         "primary_pages": [
-          3
+          3,
+          4
         ],
         "match_policy": "overlap_at_least_one"
       }
@@ -155,7 +159,7 @@
       "language": "en",
       "expected_citations": {
         "primary_pages": [
-          5
+          1
         ],
         "match_policy": "overlap_at_least_one"
       }
@@ -180,7 +184,8 @@
       "language": "en",
       "expected_citations": {
         "primary_pages": [
-          4
+          3,
+          11
         ],
         "match_policy": "overlap_at_least_one"
       }
@@ -206,7 +211,8 @@
       "language": "en",
       "expected_citations": {
         "primary_pages": [
-          7
+          3,
+          4
         ],
         "match_policy": "overlap_at_least_one"
       }
@@ -231,7 +237,8 @@
       "language": "en",
       "expected_citations": {
         "primary_pages": [
-          15
+          3,
+          8
         ],
         "match_policy": "overlap_at_least_one"
       }
@@ -256,7 +263,7 @@
       "language": "en",
       "expected_citations": {
         "primary_pages": [
-          3
+          2
         ],
         "match_policy": "overlap_at_least_one"
       }
@@ -281,7 +288,8 @@
       "language": "en",
       "expected_citations": {
         "primary_pages": [
-          4
+          2,
+          5
         ],
         "match_policy": "overlap_at_least_one"
       }
@@ -306,7 +314,7 @@
       "language": "en",
       "expected_citations": {
         "primary_pages": [
-          9
+          12
         ],
         "match_policy": "overlap_at_least_one"
       }
@@ -330,7 +338,8 @@
       "language": "en",
       "expected_citations": {
         "primary_pages": [
-          3
+          3,
+          5
         ],
         "match_policy": "overlap_at_least_one"
       }
@@ -354,7 +363,8 @@
       "language": "en",
       "expected_citations": {
         "primary_pages": [
-          7
+          3,
+          6
         ],
         "match_policy": "overlap_at_least_one"
       }
@@ -379,7 +389,7 @@
       "language": "en",
       "expected_citations": {
         "primary_pages": [
-          8
+          6
         ],
         "match_policy": "overlap_at_least_one"
       }
@@ -403,7 +413,8 @@
       "language": "en",
       "expected_citations": {
         "primary_pages": [
-          12
+          2,
+          10
         ],
         "match_policy": "overlap_at_least_one"
       }
@@ -429,7 +440,8 @@
       "language": "en",
       "expected_citations": {
         "primary_pages": [
-          11
+          3,
+          9
         ],
         "match_policy": "overlap_at_least_one"
       }
@@ -453,7 +465,8 @@
       "language": "en",
       "expected_citations": {
         "primary_pages": [
-          5
+          1,
+          2
         ],
         "match_policy": "overlap_at_least_one"
       }
@@ -479,7 +492,8 @@
       "language": "en",
       "expected_citations": {
         "primary_pages": [
-          6
+          2,
+          5
         ],
         "match_policy": "overlap_at_least_one"
       }
@@ -506,7 +520,8 @@
       "language": "en",
       "expected_citations": {
         "primary_pages": [
-          9
+          2,
+          3
         ],
         "match_policy": "overlap_at_least_one"
       }
@@ -531,7 +546,7 @@
       "language": "en",
       "expected_citations": {
         "primary_pages": [
-          10
+          3
         ],
         "match_policy": "overlap_at_least_one"
       }
@@ -557,6 +572,7 @@
       "language": "en",
       "expected_citations": {
         "primary_pages": [
+          3,
           6
         ],
         "match_policy": "overlap_at_least_one"
@@ -583,7 +599,8 @@
       "language": "en",
       "expected_citations": {
         "primary_pages": [
-          7
+          3,
+          6
         ],
         "match_policy": "overlap_at_least_one"
       }
@@ -608,7 +625,7 @@
       "language": "en",
       "expected_citations": {
         "primary_pages": [
-          5
+          8
         ],
         "match_policy": "overlap_at_least_one"
       }
@@ -634,7 +651,7 @@
       "language": "en",
       "expected_citations": {
         "primary_pages": [
-          9
+          6
         ],
         "match_policy": "overlap_at_least_one"
       }
@@ -661,7 +678,8 @@
       "language": "en",
       "expected_citations": {
         "primary_pages": [
-          10
+          3,
+          8
         ],
         "match_policy": "overlap_at_least_one"
       }
@@ -687,7 +705,8 @@
       "language": "en",
       "expected_citations": {
         "primary_pages": [
-          10
+          6,
+          9
         ],
         "match_policy": "overlap_at_least_one"
       }
@@ -714,7 +733,7 @@
       "language": "en",
       "expected_citations": {
         "primary_pages": [
-          4
+          11
         ],
         "match_policy": "overlap_at_least_one"
       }


### PR DESCRIPTION
## Cosa

Primo **baseline reale non-degenere** del golden eval-set (#3467), eseguito sul corpus live di staging (dopo il fix harness #3475), committato sotto `docs/for-developers/evaluation-reports/`. + **calibrazione delle pagine golden** contro il corpus reale.

## Baseline (34 sample, 5 giochi golden, retrieval hybrid, `bypassCache=true`)

| Metrica | Valore | Gate #3390 |
|---|---|---|
| **Citation accuracy** (page-level) | **0.286** (8/28) | ≥0.80 (floor da battere) |
| **Structural validity** | **1.00** | — |
| **Answer correctness** | **0.55** | — |
| **P95 latency** | **2529ms** | <1500ms |
| Recall@k | 0 → **N/A** | limite harness (source doc-level) |

## Calibrazione

Le `source_page` autorate nel seed NON combaciavano col rulebook indicizzato (es. Catan "10 VP to win" assunto p12, reale p2). Ogni `expected_citations.primary_pages` ricalibrato da dove i suoi `expected_keywords` co-occorrono nel corpus reale → citation-accuracy **0.071 → 0.286**.

## Contesto (percorso per arrivarci)

Sbloccare il baseline ha richiesto: deploy #3467, sblocco coda processing staging (3 job zombie occupavano tutti gli slot), soft-delete di 4 doc rotti, e **il fix harness #3475** (l'eval usava `AskAsync` = path legacy morto → sempre vuoto; ora `AskWithHybridSearchAsync`). Dettagli nel report.

## Test

`EvaluationSeedDatasetTests` verde (3/3) col golden calibrato (≥30 sample, citation-graded con pagine).

## Per #3390

È il floor da cui gli enhancement live-path devono migliorare verso 0.80 (senza regressione). Follow-up: human-verify delle pagine auto-calibrate; chunk-level id per un recall reale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)