### PR TITLE
feat(ai): vision-derived retrieval query for empty turns (#3390 Slice 3)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ChatCommandHandlers.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ChatCommandHandlers.cs
@@ -151,21 +151,37 @@ internal class AskSessionAgentCommandHandler : IRequestHandler<AskSessionAgentCo
         _ = session.Participants.FirstOrDefault(p => p.Id == request.SenderId)
             ?? throw new NotFoundException($"Participant {request.SenderId} not found in session");
 
-        // Save the user's question as a chat message
+        // #3390 Slice 3: extract the vision board-state BEFORE writing the user message, so an empty
+        // turn text can be replaced by a query derived from the vision (non-blocking, returns cached).
+        var gameState = await _gameStateExtractor.ExtractIfNeededAsync(
+            request.SessionId, null, cancellationToken).ConfigureAwait(false);
+
+        // #3390 Slice 3: empty turn text + flag ON → derive the retrieval query from the vision
+        // board-state. The derived query is BOTH the retrieval query and the user-visible chat-message
+        // content (transparent). Deterministic: fires ONLY on truly-empty text, never overriding a
+        // real question. Flag rag.live-vision-query-expansion, default OFF.
+        var effectiveQuery = request.Question;
+        if (string.IsNullOrWhiteSpace(request.Question)
+            && _featureFlags is not null
+            && await _featureFlags.IsEnabledAsync(FeatureFlagConstants.LiveVisionQueryExpansionKey).ConfigureAwait(false))
+        {
+            effectiveQuery = DeriveQueryFromVision(gameState);
+            _logger.LogInformation(
+                "Empty turn text for session {SessionId}; derived retrieval query from vision board-state",
+                request.SessionId);
+        }
+
+        // Save the user's question (or the vision-derived query) as a chat message.
         var userSeq = await _chatRepository.GetNextSequenceNumberAsync(request.SessionId, cancellationToken).ConfigureAwait(false);
         var userMessage = SessionChatMessage.CreateTextMessage(
             request.SessionId,
             request.SenderId,
-            request.Question,
+            effectiveQuery,
             userSeq,
             request.TurnNumber);
 
         await _chatRepository.AddAsync(userMessage, cancellationToken).ConfigureAwait(false);
         await _chatRepository.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-
-        // Extract game state from latest vision snapshot (non-blocking, returns cached if available)
-        var gameState = await _gameStateExtractor.ExtractIfNeededAsync(
-            request.SessionId, null, cancellationToken).ConfigureAwait(false);
 
         // Build system prompt with optional game state context
         var agentType = "tutor";
@@ -186,9 +202,8 @@ internal class AskSessionAgentCommandHandler : IRequestHandler<AskSessionAgentCo
         var citationCount = 0;
         var hasImages = request.Images is { Count: > 0 };
 
-        // #3390 Slice 2: the turn TEXT is the retrieval query. Isolated in one variable so Slice 3
-        // (empty-text → vision-derived query) has a single seam to intercept.
-        var retrievalQuery = request.Question;
+        // #3390 Slice 2/3: the (possibly vision-derived) query drives retrieval and the LLM prompt.
+        var retrievalQuery = effectiveQuery;
 
         // Feature-gated (rag.live-image-retrieval, default OFF). Requires non-empty text (the
         // empty-text case is Slice 3). Null feature-flag service (test construction) ⇒ treated as OFF.
@@ -276,7 +291,7 @@ internal class AskSessionAgentCommandHandler : IRequestHandler<AskSessionAgentCo
                     contentParts.Add(new ImageContentPart(base64, processed.MediaType));
                 }
 
-                contentParts.Add(new TextContentPart(request.Question));
+                contentParts.Add(new TextContentPart(effectiveQuery));
 
                 var messages = new List<LlmMessage>
                 {
@@ -308,7 +323,7 @@ internal class AskSessionAgentCommandHandler : IRequestHandler<AskSessionAgentCo
                 // Text-only path (existing behavior)
                 var result = await _llmService.GenerateCompletionAsync(
                     systemPrompt,
-                    request.Question,
+                    effectiveQuery,
                     RequestSource.AgentTask,
                     cancellationToken).ConfigureAwait(false);
 
@@ -376,6 +391,96 @@ internal class AskSessionAgentCommandHandler : IRequestHandler<AskSessionAgentCo
         }
 
         return new AskSessionAgentResult(agentMessage.Id, answer, agentType, agentMessage.Confidence, citationsJson, groundingStatus);
+    }
+
+    // #3390 Slice 3: default retrieval query when the turn has no text and no usable vision state.
+    private const string VisionQueryFallback = "What should I do now based on the current board state?";
+
+    /// <summary>
+    /// Derives a concise retrieval query from the GameStateExtractor vision JSON (observations +
+    /// game_phase + scalar visible_elements keywords). Defensive: any parse failure or empty state
+    /// falls back to <see cref="VisionQueryFallback"/> so the turn never breaks. The result is used
+    /// both as the retrieval query and as the user-visible chat message (transparency).
+    /// </summary>
+    private static string DeriveQueryFromVision(string? gameState)
+    {
+        if (string.IsNullOrWhiteSpace(gameState))
+        {
+            return VisionQueryFallback;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(gameState);
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+            {
+                return VisionQueryFallback;
+            }
+
+            var parts = new List<string>();
+
+            if (root.TryGetProperty("observations", out var obs) && obs.ValueKind == JsonValueKind.String)
+            {
+                var o = obs.GetString();
+                if (!string.IsNullOrWhiteSpace(o)) parts.Add(o!.Trim());
+            }
+
+            if (root.TryGetProperty("game_phase", out var phase) && phase.ValueKind == JsonValueKind.String)
+            {
+                var p = phase.GetString();
+                if (!string.IsNullOrWhiteSpace(p)) parts.Add($"phase: {p!.Trim()}");
+            }
+
+            if (root.TryGetProperty("visible_elements", out var ve))
+            {
+                CollectScalarText(ve, parts);
+            }
+
+            if (parts.Count == 0)
+            {
+                return VisionQueryFallback;
+            }
+
+            var summary = string.Join("; ", parts);
+            if (summary.Length > 400)
+            {
+                summary = summary[..400];
+            }
+
+            return $"Given the current board state ({summary}), what can I do on my turn?";
+        }
+        catch (JsonException)
+        {
+            return VisionQueryFallback;
+        }
+    }
+
+    /// <summary>
+    /// Recursively collects non-empty string leaves from a JSON element (visible_elements can nest
+    /// objects/arrays). Numbers/bools/null are skipped — they are not useful retrieval terms.
+    /// </summary>
+    private static void CollectScalarText(JsonElement element, List<string> sink)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.String:
+                var s = element.GetString();
+                if (!string.IsNullOrWhiteSpace(s)) sink.Add(s!.Trim());
+                break;
+            case JsonValueKind.Array:
+                foreach (var item in element.EnumerateArray())
+                {
+                    CollectScalarText(item, sink);
+                }
+                break;
+            case JsonValueKind.Object:
+                foreach (var prop in element.EnumerateObject())
+                {
+                    CollectScalarText(prop.Value, sink);
+                }
+                break;
+        }
     }
 }
 

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ChatCommandValidators.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ChatCommandValidators.cs
@@ -31,8 +31,14 @@ public class AskSessionAgentCommandValidator : AbstractValidator<AskSessionAgent
     {
         RuleFor(x => x.SessionId).NotEmpty().WithMessage("Session ID is required.");
         RuleFor(x => x.SenderId).NotEmpty().WithMessage("Sender ID is required.");
-        RuleFor(x => x.Question).NotEmpty().MaximumLength(2000)
-            .WithMessage("Question must be 1-2000 characters.");
+        RuleFor(x => x.Question)
+            .MaximumLength(2000).WithMessage("Question must be at most 2000 characters.");
+        // #3390 Slice 3: the turn text may be empty ONLY when an image is attached — that is the
+        // vision-derived-query path (the handler derives the retrieval query from the board state).
+        // A text-only turn still requires a non-empty question.
+        RuleFor(x => x)
+            .Must(cmd => !string.IsNullOrWhiteSpace(cmd.Question) || cmd.Images is { Count: > 0 })
+            .WithMessage("A question is required unless an image is attached.");
         RuleFor(x => x.Images)
             .Must(imgs => imgs is null || imgs.Count <= MaxImages)
             .WithMessage($"Maximum {MaxImages} images per request.");

--- a/apps/api/src/Api/Infrastructure/Seeders/Core/FeatureFlagSeeder.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Core/FeatureFlagSeeder.cs
@@ -50,6 +50,9 @@ internal static class FeatureFlagSeeder
         // #3390 Slice 2: route the in-session image agent path through RAG retrieval (grounded). Default OFF (all tiers).
         new("rag.live-image-retrieval", "Route the in-session image agent path through grounded RAG retrieval", false, false, false, false),
 
+        // #3390 Slice 3: derive the retrieval query from the vision board-state when the turn has no text. Default OFF (all tiers).
+        new("rag.live-vision-query-expansion", "Derive the in-session retrieval query from vision when the turn text is empty", false, false, false, false),
+
         // RAG Enhancement flags
         new("rag.enhancement.adaptive-routing", "Adaptive RAG: skip retrieval for simple queries", true, false, true, true),
         new("rag.enhancement.crag-evaluation", "CRAG: evaluate retrieval quality before generation", true, false, false, true),

--- a/apps/api/src/Api/Routing/SessionTracking/SessionPlayerActionsEndpoints.cs
+++ b/apps/api/src/Api/Routing/SessionTracking/SessionPlayerActionsEndpoints.cs
@@ -598,9 +598,11 @@ internal static class SessionPlayerActionsEndpoints
                 // Multipart form: supports image attachments
                 var form = await httpRequest.ReadFormAsync(ct).ConfigureAwait(false);
 
+                // #3390 Slice 3: empty question is allowed on the multipart (image) path — the
+                // AskSessionAgentCommandValidator enforces "question required unless an image is
+                // attached", so the empty-text vision turn reaches the handler (and its
+                // vision-derived query) instead of being rejected here.
                 var questionStr = form["question"].ToString();
-                if (string.IsNullOrWhiteSpace(questionStr))
-                    return Results.BadRequest(new { error = "Question is required" });
 
                 if (!Guid.TryParse(form["senderId"].ToString(), out var senderId))
                     return Results.BadRequest(new { error = "Valid senderId is required" });

--- a/apps/api/src/Api/Services/FeatureFlagService.cs
+++ b/apps/api/src/Api/Services/FeatureFlagService.cs
@@ -23,6 +23,10 @@ public static class FeatureFlagConstants
     // citations) instead of the multimodal-only path. Default OFF (rollback-safe migration).
     public const string LiveImageRetrievalKey = "rag.live-image-retrieval";
 
+    // #3390 Slice 3: when the in-session turn has no text, derive the retrieval query (and the
+    // user-visible chat message) from the vision board-state. Default OFF.
+    public const string LiveVisionQueryExpansionKey = "rag.live-vision-query-expansion";
+
     public static readonly string[] RagEnhancements =
     [
         "rag.enhancement.adaptive-routing",

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/ChatCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/ChatCommandHandlerTests.cs
@@ -578,6 +578,100 @@ public class AskSessionAgentCommandHandlerTests
         mockLlm.Verify(l => l.GenerateMultimodalCompletionAsync(It.IsAny<IReadOnlyList<LlmMessage>>(), It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
+    // ──────────────────────────────────────────────────────────────────────────
+    // #3390 Slice 3: vision-derived retrieval query for empty-text turns
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_VisionExpansionOn_EmptyText_DerivesQueryFromVisionState()
+    {
+        // Arrange — empty turn text, vision-expansion + image-retrieval flags ON, a vision snapshot exists.
+        var sessionId = Guid.NewGuid();
+        var senderId = Guid.NewGuid();
+        var session = CreateSessionWithParticipant(sessionId, senderId);
+
+        var mockSessionRepo = new Mock<ISessionRepository>();
+        mockSessionRepo.Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>())).ReturnsAsync(session);
+        var mockChatRepo = new Mock<ISessionChatRepository>();
+        mockChatRepo.SetupSequence(r => r.GetNextSequenceNumberAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1).ReturnsAsync(2);
+        SessionChatMessage? capturedUserMessage = null;
+        mockChatRepo.Setup(r => r.AddAsync(It.IsAny<SessionChatMessage>(), It.IsAny<CancellationToken>()))
+            .Callback<SessionChatMessage, CancellationToken>((m, _) => capturedUserMessage ??= m)
+            .Returns(Task.CompletedTask);
+
+        var mockExtractor = new Mock<IGameStateExtractor>();
+        mockExtractor
+            .Setup(e => e.ExtractIfNeededAsync(It.IsAny<Guid>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("{\"observations\":\"Red player has 3 settlements\",\"game_phase\":\"main\",\"visible_elements\":{\"resources\":[\"wood\",\"brick\"]}}");
+
+        var mockMediator = new Mock<IMediator>();
+        mockMediator
+            .Setup(m => m.Send(It.IsAny<AskGroundedSessionQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GroundedSessionAnswerDto("You can build. [Page 3]", new List<Api.Models.CitationDto> { new("d", 3, 0.9f, "s", "full") }, GroundingStatus.Grounded, 0.8));
+        var mockLlm = new Mock<ILlmService>();
+
+        var mockFlags = new Mock<IFeatureFlagService>();
+        mockFlags.Setup(f => f.IsEnabledAsync(FeatureFlagConstants.LiveVisionQueryExpansionKey, It.IsAny<Api.Infrastructure.Entities.UserRole?>())).ReturnsAsync(true);
+        mockFlags.Setup(f => f.IsEnabledAsync(FeatureFlagConstants.LiveImageRetrievalKey, It.IsAny<Api.Infrastructure.Entities.UserRole?>())).ReturnsAsync(true);
+
+        var handler = new AskSessionAgentCommandHandler(
+            mockSessionRepo.Object, mockChatRepo.Object, mockMediator.Object, mockLlm.Object,
+            new Mock<IImagePreprocessor>().Object, mockExtractor.Object,
+            new Mock<ILogger<AskSessionAgentCommandHandler>>().Object,
+            mockFlags.Object);
+
+        // Act — empty turn text.
+        await handler.Handle(new AskSessionAgentCommand(sessionId, senderId, "", 1), TestContext.Current.CancellationToken);
+
+        // Assert — retrieval query derived from vision terms, and the user message shows the same query.
+        mockMediator.Verify(m => m.Send(
+            It.Is<AskGroundedSessionQuery>(q => q.Question.Contains("settlements") && q.Question.Contains("board state")),
+            It.IsAny<CancellationToken>()), Times.Once);
+        capturedUserMessage.Should().NotBeNull();
+        capturedUserMessage!.Content.Should().Contain("settlements", "the user message shows the vision-derived query (transparency)");
+    }
+
+    [Fact]
+    public async Task Handle_VisionExpansionOn_EmptyText_NoVision_UsesFallbackQuery()
+    {
+        // Arrange — empty turn text, flag ON, but no vision snapshot → deterministic fallback query.
+        var sessionId = Guid.NewGuid();
+        var senderId = Guid.NewGuid();
+        var session = CreateSessionWithParticipant(sessionId, senderId);
+
+        var mockSessionRepo = new Mock<ISessionRepository>();
+        mockSessionRepo.Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>())).ReturnsAsync(session);
+        var mockChatRepo = new Mock<ISessionChatRepository>();
+        mockChatRepo.SetupSequence(r => r.GetNextSequenceNumberAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1).ReturnsAsync(2);
+        var mockExtractor = new Mock<IGameStateExtractor>(); // ExtractIfNeededAsync → null (no snapshot)
+
+        var mockMediator = new Mock<IMediator>();
+        mockMediator
+            .Setup(m => m.Send(It.IsAny<AskGroundedSessionQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GroundedSessionAnswerDto("No match.", new List<Api.Models.CitationDto>(), GroundingStatus.Ungrounded, null));
+        var mockLlm = new Mock<ILlmService>();
+
+        var mockFlags = new Mock<IFeatureFlagService>();
+        mockFlags.Setup(f => f.IsEnabledAsync(FeatureFlagConstants.LiveVisionQueryExpansionKey, It.IsAny<Api.Infrastructure.Entities.UserRole?>())).ReturnsAsync(true);
+        mockFlags.Setup(f => f.IsEnabledAsync(FeatureFlagConstants.LiveImageRetrievalKey, It.IsAny<Api.Infrastructure.Entities.UserRole?>())).ReturnsAsync(true);
+
+        var handler = new AskSessionAgentCommandHandler(
+            mockSessionRepo.Object, mockChatRepo.Object, mockMediator.Object, mockLlm.Object,
+            new Mock<IImagePreprocessor>().Object, mockExtractor.Object,
+            new Mock<ILogger<AskSessionAgentCommandHandler>>().Object,
+            mockFlags.Object);
+
+        // Act — whitespace text.
+        await handler.Handle(new AskSessionAgentCommand(sessionId, senderId, "   ", 1), TestContext.Current.CancellationToken);
+
+        // Assert — deterministic fallback retrieval query.
+        mockMediator.Verify(m => m.Send(
+            It.Is<AskGroundedSessionQuery>(q => q.Question == "What should I do now based on the current board state?"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
     private static MeterListener BuildCounterListener(
         string metricName,
         List<(long Value, Dictionary<string, object?> Tags)> captures)

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Validators/ChatCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Validators/ChatCommandValidatorTests.cs
@@ -95,9 +95,22 @@ public class AskSessionAgentCommandValidatorTests
     [Fact]
     public void Validate_EmptyQuestion_ShouldFail()
     {
+        // Text-only turn (no image) still requires a question.
         var cmd = new AskSessionAgentCommand(Guid.NewGuid(), Guid.NewGuid(), "", 1);
         var result = _validator.Validate(cmd);
         result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validate_EmptyQuestion_WithImage_ShouldPass()
+    {
+        // #3390 Slice 3: an image turn may omit the question — the retrieval query is derived from
+        // the vision board-state. This is the guard the endpoint previously rejected upstream.
+        var cmd = new AskSessionAgentCommand(
+            Guid.NewGuid(), Guid.NewGuid(), "", 1,
+            new List<ChatImageAttachment> { new(new byte[] { 1, 2, 3 }, "image/jpeg", "board.jpg") });
+        var result = _validator.Validate(cmd);
+        result.IsValid.Should().BeTrue("an image turn may omit the question");
     }
 }
 


### PR DESCRIPTION
## Epic #3390 — Slice 3 di 5 (Query-expansion da vision)

Quando un turno in-sessione **non ha testo** (foto senza domanda), la query di retrieval viene **derivata dallo stato del tavolo** (vision) invece di rifiutare/perdere il turno. Completa il caso che lo Slice 2 lasciava scoperto.

## Comportamento (decisioni confermate con l'utente)

- **Trigger deterministico**: la derivazione scatta SOLO su testo vuoto — non scavalca mai una domanda reale.
- **Trasparenza**: la query derivata diventa **sia** la query di retrieval **sia** il messaggio dell'utente nel thread (l'utente vede cosa è stato chiesto al rulebook).
- Nuovo flag `rag.live-vision-query-expansion` (default **OFF**). La query è derivata dal JSON di `GameStateExtractor` (observations + game_phase + keyword `visible_elements`, parse difensivo, cap 400 char, fallback su vuoto/malformato). `gameState` estratto **prima** della user-message. Una sola variabile `effectiveQuery` sostituisce `request.Question` a valle (retrieval + LLM fallback).

## Code review — 1 BLOCKER trovato e risolto

Il finder ha rilevato che lo Slice 3 era **irraggiungibile in produzione**: il turno testo-vuoto veniva rifiutato a monte del handler da **due guardie** (validator `NotEmpty()` → 422, endpoint multipart → 400), e i test chiamavano `Handle` direttamente mascherando il gap (lesson #1555 "i test devono esercitare la pipeline reale"). **Fix**: il validator ora permette Question vuoto **solo con immagine allegata**; rimosso il guard ridondante dell'endpoint; test aggiunto sulla superficie di validazione reale (empty+image → valid, empty+no-image → invalid).

Verificato pulito dal finder: parse JSON difensivo (null/malformato/tipi/nesting con MaxDepth 64), cap substring, interazione flag, cancellation/metrica Slice 2 preservate, nessun log del contenuto (no PII).

## Test

- Handler: empty text + vision → query derivata dai termini dello stato (e mostrata nel messaggio utente); empty text + no vision → fallback deterministico.
- Validator: empty question + image → valid; empty + no image → invalid.
- **16/16 verdi**, build 0 errori.

## Roadmap restante

4. Enhancement live-path per-enhancement (richiede eval su staging) · 5. Ownership collapse ADR (consolida la duplicazione Slice 2).

Part of #3390. Epic #3397.

🤖 Generated with [Claude Code](https://claude.com/claude-code)