### PR TITLE
feat(ai): grounded RAG for in-session image path (#3390 Slice 2)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Configuration/SessionAgentOptions.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Configuration/SessionAgentOptions.cs
@@ -17,4 +17,19 @@ internal sealed class SessionAgentOptions
     /// valid and used in unit tests to avoid waiting 30 s.
     /// </summary>
     public double LlmPerChunkTimeoutSeconds { get; set; } = 30.0;
+
+    /// <summary>
+    /// #3390 Slice 2 — latency budget (in milliseconds) for the grounded RAG retrieval on the
+    /// in-session IMAGE path (embedding + pgvector + rerank). When it expires, the handler
+    /// degrades to the multimodal-only path (which stays Ungrounded, #3388) instead of making
+    /// the user wait. The retrieval respects the caller's CancellationToken end-to-end, so the
+    /// budget is enforced caller-side via a linked CTS + CancelAfter.
+    /// Default: 700 ms.
+    ///
+    /// NEEDS TUNING: the live path is the hottest (user at the table) and the baseline P95 is
+    /// already ~2500 ms. Observe the retrieval_profile=none fallback rate on
+    /// meepleai.agent.response.grounding and the meepleai.rag.retrieval.fallbacks{fallback_type=retrieval_budget}
+    /// counter before widening.
+    /// </summary>
+    public int RetrievalBudgetMs { get; set; } = 700;
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/GroundedSessionAnswerDto.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/GroundedSessionAnswerDto.cs
@@ -1,0 +1,20 @@
+using Api.SharedKernel.Domain.Enums;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+
+/// <summary>
+/// #3390 Slice 2 — public cross-BC result of a non-streaming grounded answer for the
+/// in-session agent. Returned by <see cref="Api.BoundedContexts.KnowledgeBase.Application.Queries.AskGroundedSessionQuery"/>
+/// and consumed by SessionTracking's image/text agent path via <c>IMediator</c>.
+///
+/// This is the Published Language boundary: SessionTracking receives this DTO — NOT the
+/// KnowledgeBase-internal <c>AssembledPrompt</c>/<c>ChunkCitation</c> models (DDD: no shared
+/// internal models between bounded contexts). <see cref="Citations"/> reuses the same
+/// <see cref="CitationDto"/> wire shape the SSE text path already emits, so the frontend
+/// citation mapper is reused unchanged.
+/// </summary>
+internal sealed record GroundedSessionAnswerDto(
+    string Answer,
+    IReadOnlyList<Api.Models.CitationDto> Citations,
+    GroundingStatus GroundingStatus,
+    double? Confidence);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/AskGroundedSessionQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/AskGroundedSessionQuery.cs
@@ -1,0 +1,33 @@
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries;
+
+/// <summary>
+/// #3390 Slice 2 — grounded, non-streaming RAG answer for the in-session agent.
+///
+/// KnowledgeBase owns "grounded answer on the rulebook"; SessionTracking (image/text agent
+/// path) consumes this capability via <c>IMediator.Send</c> (same cross-BC pattern as
+/// <c>CreateSessionCommandHandler</c> → <c>GetKbReadinessQuery</c>), never by injecting a KB
+/// service directly (CLAUDE.md DDD rule: "Direct service injection (use MediatR)").
+///
+/// The turn TEXT (<see cref="Question"/>) is the retrieval query; the vision output
+/// (<see cref="GameStateContext"/>, already distilled to JSON by SessionTracking's
+/// GameStateExtractor) is injected as STATE CONTEXT into the generation prompt — it does NOT
+/// bypass the rulebook. Retrieval runs under <c>RetrievalPolicy.LiveSession</c> (enhancements
+/// OFF, CRAG web-fallback off) exactly like the SSE text path.
+/// </summary>
+/// <param name="GameId">Game whose indexed rulebook is retrieved against.</param>
+/// <param name="Question">The turn text — used as the retrieval query. Must be non-empty
+/// (the empty-text → vision-derived-query case is #3390 Slice 3).</param>
+/// <param name="GameStateContext">Optional distilled board state (vision JSON) injected as
+/// prompt context. Null when no readable snapshot exists.</param>
+/// <param name="UserId">Resolved user id for copyright-tier gating of citations. Guest →
+/// <c>Guid.Empty</c> (most restrictive tier).</param>
+/// <param name="AgentLanguage">ISO 639-1 language for generation + copyright fallback copy.</param>
+internal sealed record AskGroundedSessionQuery(
+    Guid GameId,
+    string Question,
+    string? GameStateContext,
+    Guid UserId,
+    string AgentLanguage = "en") : IQuery<GroundedSessionAnswerDto>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/AskGroundedSessionQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/AskGroundedSessionQueryHandler.cs
@@ -116,12 +116,22 @@ internal sealed class AskGroundedSessionQueryHandler
         }
 
         var responseText = completion.Response;
+        if (string.IsNullOrWhiteSpace(responseText))
+        {
+            // Success but empty body — treat as failure so the caller degrades (matches the SSE
+            // text path's EMPTY_RESPONSE guard) instead of shipping a blank "grounded" answer,
+            // which would also throw at SessionChatMessage.CreateAgentResponse (empty content → 500).
+            throw new GroundedSessionGenerationException("empty grounded answer");
+        }
 
-        // 5. Copyright leak guard (fail-open) — same posture as the SSE text path (#447).
+        // 5. Copyright leak guard (#447). The SCAN is fail-open (a guard fault must not break the
+        //    answer), but leak HANDLING/sanitization runs OUTSIDE the try so a fault while sanitizing
+        //    can never ship the original verbatim-leaking text — the leak handling itself fails CLOSED.
         var protectedCitations = resolvedCitations
             .Where(c => c.CopyrightTier == CopyrightTier.Protected)
             .ToList();
 
+        CopyrightLeakResult? leakResult = null;
         if (protectedCitations.Count > 0)
         {
             try
@@ -130,34 +140,42 @@ internal sealed class AskGroundedSessionQueryHandler
                 scanCts.CancelAfter(TimeSpan.FromMilliseconds(_copyrightOptions.Value.ScanTimeoutMs));
 
                 var scanSw = Stopwatch.StartNew();
-                var leakResult = await _copyrightLeakGuard
+                leakResult = await _copyrightLeakGuard
                     .ScanAsync(responseText, protectedCitations, scanCts.Token)
                     .ConfigureAwait(false);
                 scanSw.Stop();
                 MeepleAiMetrics.CopyrightScanDurationMs.Record(scanSw.ElapsedMilliseconds);
-
-                if (leakResult.HasLeak)
-                {
-                    foreach (var match in leakResult.Matches)
-                    {
-                        MeepleAiMetrics.CopyrightVerbatimDetected.Add(1,
-                            new KeyValuePair<string, object?>("run_length", match.RunLength),
-                            new KeyValuePair<string, object?>("document_id", match.DocumentId));
-                    }
-                    _logger.LogWarning(
-                        "Copyright leak detected in grounded session answer (game {GameId}): {MatchCount} matches, sanitizing",
-                        request.GameId, leakResult.Matches.Count);
-                    responseText = _fallbackMessageProvider.GetMessage(request.AgentLanguage);
-                }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // The caller's latency budget / client cancellation fired — propagate so
+                // SessionTracking degrades, don't fail-open into a possibly-unscanned answer.
+                throw;
             }
             catch (Exception ex)
             {
                 MeepleAiMetrics.CopyrightScanErrors.Add(1,
                     new KeyValuePair<string, object?>("error_type", ex.GetType().Name));
                 _logger.LogError(ex,
-                    "Copyright leak guard failed for grounded session answer (game {GameId}), allowing response (fail-open)",
+                    "Copyright leak guard failed for grounded session answer (game {GameId}), allowing response (fail-open on the scan)",
                     request.GameId);
+                leakResult = null; // fail-open on the SCAN only
             }
+        }
+
+        // Leak handling OUTSIDE the fail-open try: once a leak is detected, sanitize unconditionally.
+        if (leakResult?.HasLeak == true)
+        {
+            foreach (var match in leakResult.Matches)
+            {
+                MeepleAiMetrics.CopyrightVerbatimDetected.Add(1,
+                    new KeyValuePair<string, object?>("run_length", match.RunLength),
+                    new KeyValuePair<string, object?>("document_id", match.DocumentId));
+            }
+            _logger.LogWarning(
+                "Copyright leak detected in grounded session answer (game {GameId}): {MatchCount} matches, sanitizing",
+                request.GameId, leakResult.Matches.Count);
+            responseText = _fallbackMessageProvider.GetMessage(request.AgentLanguage);
         }
 
         // 6. Map to the wire CitationDto (tier-nulling identical to ChatWithSessionAgentCommandHandler).

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/AskGroundedSessionQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/AskGroundedSessionQueryHandler.cs
@@ -1,0 +1,182 @@
+using System.Diagnostics;
+using Api.BoundedContexts.KnowledgeBase.Application.Configuration;
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.BoundedContexts.KnowledgeBase.Application.Models;
+using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using Api.Models;
+using Api.Observability;
+using Api.Services;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Domain.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+// This file references both Api.Models.CitationDto (the wire shape) and Api.Models.CitationRegion;
+// the KnowledgeBase.Application.DTOs namespace also declares a CitationDto, so pin the wire one.
+using CitationDto = Api.Models.CitationDto;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries;
+
+/// <summary>
+/// Thrown when the grounded generation step fails (LLM unavailable/error). SessionTracking
+/// catches this to degrade to its multimodal-only path (which stays Ungrounded, #3388).
+/// </summary>
+public sealed class GroundedSessionGenerationException : Exception
+{
+    public GroundedSessionGenerationException(string? message) : base(message) { }
+}
+
+/// <summary>
+/// #3390 Slice 2 — produces a grounded, non-streaming answer for the in-session agent.
+///
+/// Replicates the grounded pipeline of <c>ChatWithSessionAgentCommandHandler</c> (the SSE text
+/// path) without streaming/thread/session concerns: assemble RAG prompt under
+/// <c>RetrievalPolicy.LiveSession</c> → resolve copyright tiers → generate (text-only) →
+/// copyright leak guard (fail-open) → map to <see cref="CitationDto"/> → derive grounding from
+/// citation count. The vision board-state (<c>GameStateContext</c>) is injected as prompt
+/// context; pixels are NOT re-sent (they were already distilled by GameStateExtractor).
+///
+/// NOTE (#3390 Slice 5): the assemble→resolve→generate→guard→map sequence duplicates
+/// <c>ChatWithSessionAgentCommandHandler</c>. Consolidating both onto a shared grounded-generation
+/// service is the ownership-collapse work tracked for Slice 5; this slice accepts the controlled
+/// duplication to keep the boundary change reviewable.
+/// Paraphrase extraction for Protected-tier snippets is intentionally omitted here (Protected
+/// snippets are already null-gated in the citation map — no verbatim leak); it is a UX follow-up.
+/// </summary>
+internal sealed class AskGroundedSessionQueryHandler
+    : IQueryHandler<AskGroundedSessionQuery, GroundedSessionAnswerDto>
+{
+    private readonly IRagPromptAssemblyService _ragPromptService;
+    private readonly ICopyrightTierResolver _copyrightTierResolver;
+    private readonly ILlmService _llmService;
+    private readonly ICopyrightLeakGuard _copyrightLeakGuard;
+    private readonly ICopyrightFallbackMessageProvider _fallbackMessageProvider;
+    private readonly IOptions<CopyrightLeakGuardOptions> _copyrightOptions;
+    private readonly ILogger<AskGroundedSessionQueryHandler> _logger;
+
+    public AskGroundedSessionQueryHandler(
+        IRagPromptAssemblyService ragPromptService,
+        ICopyrightTierResolver copyrightTierResolver,
+        ILlmService llmService,
+        ICopyrightLeakGuard copyrightLeakGuard,
+        ICopyrightFallbackMessageProvider fallbackMessageProvider,
+        IOptions<CopyrightLeakGuardOptions> copyrightOptions,
+        ILogger<AskGroundedSessionQueryHandler> logger)
+    {
+        _ragPromptService = ragPromptService ?? throw new ArgumentNullException(nameof(ragPromptService));
+        _copyrightTierResolver = copyrightTierResolver ?? throw new ArgumentNullException(nameof(copyrightTierResolver));
+        _llmService = llmService ?? throw new ArgumentNullException(nameof(llmService));
+        _copyrightLeakGuard = copyrightLeakGuard ?? throw new ArgumentNullException(nameof(copyrightLeakGuard));
+        _fallbackMessageProvider = fallbackMessageProvider ?? throw new ArgumentNullException(nameof(fallbackMessageProvider));
+        _copyrightOptions = copyrightOptions ?? throw new ArgumentNullException(nameof(copyrightOptions));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<GroundedSessionAnswerDto> Handle(AskGroundedSessionQuery request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // 1. Assemble RAG prompt with retrieval. LiveSession policy = enhancements OFF, CRAG web
+        //    off (#3389/#3390). The turn text is the retrieval query. Honors the caller's
+        //    CancellationToken (SessionTracking arms a latency budget on it).
+        var assembled = await _ragPromptService.AssemblePromptAsync(
+            agentTypology: "tutor",
+            gameTitle: string.Empty,
+            gameState: null,
+            userQuestion: request.Question,
+            gameId: request.GameId,
+            chatThread: null,
+            userTier: null,
+            agentLanguage: request.AgentLanguage,
+            cancellationToken,
+            retrievalPolicy: RetrievalPolicy.LiveSession).ConfigureAwait(false);
+
+        // 2. Resolve copyright tiers for the retrieved citations.
+        var resolvedCitations = await _copyrightTierResolver
+            .ResolveAsync(assembled.Citations, request.UserId, cancellationToken)
+            .ConfigureAwait(false);
+
+        // 3. Inject the vision board-state as CONTEXT (not a rulebook bypass). Text-only from here.
+        var systemPrompt = assembled.SystemPrompt;
+        if (!string.IsNullOrWhiteSpace(request.GameStateContext))
+        {
+            systemPrompt += $"\n\nCurrent game state from board analysis:\n{request.GameStateContext}";
+        }
+
+        // 4. Generate the answer (text-only; pixels already distilled into GameStateContext).
+        var completion = await _llmService
+            .GenerateCompletionAsync(systemPrompt, assembled.UserPrompt, RequestSource.AgentTask, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!completion.Success)
+        {
+            // Let SessionTracking degrade to the multimodal-only path (stays Ungrounded, #3388).
+            throw new GroundedSessionGenerationException(completion.ErrorMessage);
+        }
+
+        var responseText = completion.Response;
+
+        // 5. Copyright leak guard (fail-open) — same posture as the SSE text path (#447).
+        var protectedCitations = resolvedCitations
+            .Where(c => c.CopyrightTier == CopyrightTier.Protected)
+            .ToList();
+
+        if (protectedCitations.Count > 0)
+        {
+            try
+            {
+                using var scanCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                scanCts.CancelAfter(TimeSpan.FromMilliseconds(_copyrightOptions.Value.ScanTimeoutMs));
+
+                var scanSw = Stopwatch.StartNew();
+                var leakResult = await _copyrightLeakGuard
+                    .ScanAsync(responseText, protectedCitations, scanCts.Token)
+                    .ConfigureAwait(false);
+                scanSw.Stop();
+                MeepleAiMetrics.CopyrightScanDurationMs.Record(scanSw.ElapsedMilliseconds);
+
+                if (leakResult.HasLeak)
+                {
+                    foreach (var match in leakResult.Matches)
+                    {
+                        MeepleAiMetrics.CopyrightVerbatimDetected.Add(1,
+                            new KeyValuePair<string, object?>("run_length", match.RunLength),
+                            new KeyValuePair<string, object?>("document_id", match.DocumentId));
+                    }
+                    _logger.LogWarning(
+                        "Copyright leak detected in grounded session answer (game {GameId}): {MatchCount} matches, sanitizing",
+                        request.GameId, leakResult.Matches.Count);
+                    responseText = _fallbackMessageProvider.GetMessage(request.AgentLanguage);
+                }
+            }
+            catch (Exception ex)
+            {
+                MeepleAiMetrics.CopyrightScanErrors.Add(1,
+                    new KeyValuePair<string, object?>("error_type", ex.GetType().Name));
+                _logger.LogError(ex,
+                    "Copyright leak guard failed for grounded session answer (game {GameId}), allowing response (fail-open)",
+                    request.GameId);
+            }
+        }
+
+        // 6. Map to the wire CitationDto (tier-nulling identical to ChatWithSessionAgentCommandHandler).
+        var citationDtos = resolvedCitations.Select(c => new CitationDto(
+            c.DocumentId,
+            c.PageNumber,
+            c.RelevanceScore,
+            c.CopyrightTier == CopyrightTier.Full ? c.SnippetPreview : null,
+            c.CopyrightTier.ToString().ToLowerInvariant(),
+            c.ParaphrasedSnippet,
+            c.IsPublic,
+            Regions: c.CopyrightTier == CopyrightTier.Full ? CitationRegion.Parse(c.BoundingBoxesJson) : null,
+            CharStart: c.CopyrightTier == CopyrightTier.Full ? c.CharStart : null,
+            CharEnd: c.CopyrightTier == CopyrightTier.Full ? c.CharEnd : null)).ToList();
+
+        // 7. Grounding derived from citation count — the same invariant as the text path (#3388).
+        var grounding = citationDtos.Count > 0 ? GroundingStatus.Grounded : GroundingStatus.Ungrounded;
+        var confidence = RagPromptAssemblyService.ComputeConfidence(resolvedCitations.ToList(), responseText);
+
+        return new GroundedSessionAnswerDto(responseText, citationDtos, grounding, confidence);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ChatCommandHandlers.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ChatCommandHandlers.cs
@@ -211,15 +211,35 @@ internal class AskSessionAgentCommandHandler : IRequestHandler<AskSessionAgentCo
                     new AskGroundedSessionQuery(session.GameId, retrievalQuery, gameState, userId),
                     retrievalCts.Token).ConfigureAwait(false);
 
-                answer = grounded.Answer;
-                confidence = grounded.Confidence.HasValue ? (float)grounded.Confidence.Value : null;
-                citationCount = grounded.Citations.Count;
-                citationsJson = citationCount > 0 ? JsonSerializer.Serialize(grounded.Citations) : null;
-                groundingStatus = grounded.GroundingStatus;
-                retrievalProfileTag = MeepleAiMetrics.AgentRetrievalProfiles.LiveSession;
-                groundedProduced = true;
+                if (hasImages && grounded.Citations.Count == 0)
+                {
+                    // Image attached but rulebook retrieval found nothing → fall through to the
+                    // multimodal path so THIS turn's image is actually analyzed. A text-only
+                    // ungrounded answer would silently drop the photo — strictly worse than the
+                    // pre-flag behavior. Text-only turns keep the (ungrounded) grounded answer,
+                    // since there is no image to analyze. groundedProduced stays false.
+                    _logger.LogInformation(
+                        "Grounded retrieval returned no citations for image turn (session {SessionId}); falling back to multimodal to analyze the image",
+                        request.SessionId);
+                }
+                else
+                {
+                    answer = grounded.Answer;
+                    confidence = grounded.Confidence.HasValue ? (float)grounded.Confidence.Value : null;
+                    citationCount = grounded.Citations.Count;
+                    citationsJson = citationCount > 0 ? JsonSerializer.Serialize(grounded.Citations) : null;
+                    groundingStatus = grounded.GroundingStatus;
+                    retrievalProfileTag = MeepleAiMetrics.AgentRetrievalProfiles.LiveSession;
+                    groundedProduced = true;
+                }
             }
-            catch (OperationCanceledException oce) when (retrievalCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // Client aborted the whole request (not the retrieval budget) → propagate, do NOT
+                // fail-open (which would waste a second LLM call and pollute the fallback metric).
+                throw;
+            }
+            catch (OperationCanceledException oce) when (retrievalCts.IsCancellationRequested)
             {
                 // Budget expired → degrade to multimodal-only (fail-open). The response must not wait.
                 _logger.LogWarning(oce,

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ChatCommandHandlers.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ChatCommandHandlers.cs
@@ -1,4 +1,6 @@
 using MediatR;
+using Api.BoundedContexts.KnowledgeBase.Application.Configuration;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries;
 using Api.BoundedContexts.SessionTracking.Application.Commands;
 using Api.BoundedContexts.SessionTracking.Application.Services;
 using Api.BoundedContexts.SessionTracking.Domain.Entities;
@@ -11,6 +13,8 @@ using Api.Services.ImageProcessing;
 using Api.Services.LlmClients;
 using Api.SharedKernel.Domain.Enums;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Text.Json;
 
 namespace Api.BoundedContexts.SessionTracking.Application.Commands;
 
@@ -112,6 +116,10 @@ internal class AskSessionAgentCommandHandler : IRequestHandler<AskSessionAgentCo
     private readonly IImagePreprocessor _imagePreprocessor;
     private readonly IGameStateExtractor _gameStateExtractor;
     private readonly ILogger<AskSessionAgentCommandHandler> _logger;
+    // #3390 Slice 2: optional (null-safe) so existing 7-arg test construction keeps compiling —
+    // null feature flags means the flag is treated as OFF (current multimodal-only behavior).
+    private readonly IFeatureFlagService? _featureFlags;
+    private readonly IOptions<SessionAgentOptions> _sessionAgentOptions;
 
     public AskSessionAgentCommandHandler(
         ISessionRepository sessionRepository,
@@ -120,7 +128,9 @@ internal class AskSessionAgentCommandHandler : IRequestHandler<AskSessionAgentCo
         ILlmService llmService,
         IImagePreprocessor imagePreprocessor,
         IGameStateExtractor gameStateExtractor,
-        ILogger<AskSessionAgentCommandHandler> logger)
+        ILogger<AskSessionAgentCommandHandler> logger,
+        IFeatureFlagService? featureFlags = null,
+        IOptions<SessionAgentOptions>? sessionAgentOptions = null)
     {
         _sessionRepository = sessionRepository;
         _chatRepository = chatRepository;
@@ -129,6 +139,8 @@ internal class AskSessionAgentCommandHandler : IRequestHandler<AskSessionAgentCo
         _imagePreprocessor = imagePreprocessor;
         _gameStateExtractor = gameStateExtractor;
         _logger = logger;
+        _featureFlags = featureFlags;
+        _sessionAgentOptions = sessionAgentOptions ?? Options.Create(new SessionAgentOptions());
     }
 
     public async Task<AskSessionAgentResult> Handle(AskSessionAgentCommand request, CancellationToken cancellationToken)
@@ -165,10 +177,70 @@ internal class AskSessionAgentCommandHandler : IRequestHandler<AskSessionAgentCo
             systemPrompt += $"\n\nCurrent game state from board analysis:\n{gameState}";
         }
 
-        string answer;
-        float? confidence;
+        // Initialized to the ungrounded defaults; the grounded path (below) overwrites them on success.
+        string answer = string.Empty;
+        float? confidence = null;
+        string? citationsJson = null;
+        var groundingStatus = GroundingStatus.Ungrounded;
+        var retrievalProfileTag = MeepleAiMetrics.AgentRetrievalProfiles.None;
+        var citationCount = 0;
         var hasImages = request.Images is { Count: > 0 };
 
+        // #3390 Slice 2: the turn TEXT is the retrieval query. Isolated in one variable so Slice 3
+        // (empty-text → vision-derived query) has a single seam to intercept.
+        var retrievalQuery = request.Question;
+
+        // Feature-gated (rag.live-image-retrieval, default OFF). Requires non-empty text (the
+        // empty-text case is Slice 3). Null feature-flag service (test construction) ⇒ treated as OFF.
+        var liveImageRetrievalEnabled = _featureFlags is not null
+            && !string.IsNullOrWhiteSpace(retrievalQuery)
+            && await _featureFlags.IsEnabledAsync(FeatureFlagConstants.LiveImageRetrievalKey).ConfigureAwait(false);
+
+        var groundedProduced = false;
+        if (liveImageRetrievalEnabled)
+        {
+            var userId = session.Participants.FirstOrDefault(p => p.Id == request.SenderId)?.UserId ?? Guid.Empty;
+            using var retrievalCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            retrievalCts.CancelAfter(TimeSpan.FromMilliseconds(_sessionAgentOptions.Value.RetrievalBudgetMs));
+            try
+            {
+                // KnowledgeBase owns "grounded answer on the rulebook" — consumed via IMediator
+                // (DDD Customer/Supplier), never by injecting a KB service. Vision stays as state
+                // context (gameState); the turn text is the retrieval query.
+                var grounded = await _mediator.Send(
+                    new AskGroundedSessionQuery(session.GameId, retrievalQuery, gameState, userId),
+                    retrievalCts.Token).ConfigureAwait(false);
+
+                answer = grounded.Answer;
+                confidence = grounded.Confidence.HasValue ? (float)grounded.Confidence.Value : null;
+                citationCount = grounded.Citations.Count;
+                citationsJson = citationCount > 0 ? JsonSerializer.Serialize(grounded.Citations) : null;
+                groundingStatus = grounded.GroundingStatus;
+                retrievalProfileTag = MeepleAiMetrics.AgentRetrievalProfiles.LiveSession;
+                groundedProduced = true;
+            }
+            catch (OperationCanceledException oce) when (retrievalCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                // Budget expired → degrade to multimodal-only (fail-open). The response must not wait.
+                _logger.LogWarning(oce,
+                    "Grounded retrieval exceeded the {BudgetMs}ms budget for session {SessionId}; degrading to multimodal (ungrounded)",
+                    _sessionAgentOptions.Value.RetrievalBudgetMs, request.SessionId);
+                MeepleAiMetrics.RecordRetrievalFallback(
+                    MeepleAiMetrics.RagFallbackTypes.RetrievalBudget, MeepleAiMetrics.RagFallbackSeverity.PartialLoss);
+            }
+            catch (Exception ex)
+            {
+                // Any retrieval/generation failure → fail-open to the existing multimodal path.
+                _logger.LogWarning(ex,
+                    "Grounded retrieval failed for session {SessionId}; degrading to multimodal (ungrounded)",
+                    request.SessionId);
+                MeepleAiMetrics.RecordRetrievalFallback(
+                    MeepleAiMetrics.RagFallbackTypes.Unknown, MeepleAiMetrics.RagFallbackSeverity.PartialLoss);
+            }
+        }
+
+        if (!groundedProduced)
+        {
         try
         {
             if (hasImages)
@@ -241,6 +313,7 @@ internal class AskSessionAgentCommandHandler : IRequestHandler<AskSessionAgentCo
             answer = "I'm sorry, an error occurred while processing your question. Please try again.";
             confidence = null;
         }
+        } // end if (!groundedProduced) — multimodal/text-only fallback (ungrounded)
 
         var agentSeq = await _chatRepository.GetNextSequenceNumberAsync(request.SessionId, cancellationToken).ConfigureAwait(false);
         var agentMessage = SessionChatMessage.CreateAgentResponse(
@@ -249,7 +322,7 @@ internal class AskSessionAgentCommandHandler : IRequestHandler<AskSessionAgentCo
             agentSeq,
             agentType,
             confidence,
-            null,
+            citationsJson,
             request.TurnNumber);
 
         await _chatRepository.AddAsync(agentMessage, cancellationToken).ConfigureAwait(false);
@@ -265,23 +338,24 @@ internal class AskSessionAgentCommandHandler : IRequestHandler<AskSessionAgentCo
             TurnNumber = request.TurnNumber,
         }, cancellationToken).ConfigureAwait(false);
 
-        // This path never produces citations (no retrieval grounding), so it is always Ungrounded (#3388).
-        // #3390 Slice 1: structured grounding observability (image or text-only, no retrieval -> profile=none).
-        // Guarded so a metrics fault can never break the agent response.
+        // #3390 Slice 1/2: structured grounding observability. retrieval_profile=live_session when the
+        // grounded path produced the answer (Slice 2), none when it fell back to multimodal/text-only.
+        // groundingStatus is Grounded iff the grounded path returned citations. Guarded so a metrics
+        // fault can never break the agent response.
         try
         {
             MeepleAiMetrics.RecordAgentResponseGrounding(
                 path: hasImages ? MeepleAiMetrics.AgentResponsePaths.Image : MeepleAiMetrics.AgentResponsePaths.Text,
-                groundingStatusWire: GroundingStatus.Ungrounded.ToString(),
-                retrievalProfile: MeepleAiMetrics.AgentRetrievalProfiles.None,
-                citationCount: 0);
+                groundingStatusWire: groundingStatus.ToString(),
+                retrievalProfile: retrievalProfileTag,
+                citationCount: citationCount);
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "agent-response grounding metric emission failed for session {SessionId}", request.SessionId);
         }
 
-        return new AskSessionAgentResult(agentMessage.Id, answer, agentType, agentMessage.Confidence, null, GroundingStatus.Ungrounded);
+        return new AskSessionAgentResult(agentMessage.Id, answer, agentType, agentMessage.Confidence, citationsJson, groundingStatus);
     }
 }
 

--- a/apps/api/src/Api/Infrastructure/Seeders/Core/FeatureFlagSeeder.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Core/FeatureFlagSeeder.cs
@@ -47,6 +47,9 @@ internal static class FeatureFlagSeeder
         // R1 (issue #3416, ADR-088): approved mechanic-card claim injection into RAG. Default OFF (all tiers).
         new("rag.mechanic-card-injection", "Inject approved mechanic-card claims into RAG answers", false, false, false, false),
 
+        // #3390 Slice 2: route the in-session image agent path through RAG retrieval (grounded). Default OFF (all tiers).
+        new("rag.live-image-retrieval", "Route the in-session image agent path through grounded RAG retrieval", false, false, false, false),
+
         // RAG Enhancement flags
         new("rag.enhancement.adaptive-routing", "Adaptive RAG: skip retrieval for simple queries", true, false, true, true),
         new("rag.enhancement.crag-evaluation", "CRAG: evaluate retrieval quality before generation", true, false, false, true),

--- a/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.AgentGrounding.cs
+++ b/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.AgentGrounding.cs
@@ -16,7 +16,9 @@ internal static partial class MeepleAiMetrics
     //
     // Two producers, one contract (mirrors the #3388 GroundingStatus wire contract):
     //   - text  -> ChatWithSessionAgentCommandHandler (KnowledgeBase, RAG, retrieval_profile=live_session)
-    //   - image -> AskSessionAgentCommandHandler       (SessionTracking, multimodal, retrieval_profile=none)
+    //   - image -> AskSessionAgentCommandHandler       (SessionTracking). Since #3390 Slice 2 this path
+    //              can be grounded too: retrieval_profile=live_session when the grounded RAG query ran
+    //              (flag rag.live-image-retrieval), or none when it fell back to multimodal-only.
     //
     // Cardinality rule (see MeepleAiMetrics.Rag.cs): tags are bounded sets ONLY — no
     // session/user/game ids. citation_count is NOT a tag (unbounded) -> separate histogram.

--- a/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.Rag.cs
+++ b/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.Rag.cs
@@ -122,6 +122,12 @@ internal static partial class MeepleAiMetrics
         public const string QueryExpansion = "query_expansion";
         public const string GraphTraversal = "graph_traversal";
         public const string Raptor = "raptor";
+
+        // #3390 Slice 2 — the in-session image-path retrieval exceeded its latency budget and
+        // degraded to the multimodal-only (ungrounded) path. Distinct from Unknown so ops can
+        // separate "budget expired on the hot path" from a generic unhandled retrieval error.
+        public const string RetrievalBudget = "retrieval_budget";
+
         public const string Unknown = "unknown";
     }
 

--- a/apps/api/src/Api/Services/FeatureFlagService.cs
+++ b/apps/api/src/Api/Services/FeatureFlagService.cs
@@ -19,6 +19,10 @@ public static class FeatureFlagConstants
     // R1 (issue #3416, ADR-088): gate approved mechanic-card claim injection into RAG answers. Default off.
     public const string MechanicCardInjectionKey = "rag.mechanic-card-injection";
 
+    // #3390 Slice 2: route the in-session IMAGE agent path through RAG retrieval (grounded, with
+    // citations) instead of the multimodal-only path. Default OFF (rollback-safe migration).
+    public const string LiveImageRetrievalKey = "rag.live-image-retrieval";
+
     public static readonly string[] RagEnhancements =
     [
         "rag.enhancement.adaptive-routing",

--- a/apps/api/src/Api/appsettings.json
+++ b/apps/api/src/Api/appsettings.json
@@ -307,7 +307,9 @@
   },
   "SessionAgent": {
     "_Comment": "SP5-c #2600: LlmPerChunkTimeoutSeconds — max seconds between consecutive LLM stream chunks. NEEDS TUNING: observe p99 inter-chunk latency in production before tightening. Default 30 s is intentionally generous.",
-    "LlmPerChunkTimeoutSeconds": 30.0
+    "LlmPerChunkTimeoutSeconds": 30.0,
+    "_RetrievalBudgetComment": "#3390 Slice 2: latency budget (ms) for grounded RAG retrieval on the in-session image path; on expiry the handler degrades to multimodal-only (Ungrounded). NEEDS TUNING.",
+    "RetrievalBudgetMs": 700
   },
   "LlmRouting": {
     "Comment": "ISSUE-958: Hybrid LLM architecture - user-tier based routing with traffic split",

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/AgentGroundingMetricsCollection.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/AgentGroundingMetricsCollection.cs
@@ -1,0 +1,16 @@
+using Xunit;
+
+namespace Api.Tests;
+
+/// <summary>
+/// #3390 — serializes the test classes that assert on the shared <c>MeepleAI.Api</c> Meter via
+/// <c>MeterListener</c> for the <c>meepleai.agent.response.grounding</c> counter. A MeterListener
+/// is global to the Meter, so two such classes running in parallel capture each other's
+/// measurements (captures.ContainSingle() then sees 0 or 2). Grouping them into one
+/// non-parallel collection removes that cross-class race (previously a known flake on
+/// ChatWithSessionAgentMetricsTests).
+/// </summary>
+[CollectionDefinition("AgentGroundingMetrics", DisableParallelization = true)]
+public sealed class AgentGroundingMetricsCollection
+{
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentMetricsTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentMetricsTests.cs
@@ -55,6 +55,7 @@ namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Commands;
 [Trait("BoundedContext", "KnowledgeBase")]
 [Trait("Area", "Observability")]
 [Trait("Issue", "2582")]
+[Collection("AgentGroundingMetrics")]
 public sealed class ChatWithSessionAgentMetricsTests
 {
     private const string FirstTokenLatencyName = "meepleai.rag.first_token_latency";

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/AskGroundedSessionQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/AskGroundedSessionQueryHandlerTests.cs
@@ -1,0 +1,147 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Models;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries;
+using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Domain.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using Api.Services;
+using Api.SharedKernel.Domain.Enums;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+using SharedUserTier = Api.SharedKernel.Domain.ValueObjects.UserTier;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Queries;
+
+/// <summary>
+/// #3390 Slice 2: <see cref="AskGroundedSessionQueryHandler"/> produces a grounded, non-streaming
+/// answer for the in-session image/text path. Grounding is derived from the citation count
+/// (Grounded iff citations > 0), mirroring the SSE text path's #3388 invariant.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Issue", "3390")]
+public sealed class AskGroundedSessionQueryHandlerTests
+{
+    [Fact]
+    public async Task Handle_WithCitations_ReturnsGroundedAnswerWithMappedCitations()
+    {
+        // Arrange — retrieval yields one Full-tier citation.
+        var citations = new List<ChunkCitation>
+        {
+            new ChunkCitation(
+                DocumentId: "doc-1",
+                PageNumber: 4,
+                RelevanceScore: 0.87f,
+                SnippetPreview: "Victory points are scored at game end.",
+                CopyrightTier: CopyrightTier.Full,
+                IsPublic: true),
+        };
+        var handler = BuildHandler(citations, llmAnswer: "You score victory points at game end. [Page 4]");
+
+        // Act
+        var result = await handler.Handle(
+            new AskGroundedSessionQuery(Guid.NewGuid(), "How do I score points?", GameStateContext: null, UserId: Guid.NewGuid()),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.GroundingStatus.Should().Be(GroundingStatus.Grounded, "citations were produced");
+        result.Citations.Should().ContainSingle();
+        result.Citations[0].DocumentId.Should().Be("doc-1");
+        result.Citations[0].PageNumber.Should().Be(4);
+        result.Citations[0].SnippetPreview.Should().Be("Victory points are scored at game end.", "Full-tier keeps the preview");
+        result.Answer.Should().Contain("[Page 4]");
+        result.Confidence.Should().NotBeNull("ComputeConfidence returns a value when citations exist");
+    }
+
+    [Fact]
+    public async Task Handle_NoCitations_ReturnsUngrounded()
+    {
+        // Arrange — retrieval yields nothing (query not covered by the rulebook).
+        var handler = BuildHandler(new List<ChunkCitation>(), llmAnswer: "I couldn't find that in the rulebook.");
+
+        // Act
+        var result = await handler.Handle(
+            new AskGroundedSessionQuery(Guid.NewGuid(), "What is the airspeed of a swallow?", GameStateContext: null, UserId: Guid.NewGuid()),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.GroundingStatus.Should().Be(GroundingStatus.Ungrounded, "zero citations -> ungrounded (never fabricate grounded)");
+        result.Citations.Should().BeEmpty();
+        result.Confidence.Should().BeNull("ComputeConfidence returns null with no citations");
+    }
+
+    [Fact]
+    public async Task Handle_GenerationFails_ThrowsSoCallerCanDegrade()
+    {
+        // Arrange — retrieval works but the LLM call fails.
+        var handler = BuildHandler(
+            new List<ChunkCitation>(),
+            llmAnswer: null,
+            llmSuccess: false);
+
+        // Act
+        var act = () => handler.Handle(
+            new AskGroundedSessionQuery(Guid.NewGuid(), "Question", GameStateContext: null, UserId: Guid.NewGuid()),
+            TestContext.Current.CancellationToken);
+
+        // Assert — SessionTracking catches this to fall back to the multimodal-only path.
+        await act.Should().ThrowAsync<GroundedSessionGenerationException>();
+    }
+
+    private static AskGroundedSessionQueryHandler BuildHandler(
+        IReadOnlyList<ChunkCitation> citations,
+        string? llmAnswer,
+        bool llmSuccess = true)
+    {
+        var assembled = new AssembledPrompt(
+            SystemPrompt: "You are a helpful board game tutor.",
+            UserPrompt: "Context...\n\nQuestion",
+            Citations: citations.ToList(),
+            EstimatedTokens: 100);
+
+        var ragPrompt = new Mock<IRagPromptAssemblyService>();
+        ragPrompt
+            .Setup(r => r.AssemblePromptAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<GameState?>(),
+                It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<ChatThread?>(),
+                It.IsAny<SharedUserTier?>(), It.IsAny<string>(), It.IsAny<CancellationToken>(),
+                It.IsAny<IRagDebugEventCollector?>(), It.IsAny<RetrievalProfile?>(), It.IsAny<RetrievalPolicy?>()))
+            .ReturnsAsync(assembled);
+
+        var tierResolver = new Mock<ICopyrightTierResolver>();
+        tierResolver
+            .Setup(r => r.ResolveAsync(It.IsAny<IReadOnlyList<ChunkCitation>>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(citations);
+
+        var llm = new Mock<ILlmService>();
+        llm
+            .Setup(l => l.GenerateCompletionAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(llmSuccess
+                ? LlmCompletionResult.CreateSuccess(llmAnswer ?? "answer")
+                : LlmCompletionResult.CreateFailure("llm down"));
+
+        var leakGuard = new Mock<ICopyrightLeakGuard>();
+        leakGuard
+            .Setup(g => g.ScanAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<ChunkCitation>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CopyrightLeakResult(HasLeak: false, Matches: Array.Empty<LeakMatch>()));
+
+        var fallbackProvider = new Mock<ICopyrightFallbackMessageProvider>();
+        fallbackProvider.Setup(f => f.GetMessage(It.IsAny<string>())).Returns("[copyright fallback]");
+
+        return new AskGroundedSessionQueryHandler(
+            ragPrompt.Object,
+            tierResolver.Object,
+            llm.Object,
+            leakGuard.Object,
+            fallbackProvider.Object,
+            Options.Create(new CopyrightLeakGuardOptions()),
+            NullLogger<AskGroundedSessionQueryHandler>.Instance);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/AskGroundedSessionQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/AskGroundedSessionQueryHandlerTests.cs
@@ -94,6 +94,22 @@ public sealed class AskGroundedSessionQueryHandlerTests
         await act.Should().ThrowAsync<GroundedSessionGenerationException>();
     }
 
+    [Fact]
+    public async Task Handle_SuccessButEmptyResponse_Throws()
+    {
+        // Arrange — provider returns Success=true but a blank body. Must be treated as a failure
+        // so the caller degrades, not shipped as a blank "grounded" answer (would 500 downstream).
+        var handler = BuildHandler(new List<ChunkCitation>(), llmAnswer: "   ", llmSuccess: true);
+
+        // Act
+        var act = () => handler.Handle(
+            new AskGroundedSessionQuery(Guid.NewGuid(), "Question", GameStateContext: null, UserId: Guid.NewGuid()),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        await act.Should().ThrowAsync<GroundedSessionGenerationException>();
+    }
+
     private static AskGroundedSessionQueryHandler BuildHandler(
         IReadOnlyList<ChunkCitation> citations,
         string? llmAnswer,

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/ChatCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/ChatCommandHandlerTests.cs
@@ -160,6 +160,7 @@ public class SendSystemEventCommandHandlerTests
 
 [Trait("Category", TestCategories.Unit)]
 [Trait("BoundedContext", "SessionTracking")]
+[Collection("AgentGroundingMetrics")]
 public class AskSessionAgentCommandHandlerTests
 {
     private readonly Mock<ISessionRepository> _mockSessionRepo;
@@ -477,6 +478,104 @@ public class AskSessionAgentCommandHandlerTests
         captures.Should().ContainSingle();
         captures[0].Tags["grounding_status"].Should().Be("ungrounded");
         captures[0].Tags["retrieval_profile"].Should().Be("none", "fallback path uses no retrieval profile");
+    }
+
+    [Fact]
+    public async Task Handle_FlagOn_ImageTurn_GroundedEmpty_FallsBackToMultimodal()
+    {
+        // Arrange — image attached, flag ON, but grounded retrieval finds 0 citations. The image
+        // must still be analyzed (multimodal fallback), not silently dropped for a text-only answer.
+        var sessionId = Guid.NewGuid();
+        var senderId = Guid.NewGuid();
+        var session = CreateSessionWithParticipant(sessionId, senderId);
+
+        var mockSessionRepo = new Mock<ISessionRepository>();
+        mockSessionRepo.Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>())).ReturnsAsync(session);
+        var mockChatRepo = new Mock<ISessionChatRepository>();
+        mockChatRepo.SetupSequence(r => r.GetNextSequenceNumberAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1).ReturnsAsync(2);
+        var mockMediator = new Mock<IMediator>();
+        mockMediator
+            .Setup(m => m.Send(It.IsAny<AskGroundedSessionQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GroundedSessionAnswerDto("Not in the rulebook.", new List<Api.Models.CitationDto>(), GroundingStatus.Ungrounded, null));
+        var mockImagePreprocessor = new Mock<IImagePreprocessor>();
+        mockImagePreprocessor
+            .Setup(p => p.ProcessAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<ImageProcessingOptions?>()))
+            .ReturnsAsync(new ProcessedImage(new byte[] { 1 }, "image/jpeg", 1, 1, 1));
+        var mockLlm = new Mock<ILlmService>();
+        mockLlm
+            .Setup(l => l.GenerateMultimodalCompletionAsync(It.IsAny<IReadOnlyList<LlmMessage>>(), It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(LlmCompletionResult.CreateSuccess("I see a board with red tokens."));
+
+        var mockFlags = new Mock<IFeatureFlagService>();
+        mockFlags.Setup(f => f.IsEnabledAsync(FeatureFlagConstants.LiveImageRetrievalKey, It.IsAny<Api.Infrastructure.Entities.UserRole?>()))
+            .ReturnsAsync(true);
+
+        var handler = new AskSessionAgentCommandHandler(
+            mockSessionRepo.Object, mockChatRepo.Object, mockMediator.Object, mockLlm.Object,
+            mockImagePreprocessor.Object, new Mock<IGameStateExtractor>().Object,
+            new Mock<ILogger<AskSessionAgentCommandHandler>>().Object,
+            mockFlags.Object);
+
+        var captures = new List<(long Value, Dictionary<string, object?> Tags)>();
+        using var listener = BuildCounterListener(AgentGroundingName, captures);
+
+        var command = new AskSessionAgentCommand(
+            sessionId, senderId, "What should I do?", 1,
+            new List<ChatImageAttachment> { new(new byte[] { 1 }, "image/jpeg", "board.jpg") });
+
+        // Act
+        var result = await handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert — multimodal fallback ran (image analyzed), ungrounded, retrieval_profile=none.
+        mockLlm.Verify(l => l.GenerateMultimodalCompletionAsync(It.IsAny<IReadOnlyList<LlmMessage>>(), It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()), Times.Once);
+        result.GroundingStatus.Should().Be(GroundingStatus.Ungrounded);
+        captures.Should().ContainSingle();
+        captures[0].Tags["path"].Should().Be("image");
+        captures[0].Tags["retrieval_profile"].Should().Be("none");
+    }
+
+    [Fact]
+    public async Task Handle_FlagOn_ClientCancels_PropagatesWithoutFallback()
+    {
+        // Arrange — the client aborts the request. Cancellation must propagate; the handler must
+        // NOT fail-open into a wasted second (multimodal) LLM call.
+        var sessionId = Guid.NewGuid();
+        var senderId = Guid.NewGuid();
+        var session = CreateSessionWithParticipant(sessionId, senderId);
+
+        var mockSessionRepo = new Mock<ISessionRepository>();
+        mockSessionRepo.Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>())).ReturnsAsync(session);
+        var mockChatRepo = new Mock<ISessionChatRepository>();
+        mockChatRepo.SetupSequence(r => r.GetNextSequenceNumberAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1).ReturnsAsync(2);
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var mockMediator = new Mock<IMediator>();
+        mockMediator
+            .Setup(m => m.Send(It.IsAny<AskGroundedSessionQuery>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+        var mockLlm = new Mock<ILlmService>();
+
+        var mockFlags = new Mock<IFeatureFlagService>();
+        mockFlags.Setup(f => f.IsEnabledAsync(FeatureFlagConstants.LiveImageRetrievalKey, It.IsAny<Api.Infrastructure.Entities.UserRole?>()))
+            .ReturnsAsync(true);
+
+        var handler = new AskSessionAgentCommandHandler(
+            mockSessionRepo.Object, mockChatRepo.Object, mockMediator.Object, mockLlm.Object,
+            new Mock<IImagePreprocessor>().Object, new Mock<IGameStateExtractor>().Object,
+            new Mock<ILogger<AskSessionAgentCommandHandler>>().Object,
+            mockFlags.Object);
+
+        // Act — client-cancelled token.
+        var act = () => handler.Handle(new AskSessionAgentCommand(sessionId, senderId, "Question", 1), cts.Token);
+
+        // Assert — cancellation propagates; no multimodal/text fallback LLM call.
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        mockLlm.Verify(l => l.GenerateCompletionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()), Times.Never);
+        mockLlm.Verify(l => l.GenerateMultimodalCompletionAsync(It.IsAny<IReadOnlyList<LlmMessage>>(), It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     private static MeterListener BuildCounterListener(

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/ChatCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/ChatCommandHandlerTests.cs
@@ -2,6 +2,8 @@ using Api.BoundedContexts.SessionTracking.Application.Commands;
 using Api.BoundedContexts.SessionTracking.Application.Queries;
 using Api.BoundedContexts.SessionTracking.Domain.Entities;
 using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries;
 using Api.Middleware.Exceptions;
 using Api.Observability;
 using Api.Services;
@@ -370,6 +372,111 @@ public class AskSessionAgentCommandHandlerTests
         tags["path"].Should().Be("image", "images attached -> vision branch");
         tags["grounding_status"].Should().Be("ungrounded");
         tags["retrieval_profile"].Should().Be("none");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // #3390 Slice 2: grounded retrieval on the image/text path (feature-gated, with fallback)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_FlagOn_GroundedRetrieval_ReturnsGroundedWithLiveSessionProfile()
+    {
+        // Arrange — flag ON, non-empty text, KnowledgeBase returns a grounded answer.
+        var sessionId = Guid.NewGuid();
+        var senderId = Guid.NewGuid();
+        var session = CreateSessionWithParticipant(sessionId, senderId);
+
+        var mockSessionRepo = new Mock<ISessionRepository>();
+        mockSessionRepo.Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>())).ReturnsAsync(session);
+        var mockChatRepo = new Mock<ISessionChatRepository>();
+        mockChatRepo.SetupSequence(r => r.GetNextSequenceNumberAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1).ReturnsAsync(2);
+        var mockMediator = new Mock<IMediator>();
+        var groundedDto = new GroundedSessionAnswerDto(
+            "You take turns placing settlements. [Page 2]",
+            new List<Api.Models.CitationDto> { new("doc-1", 2, 0.9f, "settlements", "full") },
+            GroundingStatus.Grounded,
+            0.82);
+        mockMediator
+            .Setup(m => m.Send(It.IsAny<AskGroundedSessionQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(groundedDto);
+        var mockLlm = new Mock<ILlmService>();
+
+        var mockFlags = new Mock<IFeatureFlagService>();
+        mockFlags.Setup(f => f.IsEnabledAsync(FeatureFlagConstants.LiveImageRetrievalKey, It.IsAny<Api.Infrastructure.Entities.UserRole?>()))
+            .ReturnsAsync(true);
+
+        var handler = new AskSessionAgentCommandHandler(
+            mockSessionRepo.Object, mockChatRepo.Object, mockMediator.Object, mockLlm.Object,
+            new Mock<IImagePreprocessor>().Object, new Mock<IGameStateExtractor>().Object,
+            new Mock<ILogger<AskSessionAgentCommandHandler>>().Object,
+            mockFlags.Object);
+
+        var captures = new List<(long Value, Dictionary<string, object?> Tags)>();
+        using var listener = BuildCounterListener(AgentGroundingName, captures);
+
+        // Act — text turn (no images).
+        var result = await handler.Handle(
+            new AskSessionAgentCommand(sessionId, senderId, "How do I start my turn?", 1),
+            TestContext.Current.CancellationToken);
+
+        // Assert — grounded result, citations persisted, LLM never called directly (retrieval owned by KB).
+        result.GroundingStatus.Should().Be(GroundingStatus.Grounded);
+        result.CitationsJson.Should().NotBeNullOrEmpty("grounded answer carries serialized citations");
+        mockLlm.Verify(l => l.GenerateCompletionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()), Times.Never);
+        captures.Should().ContainSingle();
+        captures[0].Tags["path"].Should().Be("text");
+        captures[0].Tags["grounding_status"].Should().Be("grounded");
+        captures[0].Tags["retrieval_profile"].Should().Be("live_session");
+    }
+
+    [Fact]
+    public async Task Handle_FlagOn_RetrievalThrows_FallsBackToMultimodalUngrounded()
+    {
+        // Arrange — flag ON, but the grounded query fails (timeout/error). Must degrade fail-open.
+        var sessionId = Guid.NewGuid();
+        var senderId = Guid.NewGuid();
+        var session = CreateSessionWithParticipant(sessionId, senderId);
+
+        var mockSessionRepo = new Mock<ISessionRepository>();
+        mockSessionRepo.Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>())).ReturnsAsync(session);
+        var mockChatRepo = new Mock<ISessionChatRepository>();
+        mockChatRepo.SetupSequence(r => r.GetNextSequenceNumberAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1).ReturnsAsync(2);
+        var mockMediator = new Mock<IMediator>();
+        mockMediator
+            .Setup(m => m.Send(It.IsAny<AskGroundedSessionQuery>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new GroundedSessionGenerationException("kb down"));
+        var mockLlm = new Mock<ILlmService>();
+        mockLlm
+            .Setup(l => l.GenerateCompletionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(LlmCompletionResult.CreateSuccess("Multimodal fallback answer"));
+
+        var mockFlags = new Mock<IFeatureFlagService>();
+        mockFlags.Setup(f => f.IsEnabledAsync(FeatureFlagConstants.LiveImageRetrievalKey, It.IsAny<Api.Infrastructure.Entities.UserRole?>()))
+            .ReturnsAsync(true);
+
+        var handler = new AskSessionAgentCommandHandler(
+            mockSessionRepo.Object, mockChatRepo.Object, mockMediator.Object, mockLlm.Object,
+            new Mock<IImagePreprocessor>().Object, new Mock<IGameStateExtractor>().Object,
+            new Mock<ILogger<AskSessionAgentCommandHandler>>().Object,
+            mockFlags.Object);
+
+        var captures = new List<(long Value, Dictionary<string, object?> Tags)>();
+        using var listener = BuildCounterListener(AgentGroundingName, captures);
+
+        // Act
+        var result = await handler.Handle(
+            new AskSessionAgentCommand(sessionId, senderId, "How do I start?", 1),
+            TestContext.Current.CancellationToken);
+
+        // Assert — degraded to multimodal-only: ungrounded, no citations, LLM WAS called (fallback).
+        result.GroundingStatus.Should().Be(GroundingStatus.Ungrounded);
+        result.CitationsJson.Should().BeNull();
+        mockLlm.Verify(l => l.GenerateCompletionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()), Times.Once);
+        captures.Should().ContainSingle();
+        captures[0].Tags["grounding_status"].Should().Be("ungrounded");
+        captures[0].Tags["retrieval_profile"].Should().Be("none", "fallback path uses no retrieval profile");
     }
 
     private static MeterListener BuildCounterListener(


### PR DESCRIPTION
## Epic #3390 — Slice 2 di 5 (Retrieval sul path immagine)

Il cuore dell'epic: il turno **multimodale** in-sessione ora può passare **attraverso il retrieval RAG grounded** e produrre citazioni verificabili, invece del path multimodale-puro che rispondeva *silenziosamente non-grounded*.

## Architettura (DDD Customer/Supplier)

`KnowledgeBase` possiede *"risposta grounded sul rulebook"* e la espone via una **nuova query MediatR** (`AskGroundedSessionQuery` → `GroundedSessionAnswerDto`); `SessionTracking` la **consuma** via `_mediator.Send` — stesso pattern cross-BC del precedente `CreateSessionCommandHandler` → `GetKbReadinessQuery`, **mai** iniettando un servizio di KB (regola `CLAUDE.md`: *"Direct service injection (use MediatR)"*). SessionTracking riceve un **DTO pubblico** (wire shape `Api.Models.CitationDto`), non i modelli `internal` `AssembledPrompt`/`ChunkCitation`.

## Comportamento

- **Nuovo `AskGroundedSessionQueryHandler`** replica il pipeline grounded non-streaming del path testo: `AssemblePrompt(LiveSession, enhancement OFF, CRAG web off)` → tier resolve → generate (**text-only**) → copyright leak guard → map citazioni → grounding da citation count (invariante #3388).
- **Vision come contesto di stato**: il JSON di `GameStateExtractor` è iniettato nel prompt; i **pixel non vengono re-inviati** (più economico sul path più caldo).
- **Feature flag** `rag.live-image-retrieval` (default **OFF**, rollback-safe). **Budget latenza** `SessionAgent:RetrievalBudgetMs=700` via linked CTS + `CancelAfter`; su timeout/errore → **fail-open** al path multimodale esistente (resta Ungrounded, #3388) + `meepleai.rag.retrieval.fallbacks{fallback_type=retrieval_budget}`. La metrica Slice 1 emette `retrieval_profile=live_session` quando grounded, `none` sul fallback.
- Guardia testo-vuoto lasciata come **gancio Slice 3** (query derivata da vision).

## Code review (2 finder avversariali) — tutti i finding risolti

| # | Finding | Fix |
|---|---|---|
| KB-1 | Sanitizzazione copyright dentro il try fail-open → un throw durante il sanitize spediva il testo con leak | Leak handling spostato **fuori** dal try (fail-**closed**) |
| KB-2 / Cons-4 | Risposta vuota (Success) → risposta "grounded" vuota / 500 downstream | Guardia → throw → degrada |
| KB-3 / Cons-1 | Cancellazione-client inghiottita dal catch generico → fail-open + 2ª chiamata LLM sprecata | Catch dedicato che **ripropaga** la cancellazione-client |
| Cons-2 | Immagine + retrieval-vuoto short-circuitava la vision (foto mai analizzata) | Fall-through al multimodale quando `hasImages && 0 citazioni` |
| Cons-5 | Commento metrica Slice 1 stale | Aggiornato |

## Test

- KB handler: grounded / ungrounded / generation-failure / **empty-response**.
- SessionTracking: grounded-success / fallback-on-error / **image-empty→multimodal** / **client-cancel→propaga**.
- **21/21 verdi**. Build BE 0 errori. Risolto il flake `MeterListener` (collection non-parallela).

## Roadmap restante

3. Query-expansion da vision (testo vuoto) · 4. Enhancement live-path per-enhancement · 5. Ownership collapse (ADR) — consolida la duplicazione controllata introdotta qui.

Part of #3390. Epic #3397.

🤖 Generated with [Claude Code](https://claude.com/claude-code)