### PR TITLE
docs(adr): ADR-090 in-session grounded answer ownership (#3390 Slice 5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,6 +304,7 @@ tests/                    # Api.Tests, k6, api-smoke, llm-eval, fixtures — see
 | [ADR-062](./docs/for-claude/architecture/adr/adr-062-config-environment-field-semantics.md) | Config `Environment` field: default to `"All"` for global keys; per-env per-row only when value diverges by design |
 | [ADR-060](./docs/for-claude/architecture/adr/adr-060-live-session-persistence.md) | LiveSession is EF-backed. Command handlers calling `_sessionRepository.AddAsync`/`UpdateAsync` MUST also `await _unitOfWork.SaveChangesAsync(ct)`. Domain events dispatch post-SaveChanges. Optimistic concurrency via Postgres `xmin` (#2097 → #2305); same on `game_night_playlists`, `mechanic_drafts` (#2306) |
 | [ADR-078](./docs/for-claude/architecture/adr/adr-078-auto-issue-noise-thresholds.md) | Every `.github/workflows/*-monitor.yml` (cron calling GH Issues Search API) MUST declare `concurrency: group: monitor-<type>-${{ github.ref }}` to stay under the 1k req/h rate limit (advisory) |
+| [ADR-090](./docs/for-claude/architecture/adr/adr-090-in-session-grounded-answer-ownership.md) | In-session grounded answer: `KnowledgeBase` OWNS it; `SessionTracking` consumes via `IMediator` (never inject KB services), public DTO boundary. The #3390 grounded pipeline is duplicated across `AskGroundedSessionQueryHandler` + `ChatWithSessionAgentCommandHandler` — a correctness/copyright fix must touch both until consolidated on a shared KB service (where Slice 4 enhancements wire) |
 
 ---
 

--- a/docs/for-claude/architecture/adr/README.md
+++ b/docs/for-claude/architecture/adr/README.md
@@ -58,13 +58,14 @@ Architecture Decision Records for MeepleAI. Each ADR captures significant archit
 | [054](adr-054-devops-multi-branch-strategy.md) | DevOps Multi-Branch Strategy | 2026-05-08 | Accepted |
 | [058](adr-058-canonical-log-sanitizers.md) | Canonical Log Sanitizers (PII masking + log-forging) | 2026-05-15 | Proposed |
 
-### Knowledge Base & RAG (080–089)
+### Knowledge Base & RAG (080–090)
 
 > Nota: 060–087 esistono su disco ma le loro righe README non sono state aggiunte nei rispettivi PR (drift pre-esistente, vedi nota in fondo). Questa sezione elenca solo l'ADR aggiunto dal suo PR.
 
 | ADR | Title | Date | Status |
 |-----|-------|------|--------|
 | [088](adr-088-mechanic-cards-as-rag-retrieval-source.md) | Mechanic Cards as RAG Retrieval Source | 2026-07-30 | Proposed |
+| [090](adr-090-in-session-grounded-answer-ownership.md) | In-Session Grounded Answer Ownership (KnowledgeBase owner, SessionTracking consumer) | 2026-08-02 | Accepted |
 
 ## ADR Lifecycle
 

--- a/docs/for-claude/architecture/adr/adr-090-in-session-grounded-answer-ownership.md
+++ b/docs/for-claude/architecture/adr/adr-090-in-session-grounded-answer-ownership.md
@@ -1,0 +1,92 @@
+# ADR-090 — Ownership della risposta grounded in-sessione: KnowledgeBase owner, SessionTracking consumer
+
+**Date**: 2026-08-02
+**Status**: Accepted — ratifica la relazione Customer/Supplier già **in vigore** dopo #3390 Slice 2 e ne fissa la direzione di consolidamento (ritiro della duplicazione controllata).
+**Issue**: #3390 (epic "unificare la risposta dell'agente in-sessione dietro un unico contratto RAG grounded") Slice 5 — parte del programma-ombrello #3397; finding C1/C10 dell'audit `docs/for-developers/audits/2026-07-29-in-session-agent-grounding-audit.md`.
+**Related**: ADR-089 (SSOT sessione/scoring — dichiara che #3390 possiede la *risposta grounded*, non lo scoring; **prerequisito di lettura**), ADR-083 (convergenza aggregati live; chat-RAG keyed su `LiveGameSession.Id`), #3388 (contratto `groundingStatus`), #3389 (`RetrievalPolicy.LiveSession`).
+
+## Context
+
+L'audit del 2026-07-29 (§3, consenso 5/5) ha diagnosticato che *"il confine è tracciato lungo la costura sbagliata: la modalità di input ha leakato fino a biforcare la Published Language"*. Due bounded context esponevano **due contratti divergenti** per la **stessa** capacità di dominio — *"rispondi alla domanda dell'utente sulle regole"*:
+
+- `KnowledgeBase` → `ChatWithSessionAgentCommandHandler` (RAG con citazioni, path testo, SSE streaming).
+- `SessionTracking` → `AskSessionAgentCommandHandler` (LLM multimodale **senza** retrieval, path immagine, non-streaming) — silenziosamente non-grounded.
+
+Gli slice 1–3 di #3390 hanno chiuso il gap **funzionale**:
+- **Slice 1** (#3480): osservabilità del grounding (`meepleai.agent.response.grounding`).
+- **Slice 2** (#3484): il path immagine ora consuma il retrieval grounded di KnowledgeBase via una query MediatR (`AskGroundedSessionQuery` → `GroundedSessionAnswerDto`), dietro flag `rag.live-image-retrieval`, con budget latenza + fallback.
+- **Slice 3** (#3485): query di retrieval derivata dalla vision quando il turno è senza testo.
+
+La relazione **Customer/Supplier** è quindi **già in vigore**: SessionTracking consuma KnowledgeBase via `IMediator.Send`, mai iniettando un servizio KB (regola DDD `CLAUDE.md`: *"Direct service injection (use MediatR)"*), e riceve un DTO pubblico — **non** i modelli `internal` `AssembledPrompt`/`ChunkCitation`. Ciò che resta **non formalizzato** — e che questo ADR fissa — è: (a) la dichiarazione esplicita di **ownership**, e (b) la direzione per ritirare la **duplicazione controllata** che lo Slice 2 ha consapevolmente introdotto (dichiarata nel doc-comment di `AskGroundedSessionQueryHandler`).
+
+Questo ADR non introduce codice: fissa il contratto architetturale, ancorato al codice reale (i `file:line` sotto sono stati letti/scritti in #3390, non inferiti).
+
+## La duplicazione verificata
+
+La generazione della risposta **grounded** esiste oggi in **due** handler, entrambi in `KnowledgeBase`, con lo **stesso** pipeline logico e **due** shape di orchestrazione (streaming vs one-shot):
+
+| Passo del pipeline grounded | `ChatWithSessionAgentCommandHandler` (SSE, path testo) | `AskGroundedSessionQueryHandler` (one-shot, path immagine, #3390 Slice 2) |
+|---|---|---|
+| Assemble prompt + retrieval (`RetrievalPolicy.LiveSession`, enhancement OFF) | `:246-259` (`AssemblePromptAsync`) | `AssemblePromptAsync(..., RetrievalPolicy.LiveSession)` |
+| Resolve copyright tier | `:266-267` (`ICopyrightTierResolver.ResolveAsync`) | idem |
+| Generate LLM (text-only) | `_llmService.GenerateCompletionStreamAsync` (stream) | `_llmService.GenerateCompletionAsync` (one-shot) |
+| Copyright leak guard (fail-open scan, sanitize fail-closed) | `:503-557` | replicato (sanitize fuori dal try, fix review Slice 2) |
+| Map `ChunkCitation` → `CitationDto` (tier-nulling) | `:651-663` | replicato identico |
+| Grounding da citation count (#3388) | `:715` (`count > 0 ? Grounded : Ungrounded`) | idem |
+| Confidence | `:739` (`RagPromptAssemblyService.ComputeConfidence`) | idem |
+
+**File**: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentCommandHandler.cs`; `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/AskGroundedSessionQueryHandler.cs`. Contratto pubblico consumato da SessionTracking: `AskGroundedSessionQuery.cs` / `GroundedSessionAnswerDto.cs` (`Api.Models.CitationDto` wire shape), invocato da `SessionTracking/Application/Commands/ChatCommandHandlers.cs` (`AskSessionAgentCommandHandler.Handle`) via `_mediator.Send`.
+
+**Rischio concreto della duplicazione** (motivo del ritiro): la review avversariale dello Slice 2 ha trovato un difetto di **sicurezza copyright** — la sanitizzazione del leak dentro il `try` fail-open poteva spedire testo verbatim se il sanitize lanciava. Il fix è stato applicato **solo** in `AskGroundedSessionQueryHandler`; lo stesso pattern nel path SSE è corretto per costruzione (iterator constraints) ma la lezione è generale: un difetto di correttezza sul pipeline grounded va corretto in *N* posti finché la logica è duplicata. Finché coesistono due copie, ogni fix/feature (nuovi enhancement dello Slice 4, copyright, citazioni) rischia di divergere.
+
+## Decisione
+
+### 1. Ownership dichiarata (Customer/Supplier)
+
+`KnowledgeBase` è il **proprietario unico e autoritativo** della capacità *"risposta grounded sul rulebook"* (retrieval + citazioni + `groundingStatus`). Coerente con ADR-089 (tabella responsabilità → SSOT, riga *"Chat-RAG con citazioni"* → `KnowledgeBase`, keyed su `LiveGameSession.Id`).
+
+`SessionTracking` è **consumer** di quella capacità per il path in-sessione (immagine/testo). Vincoli di consumo (già rispettati, qui ratificati):
+- Consumo **solo** via `IMediator` (nessuna injection di servizi KB cross-BC).
+- Confine di Published Language = **DTO pubblico** (`GroundedSessionAnswerDto`, `Api.Models.CitationDto`). SessionTracking **non** referenzia mai i modelli `internal` di KB (`AssembledPrompt`/`ChunkCitation`).
+- SessionTracking possiede sessione, stato-tavolo (vision), persistenza chat-message, budget/fallback e la scelta di path; **non** possiede la generazione grounded.
+
+### 2. Direzione — consolidare il pipeline grounded in un servizio KB condiviso
+
+La generazione grounded (assemble → tier resolve → generate → leak guard → map citazioni → grounding/confidence) va estratta in **un unico servizio di applicazione interno a KnowledgeBase** (working name `IGroundedAnswerService`), consumato da **entrambi** gli handler:
+- `ChatWithSessionAgentCommandHandler` (adapter **streaming**: thread/AgentSession, broadcast live, summary — resta owner di questi concern).
+- `AskGroundedSessionQueryHandler` (adapter **one-shot**: query dedicata).
+
+Il servizio incapsula il pipeline e i suoi invarianti (LiveSession policy, CRAG web OFF, leak-guard fail-closed sul sanitize, grounding da citation count #3388). I due handler diventano **adapter sottili** sulla forma di consegna (stream di token vs risposta unica), non due implementazioni del pipeline.
+
+**Questo ADR dichiara la direzione, non esegue il refactoring** (vedi Follow-up). Il refactoring è a scope chiuso e a rischio contenuto: il pipeline non-streaming è già isolato in `AskGroundedSessionQueryHandler` (Slice 2), quindi il consolidamento parte da lì; il path SSE ha un vincolo iterator che l'estrazione deve rispettare (la generazione streaming resta nel handler, il servizio espone i passi non-streaming attorno al token-stream).
+
+### 3. Fuori scope
+
+- **Scoring**: ADR-089 è esplicito — #3390 riguarda la *risposta dell'agente*, **non** lo scoring. Questo ADR non tocca `RoundScores`/`ScoreData`/`ScoreEntry`.
+- **Rimozione del path multimodale-puro**: il fallback multimodale (quando il retrieval fallisce/scade o l'immagine non è coperta dal rulebook) resta e resta legittimamente `Ungrounded` (#3388). L'ownership collapse **non** elimina il fallback; unifica la sola generazione *grounded*.
+
+## Consequences
+
+### Positive
+- Un solo posto possiede il pipeline grounded → un fix di correttezza/sicurezza (es. leak-guard) vive in un punto solo; gli enhancement dello Slice 4 si cablano una volta.
+- La Published Language è dichiarata: SessionTracking non può accidentalmente accoppiarsi ai modelli interni di KB.
+- Sblocca lo Slice 4 (enhancement live-path) su una superficie unica, non su due copie divergenti.
+
+### Negative / debt
+- Il refactoring del servizio condiviso è debito reale, qui **dichiarato ma non eseguito**. Finché non è fatto, la duplicazione controllata resta e va tenuta allineata a mano (un fix sul pipeline grounded va verificato in entrambi gli handler).
+- L'estrazione deve accomodare due forme di consegna (streaming vs one-shot) senza rompere il vincolo iterator del path SSE: complessità non banale, da fare con test di parità di comportamento tra i due path.
+
+### Neutral
+- Nessun cambiamento di schema, DTO wire o API. Nessun impatto su test esistenti. I due flag di #3390 (`rag.live-image-retrieval`, `rag.live-vision-query-expansion`) restano default OFF: il comportamento in produzione è invariato.
+
+## Follow-up (tracciati, non parte di questo ADR)
+- **Refactoring `IGroundedAnswerService`**: estrarre il pipeline grounded condiviso; far diventare i due handler adapter (streaming/one-shot); test di parità di comportamento. Da aprire come issue di cleanup figlia di #3390.
+- **Slice 4** (#3390) — enhancement live-path per-enhancement, misurati vs baseline su staging (citation-accuracy → 0.80, no regressione, CRAG web OFF): da cablare **sul servizio consolidato**, non sulle due copie.
+- Follow-up minori ereditati dallo Slice 2: `RetrievalBudgetMs` vive nel namespace KB (`SessionAgentOptions`) mentre il budget è concern SessionTracking (mild BC-coupling, LOW); `wikidata-sse.yml` non montato in `docker-compose.yml` dev (pre-esistente).
+
+## References
+- Epic #3390; audit `docs/for-developers/audits/2026-07-29-in-session-agent-grounding-audit.md` (finding C1 — doppio backend chat in-session; §3 lente 🏗️ architettura); programma-ombrello #3397.
+- PR #3480 (Slice 1), #3484 (Slice 2), #3485 (Slice 3).
+- ADR-089 (SSOT sessione/scoring; tabella responsabilità → SSOT, riga Chat-RAG → KnowledgeBase), ADR-083 (chat-RAG keyed su `LiveGameSession.Id`), #3388 (`groundingStatus`), #3389 (`RetrievalPolicy.LiveSession`).
+- Codice: `KnowledgeBase/Application/Commands/ChatWithSessionAgentCommandHandler.cs`, `KnowledgeBase/Application/Queries/{AskGroundedSessionQuery,AskGroundedSessionQueryHandler}.cs`, `KnowledgeBase/Application/DTOs/GroundedSessionAnswerDto.cs`, `SessionTracking/Application/Commands/ChatCommandHandlers.cs`.
+- CLAUDE.md § Known Pitfalls (pointer a questo ADR).


### PR DESCRIPTION
## Epic #3390 — Slice 5 di 5 (Ownership collapse — ADR)

Documento di decisione architettonica (nessun codice). **Completa la roadmap dell'epic** dichiarando formalmente l'ownership della capacità *"risposta grounded sul rulebook"* e fissando la direzione per consolidare la duplicazione introdotta dallo Slice 2.

## Decisione

- **`KnowledgeBase` è l'owner unico** della risposta grounded (retrieval + citazioni + `groundingStatus`), coerente con ADR-089 (tabella responsabilità → SSOT, riga Chat-RAG → KnowledgeBase).
- **`SessionTracking` è consumer** (Customer/Supplier): consuma via `IMediator`, riceve un DTO pubblico, non tocca mai i modelli `internal` di KB. Ratifica la relazione **già in vigore** dopo lo Slice 2.
- **Direzione**: consolidare il pipeline grounded (assemble → tier resolve → generate → leak guard → map citazioni → grounding) — oggi duplicato tra `AskGroundedSessionQueryHandler` (one-shot) e `ChatWithSessionAgentCommandHandler` (streaming) — in un servizio KB condiviso (`IGroundedAnswerService`), su cui lo **Slice 4** cablerà gli enhancement una volta sola. L'ADR **dichiara** la direzione, non esegue il refactoring (follow-up tracciato).

Il rischio concreto della duplicazione è documentato: la review dello Slice 2 ha trovato un difetto di sicurezza copyright fixato in un solo handler — finché il pipeline è duplicato, ogni fix va applicato in N posti.

## Fuori scope (esplicito)

- **Scoring** (ADR-089 lo separa da #3390).
- **Rimozione del fallback multimodale-puro** (resta, legittimamente `Ungrounded` per #3388).

## Contenuto

- `docs/for-claude/architecture/adr/adr-090-in-session-grounded-answer-ownership.md` (ancorato al codice reale con file:line, come ADR-089).
- Riga nell'indice ADR (README, sezione 080–090).
- Pointer in `CLAUDE.md` § Known Pitfalls.

Con questo, i **5 slice dell'epic #3390 sono completi** (Slice 1 #3480, 2 #3484, 3 #3485, 5 #ADR; Slice 4 resta come lavoro di validazione su staging, tracciato nell'ADR come follow-up).

Part of #3390. Epic #3397.

🤖 Generated with [Claude Code](https://claude.com/claude-code)