### PR TITLE
feat(catalog): cover assign/remove write API (#3470 Slice 1c)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AssignCoverCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AssignCoverCommand.cs
@@ -1,0 +1,18 @@
+using Api.BoundedContexts.SharedGameCatalog.Application;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Domain.Covers;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+
+/// <summary>
+/// Epic #3470 — pins a cover source (and crop focal point) for a UI context on a
+/// game, creating the assignment or updating the existing one for that context.
+/// </summary>
+internal record AssignCoverCommand(
+    Guid GameId,
+    CoverContext Context,
+    CoverAssignmentSource Source,
+    Guid AdminId,
+    double FocalX = 0.5,
+    double FocalY = 0.5) : ICommand<CoverAssignmentDto>;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AssignCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AssignCoverCommandHandler.cs
@@ -1,0 +1,52 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+
+/// <summary>
+/// Epic #3470 — persists an admin's per-context cover choice through the aggregate
+/// (<see cref="Domain.Aggregates.SharedGame.AssignCover"/>) and the child-safe
+/// <see cref="ISharedGameRepository.ReconcileCoverAssignmentsAsync"/>. Returns the
+/// persisted assignment so the picker can reflect the new state.
+/// </summary>
+internal sealed class AssignCoverCommandHandler : ICommandHandler<AssignCoverCommand, CoverAssignmentDto>
+{
+    private readonly ISharedGameRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly ILogger<AssignCoverCommandHandler> _logger;
+
+    public AssignCoverCommandHandler(
+        ISharedGameRepository repository,
+        IUnitOfWork unitOfWork,
+        ILogger<AssignCoverCommandHandler> logger)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<CoverAssignmentDto> Handle(AssignCoverCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var game = await _repository.GetByIdAsync(command.GameId, cancellationToken).ConfigureAwait(false);
+        if (game is null)
+        {
+            throw new NotFoundException("SharedGame", command.GameId.ToString());
+        }
+
+        var assignment = game.AssignCover(command.Context, command.Source, command.AdminId, command.FocalX, command.FocalY);
+
+        await _repository.ReconcileCoverAssignmentsAsync(game, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Assigned {Source} cover to {Context} for game {GameId} by {AdminId}",
+            command.Source, command.Context, command.GameId, command.AdminId);
+
+        return new CoverAssignmentDto(assignment.Context, assignment.Source, assignment.FocalX, assignment.FocalY);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AssignCoverCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AssignCoverCommandValidator.cs
@@ -1,0 +1,21 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+
+/// <summary>
+/// Boundary validation for <see cref="AssignCoverCommand"/> — turns bad input into a
+/// 400 rather than letting the domain factory throw a 500. Mirrors the domain guards
+/// on <c>GameCoverAssignment.Create</c> (focal in [0,1], defined enums).
+/// </summary>
+internal sealed class AssignCoverCommandValidator : AbstractValidator<AssignCoverCommand>
+{
+    public AssignCoverCommandValidator()
+    {
+        RuleFor(x => x.GameId).NotEqual(Guid.Empty).WithMessage("GameId is required");
+        RuleFor(x => x.AdminId).NotEqual(Guid.Empty).WithMessage("AdminId is required");
+        RuleFor(x => x.Context).IsInEnum().WithMessage("Context must be a defined CoverContext");
+        RuleFor(x => x.Source).IsInEnum().WithMessage("Source must be a defined CoverAssignmentSource");
+        RuleFor(x => x.FocalX).InclusiveBetween(0.0, 1.0).WithMessage("FocalX must be in [0, 1]");
+        RuleFor(x => x.FocalY).InclusiveBetween(0.0, 1.0).WithMessage("FocalY must be in [0, 1]");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RemoveCoverAssignmentCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RemoveCoverAssignmentCommand.cs
@@ -1,0 +1,15 @@
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Domain.Covers;
+using MediatR;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+
+/// <summary>
+/// Epic #3470 — removes the cover assignment for a UI context, resetting it to the
+/// resolver's implicit precedence. Idempotent: removing an absent assignment is a
+/// no-op (still 204), only a missing game is a 404.
+/// </summary>
+internal record RemoveCoverAssignmentCommand(
+    Guid GameId,
+    CoverContext Context,
+    Guid AdminId) : ICommand<Unit>;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RemoveCoverAssignmentCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RemoveCoverAssignmentCommandHandler.cs
@@ -1,0 +1,52 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+
+/// <summary>
+/// Epic #3470 — removes a context's cover assignment (resetting it to the resolver's
+/// implicit precedence) through the aggregate + reconcile path. Removing an absent
+/// assignment is an idempotent no-op; only a missing game is a 404.
+/// </summary>
+internal sealed class RemoveCoverAssignmentCommandHandler : ICommandHandler<RemoveCoverAssignmentCommand, Unit>
+{
+    private readonly ISharedGameRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly ILogger<RemoveCoverAssignmentCommandHandler> _logger;
+
+    public RemoveCoverAssignmentCommandHandler(
+        ISharedGameRepository repository,
+        IUnitOfWork unitOfWork,
+        ILogger<RemoveCoverAssignmentCommandHandler> logger)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<Unit> Handle(RemoveCoverAssignmentCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var game = await _repository.GetByIdAsync(command.GameId, cancellationToken).ConfigureAwait(false);
+        if (game is null)
+        {
+            throw new NotFoundException("SharedGame", command.GameId.ToString());
+        }
+
+        game.RemoveCoverAssignment(command.Context);
+
+        await _repository.ReconcileCoverAssignmentsAsync(game, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Removed cover assignment for {Context} on game {GameId} by {AdminId}",
+            command.Context, command.GameId, command.AdminId);
+
+        return Unit.Value;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RemoveCoverAssignmentCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RemoveCoverAssignmentCommandValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+
+/// <summary>Boundary validation for <see cref="RemoveCoverAssignmentCommand"/>.</summary>
+internal sealed class RemoveCoverAssignmentCommandValidator : AbstractValidator<RemoveCoverAssignmentCommand>
+{
+    public RemoveCoverAssignmentCommandValidator()
+    {
+        RuleFor(x => x.GameId).NotEqual(Guid.Empty).WithMessage("GameId is required");
+        RuleFor(x => x.AdminId).NotEqual(Guid.Empty).WithMessage("AdminId is required");
+        RuleFor(x => x.Context).IsInEnum().WithMessage("Context must be a defined CoverContext");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/CoverAssignmentDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/CoverAssignmentDto.cs
@@ -1,0 +1,15 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.SharedKernel.Domain.Covers;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application;
+
+/// <summary>
+/// Epic #3470 — the persisted per-context cover assignment returned by the write
+/// command, so the picker can reflect the new state without a round-trip. The enums
+/// serialize as their names via the global <c>JsonStringEnumConverter</c>.
+/// </summary>
+public sealed record CoverAssignmentDto(
+    CoverContext Context,
+    CoverAssignmentSource Source,
+    double FocalX,
+    double FocalY);

--- a/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogAdminEndpoints.cs
+++ b/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogAdminEndpoints.cs
@@ -15,6 +15,7 @@ using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
 using Api.Extensions;
 using Api.Middleware.Exceptions;
 using Api.Models;
+using Api.SharedKernel.Domain.Covers;
 using Api.SharedKernel.Domain.Exceptions;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
@@ -65,6 +66,27 @@ internal static class SharedGameCatalogAdminEndpoints
             .WithSummary("Get cover source candidates for a game (Admin/Editor)")
             .WithDescription("Returns the materialized cover sources (each with a preview URL) and the current per-context cover assignments, feeding the admin cover picker.")
             .Produces<CoverCandidatesDto>()
+            .Produces(StatusCodes.Status404NotFound);
+
+        // Cover picker upsert: pin a source (+ focal point) for a UI context (epic #3470)
+        group.MapPut("/admin/shared-games/{id:guid}/cover-assignments/{context}", HandleAssignCover)
+            .RequireAuthorization("AdminOrEditorPolicy")
+            .RequireRateLimiting("SharedGamesAdmin")
+            .WithName("AssignCover")
+            .WithSummary("Pin a cover source for a UI context (Admin/Editor)")
+            .WithDescription("Upserts the per-context cover assignment for a game (at most one per context) and returns the persisted assignment.")
+            .Produces<CoverAssignmentDto>()
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status404NotFound);
+
+        // Cover picker reset: remove a context's assignment → back to implicit precedence (epic #3470)
+        group.MapDelete("/admin/shared-games/{id:guid}/cover-assignments/{context}", HandleRemoveCoverAssignment)
+            .RequireAuthorization("AdminOrEditorPolicy")
+            .RequireRateLimiting("SharedGamesAdmin")
+            .WithName("RemoveCoverAssignment")
+            .WithSummary("Reset a UI context's cover to implicit precedence (Admin/Editor)")
+            .WithDescription("Removes the per-context cover assignment for a game; idempotent (no-op when absent).")
+            .Produces(StatusCodes.Status204NoContent)
             .Produces(StatusCodes.Status404NotFound);
 
         // Submit game for approval (Draft → PendingApproval) - Issue #2514
@@ -881,6 +903,38 @@ internal static class SharedGameCatalogAdminEndpoints
     {
         var result = await mediator.Send(new GetCoverCandidatesQuery(id), ct).ConfigureAwait(false);
         return result is null ? Results.NotFound() : Results.Ok(result);
+    }
+
+    private static async Task<IResult> HandleAssignCover(
+        Guid id,
+        CoverContext context,
+        AssignCoverRequest request,
+        IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken ct)
+    {
+        var (authorized, session, error) = httpContext.RequireAdminOrEditorSession();
+        if (!authorized) return error!;
+
+        var command = new AssignCoverCommand(
+            id, context, request.Source, session!.Principal!.Subject.Id, request.FocalX, request.FocalY);
+        var result = await mediator.Send(command, ct).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> HandleRemoveCoverAssignment(
+        Guid id,
+        CoverContext context,
+        IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken ct)
+    {
+        var (authorized, session, error) = httpContext.RequireAdminOrEditorSession();
+        if (!authorized) return error!;
+
+        await mediator.Send(new RemoveCoverAssignmentCommand(id, context, session!.Principal!.Subject.Id), ct)
+            .ConfigureAwait(false);
+        return Results.NoContent();
     }
 
     private static async Task<IResult> HandleGetApprovalQueue(

--- a/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogRequestDtos.cs
+++ b/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogRequestDtos.cs
@@ -4,8 +4,19 @@ using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
 using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.SharedKernel.Domain.Covers;
 
 namespace Api.Routing;
+
+/// <summary>
+/// Request body for the cover-picker upsert (epic #3470). The UI context is a route
+/// segment; the body carries the pinned source and the crop focal point (defaults
+/// to center). The acting admin comes from the session, never the body.
+/// </summary>
+internal record AssignCoverRequest(
+    CoverAssignmentSource Source,
+    double FocalX = 0.5,
+    double FocalY = 0.5);
 
 // ========================================
 // REQUEST DTOS

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/AssignCoverCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/AssignCoverCommandHandlerTests.cs
@@ -1,0 +1,107 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Domain.Covers;
+using Api.SharedKernel.Infrastructure.Persistence;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands;
+
+/// <summary>
+/// Epic #3470 Slice 1c (write vertical) — the command that persists an admin's
+/// per-context cover choice through the aggregate + reconcile path. Orchestration
+/// is unit-tested here (mocked repo + unit of work over a REAL aggregate); the
+/// actual Postgres persistence of the reconcile is covered by
+/// <c>SharedGameCoverAssignmentReconcileIntegrationTests</c>.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class AssignCoverCommandHandlerTests
+{
+    private static readonly Guid AdminId = Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd");
+
+    private readonly Mock<ISharedGameRepository> _repository = new();
+    private readonly Mock<IUnitOfWork> _unitOfWork = new();
+
+    private AssignCoverCommandHandler CreateAssignHandler() =>
+        new(_repository.Object, _unitOfWork.Object, NullLogger<AssignCoverCommandHandler>.Instance);
+
+    private RemoveCoverAssignmentCommandHandler CreateRemoveHandler() =>
+        new(_repository.Object, _unitOfWork.Object, NullLogger<RemoveCoverAssignmentCommandHandler>.Instance);
+
+    private static SharedGame NewGame() => SharedGame.Create(
+        "Catan", 1995, "desc", 3, 4, 90, 10, 2.5m, 7.8m,
+        "https://example.com/c.jpg", "https://example.com/c-thumb.jpg", null, AdminId);
+
+    [Fact]
+    public async Task Assign_MutatesAggregate_Reconciles_Saves_ReturnsDto()
+    {
+        var game = NewGame();
+        _repository.Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>())).ReturnsAsync(game);
+        var handler = CreateAssignHandler();
+
+        var dto = await handler.Handle(
+            new AssignCoverCommand(game.Id, CoverContext.Card, CoverAssignmentSource.Wikidata, AdminId, 0.3, 0.7),
+            CancellationToken.None);
+
+        game.CoverAssignments.Should().ContainSingle();
+        game.CoverAssignments.Single().Source.Should().Be(CoverAssignmentSource.Wikidata);
+
+        _repository.Verify(r => r.ReconcileCoverAssignmentsAsync(game, It.IsAny<CancellationToken>()), Times.Once);
+        _unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+
+        dto.Context.Should().Be(CoverContext.Card);
+        dto.Source.Should().Be(CoverAssignmentSource.Wikidata);
+        dto.FocalX.Should().Be(0.3);
+        dto.FocalY.Should().Be(0.7);
+    }
+
+    [Fact]
+    public async Task Assign_GameNotFound_ThrowsNotFound_NoSave()
+    {
+        _repository.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                   .ReturnsAsync((SharedGame?)null);
+        var handler = CreateAssignHandler();
+
+        var act = () => handler.Handle(
+            new AssignCoverCommand(Guid.NewGuid(), CoverContext.Card, CoverAssignmentSource.Wikidata, AdminId),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+        _unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Remove_ExistingAssignment_Reconciles_Saves()
+    {
+        var game = NewGame();
+        game.AssignCover(CoverContext.Card, CoverAssignmentSource.Wikidata, AdminId);
+        _repository.Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>())).ReturnsAsync(game);
+        var handler = CreateRemoveHandler();
+
+        await handler.Handle(new RemoveCoverAssignmentCommand(game.Id, CoverContext.Card, AdminId), CancellationToken.None);
+
+        game.CoverAssignments.Should().BeEmpty();
+        _repository.Verify(r => r.ReconcileCoverAssignmentsAsync(game, It.IsAny<CancellationToken>()), Times.Once);
+        _unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Remove_GameNotFound_ThrowsNotFound()
+    {
+        _repository.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                   .ReturnsAsync((SharedGame?)null);
+        var handler = CreateRemoveHandler();
+
+        var act = () => handler.Handle(
+            new RemoveCoverAssignmentCommand(Guid.NewGuid(), CoverContext.Card, AdminId),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/AssignCoverCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/AssignCoverCommandValidatorTests.cs
@@ -1,0 +1,65 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.SharedKernel.Domain.Covers;
+using FluentAssertions;
+using FluentValidation.TestHelper;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class AssignCoverCommandValidatorTests
+{
+    private static readonly Guid GameId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static readonly Guid AdminId = Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd");
+    private readonly AssignCoverCommandValidator _validator = new();
+
+    private static AssignCoverCommand Valid() =>
+        new(GameId, CoverContext.Card, CoverAssignmentSource.Wikidata, AdminId, 0.5, 0.5);
+
+    [Fact]
+    public void Passes_ForAValidCommand()
+    {
+        _validator.TestValidate(Valid()).ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Fails_WhenGameIdEmpty()
+    {
+        _validator.TestValidate(Valid() with { GameId = Guid.Empty })
+            .ShouldHaveValidationErrorFor(x => x.GameId);
+    }
+
+    [Fact]
+    public void Fails_WhenAdminIdEmpty()
+    {
+        _validator.TestValidate(Valid() with { AdminId = Guid.Empty })
+            .ShouldHaveValidationErrorFor(x => x.AdminId);
+    }
+
+    [Theory]
+    [InlineData(-0.01, 0.5)]
+    [InlineData(1.01, 0.5)]
+    [InlineData(0.5, -0.01)]
+    [InlineData(0.5, 1.01)]
+    public void Fails_WhenFocalOutOfRange(double x, double y)
+    {
+        var result = _validator.TestValidate(Valid() with { FocalX = x, FocalY = y });
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Fails_WhenContextUndefined()
+    {
+        _validator.TestValidate(Valid() with { Context = (CoverContext)99 })
+            .ShouldHaveValidationErrorFor(x => x.Context);
+    }
+
+    [Fact]
+    public void Fails_WhenSourceUndefined()
+    {
+        _validator.TestValidate(Valid() with { Source = (CoverAssignmentSource)99 })
+            .ShouldHaveValidationErrorFor(x => x.Source);
+    }
+}


### PR DESCRIPTION
## Epic #3470 — cover assign/remove write API (backend write vertical)

Completes the backend write path for the admin cover picker: persists the per-context cover choice through the `SharedGame` aggregate and the child-safe `ReconcileCoverAssignmentsAsync`. With 1c-1/1c-2/1c-3 already merged, this unblocks the FE picker (Slice 1d) — the FE now has a read (`GET .../cover-candidates`) and a write (`PUT/DELETE .../cover-assignments/{context}`).

### What
- **`AssignCoverCommand` + handler + validator**: loads the game, `AssignCover` (idempotent upsert through the aggregate), `ReconcileCoverAssignmentsAsync`, `IUnitOfWork.SaveChanges`; returns the persisted `CoverAssignmentDto`. `NotFoundException` → 404. Validator guards focal ∈ [0,1] + defined enums (400 instead of a domain 500).
- **`RemoveCoverAssignmentCommand` + handler + validator**: resets a context to implicit precedence; idempotent (removing an absent assignment is a no-op → 204).
- **Endpoints** (RESTful, context in the path, `RequireAdminOrEditorSession` — SD5, actor from the session never the body; CQRS: pure `IMediator.Send`):
  - `PUT /admin/shared-games/{id}/cover-assignments/{context}` → 200 `CoverAssignmentDto`
  - `DELETE /admin/shared-games/{id}/cover-assignments/{context}` → 204

### Testing (TDD)
- 4 handler unit tests (mutation applied to a **real** aggregate; reconcile + save called exactly once; 404 → no save; remove) + 9 validator tests, with mocked repo/unit-of-work.
- The Postgres persistence of the reconcile path is covered by `SharedGameCoverAssignmentReconcileIntegrationTests` (1c-2) — this handler orchestrates that proven path.
- Release build clean (SonarAnalyzer warnings-as-errors).
- Adversarial multi-lens review (correctness/CQRS · security/auth · concurrency/persistence) before merge.

### Note on concurrency
The write is last-write-wins within the reconcile transaction (fresh `xmin` per save). The spec §4.4 optimistic-concurrency `409` (picker submits the `xmin` it saw) is a deliberate refinement, not implemented here — the core persistence is correct and the child rows still carry `xmin`.

### DoD
- [x] TDD (red→green), tests over a real aggregate
- [x] Release build clean (warnings-as-errors)
- [x] Role-gated (AdminOrEditor, SD5); actor from session; 404 on missing game
- [x] CQRS (IMediator only); reconcile + unit-of-work (no detached `.Update()`)
- [ ] Merged to `main-dev`

Part of epic #3470. Next: Slice 1d (FE overlay picker + focal-point control + WebpVariantGenerator focal-point + source-aware attribution footer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
