### PR TITLE
feat(ai): in-session agent grounding observability (#3390 Slice 1)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentCommandHandler.cs
@@ -712,6 +712,23 @@ internal sealed class ChatWithSessionAgentCommandHandler : IStreamingQueryHandle
             }
         }
 
+        var groundingStatus = citationDtos.Count > 0 ? "Grounded" : "Ungrounded";
+
+        // #3390 Slice 1: structured grounding observability (text path -> RAG, LiveSession profile).
+        // Wrapped so a metrics fault can never break the user's stream (mirrors the broadcast guard above).
+        try
+        {
+            MeepleAiMetrics.RecordAgentResponseGrounding(
+                path: MeepleAiMetrics.AgentResponsePaths.Text,
+                groundingStatusWire: groundingStatus,
+                retrievalProfile: MeepleAiMetrics.AgentRetrievalProfiles.LiveSession,
+                citationCount: citationDtos.Count);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "agent-response grounding metric emission failed; stream unaffected");
+        }
+
         yield return CreateEvent(
             StreamingEventType.Complete,
             new StreamingComplete(
@@ -722,7 +739,7 @@ internal sealed class ChatWithSessionAgentCommandHandler : IStreamingQueryHandle
                 confidence: RagPromptAssemblyService.ComputeConfidence(assembled.Citations, responseText),
                 chatThreadId: thread.Id,
                 Citations: citationDtos,
-                GroundingStatus: citationDtos.Count > 0 ? "Grounded" : "Ungrounded"));
+                GroundingStatus: groundingStatus));
     }
 
     private async Task GenerateConversationSummaryAsync(Guid threadId)

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ChatCommandHandlers.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ChatCommandHandlers.cs
@@ -5,6 +5,7 @@ using Api.BoundedContexts.SessionTracking.Domain.Entities;
 using Api.BoundedContexts.SessionTracking.Domain.Events;
 using Api.BoundedContexts.SessionTracking.Domain.Repositories;
 using Api.Middleware.Exceptions;
+using Api.Observability;
 using Api.Services;
 using Api.Services.ImageProcessing;
 using Api.Services.LlmClients;
@@ -265,6 +266,21 @@ internal class AskSessionAgentCommandHandler : IRequestHandler<AskSessionAgentCo
         }, cancellationToken).ConfigureAwait(false);
 
         // This path never produces citations (no retrieval grounding), so it is always Ungrounded (#3388).
+        // #3390 Slice 1: structured grounding observability (image or text-only, no retrieval -> profile=none).
+        // Guarded so a metrics fault can never break the agent response.
+        try
+        {
+            MeepleAiMetrics.RecordAgentResponseGrounding(
+                path: hasImages ? MeepleAiMetrics.AgentResponsePaths.Image : MeepleAiMetrics.AgentResponsePaths.Text,
+                groundingStatusWire: GroundingStatus.Ungrounded.ToString(),
+                retrievalProfile: MeepleAiMetrics.AgentRetrievalProfiles.None,
+                citationCount: 0);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "agent-response grounding metric emission failed for session {SessionId}", request.SessionId);
+        }
+
         return new AskSessionAgentResult(agentMessage.Id, answer, agentType, agentMessage.Confidence, null, GroundingStatus.Ungrounded);
     }
 }

--- a/apps/api/src/Api/Observability/MeepleAiMetrics.cs
+++ b/apps/api/src/Api/Observability/MeepleAiMetrics.cs
@@ -24,6 +24,7 @@ namespace Api.Observability;
 ///   - MeepleAiMetrics.WikidataEnrichment.cs — Wikidata cover enrichment attempts, SPARQL latency, QID hit-rate (#1823 DEC-3g)
 ///   - MeepleAiMetrics.LiveSession.cs        — LiveSession write counters and UpdateAsync duration (#2097 ADR-060)
 ///   - MeepleAiMetrics.LiveSessionSse.cs    — Native SSE active-connections gauge + reconnect counter (#2561 SP2 T12)
+///   - MeepleAiMetrics.AgentGrounding.cs    — In-session agent response grounding by path/status/profile + citation count (#3390 Slice 1)
 /// </summary>
 internal static partial class MeepleAiMetrics
 {

--- a/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.AgentGrounding.cs
+++ b/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.AgentGrounding.cs
@@ -1,0 +1,113 @@
+// Issue #3390 (epic #3397) Slice 1: structured grounding observability for the in-session agent.
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace Api.Observability;
+
+internal static partial class MeepleAiMetrics
+{
+    // === Issue #3390 (epic #3397) Slice 1 — In-session agent grounding observability ===
+    //
+    // Makes the grounding state of every in-session agent response measurable BEFORE the
+    // structural unification (Slices 2-5) touches the hot live path. The audit
+    // (docs/for-developers/audits/2026-07-29-in-session-agent-grounding-audit.md) flagged the
+    // grounding signal as invisible to ops ("painted gauge"): no metric distinguished a grounded
+    // (cited) answer from a silently ungrounded one, and none carried the input path.
+    //
+    // Two producers, one contract (mirrors the #3388 GroundingStatus wire contract):
+    //   - text  -> ChatWithSessionAgentCommandHandler (KnowledgeBase, RAG, retrieval_profile=live_session)
+    //   - image -> AskSessionAgentCommandHandler       (SessionTracking, multimodal, retrieval_profile=none)
+    //
+    // Cardinality rule (see MeepleAiMetrics.Rag.cs): tags are bounded sets ONLY — no
+    // session/user/game ids. citation_count is NOT a tag (unbounded) -> separate histogram.
+
+    /// <summary>
+    /// Counter incremented once per completed in-session agent response.
+    /// Tags: path (<see cref="AgentResponsePaths"/>), grounding_status
+    /// (<see cref="AgentGroundingStatuses"/>), retrieval_profile
+    /// (<see cref="AgentRetrievalProfiles"/>). Drives the ungrounded-rate alert
+    /// (infra/prometheus/alerts/agent-grounding.yml).
+    /// </summary>
+    public static readonly Counter<long> AgentResponseGrounding = Meter.CreateCounter<long>(
+        name: "meepleai.agent.response.grounding",
+        unit: "responses",
+        description: "In-session agent responses by input path, grounding status, and retrieval profile");
+
+    /// <summary>
+    /// Histogram of citation counts per in-session agent response, split by input path.
+    /// The <c>le=0</c> bucket captures ungrounded (uncited) responses. Tag: path only (bounded).
+    /// </summary>
+    public static readonly Histogram<int> AgentResponseCitationCount = Meter.CreateHistogram<int>(
+        name: "meepleai.agent.response.citation_count",
+        unit: "citations",
+        description: "Number of citations per in-session agent response, by input path");
+
+    /// <summary>
+    /// Bounded set of in-session agent input paths. The seam #3390 unifies:
+    /// <c>text</c> already flows through retrieval (grounded-capable); <c>image</c> does not (yet).
+    /// </summary>
+    public static class AgentResponsePaths
+    {
+        public const string Text = "text";
+        public const string Image = "image";
+    }
+
+    /// <summary>
+    /// Bounded set of grounding-status tag values (lowercase of the #3388 wire enum).
+    /// </summary>
+    public static class AgentGroundingStatuses
+    {
+        public const string Grounded = "grounded";
+        public const string Partial = "partial";
+        public const string Ungrounded = "ungrounded";
+
+        /// <summary>
+        /// Maps the wire grounding string ("Grounded"/"Partial"/"Ungrounded", produced by both
+        /// in-session handlers) to the bounded lowercase tag value. Unknown -> <see cref="Ungrounded"/>
+        /// (fail-safe: never fabricate a grounded label from an unexpected value).
+        /// </summary>
+        public static string FromWire(string? wire) => wire switch
+        {
+            "Grounded" => Grounded,
+            "Partial" => Partial,
+            _ => Ungrounded,
+        };
+    }
+
+    /// <summary>
+    /// Bounded set of retrieval-profile tag values. <c>none</c> marks a response produced with
+    /// no retrieval at all (today's image/text multimodal path). Slices 2-4 will emit
+    /// <c>live_session</c> from the image path once retrieval is wired.
+    /// </summary>
+    public static class AgentRetrievalProfiles
+    {
+        public const string LiveSession = "live_session";
+        public const string Default = "default";
+        public const string None = "none";
+    }
+
+    /// <summary>
+    /// Records one completed in-session agent response.
+    /// Call once, at the point where the final grounding status and citation count are known.
+    /// </summary>
+    /// <param name="path">Input path (<see cref="AgentResponsePaths"/>).</param>
+    /// <param name="groundingStatusWire">Wire grounding string ("Grounded"/"Partial"/"Ungrounded").</param>
+    /// <param name="retrievalProfile">Retrieval profile (<see cref="AgentRetrievalProfiles"/>).</param>
+    /// <param name="citationCount">Number of citations in the response (0 when ungrounded/uncited).</param>
+    public static void RecordAgentResponseGrounding(
+        string path,
+        string groundingStatusWire,
+        string retrievalProfile,
+        int citationCount)
+    {
+        var tags = new TagList
+        {
+            { "path", path },
+            { "grounding_status", AgentGroundingStatuses.FromWire(groundingStatusWire) },
+            { "retrieval_profile", retrievalProfile }
+        };
+        AgentResponseGrounding.Add(1, tags);
+
+        AgentResponseCitationCount.Record(citationCount, new TagList { { "path", path } });
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentMetricsTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentMetricsTests.cs
@@ -212,8 +212,95 @@ public sealed class ChatWithSessionAgentMetricsTests
     }
 
     // ──────────────────────────────────────────────────────────────────────────
+    // #3390 Slice 1: structured grounding observability (text path)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    private const string AgentGroundingName = "meepleai.agent.response.grounding";
+
+    [Fact(DisplayName = "#3390 Slice 1: text path WITH citations emits grounding{path=text,status=grounded,profile=live_session} once")]
+    public async Task Handle_TextPathWithCitations_EmitsGroundedMetric()
+    {
+        // Arrange
+        var captures = new List<(long Value, Dictionary<string, object?> Tags)>();
+        using var listener = BuildCounterListener(AgentGroundingName, captures);
+
+        var citations = new List<ChunkCitation>
+        {
+            new ChunkCitation(
+                DocumentId: "doc-1",
+                PageNumber: 1,
+                RelevanceScore: 0.9f,
+                SnippetPreview: "snippet A",
+                CopyrightTier: CopyrightTier.Full,
+                IsPublic: true),
+        };
+        var handler = BuildHandler(resolvedCitations: citations, ragPromptMock: out _, tokenContent: "cited answer");
+
+        // Act
+        await foreach (var _ in handler.Handle(BuildCommand(), CancellationToken.None)) { }
+
+        // Assert — exactly one grounding measurement, correct bounded tags
+        captures.Should().ContainSingle("grounding must be recorded exactly once per response");
+        var (value, tags) = captures[0];
+        value.Should().Be(1L);
+        tags["path"].Should().Be("text");
+        tags["grounding_status"].Should().Be("grounded", "a cited RAG answer is grounded");
+        tags["retrieval_profile"].Should().Be("live_session", "the in-session live path uses RetrievalPolicy.LiveSession (#3389)");
+    }
+
+    [Fact(DisplayName = "#3390 Slice 1: text path WITHOUT citations emits grounding{path=text,status=ungrounded}")]
+    public async Task Handle_TextPathNoCitations_EmitsUngroundedMetric()
+    {
+        // Arrange
+        var captures = new List<(long Value, Dictionary<string, object?> Tags)>();
+        using var listener = BuildCounterListener(AgentGroundingName, captures);
+
+        var handler = BuildHandler(resolvedCitations: new List<ChunkCitation>(), ragPromptMock: out _, tokenContent: "uncited answer");
+
+        // Act
+        await foreach (var _ in handler.Handle(BuildCommand(), CancellationToken.None)) { }
+
+        // Assert
+        captures.Should().ContainSingle();
+        captures[0].Tags["path"].Should().Be("text");
+        captures[0].Tags["grounding_status"].Should().Be("ungrounded", "zero citations -> ungrounded (never fabricate grounded)");
+        captures[0].Tags["retrieval_profile"].Should().Be("live_session");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
     // Helpers
     // ──────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Captures counter measurements with their tag set (copied out of the ref-struct span).
+    /// </summary>
+    private static MeterListener BuildCounterListener(
+        string metricName,
+        List<(long Value, Dictionary<string, object?> Tags)> captures)
+    {
+        var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Meter.Name == MeepleAiMetrics.MeterName
+                    && instrument.Name == metricName)
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            },
+        };
+        listener.SetMeasurementEventCallback<long>((_, value, tags, _) =>
+        {
+            var dict = new Dictionary<string, object?>();
+            foreach (var kv in tags)
+            {
+                dict[kv.Key] = kv.Value;
+            }
+            captures.Add((value, dict));
+        });
+        listener.Start();
+        return listener;
+    }
 
     private static MeterListener BuildHistogramListener<T>(string metricName, List<T> observations)
         where T : struct

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/ChatCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/ChatCommandHandlerTests.cs
@@ -3,9 +3,11 @@ using Api.BoundedContexts.SessionTracking.Application.Queries;
 using Api.BoundedContexts.SessionTracking.Domain.Entities;
 using Api.BoundedContexts.SessionTracking.Domain.Repositories;
 using Api.Middleware.Exceptions;
+using Api.Observability;
 using Api.Services;
 using Api.BoundedContexts.SessionTracking.Application.Services;
 using Api.Services.ImageProcessing;
+using Api.Services.LlmClients;
 using Api.SharedKernel.Domain.Enums;
 using Api.Tests.Constants;
 using MediatR;
@@ -13,6 +15,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
 using FluentAssertions;
+using System.Diagnostics.Metrics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -277,6 +280,124 @@ public class AskSessionAgentCommandHandlerTests
 
         var act4 = () => _handler.Handle(command, TestContext.Current.CancellationToken);
         await act4.Should().ThrowAsync<NotFoundException>();
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // #3390 Slice 1: structured grounding observability (image / text-only path)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    private const string AgentGroundingName = "meepleai.agent.response.grounding";
+
+    [Fact]
+    public async Task Handle_TextOnlyPath_EmitsGroundingMetricTextUngroundedNone()
+    {
+        // Arrange — the text-only branch (no images) of the multimodal handler: no retrieval.
+        var sessionId = Guid.NewGuid();
+        var senderId = Guid.NewGuid();
+        var session = CreateSessionWithParticipant(sessionId, senderId);
+        _mockSessionRepo.Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+        _mockChatRepo.SetupSequence(r => r.GetNextSequenceNumberAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1).ReturnsAsync(2);
+
+        var captures = new List<(long Value, Dictionary<string, object?> Tags)>();
+        using var listener = BuildCounterListener(AgentGroundingName, captures);
+
+        var command = new AskSessionAgentCommand(sessionId, senderId, "What are the rules?", 1);
+
+        // Act
+        await _handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        captures.Should().ContainSingle("grounding must be recorded exactly once per response");
+        var (value, tags) = captures[0];
+        value.Should().Be(1L);
+        tags["path"].Should().Be("text", "no images attached -> text branch");
+        tags["grounding_status"].Should().Be("ungrounded", "this handler never retrieves, so it is always ungrounded (#3388)");
+        tags["retrieval_profile"].Should().Be("none", "no retrieval on this path");
+    }
+
+    [Fact]
+    public async Task Handle_ImagePath_EmitsGroundingMetricImageUngroundedNone()
+    {
+        // Arrange — the vision branch: images attached, multimodal LLM, still no retrieval.
+        var sessionId = Guid.NewGuid();
+        var senderId = Guid.NewGuid();
+        var session = CreateSessionWithParticipant(sessionId, senderId);
+
+        var mockSessionRepo = new Mock<ISessionRepository>();
+        mockSessionRepo.Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+        var mockChatRepo = new Mock<ISessionChatRepository>();
+        mockChatRepo.SetupSequence(r => r.GetNextSequenceNumberAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1).ReturnsAsync(2);
+        var mockMediator = new Mock<IMediator>();
+
+        var mockImagePreprocessor = new Mock<IImagePreprocessor>();
+        mockImagePreprocessor
+            .Setup(p => p.ProcessAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<ImageProcessingOptions?>()))
+            .ReturnsAsync(new ProcessedImage(new byte[] { 1, 2, 3 }, "image/jpeg", 10, 10, 3));
+
+        var mockLlm = new Mock<ILlmService>();
+        mockLlm
+            .Setup(s => s.GenerateMultimodalCompletionAsync(
+                It.IsAny<IReadOnlyList<LlmMessage>>(), It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(LlmCompletionResult.CreateSuccess("I see a Catan board mid-game."));
+
+        var handler = new AskSessionAgentCommandHandler(
+            mockSessionRepo.Object,
+            mockChatRepo.Object,
+            mockMediator.Object,
+            mockLlm.Object,
+            mockImagePreprocessor.Object,
+            new Mock<IGameStateExtractor>().Object,
+            new Mock<ILogger<AskSessionAgentCommandHandler>>().Object);
+
+        var captures = new List<(long Value, Dictionary<string, object?> Tags)>();
+        using var listener = BuildCounterListener(AgentGroundingName, captures);
+
+        var command = new AskSessionAgentCommand(
+            sessionId, senderId, "What should I do?", 1,
+            new List<ChatImageAttachment> { new(new byte[] { 1, 2, 3 }, "image/jpeg", "board.jpg") });
+
+        // Act
+        await handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        captures.Should().ContainSingle();
+        var (value, tags) = captures[0];
+        value.Should().Be(1L);
+        tags["path"].Should().Be("image", "images attached -> vision branch");
+        tags["grounding_status"].Should().Be("ungrounded");
+        tags["retrieval_profile"].Should().Be("none");
+    }
+
+    private static MeterListener BuildCounterListener(
+        string metricName,
+        List<(long Value, Dictionary<string, object?> Tags)> captures)
+    {
+        var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Meter.Name == MeepleAiMetrics.MeterName
+                    && instrument.Name == metricName)
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            },
+        };
+        listener.SetMeasurementEventCallback<long>((_, value, tags, _) =>
+        {
+            var dict = new Dictionary<string, object?>();
+            foreach (var kv in tags)
+            {
+                dict[kv.Key] = kv.Value;
+            }
+            captures.Add((value, dict));
+        });
+        listener.Start();
+        return listener;
     }
 }
 

--- a/infra/compose.prod.yml
+++ b/infra/compose.prod.yml
@@ -249,6 +249,8 @@ services:
       - ./prometheus/alerts/domain-event-outbox-duplicate-publish.yml:/etc/prometheus/domain-event-outbox-duplicate-publish.yml:ro
       # Issue #3248 (epic #448 C5) — copyright enforcement observability alerts.
       - ./prometheus/alerts/copyright-enforcement.yml:/etc/prometheus/copyright-enforcement.yml:ro
+      # Issue #3390 (epic #3397) Slice 1 — in-session agent grounding observability (referenced from prometheus.prod.yml rule_files).
+      - ./prometheus/alerts/agent-grounding.yml:/etc/prometheus/agent-grounding.yml:ro
       - prometheus-prod:/prometheus
     deploy:
       resources:

--- a/infra/compose.staging.yml
+++ b/infra/compose.staging.yml
@@ -364,6 +364,8 @@ services:
       - ./prometheus/alerts/domain-event-outbox-duplicate-publish.yml:/etc/prometheus/domain-event-outbox-duplicate-publish.yml:ro
       # Issue #3248 (epic #448 C5) — copyright enforcement observability alerts.
       - ./prometheus/alerts/copyright-enforcement.yml:/etc/prometheus/copyright-enforcement.yml:ro
+      # Issue #3390 (epic #3397) Slice 1 — in-session agent grounding observability (referenced from prometheus.staging.yml rule_files).
+      - ./prometheus/alerts/agent-grounding.yml:/etc/prometheus/agent-grounding.yml:ro
       - prometheus-staging:/prometheus
 
   alertmanager:

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -363,6 +363,8 @@ services:
       - ./prometheus/alerts/wikidata-enrichment.yml:/etc/prometheus/wikidata-enrichment.yml:ro
       # Issue #3248 (epic #448 C5) — copyright enforcement observability alerts.
       - ./prometheus/alerts/copyright-enforcement.yml:/etc/prometheus/copyright-enforcement.yml:ro
+      # Issue #3390 (epic #3397) Slice 1 — in-session agent grounding observability (referenced from prometheus.yml rule_files).
+      - ./prometheus/alerts/agent-grounding.yml:/etc/prometheus/agent-grounding.yml:ro
       - prometheus_data:/prometheus
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:9090/-/healthy"]

--- a/infra/prometheus.prod.yml
+++ b/infra/prometheus.prod.yml
@@ -35,6 +35,8 @@ rule_files:
   - '/etc/prometheus/domain-event-outbox-duplicate-publish.yml'
   # Issue #3248 (epic #448 C5) — copyright enforcement observability alerts.
   - '/etc/prometheus/copyright-enforcement.yml'
+  # Issue #3390 (epic #3397) Slice 1 — in-session agent grounding observability (ungrounded-rate on RAG live path).
+  - '/etc/prometheus/agent-grounding.yml'
 
 scrape_configs:
   - job_name: 'prometheus'

--- a/infra/prometheus.staging.yml
+++ b/infra/prometheus.staging.yml
@@ -35,6 +35,8 @@ rule_files:
   - '/etc/prometheus/domain-event-outbox-duplicate-publish.yml'
   # Issue #3248 (epic #448 C5) — copyright enforcement observability alerts.
   - '/etc/prometheus/copyright-enforcement.yml'
+  # Issue #3390 (epic #3397) Slice 1 — in-session agent grounding observability (ungrounded-rate on RAG live path).
+  - '/etc/prometheus/agent-grounding.yml'
 
 scrape_configs:
   - job_name: 'prometheus'

--- a/infra/prometheus.yml
+++ b/infra/prometheus.yml
@@ -40,6 +40,8 @@ rule_files:
   - '/etc/prometheus/domain-event-outbox-duplicate-publish.yml'
   # Issue #3248 (epic #448 C5) — copyright enforcement observability alerts.
   - '/etc/prometheus/copyright-enforcement.yml'
+  # Issue #3390 (epic #3397) Slice 1 — in-session agent grounding observability (ungrounded-rate on RAG live path).
+  - '/etc/prometheus/agent-grounding.yml'
 
 # Scrape configurations
 scrape_configs:

--- a/infra/prometheus/alerts/agent-grounding.test.yml
+++ b/infra/prometheus/alerts/agent-grounding.test.yml
@@ -1,0 +1,70 @@
+# promtool unit tests for agent-grounding.yml (#3390 Slice 1).
+#
+# Run locally (Windows/Git Bash, from repo root):
+#   docker run --rm -v "$(pwd)/infra/prometheus/alerts:/work" prom/prometheus:v3.7.0 \
+#     promtool test rules /work/agent-grounding.test.yml
+#
+# There is no promtool CI gate in this repo (see recon in #3082); this file documents +
+# verifies the alert behaviour on demand. It guards the two subtle properties of the alert:
+#   1. the ratio is scoped to the RAG-capable path only (path=text, retrieval_profile=live_session),
+#      so by-design-ungrounded image traffic can NEVER make it fire;
+#   2. no traffic / flat counters never fire (clamp_min + superset-denominator safety).
+rule_files:
+  - agent-grounding.yml
+
+evaluation_interval: 1m
+
+tests:
+  # 1. Text/RAG path ungrounded 100% (grounded flat) sustained → alert fires.
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_agent_response_grounding_total{path="text",retrieval_profile="live_session",grounding_status="ungrounded"}'
+        values: '0+10x60'
+      - series: 'meepleai_agent_response_grounding_total{path="text",retrieval_profile="live_session",grounding_status="grounded"}'
+        values: '0x60'
+    alert_rule_test:
+      - eval_time: 46m
+        alertname: HighUngroundedRateOnRagLivePath
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              subsystem: in-session-agent
+            exp_annotations:
+              summary: "In-session RAG agent is ungrounded on >50% of text turns (15m)"
+              description: "More than half of the in-session live-path (RAG) answers over the last 15m carried zero citations (grounding_status=ungrounded). The live path should be grounded-capable; a sustained ungrounded majority means retrieval is failing to produce citations. Baseline citation-accuracy floor is tracked in docs/for-developers/evaluation-reports/baseline-2026-08-02.md (#3390)."
+
+  # 2. Text/RAG path 40% ungrounded (below the 50% threshold) → no alert.
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_agent_response_grounding_total{path="text",retrieval_profile="live_session",grounding_status="ungrounded"}'
+        values: '0+4x60'
+      - series: 'meepleai_agent_response_grounding_total{path="text",retrieval_profile="live_session",grounding_status="grounded"}'
+        values: '0+6x60'
+    alert_rule_test:
+      - eval_time: 46m
+        alertname: HighUngroundedRateOnRagLivePath
+        exp_alerts: []
+
+  # 3. Idle: text counters present but flat at 0 (rate 0/0) → clamp_min keeps it 0 → no alert.
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_agent_response_grounding_total{path="text",retrieval_profile="live_session",grounding_status="ungrounded"}'
+        values: '0x60'
+      - series: 'meepleai_agent_response_grounding_total{path="text",retrieval_profile="live_session",grounding_status="grounded"}'
+        values: '0x60'
+    alert_rule_test:
+      - eval_time: 46m
+        alertname: HighUngroundedRateOnRagLivePath
+        exp_alerts: []
+
+  # 4. Scoping guard: only image traffic, 100% ungrounded by design (retrieval_profile=none).
+  #    The text/live_session series set is empty → alert must NOT fire. This is the calibration
+  #    invariant — dropping the path/retrieval_profile matchers would regress this to a firing.
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_agent_response_grounding_total{path="image",retrieval_profile="none",grounding_status="ungrounded"}'
+        values: '0+20x60'
+    alert_rule_test:
+      - eval_time: 46m
+        alertname: HighUngroundedRateOnRagLivePath
+        exp_alerts: []

--- a/infra/prometheus/alerts/agent-grounding.yml
+++ b/infra/prometheus/alerts/agent-grounding.yml
@@ -1,0 +1,35 @@
+# Issue #3390 (epic #3397) Slice 1 — In-session agent grounding observability.
+#
+# Metric source (apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.AgentGrounding.cs):
+#   - meepleai_agent_response_grounding_total (Counter<long>)
+#       labels: path (text|image), grounding_status (grounded|partial|ungrounded),
+#               retrieval_profile (live_session|default|none)
+#   - meepleai_agent_response_citation_count (Histogram<int>, label: path)
+#
+# Emitted by the two in-session agent producers:
+#   - text  -> ChatWithSessionAgentCommandHandler (KnowledgeBase, RAG, retrieval_profile=live_session)
+#   - image -> AskSessionAgentCommandHandler       (SessionTracking, multimodal, retrieval_profile=none)
+#
+# CALIBRATION: the image path is ungrounded 100% by design until #3390 Slice 2 wires
+# retrieval into it, so this alert scopes to the RAG-capable path ONLY
+# (path=text, retrieval_profile=live_session). A high ungrounded rate THERE means the
+# retrieval is silently failing to cite — the exact trust-critical failure the #3397 audit
+# named ("a system honest intermittently is less trustworthy than one never honest").
+# Do NOT drop the path/retrieval_profile filters or the image traffic will mask the signal.
+groups:
+  - name: meepleai_agent_grounding_alerts
+    rules:
+      - alert: HighUngroundedRateOnRagLivePath
+        expr: |
+          (
+            sum(rate(meepleai_agent_response_grounding_total{path="text",retrieval_profile="live_session",grounding_status="ungrounded"}[15m]))
+            /
+            clamp_min(sum(rate(meepleai_agent_response_grounding_total{path="text",retrieval_profile="live_session"}[15m])), 1e-9)
+          ) > 0.5
+        for: 30m
+        labels:
+          severity: warning
+          subsystem: in-session-agent
+        annotations:
+          summary: "In-session RAG agent is ungrounded on >50% of text turns (15m)"
+          description: "More than half of the in-session live-path (RAG) answers over the last 15m carried zero citations (grounding_status=ungrounded). The live path should be grounded-capable; a sustained ungrounded majority means retrieval is failing to produce citations. Baseline citation-accuracy floor is tracked in docs/for-developers/evaluation-reports/baseline-2026-08-02.md (#3390)."


### PR DESCRIPTION
## Epic #3390 — Slice 1 di 5 (Osservabilità)

Primo slice dell'epic **#3390** (unificare la risposta dell'agente in-sessione dietro un unico contratto RAG grounded). Il prerequisito bloccante — eval-set golden + baseline — è stato soddisfatto oggi (#3467 + baseline #3477). Questo slice **rende misurabile lo stato di grounding di ogni risposta agente in-sessione PRIMA** che gli slice strutturali (2-5) tocchino il path live più caldo.

L'audit `docs/for-developers/audits/2026-07-29-in-session-agent-grounding-audit.md` (§3, lente 🛡️) segnalava il segnale di grounding come invisibile alle ops (*"manometro dipinto"*): nessuna metrica distingueva una risposta grounded (con citazioni) da una silenziosamente ungrounded, né portava il path di input.

## Cosa fa

- **Nuova metrica** `meepleai.agent.response.grounding` (Counter; tag `path`, `grounding_status`, `retrieval_profile`) + `meepleai.agent.response.citation_count` (Histogram; tag `path`). Solo bounded-set come tag (regola cardinality del repo — nessun id sessione/utente/gioco).
- **Cablata ai due produttori in-sessione**:
  - `text` → `ChatWithSessionAgentCommandHandler` (KnowledgeBase, RAG, `retrieval_profile=live_session`)
  - `image` → `AskSessionAgentCommandHandler` (SessionTracking, multimodale, `retrieval_profile=none`)
  - Emissione **guardata** (try/catch): un errore di metrica non può mai rompere la risposta/stream.
- **Alert Prometheus** `HighUngroundedRateOnRagLivePath`, cablato in `rule_files` (dev/staging/prod) + mount compose.

## Calibrazione dell'alert (nota importante)

Il path `image` è **ungrounded al 100% by design** finché lo Slice 2 non ci cabla il retrieval. L'alert è quindi **scoped al solo path RAG-capable** (`path=text, retrieval_profile=live_session`): un tasso di ungrounded alto *lì* è il vero segnale trust-critical (retrieval che fallisce silenziosamente a citare). Non rimuovere i filtri `path`/`retrieval_profile` o il traffico immagine maschererebbe il segnale.

## Test

- `ChatWithSessionAgentMetricsTests`: emissione grounded/ungrounded con tag corretti sul path testo.
- `AskSessionAgentCommandHandlerTests`: emissione con `path=image` (branch vision) e `path=text` (branch text-only), sempre `ungrounded`/`none`.
- **13/13 verdi** (4 nuovi + 9 pre-esistenti delle due classi). Build BE: 0 errori.

## Roadmap slice successivi (non in questa PR)

2. Retrieval sul path immagine (testo-first) dietro flag `rag.live-image-retrieval`
3. Query-expansion da vision (`GameStateExtractor`) quando il testo è vuoto
4. Enhancement live-path per-enhancement (misurati vs baseline; CRAG web OFF esplicito)
5. Ownership collapse `SessionTracking` → consumer di `KnowledgeBase` (ADR)

Part of #3390. Epic #3397.

🤖 Generated with [Claude Code](https://claude.com/claude-code)