### PR TITLE
fix(catalog): source-aware cover attribution footer (#3470 Slice 1d-a)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetAllSharedGamesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetAllSharedGamesQueryHandler.cs
@@ -81,9 +81,10 @@ internal sealed class GetAllSharedGamesQueryHandler : IRequestHandler<GetAllShar
 
         foreach (var g in entities)
         {
-            var coverUrl = await CoverUrlResolver
-                .ResolvePublicAsync(g, _blobStorage)
+            var cover = await CoverUrlResolver
+                .ResolvePublicWithSourceAsync(g, _blobStorage)
                 .ConfigureAwait(false);
+            var (coverLicense, coverAttribution, coverSourceUrl) = CoverAttribution.ForWinningSource(cover.Kind, g);
 
             games.Add(new SharedGameDto(
                 g.Id,
@@ -115,11 +116,12 @@ internal sealed class GetAllSharedGamesQueryHandler : IRequestHandler<GetAllShar
                 0,      // ContributorsCount
                 false,  // IsTopRated
                 false,  // IsNew
-                CoverUrl: coverUrl,
-                // Issue #2055 Phase G AC-G6 — Wikidata cover attribution (HTML-stripped per DEC-G6-1).
-                WikidataCoverLicense: g.WikidataCoverLicense,
-                WikidataCoverAttribution: AttributionTextExtractor.Strip(g.WikidataCoverAttribution),
-                WikidataCoverSourceUrl: g.WikidataCoverSourceUrl));
+                CoverUrl: cover.Url,
+                // Epic #3470 Slice 1d-a — attribution follows the WINNING source (was
+                // emitted unconditionally); all-null unless the Wikidata cover won.
+                WikidataCoverLicense: coverLicense,
+                WikidataCoverAttribution: coverAttribution,
+                WikidataCoverSourceUrl: coverSourceUrl));
         }
 
         // Issue #2339 (Wave 4 Task 13 — DEC-WIRING): enrich SharedGameDto.Translations

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetFilteredSharedGamesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetFilteredSharedGamesQueryHandler.cs
@@ -111,9 +111,10 @@ internal sealed class GetFilteredSharedGamesQueryHandler : IRequestHandler<GetFi
 
         foreach (var g in entities)
         {
-            var coverUrl = await CoverUrlResolver
-                .ResolvePublicAsync(g, _blobStorage)
+            var cover = await CoverUrlResolver
+                .ResolvePublicWithSourceAsync(g, _blobStorage)
                 .ConfigureAwait(false);
+            var (coverLicense, coverAttribution, coverSourceUrl) = CoverAttribution.ForWinningSource(cover.Kind, g);
 
             games.Add(new SharedGameDto(
                 g.Id,
@@ -145,11 +146,11 @@ internal sealed class GetFilteredSharedGamesQueryHandler : IRequestHandler<GetFi
                 0,      // ContributorsCount
                 false,  // IsTopRated
                 false,  // IsNew
-                CoverUrl: coverUrl,
-                // Issue #2055 Phase G AC-G6 — Wikidata cover attribution (HTML-stripped per DEC-G6-1).
-                WikidataCoverLicense: g.WikidataCoverLicense,
-                WikidataCoverAttribution: AttributionTextExtractor.Strip(g.WikidataCoverAttribution),
-                WikidataCoverSourceUrl: g.WikidataCoverSourceUrl));
+                CoverUrl: cover.Url,
+                // Epic #3470 Slice 1d-a — attribution follows the winning source.
+                WikidataCoverLicense: coverLicense,
+                WikidataCoverAttribution: coverAttribution,
+                WikidataCoverSourceUrl: coverSourceUrl));
         }
 
         // Issue #2339 (Wave 4 Task 13 — DEC-WIRING): enrich SharedGameDto.Translations

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetPendingApprovalGamesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetPendingApprovalGamesQueryHandler.cs
@@ -62,9 +62,10 @@ internal sealed class GetPendingApprovalGamesQueryHandler : IRequestHandler<GetP
         var games = new List<SharedGameDto>(entities.Count);
         foreach (var g in entities)
         {
-            var coverUrl = await CoverUrlResolver
-                .ResolvePublicAsync(g, _blobStorage)
+            var cover = await CoverUrlResolver
+                .ResolvePublicWithSourceAsync(g, _blobStorage)
                 .ConfigureAwait(false);
+            var (coverLicense, coverAttribution, coverSourceUrl) = CoverAttribution.ForWinningSource(cover.Kind, g);
 
             games.Add(new SharedGameDto(
                 g.Id,
@@ -96,11 +97,11 @@ internal sealed class GetPendingApprovalGamesQueryHandler : IRequestHandler<GetP
                 0,      // ContributorsCount
                 false,  // IsTopRated
                 false,  // IsNew
-                CoverUrl: coverUrl,
-                // Issue #2055 Phase G AC-G6 — Wikidata cover attribution (HTML-stripped per DEC-G6-1).
-                WikidataCoverLicense: g.WikidataCoverLicense,
-                WikidataCoverAttribution: AttributionTextExtractor.Strip(g.WikidataCoverAttribution),
-                WikidataCoverSourceUrl: g.WikidataCoverSourceUrl));
+                CoverUrl: cover.Url,
+                // Epic #3470 Slice 1d-a — attribution follows the winning source.
+                WikidataCoverLicense: coverLicense,
+                WikidataCoverAttribution: coverAttribution,
+                WikidataCoverSourceUrl: coverSourceUrl));
         }
 
         // Issue #2339 (Wave 4 Task 13 — DEC-WIRING): enrich SharedGameDto.Translations

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetSharedGameByIdQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetSharedGameByIdQueryHandler.cs
@@ -393,11 +393,20 @@ internal sealed class GetSharedGameByIdQueryHandler : IRequestHandler<GetSharedG
             .FirstOrDefaultAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        var coverUrl = sharedGameEntity is not null
-            ? await CoverUrlResolver
-                .ResolvePublicAsync(sharedGameEntity, _blobStorage)
-                .ConfigureAwait(false)
-            : null;
+        // Epic #3470 Slice 1d-a — resolve the cover AND its winning source so the
+        // attribution footer follows the actual image (previously emitted Wikidata
+        // license/attribution unconditionally, even for a PDF/BGG-sourced cover).
+        string? coverUrl = null;
+        string? coverLicense = null, coverAttribution = null, coverSourceUrl = null;
+        if (sharedGameEntity is not null)
+        {
+            var cover = await CoverUrlResolver
+                .ResolvePublicWithSourceAsync(sharedGameEntity, _blobStorage)
+                .ConfigureAwait(false);
+            coverUrl = cover.Url;
+            (coverLicense, coverAttribution, coverSourceUrl) =
+                CoverAttribution.ForWinningSource(cover.Kind, sharedGameEntity);
+        }
 
         return new SharedGameDetailDto(
             game.Id,
@@ -437,9 +446,10 @@ internal sealed class GetSharedGameByIdQueryHandler : IRequestHandler<GetSharedG
             isTopRated,
             isNew,
             CoverUrl: coverUrl,
-            // Issue #2055 Phase G AC-G6 — Wikidata cover attribution (HTML-stripped per DEC-G6-1).
-            WikidataCoverLicense: game.WikidataCoverLicense,
-            WikidataCoverAttribution: AttributionTextExtractor.Strip(game.WikidataCoverAttribution),
-            WikidataCoverSourceUrl: game.WikidataCoverSourceUrl);
+            // Epic #3470 Slice 1d-a — source-aware attribution (read from the entity, gated
+            // on the winning cover source; was emitted unconditionally from the aggregate).
+            WikidataCoverLicense: coverLicense,
+            WikidataCoverAttribution: coverAttribution,
+            WikidataCoverSourceUrl: coverSourceUrl);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQueryHandler.cs
@@ -412,9 +412,10 @@ internal sealed class SearchSharedGamesQueryHandler : IRequestHandler<SearchShar
         var games = new List<SharedGameDto>(projected2.Count);
         foreach (var p in projected2)
         {
-            var coverUrl = await CoverUrlResolver
-                .ResolvePublicAsync(p.Game, _blobStorage)
+            var cover = await CoverUrlResolver
+                .ResolvePublicWithSourceAsync(p.Game, _blobStorage)
                 .ConfigureAwait(false);
+            var (coverLicense, coverAttribution, coverSourceUrl) = CoverAttribution.ForWinningSource(cover.Kind, p.Game);
 
             games.Add(new SharedGameDto(
                 p.Game.Id,
@@ -445,11 +446,11 @@ internal sealed class SearchSharedGamesQueryHandler : IRequestHandler<SearchShar
                 p.Game.AverageRating != null && p.Game.AverageRating >= topRatedThreshold,
                 // IsNew: derived from NewThisWeekCount per mockup sp3-shared-games.jsx:127.
                 p.NewThisWeekCount >= IsNewMinThreshold,
-                CoverUrl: coverUrl,
-                // Issue #2055 Phase G AC-G6 — Wikidata cover attribution (HTML-stripped per DEC-G6-1).
-                WikidataCoverLicense: p.Game.WikidataCoverLicense,
-                WikidataCoverAttribution: AttributionTextExtractor.Strip(p.Game.WikidataCoverAttribution),
-                WikidataCoverSourceUrl: p.Game.WikidataCoverSourceUrl));
+                CoverUrl: cover.Url,
+                // Epic #3470 Slice 1d-a — attribution follows the winning source.
+                WikidataCoverLicense: coverLicense,
+                WikidataCoverAttribution: coverAttribution,
+                WikidataCoverSourceUrl: coverSourceUrl));
         }
 
         // Issue #2339 (Wave 4 Task 13 — DEC-WIRING): enrich SharedGameDto.Translations

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CoverAttribution.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CoverAttribution.cs
@@ -1,0 +1,34 @@
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.SharedKernel.Domain.Covers;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
+
+/// <summary>
+/// Epic #3470 Slice 1d-a — maps the WINNING cover source to the license / attribution /
+/// source-url triple the shared-game DTOs surface. Only sources that carry a license
+/// emit one: today that is Wikidata (the DTOs expose Wikidata attribution fields only).
+/// When a PDF / BGG / user cover wins — or nothing wins — the triple is all-null, so the
+/// footer never credits Wikidata over a non-Wikidata image (the source-mislabeling bug
+/// this fixes). Manual-cover attribution surfacing is deferred: no DTO fields exist yet.
+/// </summary>
+internal static class CoverAttribution
+{
+    /// <summary>
+    /// Returns the attribution triple for the <paramref name="winningKind"/>, reading
+    /// from <paramref name="entity"/>. HTML in the Wikidata attribution is stripped
+    /// (DEC-G6-1). All-null for any non-Wikidata winner or when no source won.
+    /// </summary>
+    public static (string? License, string? Attribution, string? SourceUrl) ForWinningSource(
+        CoverKind? winningKind,
+        SharedGameEntity entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+
+        return winningKind == CoverKind.Wikidata
+            ? (entity.WikidataCoverLicense,
+               AttributionTextExtractor.Strip(entity.WikidataCoverAttribution),
+               entity.WikidataCoverSourceUrl)
+            : (null, null, null);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolver.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolver.cs
@@ -41,6 +41,14 @@ internal static class CoverUrlResolver
 {
     private const string SourceTag = "source";
 
+    /// <summary>
+    /// The outcome of a source-aware resolution: the presigned <see cref="Url"/>
+    /// (null on placeholder/miss) and the <see cref="Kind"/> of the layer that won
+    /// (null on placeholder). Lets the caller gate license/attribution on the actual
+    /// winning source rather than emitting it unconditionally (epic #3470 Slice 1d-a).
+    /// </summary>
+    internal readonly record struct ResolvedCover(string? Url, CoverKind? Kind);
+
     public static async Task<string?> ResolveForUserAsync(
         SharedGameEntity sharedGame,
         UserLibraryEntryEntity? userEntry,
@@ -75,6 +83,18 @@ internal static class CoverUrlResolver
 
     public static async Task<string?> ResolvePublicAsync(
         SharedGameEntity sharedGame,
+        IBlobStorageService blobStorage) =>
+        (await ResolvePublicWithSourceAsync(sharedGame, blobStorage).ConfigureAwait(false)).Url;
+
+    /// <summary>
+    /// Source-aware variant of <see cref="ResolvePublicAsync"/> (epic #3470 Slice 1d-a):
+    /// returns both the URL and the winning <see cref="CoverKind"/> so callers can render
+    /// a source-correct attribution footer instead of crediting Wikidata unconditionally.
+    /// Owns the single <see cref="MeepleAiMetrics.CoverResolution"/> emission — the string
+    /// overload delegates here, preserving the exactly-one-event-per-call invariant.
+    /// </summary>
+    public static async Task<ResolvedCover> ResolvePublicWithSourceAsync(
+        SharedGameEntity sharedGame,
         IBlobStorageService blobStorage)
     {
         ArgumentNullException.ThrowIfNull(sharedGame);
@@ -89,7 +109,7 @@ internal static class CoverUrlResolver
             if (url is not null)
             {
                 EmitResolution("r2_pdf");
-                return url;
+                return new ResolvedCover(url, CoverKind.Pdf);
             }
         }
 
@@ -109,7 +129,7 @@ internal static class CoverUrlResolver
             if (url is not null)
             {
                 EmitResolution("r2_bgg");
-                return url;
+                return new ResolvedCover(url, CoverKind.Bgg);
             }
         }
 
@@ -123,12 +143,12 @@ internal static class CoverUrlResolver
             if (url is not null)
             {
                 EmitResolution("r2_wikidata");
-                return url;
+                return new ResolvedCover(url, CoverKind.Wikidata);
             }
         }
 
         EmitResolution("placeholder");
-        return null;
+        return new ResolvedCover(null, null);
     }
 
     /// <summary>

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/CoverAttributionTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/CoverAttributionTests.cs
@@ -1,0 +1,77 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.SharedKernel.Domain.Covers;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Services;
+
+/// <summary>
+/// Epic #3470 Slice 1d-a — the cover attribution footer must follow the WINNING
+/// source, not be emitted unconditionally. A game can carry Wikidata attribution
+/// columns while a PDF/BGG cover actually wins; crediting Wikidata over a
+/// non-Wikidata image is the legal-correctness bug this maps against.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class CoverAttributionTests
+{
+    private static SharedGameEntity EntityWithWikidata() => new()
+    {
+        WikidataCoverLicense = "CC BY-SA 4.0",
+        WikidataCoverAttribution = "<a href=\"x\">Artist</a>",
+        WikidataCoverSourceUrl = "https://www.wikidata.org/wiki/Q1",
+    };
+
+    [Fact]
+    public void ForWinningSource_Wikidata_ReturnsStrippedWikidataTriple()
+    {
+        var (license, attribution, sourceUrl) = CoverAttribution.ForWinningSource(CoverKind.Wikidata, EntityWithWikidata());
+
+        license.Should().Be("CC BY-SA 4.0");
+        attribution.Should().Be("Artist", "the HTML must be stripped (DEC-G6-1)");
+        sourceUrl.Should().Be("https://www.wikidata.org/wiki/Q1");
+    }
+
+    [Fact]
+    public void ForWinningSource_PdfWins_SuppressesWikidataAttribution()
+    {
+        // The game HAS Wikidata columns, but PDF is the winning cover — the footer
+        // must NOT credit Wikidata over the PDF-derived image.
+        var (license, attribution, sourceUrl) = CoverAttribution.ForWinningSource(CoverKind.Pdf, EntityWithWikidata());
+
+        license.Should().BeNull();
+        attribution.Should().BeNull();
+        sourceUrl.Should().BeNull();
+    }
+
+    [Fact]
+    public void ForWinningSource_BggWins_SuppressesWikidataAttribution()
+    {
+        var (license, attribution, sourceUrl) = CoverAttribution.ForWinningSource(CoverKind.Bgg, EntityWithWikidata());
+
+        license.Should().BeNull();
+        attribution.Should().BeNull();
+        sourceUrl.Should().BeNull();
+    }
+
+    [Fact]
+    public void ForWinningSource_NoWinner_SuppressesAttribution()
+    {
+        var (license, attribution, sourceUrl) = CoverAttribution.ForWinningSource(null, EntityWithWikidata());
+
+        license.Should().BeNull();
+        attribution.Should().BeNull();
+        sourceUrl.Should().BeNull();
+    }
+
+    [Fact]
+    public void ForWinningSource_WikidataWinsButNoColumns_ReturnsNulls()
+    {
+        var (license, attribution, sourceUrl) = CoverAttribution.ForWinningSource(CoverKind.Wikidata, new SharedGameEntity());
+
+        license.Should().BeNull();
+        attribution.Should().BeNull();
+        sourceUrl.Should().BeNull();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolverTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolverTests.cs
@@ -590,4 +590,72 @@ public class CoverUrlResolverTests
         emissions.Should().HaveCount(1);
         emissions[0].Tags["source"].Should().Be("r2_pdf");
     }
+
+    // ----- Epic #3470 Slice 1d-a: source-aware resolution --------------------
+
+    [Fact]
+    public async Task ResolvePublicWithSourceAsync_PdfWins_ReturnsPdfKind()
+    {
+        var sg = new SharedGameEntity { PdfCoverR2Key = "pdf-key", WikidataCoverR2Key = "wiki-key" };
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("pdf-key-preview.webp", null))
+             .ReturnsAsync("https://r2/pdf.webp");
+
+        var result = await CoverUrlResolver.ResolvePublicWithSourceAsync(sg, _blob.Object);
+
+        result.Url.Should().Be("https://r2/pdf.webp");
+        result.Kind.Should().Be(CoverKind.Pdf);
+    }
+
+    [Fact]
+    public async Task ResolvePublicWithSourceAsync_WikidataWins_ReturnsWikidataKind()
+    {
+        var sg = new SharedGameEntity { WikidataCoverR2Key = "wiki-key" };
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("wiki-key.webp", null))
+             .ReturnsAsync("https://r2/wiki.webp");
+
+        var result = await CoverUrlResolver.ResolvePublicWithSourceAsync(sg, _blob.Object);
+
+        result.Url.Should().Be("https://r2/wiki.webp");
+        result.Kind.Should().Be(CoverKind.Wikidata);
+    }
+
+    [Fact]
+    public async Task ResolvePublicWithSourceAsync_AllMiss_ReturnsNullUrlAndKind()
+    {
+        var result = await CoverUrlResolver.ResolvePublicWithSourceAsync(new SharedGameEntity(), _blob.Object);
+
+        result.Url.Should().BeNull();
+        result.Kind.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ResolvePublicWithSourceAsync_EmitsExactlyOneMetric()
+    {
+        using var capture = new CoverMetricsCapture();
+        var sg = new SharedGameEntity { PdfCoverR2Key = "pdf-key" };
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("pdf-key-preview.webp", null))
+             .ReturnsAsync("https://r2/pdf.webp");
+
+        await CoverUrlResolver.ResolvePublicWithSourceAsync(sg, _blob.Object);
+
+        capture.LongMeasurements
+            .Where(m => m.Name == "meepleai.cover.resolution.total")
+            .Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task ResolvePublicAsync_DelegatesToWithSource_StillReturnsUrlAndEmitsOnce()
+    {
+        using var capture = new CoverMetricsCapture();
+        var sg = new SharedGameEntity { WikidataCoverR2Key = "wiki-key" };
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("wiki-key.webp", null))
+             .ReturnsAsync("https://r2/wiki.webp");
+
+        var url = await CoverUrlResolver.ResolvePublicAsync(sg, _blob.Object);
+
+        url.Should().Be("https://r2/wiki.webp");
+        capture.LongMeasurements
+            .Where(m => m.Name == "meepleai.cover.resolution.total")
+            .Should().HaveCount(1);
+    }
 }


### PR DESCRIPTION
## Epic #3470 — Slice 1d-a: source-aware cover attribution

The cover attribution footer credited **Wikidata unconditionally** — even when a PDF/BGG-sourced cover actually won — because the query handlers emitted `WikidataCoverLicense/Attribution/SourceUrl` straight from the columns without checking which source the resolver picked. Legal-correctness bug (spec §7; found by the design panel).

### What
- **`CoverUrlResolver.ResolvePublicWithSourceAsync`** → `ResolvedCover(Url, Kind)`: the precedence engine now returns the URL **and** the winning `CoverKind`, and owns the single `CoverResolution` metric emission. `ResolvePublicAsync` is now a thin delegate (`.Url`), so the exactly-one-event-per-call invariant and all unaffected callers are preserved.
- **`CoverAttribution.ForWinningSource(kind, entity)`**: maps the winning source to the license/attribution/source-url triple — Wikidata only (the DTOs expose Wikidata attribution fields); all-null for PDF/BGG/user/none. Manual-cover attribution surfacing is deferred (no DTO fields yet).
- **All 5 emission sites fixed**: detail (`GetSharedGameByIdQueryHandler`) + the 4 list handlers (`GetAll`/`GetFiltered`/`Search`/`GetPendingApproval`). The detail handler now reads attribution from the entity (not the aggregate) so future sources can be supported.

### Testing (TDD)
- `CoverAttributionTests`: PDF/BGG/none win → **no Wikidata leak**; Wikidata win → stripped triple.
- `CoverUrlResolverTests`: winning-kind returned per layer; delegate still emits exactly one metric.
- 38 tests green; Release build clean (warnings-as-errors). Adversarial review: no material issues.

### DoD
- [x] TDD (red→green); metric invariant preserved
- [x] Release build clean
- [x] All 5 attribution sites source-gated
- [ ] Merged to `main-dev`

Part of epic #3470 Slice 1d. Remaining: 1d-b (WebpVariantGenerator focal-point) + 1d-c (FE overlay picker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)