### PR TITLE
feat(catalog): cover picker candidates read API (#3470 Slice 1c-3)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/CoverCandidatesDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/CoverCandidatesDto.cs
@@ -1,0 +1,37 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application;
+
+/// <summary>
+/// Epic #3470 (Slice 1c-3) — the admin cover-picker read shape: the MATERIALIZED
+/// source candidates a game can be pinned to (each with a preview URL), plus which
+/// source is currently in use per UI context. Unlike <see cref="SharedGameDto.CoverUrl"/>
+/// (winner-only), this exposes every available source so the picker can offer a choice.
+/// </summary>
+public sealed record CoverCandidatesDto(
+    Guid GameId,
+    IReadOnlyList<CoverCandidateDto> Candidates,
+    CoverContextAssignmentsDto Assignments);
+
+/// <summary>
+/// A single materialized cover source available to the picker. License / attribution
+/// / source URL are populated only for the sources that carry them (Wikidata, Manual).
+/// The <c>Source</c> enum serializes as its name (e.g. <c>"Wikidata"</c>) via the global
+/// <c>JsonStringEnumConverter</c>.
+/// </summary>
+public sealed record CoverCandidateDto(
+    CoverAssignmentSource Source,
+    string PreviewUrl,
+    string? License,
+    string? Attribution,
+    string? SourceUrl);
+
+/// <summary>
+/// Which cover source is currently pinned for each UI context. A <see langword="null"/>
+/// field means the context has no explicit admin assignment and falls back to the
+/// resolver's implicit precedence.
+/// </summary>
+public sealed record CoverContextAssignmentsDto(
+    CoverAssignmentSource? Card,
+    CoverAssignmentSource? Hero,
+    CoverAssignmentSource? Social);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetCoverCandidatesQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetCoverCandidatesQuery.cs
@@ -1,0 +1,10 @@
+using MediatR;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries;
+
+/// <summary>
+/// Epic #3470 (Slice 1c-3) — fetches the admin cover-picker read shape for a game:
+/// the materialized source candidates + the current per-context assignments.
+/// Returns <see langword="null"/> when the game does not exist (or is soft-deleted).
+/// </summary>
+public sealed record GetCoverCandidatesQuery(Guid GameId) : IRequest<CoverCandidatesDto?>;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetCoverCandidatesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetCoverCandidatesQueryHandler.cs
@@ -1,0 +1,95 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Services.Pdf;
+using Api.SharedKernel.Domain.Covers;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries;
+
+/// <summary>
+/// Epic #3470 (Slice 1c-3) — builds the admin cover-picker read shape. For each cover
+/// source with a MATERIALIZED R2 key it mints a presigned preview URL (omitting the
+/// source when its blob cannot be resolved, e.g. in local/dev where R2 is absent), and
+/// reports which source is currently pinned per UI context. PDF-page enumeration and
+/// on-demand Wikidata materialization are out of scope here (Slice 2).
+/// </summary>
+internal sealed class GetCoverCandidatesQueryHandler
+    : IRequestHandler<GetCoverCandidatesQuery, CoverCandidatesDto?>
+{
+    private readonly MeepleAiDbContext _context;
+    private readonly IBlobStorageService _blobStorage;
+
+    public GetCoverCandidatesQueryHandler(MeepleAiDbContext context, IBlobStorageService blobStorage)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _blobStorage = blobStorage ?? throw new ArgumentNullException(nameof(blobStorage));
+    }
+
+    public async Task<CoverCandidatesDto?> Handle(GetCoverCandidatesQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var game = await _context.SharedGames
+            .AsNoTracking()
+            .Include(g => g.CoverAssignments)
+            .FirstOrDefaultAsync(g => g.Id == query.GameId && !g.IsDeleted, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (game is null)
+        {
+            return null;
+        }
+
+        // Resolve every materialized source's preview URL in parallel. Each call
+        // is an independent network round-trip (GetPresignedUrlForRawKeyAsync issues
+        // an S3 HEAD before signing), the blob client is thread-safe, and none of
+        // these touch the DbContext — so WhenAll cuts the worst-case latency from
+        // sum-of-four to max-of-four. Task order is preserved, keeping the fixed
+        // Pdf → Bgg → Wikidata → Manual candidate ordering.
+        var resolved = await Task.WhenAll(
+            ResolveCandidateAsync(CoverAssignmentSource.Pdf, game.PdfCoverR2Key, license: null, attribution: null, sourceUrl: null),
+            ResolveCandidateAsync(CoverAssignmentSource.Bgg, game.BggCoverR2Key, license: null, attribution: null, sourceUrl: null),
+            ResolveCandidateAsync(CoverAssignmentSource.Wikidata, game.WikidataCoverR2Key,
+                game.WikidataCoverLicense, game.WikidataCoverAttribution, game.WikidataCoverSourceUrl),
+            ResolveCandidateAsync(CoverAssignmentSource.Manual, game.ManualCoverR2Key,
+                game.ManualCoverLicense, game.ManualCoverAttribution, game.ManualCoverSourceUrl))
+            .ConfigureAwait(false);
+
+        var candidates = resolved.Where(c => c is not null).Select(c => c!).ToList();
+
+        var assignments = new CoverContextAssignmentsDto(
+            Card: SourceForContext(game, CoverContext.Card),
+            Hero: SourceForContext(game, CoverContext.Hero),
+            Social: SourceForContext(game, CoverContext.Social));
+
+        return new CoverCandidatesDto(game.Id, candidates, assignments);
+    }
+
+    private async Task<CoverCandidateDto?> ResolveCandidateAsync(
+        CoverAssignmentSource source,
+        string? dbKey,
+        string? license,
+        string? attribution,
+        string? sourceUrl)
+    {
+        if (string.IsNullOrWhiteSpace(dbKey))
+        {
+            return null;
+        }
+
+        var physicalKey = CoverKeyBuilder.PhysicalKeyFor(source.ToCoverKind(), dbKey);
+        var previewUrl = await _blobStorage.GetPresignedUrlForRawKeyAsync(physicalKey).ConfigureAwait(false);
+        if (previewUrl is null)
+        {
+            return null;
+        }
+
+        return new CoverCandidateDto(source, previewUrl, license, attribution, sourceUrl);
+    }
+
+    private static CoverAssignmentSource? SourceForContext(SharedGameEntity game, CoverContext context) =>
+        game.CoverAssignments.FirstOrDefault(a => a.Context == context)?.Source;
+}

--- a/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogAdminEndpoints.cs
+++ b/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogAdminEndpoints.cs
@@ -57,6 +57,16 @@ internal static class SharedGameCatalogAdminEndpoints
             .Produces(StatusCodes.Status204NoContent)
             .Produces(StatusCodes.Status404NotFound);
 
+        // Cover picker read shape: materialized source candidates + per-context assignments (epic #3470)
+        group.MapGet("/admin/shared-games/{id:guid}/cover-candidates", HandleGetCoverCandidates)
+            .RequireAuthorization("AdminOrEditorPolicy")
+            .RequireRateLimiting("SharedGamesAdmin")
+            .WithName("GetCoverCandidates")
+            .WithSummary("Get cover source candidates for a game (Admin/Editor)")
+            .WithDescription("Returns the materialized cover sources (each with a preview URL) and the current per-context cover assignments, feeding the admin cover picker.")
+            .Produces<CoverCandidatesDto>()
+            .Produces(StatusCodes.Status404NotFound);
+
         // Submit game for approval (Draft → PendingApproval) - Issue #2514
         group.MapPost("/admin/shared-games/{id:guid}/submit-for-approval", HandleSubmitForApproval)
             .RequireAuthorization("AdminOrEditorPolicy")
@@ -864,6 +874,15 @@ internal static class SharedGameCatalogAdminEndpoints
     }
 
     // Issue #3533: New handlers for admin approval workflow
+    private static async Task<IResult> HandleGetCoverCandidates(
+        Guid id,
+        IMediator mediator,
+        CancellationToken ct = default)
+    {
+        var result = await mediator.Send(new GetCoverCandidatesQuery(id), ct).ConfigureAwait(false);
+        return result is null ? Results.NotFound() : Results.Ok(result);
+    }
+
     private static async Task<IResult> HandleGetApprovalQueue(
         IMediator mediator,
         [FromQuery] bool? urgency = null,

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetCoverCandidatesQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetCoverCandidatesQueryHandlerTests.cs
@@ -1,0 +1,136 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Services.Pdf;
+using Api.SharedKernel.Domain.Covers;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Queries;
+
+/// <summary>
+/// Epic #3470 Slice 1c-3 — the read-side that feeds the admin cover picker: the
+/// MATERIALIZED source candidates (each with a preview URL) plus which source is
+/// currently pinned per UI context. Distinct from the winner-only DTO the public
+/// catalog surfaces expose.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class GetCoverCandidatesQueryHandlerTests
+{
+    private readonly Mock<IBlobStorageService> _blob = new();
+
+    private GetCoverCandidatesQueryHandler CreateHandler(MeepleAiDbContext ctx) => new(ctx, _blob.Object);
+
+    private static SharedGameEntity SeedGame(MeepleAiDbContext ctx, Action<SharedGameEntity> configure)
+    {
+        var game = new SharedGameEntity
+        {
+            Id = Guid.NewGuid(),
+            Title = "Catan",
+            Description = "desc",
+            Status = 1,
+        };
+        configure(game);
+        ctx.SharedGames.Add(game);
+        ctx.SaveChanges();
+        return game;
+    }
+
+    [Fact]
+    public async Task Handle_GameNotFound_ReturnsNull()
+    {
+        using var ctx = TestDbContextFactory.CreateInMemoryDbContext();
+        var handler = CreateHandler(ctx);
+
+        var result = await handler.Handle(new GetCoverCandidatesQuery(Guid.NewGuid()), CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_ExposesMaterializedSourcesOnly_WithPreviewsAndLicense()
+    {
+        using var ctx = TestDbContextFactory.CreateInMemoryDbContext();
+        var game = SeedGame(ctx, g =>
+        {
+            g.PdfCoverR2Key = "covers/pdf/x/cover";
+            g.WikidataCoverR2Key = "covers/y/cover";
+            g.WikidataCoverLicense = "CC BY-SA 4.0";
+            g.WikidataCoverAttribution = "Artist";
+            g.WikidataCoverSourceUrl = "https://www.wikidata.org/wiki/Q1";
+            // BGG + Manual keys deliberately null → not materialized → not candidates.
+        });
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("covers/pdf/x/cover-preview.webp", null))
+             .ReturnsAsync("https://r2/pdf.webp");
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("covers/y/cover.webp", null))
+             .ReturnsAsync("https://r2/wiki.webp");
+        var handler = CreateHandler(ctx);
+
+        var result = await handler.Handle(new GetCoverCandidatesQuery(game.Id), CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.GameId.Should().Be(game.Id);
+        result.Candidates.Select(c => c.Source)
+            .Should().BeEquivalentTo(new[] { CoverAssignmentSource.Pdf, CoverAssignmentSource.Wikidata });
+
+        var pdf = result.Candidates.Single(c => c.Source == CoverAssignmentSource.Pdf);
+        pdf.PreviewUrl.Should().Be("https://r2/pdf.webp");
+        pdf.License.Should().BeNull();
+
+        var wiki = result.Candidates.Single(c => c.Source == CoverAssignmentSource.Wikidata);
+        wiki.PreviewUrl.Should().Be("https://r2/wiki.webp");
+        wiki.License.Should().Be("CC BY-SA 4.0");
+        wiki.Attribution.Should().Be("Artist");
+        wiki.SourceUrl.Should().Be("https://www.wikidata.org/wiki/Q1");
+    }
+
+    [Fact]
+    public async Task Handle_UnresolvableKey_OmitsThatCandidate()
+    {
+        using var ctx = TestDbContextFactory.CreateInMemoryDbContext();
+        var game = SeedGame(ctx, g =>
+        {
+            g.PdfCoverR2Key = "covers/pdf/x/cover";
+            g.WikidataCoverR2Key = "covers/y/cover";
+        });
+        // PDF preview resolves; Wikidata blob returns null (unreachable) → omitted.
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("covers/pdf/x/cover-preview.webp", null))
+             .ReturnsAsync("https://r2/pdf.webp");
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("covers/y/cover.webp", null))
+             .ReturnsAsync((string?)null);
+        var handler = CreateHandler(ctx);
+
+        var result = await handler.Handle(new GetCoverCandidatesQuery(game.Id), CancellationToken.None);
+
+        result!.Candidates.Should().ContainSingle()
+            .Which.Source.Should().Be(CoverAssignmentSource.Pdf);
+    }
+
+    [Fact]
+    public async Task Handle_ReportsPerContextAssignments()
+    {
+        using var ctx = TestDbContextFactory.CreateInMemoryDbContext();
+        var game = SeedGame(ctx, g =>
+        {
+            g.WikidataCoverR2Key = "covers/y/cover";
+            g.CoverAssignments = new List<GameCoverAssignmentEntity>
+            {
+                new() { Id = Guid.NewGuid(), Context = CoverContext.Card, Source = CoverAssignmentSource.Wikidata, CreatedBy = Guid.NewGuid() },
+                new() { Id = Guid.NewGuid(), Context = CoverContext.Hero, Source = CoverAssignmentSource.Pdf, CreatedBy = Guid.NewGuid() },
+            };
+        });
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync(It.IsAny<string>(), null))
+             .ReturnsAsync("https://r2/x.webp");
+        var handler = CreateHandler(ctx);
+
+        var result = await handler.Handle(new GetCoverCandidatesQuery(game.Id), CancellationToken.None);
+
+        result!.Assignments.Card.Should().Be(CoverAssignmentSource.Wikidata);
+        result.Assignments.Hero.Should().Be(CoverAssignmentSource.Pdf);
+        result.Assignments.Social.Should().BeNull("no assignment pins the Social context");
+    }
+}


### PR DESCRIPTION
## Epic #3470 — Slice 1c-3 (cover picker read API)

The read-side that feeds the admin cover picker: the **materialized** cover source candidates (each with a presigned preview URL) plus which source is currently pinned per UI context — distinct from the winner-only `CoverUrl` the public catalog surfaces expose.

### What
- **DTOs**: `CoverCandidatesDto` (gameId + candidates + per-context assignments), `CoverCandidateDto` (source + previewUrl + optional license/attribution/sourceUrl), `CoverContextAssignmentsDto` (Card/Hero/Social → source or null). The `CoverAssignmentSource` enum serializes as its name (e.g. `"Wikidata"`) via the global `JsonStringEnumConverter`.
- **`GetCoverCandidatesQuery` + handler**: loads the game (with `CoverAssignments`), mints a preview URL per source that has a materialized R2 key via `CoverKeyBuilder.PhysicalKeyFor(source.ToCoverKind(), dbKey)` + the blob raw-key primitive, **omitting** a source when its blob can't be resolved (dev/no-R2), and reports the per-context assignments. PDF-page enumeration + on-demand Wikidata materialization are Slice 2.
- **Endpoint**: `GET /admin/shared-games/{id}/cover-candidates`, `RequireAuthorization("AdminOrEditorPolicy")` (SD5: pick = Admin or Editor), 404 when the game is absent. CQRS: pure `IMediator.Send`.

### Testing (TDD)
- 4 handler unit tests on an InMemory `DbContext` + mocked `IBlobStorageService`: game-not-found → null; materialized sources only (+ Wikidata license/attribution/sourceUrl); an unresolvable key is omitted; per-context assignments reported correctly (Card/Hero pinned, Social null).
- Release build clean (SonarAnalyzer warnings-as-errors).
- Adversarial code review before merge.

### DoD
- [x] TDD (red→green), tests assert real behavior
- [x] Release build clean (warnings-as-errors)
- [x] Role-gated (AdminOrEditor, SD5); 404 on missing game
- [x] CQRS (IMediator only); MediatR auto-registers the handler
- [ ] Merged to `main-dev`

Part of epic #3470. Completes the backend application layer for the picker (with 1c-1 resolver #3476 + 1c-2 aggregate/reconcile #3478). Next: Slice 1d (FE overlay picker + WebpVariantGenerator focal-point + source-aware attribution footer) and the write command (`AssignCoverCommand`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
