### PR TITLE
feat(catalog): WebP focal-point crop overload (#3470 Slice 1d-b)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/IWebpVariantGenerator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/IWebpVariantGenerator.cs
@@ -52,4 +52,14 @@ internal interface IWebpVariantGenerator
     /// Thrown when <paramref name="ct"/> fires before completion.
     /// </exception>
     Task<byte[]> GenerateWebpAsync(byte[] originalImage, int width, int height, CancellationToken ct);
+
+    /// <summary>
+    /// Focal-point variant (epic #3470): crops the aspect-ratio-filled image toward the
+    /// given focal point (<c>focalX</c>/<c>focalY</c>, each in <c>[0,1]</c>; <c>0.5,0.5</c>
+    /// = center, byte-identical to the 3-argument overload) instead of always the center.
+    /// The crop window centers on the focal point, clamped to the image bounds. Used to
+    /// render the per-context cover crop from an admin-set <c>GameCoverAssignment</c>.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when a focal component is NaN/Infinity or outside [0,1].</exception>
+    Task<byte[]> GenerateWebpAsync(byte[] originalImage, int width, int height, double focalX, double focalY, CancellationToken ct);
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WebpVariantGenerator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WebpVariantGenerator.cs
@@ -37,10 +37,19 @@ internal sealed class WebpVariantGenerator : IWebpVariantGenerator
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
+    public Task<byte[]> GenerateWebpAsync(
+        byte[] originalImage,
+        int width,
+        int height,
+        CancellationToken ct) =>
+        GenerateWebpAsync(originalImage, width, height, focalX: 0.5, focalY: 0.5, ct);
+
     public async Task<byte[]> GenerateWebpAsync(
         byte[] originalImage,
         int width,
         int height,
+        double focalX,
+        double focalY,
         CancellationToken ct)
     {
         if (originalImage is null || originalImage.Length == 0)
@@ -63,6 +72,9 @@ internal sealed class WebpVariantGenerator : IWebpVariantGenerator
                 $"Target height must be > 0 (got {height}).",
                 nameof(height));
         }
+
+        EnsureFocalInRange(focalX, nameof(focalX));
+        EnsureFocalInRange(focalY, nameof(focalY));
 
         ct.ThrowIfCancellationRequested();
 
@@ -88,13 +100,12 @@ internal sealed class WebpVariantGenerator : IWebpVariantGenerator
         {
             ct.ThrowIfCancellationRequested();
 
-            // FillArea=true + Extent(Center) reproduces ImageSharp's
-            // ResizeMode.Crop semantics: aspect-ratio-preserving CENTER crop
-            // that lands on EXACT target dimensions. This is the
-            // BoardGameGeek thumbnail convention reproduced for #1823
-            // cover normalization.
+            // FillArea=true reproduces ImageSharp's ResizeMode.Crop "cover" semantics:
+            // aspect-ratio-preserving fill (both dimensions >= target). The crop that
+            // lands on EXACT target dimensions is then positioned by the focal point
+            // (center by default — the BoardGameGeek thumbnail convention, #1823).
             image.Resize(new MagickGeometry((uint)width, (uint)height) { FillArea = true });
-            image.Extent((uint)width, (uint)height, Gravity.Center);
+            ApplyFocalCrop(image, (uint)width, (uint)height, focalX, focalY);
 
             image.Format = MagickFormat.WebP;
             image.Quality = WebpQuality;
@@ -115,6 +126,46 @@ internal sealed class WebpVariantGenerator : IWebpVariantGenerator
         finally
         {
             image.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Crops the aspect-filled image to exactly <paramref name="width"/>×<paramref name="height"/>,
+    /// positioning the window on the focal point. Center (0.5, 0.5) uses
+    /// <c>Extent(Center)</c> so it is byte-identical to the legacy center crop; any other
+    /// focal uses an offset <c>Crop</c>.
+    /// </summary>
+    private static void ApplyFocalCrop(MagickImage image, uint width, uint height, double focalX, double focalY)
+    {
+        if (focalX.Equals(0.5) && focalY.Equals(0.5))
+        {
+            image.Extent(width, height, Gravity.Center);
+            return;
+        }
+
+        var cropX = FocalOffset(focalX, image.Width, width);
+        var cropY = FocalOffset(focalY, image.Height, height);
+        image.Crop(new MagickGeometry(cropX, cropY, width, height));
+        image.ResetPage();
+    }
+
+    /// <summary>
+    /// Top-left offset of a <paramref name="targetDim"/>-sized crop window centered on the
+    /// focal point within a <paramref name="filledDim"/>-sized image, clamped so the window
+    /// stays fully inside the image (which is &gt;= target after the fill resize).
+    /// </summary>
+    private static int FocalOffset(double focal, uint filledDim, uint targetDim)
+    {
+        var ideal = (int)Math.Round(focal * filledDim, MidpointRounding.AwayFromZero) - (int)(targetDim / 2);
+        var max = (int)filledDim - (int)targetDim;
+        return Math.Clamp(ideal, 0, Math.Max(0, max));
+    }
+
+    private static void EnsureFocalInRange(double value, string paramName)
+    {
+        if (double.IsNaN(value) || double.IsInfinity(value) || value < 0.0 || value > 1.0)
+        {
+            throw new ArgumentOutOfRangeException(paramName, value, "Focal point must be a finite value in [0, 1].");
         }
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WebpVariantGeneratorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WebpVariantGeneratorTests.cs
@@ -220,10 +220,107 @@ public class WebpVariantGeneratorTests
     }
 
     // ──────────────────────────────────────────────────────────────────────────
+    // Epic #3470 Slice 1d-b — focal-point crop overload
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GenerateWebpAsync_FocalOverload_ProducesTargetDimensions()
+    {
+        var pngBytes = CreateSolidImagePng(width: 900, height: 300, color: MagickColors.Red);
+        var sut = CreateSut();
+
+        var output = await sut.GenerateWebpAsync(pngBytes, 300, 300, focalX: 0.2, focalY: 0.8, CancellationToken.None);
+
+        using var decoded = new MagickImage(output);
+        decoded.Width.Should().Be(300u);
+        decoded.Height.Should().Be(300u);
+    }
+
+    [Fact]
+    public async Task GenerateWebpAsync_CenterFocal_IsByteIdenticalToThreeArgOverload()
+    {
+        // The 3-arg overload delegates to the focal one with (0.5, 0.5), and the
+        // center path keeps the original Extent(Center) crop — so a center focal
+        // must reproduce the legacy output exactly (no re-render drift).
+        var pngBytes = CreateSolidImagePng(width: 800, height: 600, color: MagickColors.Green);
+        var sut = CreateSut();
+
+        var legacy = await sut.GenerateWebpAsync(pngBytes, TargetWidth, TargetHeight, CancellationToken.None);
+        var centered = await sut.GenerateWebpAsync(pngBytes, TargetWidth, TargetHeight, 0.5, 0.5, CancellationToken.None);
+
+        centered.Should().Equal(legacy);
+    }
+
+    [Theory]
+    [InlineData(-0.01, 0.5)]
+    [InlineData(1.01, 0.5)]
+    [InlineData(0.5, -0.01)]
+    [InlineData(0.5, 1.01)]
+    public async Task GenerateWebpAsync_OutOfRangeFocal_ThrowsArgumentException(double focalX, double focalY)
+    {
+        var pngBytes = CreateSolidImagePng(width: 400, height: 400, color: MagickColors.Red);
+        var sut = CreateSut();
+
+        var act = async () => await sut.GenerateWebpAsync(pngBytes, TargetWidth, TargetHeight, focalX, focalY, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task GenerateWebpAsync_NonFiniteFocal_ThrowsArgumentException()
+    {
+        var pngBytes = CreateSolidImagePng(width: 400, height: 400, color: MagickColors.Red);
+        var sut = CreateSut();
+
+        var actNan = async () => await sut.GenerateWebpAsync(pngBytes, TargetWidth, TargetHeight, double.NaN, 0.5, CancellationToken.None);
+        var actInf = async () => await sut.GenerateWebpAsync(pngBytes, TargetWidth, TargetHeight, 0.5, double.PositiveInfinity, CancellationToken.None);
+
+        await actNan.Should().ThrowAsync<ArgumentException>();
+        await actInf.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task GenerateWebpAsync_HorizontalFocal_KeepsTheFocusedHalf()
+    {
+        // 900x300 source, left half red / right half blue. A 300x300 crop must slide
+        // horizontally with the focal X: focal 0 keeps the red left edge, focal 1 the
+        // blue right edge. Proves the focal point drives the crop window.
+        var split = CreateHorizontalSplitPng(900, 300, MagickColors.Red, MagickColors.Blue);
+        var sut = CreateSut();
+
+        var left = await sut.GenerateWebpAsync(split, 300, 300, focalX: 0.0, focalY: 0.5, CancellationToken.None);
+        var right = await sut.GenerateWebpAsync(split, 300, 300, focalX: 1.0, focalY: 0.5, CancellationToken.None);
+
+        left.Should().NotEqual(right, "different focal points must crop different regions");
+        DominantIsRed(left).Should().BeTrue("focal 0 keeps the red left edge");
+        DominantIsRed(right).Should().BeFalse("focal 1 keeps the blue right edge");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
     // Helpers
     // ──────────────────────────────────────────────────────────────────────────
 
     private static WebpVariantGenerator CreateSut() => new(NullLogger<WebpVariantGenerator>.Instance);
+
+    private static byte[] CreateHorizontalSplitPng(int width, int height, MagickColor left, MagickColor right)
+    {
+        using var image = new MagickImage(left, (uint)width, (uint)height);
+        using var rightHalf = new MagickImage(right, (uint)(width / 2), (uint)height);
+        image.Composite(rightHalf, width / 2, 0, CompositeOperator.Over);
+        image.Format = MagickFormat.Png;
+        using var ms = new MemoryStream();
+        image.Write(ms);
+        return ms.ToArray();
+    }
+
+    private static bool DominantIsRed(byte[] webp)
+    {
+        using var decoded = new MagickImage(webp);
+        using var pixels = decoded.GetPixels();
+        var color = pixels.GetPixel((int)(decoded.Width / 2), (int)(decoded.Height / 2)).ToColor();
+        color.Should().NotBeNull();
+        return color!.R > color.B;
+    }
 
     private static byte[] CreateSolidImagePng(int width, int height, MagickColor color)
     {


### PR DESCRIPTION
## Epic #3470 — Slice 1d-b: WebP focal-point crop

`WebpVariantGenerator` only ever center-cropped (`Extent(Center)` hardcoded). The per-context cover crop needs to honour an admin-set focal point.

### What
- New `GenerateWebpAsync(bytes, w, h, focalX, focalY, ct)` overload. The crop window centers on the focal point (0..1 per axis), clamped inside the aspect-filled image. **Center (0.5, 0.5) keeps the original `Extent(Center)` path — byte-identical to the legacy crop**; the 3-arg overload now delegates to it with `(0.5, 0.5)`, so every existing caller (Wikidata/PDF/BGG enrichment) is unchanged.
- Focal validation: NaN/Infinity or outside [0,1] → `ArgumentOutOfRangeException`. `.Equals(0.5)` (not `==`) sidesteps the SonarAnalyzer S1244 float-equality trap.

### Testing (TDD)
- 6 new tests: focal overload → target dims; center byte-identical to the 3-arg overload; out-of-range/non-finite focal rejected; a **900×300 red|blue split proves a horizontal focal slides the crop window** (focal 0 keeps red, focal 1 keeps blue — verified by decoding the center pixel).
- 24 WebP tests green; Release clean. Adversarial review: no findings.

### Note
This is the crop **capability**; wiring it into a per-context render pipeline that stores `GameCoverAssignment.GeneratedR2Key` is a follow-up (Slice 2).

### DoD
- [x] TDD (red→green); backward-compat byte-identical center
- [x] Release clean (S1244 avoided)
- [x] No caller breakage (purely additive overload)
- [ ] Merged to `main-dev`

Part of epic #3470 Slice 1d. Next: 1d-c (FE overlay picker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)