### PR TITLE
feat(catalog): cover picker FE data layer (#3470 Slice 1d-c)

### DIFF
--- a/apps/web/src/hooks/admin/__tests__/useAssignCover.test.tsx
+++ b/apps/web/src/hooks/admin/__tests__/useAssignCover.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { type ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/api', () => ({
+  api: { admin: { assignCover: vi.fn() } },
+}));
+
+import { api } from '@/lib/api';
+import type { CoverCandidates } from '@/lib/api/schemas/admin/admin-cover.schemas';
+
+import { coverEditorKeys } from '../coverEditorKeys';
+import { useAssignCover } from '../useAssignCover';
+
+const mockAssign = api.admin.assignCover as ReturnType<typeof vi.fn>;
+const GAME_ID = '550e8400-e29b-41d4-a716-446655440000';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+  return {
+    queryClient,
+    invalidateSpy,
+    wrapper: ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+  };
+}
+
+const seededCandidates: CoverCandidates = {
+  gameId: GAME_ID,
+  candidates: [{ source: 'Pdf', previewUrl: 'https://r2.example/p.webp' }],
+  assignments: { card: null, hero: null, social: null },
+};
+
+describe('useAssignCover', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls api.admin.assignCover with gameId, context, and body', async () => {
+    mockAssign.mockResolvedValue({ context: 'Hero', source: 'Pdf', focalX: 0.5, focalY: 0.5 });
+    const body = { source: 'Pdf' as const, focalX: 0.5, focalY: 0.5 };
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAssignCover(), { wrapper });
+
+    result.current.mutate({ gameId: GAME_ID, context: 'Hero', body });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockAssign).toHaveBeenCalledWith(GAME_ID, 'Hero', body);
+  });
+
+  it('invalidates the candidates query and the shared-game detail on settle', async () => {
+    mockAssign.mockResolvedValue({ context: 'Hero', source: 'Pdf', focalX: 0.5, focalY: 0.5 });
+
+    const { wrapper, invalidateSpy } = createWrapper();
+    const { result } = renderHook(() => useAssignCover(), { wrapper });
+
+    result.current.mutate({
+      gameId: GAME_ID,
+      context: 'Hero',
+      body: { source: 'Pdf', focalX: 0.5, focalY: 0.5 },
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: coverEditorKeys.candidates(GAME_ID) });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['admin', 'shared-games', GAME_ID] });
+  });
+
+  it('optimistically updates the cached assignment for the pinned context', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    queryClient.setQueryData(coverEditorKeys.candidates(GAME_ID), seededCandidates);
+
+    // Keep the mutation pending so we can observe the optimistic cache state.
+    let resolveAssign: (v: unknown) => void = () => {};
+    mockAssign.mockReturnValue(
+      new Promise(resolve => {
+        resolveAssign = resolve;
+      })
+    );
+
+    const { result } = renderHook(() => useAssignCover(), { wrapper });
+
+    result.current.mutate({
+      gameId: GAME_ID,
+      context: 'Hero',
+      body: { source: 'Wikidata', focalX: 0.5, focalY: 0.5 },
+    });
+
+    await waitFor(() => {
+      const cached = queryClient.getQueryData<CoverCandidates>(coverEditorKeys.candidates(GAME_ID));
+      expect(cached?.assignments.hero).toBe('Wikidata');
+    });
+
+    resolveAssign({ context: 'Hero', source: 'Wikidata', focalX: 0.5, focalY: 0.5 });
+  });
+
+  it('rolls back the optimistic update when the pin fails', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    queryClient.setQueryData(coverEditorKeys.candidates(GAME_ID), seededCandidates);
+    mockAssign.mockRejectedValue(new Error('boom'));
+
+    const { result } = renderHook(() => useAssignCover(), { wrapper });
+
+    result.current.mutate({
+      gameId: GAME_ID,
+      context: 'Hero',
+      body: { source: 'Wikidata', focalX: 0.5, focalY: 0.5 },
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    const cached = queryClient.getQueryData<CoverCandidates>(coverEditorKeys.candidates(GAME_ID));
+    expect(cached?.assignments.hero).toBeNull();
+  });
+});

--- a/apps/web/src/hooks/admin/__tests__/useCoverCandidates.test.tsx
+++ b/apps/web/src/hooks/admin/__tests__/useCoverCandidates.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { type ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/api', () => ({
+  api: { admin: { getCoverCandidates: vi.fn() } },
+}));
+
+import { api } from '@/lib/api';
+
+import { useCoverCandidates } from '../useCoverCandidates';
+
+const mockGet = api.admin.getCoverCandidates as ReturnType<typeof vi.fn>;
+const GAME_ID = '550e8400-e29b-41d4-a716-446655440000';
+
+function createWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return {
+    queryClient,
+    wrapper: ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+  };
+}
+
+const candidates = {
+  gameId: GAME_ID,
+  candidates: [],
+  assignments: { card: null, hero: null, social: null },
+};
+
+describe('useCoverCandidates', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('fetches the cover candidates for the game', async () => {
+    mockGet.mockResolvedValue(candidates);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCoverCandidates(GAME_ID), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGet).toHaveBeenCalledWith(GAME_ID);
+    expect(result.current.data).toEqual(candidates);
+  });
+
+  it('does not fetch when gameId is empty (disabled query)', () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCoverCandidates(''), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/hooks/admin/__tests__/useRemoveCoverAssignment.test.tsx
+++ b/apps/web/src/hooks/admin/__tests__/useRemoveCoverAssignment.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { type ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/api', () => ({
+  api: { admin: { removeCoverAssignment: vi.fn() } },
+}));
+
+import { api } from '@/lib/api';
+import type { CoverCandidates } from '@/lib/api/schemas/admin/admin-cover.schemas';
+
+import { coverEditorKeys } from '../coverEditorKeys';
+import { useRemoveCoverAssignment } from '../useRemoveCoverAssignment';
+
+const mockRemove = api.admin.removeCoverAssignment as ReturnType<typeof vi.fn>;
+const GAME_ID = '550e8400-e29b-41d4-a716-446655440000';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+  return {
+    queryClient,
+    invalidateSpy,
+    wrapper: ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+  };
+}
+
+const seededCandidates: CoverCandidates = {
+  gameId: GAME_ID,
+  candidates: [{ source: 'Wikidata', previewUrl: 'https://r2.example/w.webp' }],
+  assignments: { card: 'Wikidata', hero: null, social: null },
+};
+
+describe('useRemoveCoverAssignment', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls api.admin.removeCoverAssignment with gameId and context', async () => {
+    mockRemove.mockResolvedValue(undefined);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useRemoveCoverAssignment(), { wrapper });
+
+    result.current.mutate({ gameId: GAME_ID, context: 'Card' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockRemove).toHaveBeenCalledWith(GAME_ID, 'Card');
+  });
+
+  it('invalidates the candidates query and the shared-game detail on settle', async () => {
+    mockRemove.mockResolvedValue(undefined);
+
+    const { wrapper, invalidateSpy } = createWrapper();
+    const { result } = renderHook(() => useRemoveCoverAssignment(), { wrapper });
+
+    result.current.mutate({ gameId: GAME_ID, context: 'Card' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: coverEditorKeys.candidates(GAME_ID) });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['admin', 'shared-games', GAME_ID] });
+  });
+
+  it('optimistically clears the cached assignment for the context', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    queryClient.setQueryData(coverEditorKeys.candidates(GAME_ID), seededCandidates);
+
+    let resolveRemove: (v: unknown) => void = () => {};
+    mockRemove.mockReturnValue(
+      new Promise(resolve => {
+        resolveRemove = resolve;
+      })
+    );
+
+    const { result } = renderHook(() => useRemoveCoverAssignment(), { wrapper });
+
+    result.current.mutate({ gameId: GAME_ID, context: 'Card' });
+
+    await waitFor(() => {
+      const cached = queryClient.getQueryData<CoverCandidates>(coverEditorKeys.candidates(GAME_ID));
+      expect(cached?.assignments.card).toBeNull();
+    });
+
+    resolveRemove(undefined);
+  });
+
+  it('rolls back the optimistic clear when the remove fails', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    queryClient.setQueryData(coverEditorKeys.candidates(GAME_ID), seededCandidates);
+    mockRemove.mockRejectedValue(new Error('boom'));
+
+    const { result } = renderHook(() => useRemoveCoverAssignment(), { wrapper });
+
+    result.current.mutate({ gameId: GAME_ID, context: 'Card' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    const cached = queryClient.getQueryData<CoverCandidates>(coverEditorKeys.candidates(GAME_ID));
+    expect(cached?.assignments.card).toBe('Wikidata');
+  });
+});

--- a/apps/web/src/hooks/admin/coverEditorKeys.ts
+++ b/apps/web/src/hooks/admin/coverEditorKeys.ts
@@ -1,0 +1,9 @@
+/**
+ * Admin Cover Picker — TanStack Query key factory (Epic #3470 — Slice 1d-c).
+ * Pattern mirrors `mechanicValidationKeys.ts` (nested `as const` tuples).
+ */
+
+export const coverEditorKeys = {
+  all: ['admin', 'cover-editor'] as const,
+  candidates: (gameId: string) => ['admin', 'cover-editor', 'candidates', gameId] as const,
+} as const;

--- a/apps/web/src/hooks/admin/useAssignCover.ts
+++ b/apps/web/src/hooks/admin/useAssignCover.ts
@@ -1,0 +1,73 @@
+/**
+ * Admin Cover Picker (Epic #3470 — Slice 1d-c).
+ *
+ * Mutation hook: pin a cover source (+ focal point) for a UI context. Optimistically
+ * updates the cached per-context assignment, rolls back on error, and invalidates the
+ * candidates query + the shared-game detail on settle. Wraps `api.admin.assignCover`.
+ *
+ * User-facing feedback is owned by the picker dialog (PR2), not this hook — matching
+ * the toast-free optimistic pattern of `useUpdateTierStrategyAccess`.
+ */
+
+'use client';
+
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
+
+import { api } from '@/lib/api';
+import type {
+  AssignCoverRequest,
+  CoverAssignment,
+  CoverCandidates,
+  CoverContext,
+} from '@/lib/api/schemas/admin/admin-cover.schemas';
+
+import { coverEditorKeys } from './coverEditorKeys';
+
+export interface UseAssignCoverVariables {
+  gameId: string;
+  context: CoverContext;
+  body: AssignCoverRequest;
+}
+
+interface AssignCoverMutationContext {
+  previous?: CoverCandidates;
+}
+
+/** Maps a `CoverContext` ("Card"/"Hero"/"Social") to its `assignments` object key. */
+function assignmentKey(context: CoverContext): keyof CoverCandidates['assignments'] {
+  return context.toLowerCase() as keyof CoverCandidates['assignments'];
+}
+
+export function useAssignCover(): UseMutationResult<
+  CoverAssignment,
+  Error,
+  UseAssignCoverVariables,
+  AssignCoverMutationContext
+> {
+  const queryClient = useQueryClient();
+
+  return useMutation<CoverAssignment, Error, UseAssignCoverVariables, AssignCoverMutationContext>({
+    mutationFn: ({ gameId, context, body }) => api.admin.assignCover(gameId, context, body),
+    onMutate: async ({ gameId, context, body }) => {
+      const key = coverEditorKeys.candidates(gameId);
+      await queryClient.cancelQueries({ queryKey: key });
+      const previous = queryClient.getQueryData<CoverCandidates>(key);
+      if (previous) {
+        queryClient.setQueryData<CoverCandidates>(key, {
+          ...previous,
+          assignments: { ...previous.assignments, [assignmentKey(context)]: body.source },
+        });
+      }
+      return { previous };
+    },
+    onError: (_error, { gameId }, mutationContext) => {
+      if (mutationContext?.previous) {
+        queryClient.setQueryData(coverEditorKeys.candidates(gameId), mutationContext.previous);
+      }
+    },
+    onSettled: (_data, _error, { gameId }) => {
+      queryClient.invalidateQueries({ queryKey: coverEditorKeys.candidates(gameId) });
+      queryClient.invalidateQueries({ queryKey: ['admin', 'shared-games', gameId] });
+    },
+  });
+}

--- a/apps/web/src/hooks/admin/useCoverCandidates.ts
+++ b/apps/web/src/hooks/admin/useCoverCandidates.ts
@@ -1,0 +1,23 @@
+/**
+ * Admin Cover Picker (Epic #3470 — Slice 1d-c).
+ *
+ * Query hook: the materialized cover source candidates + per-context assignments
+ * for a shared game. Wraps `api.admin.getCoverCandidates(gameId)`.
+ */
+
+'use client';
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { api } from '@/lib/api';
+import type { CoverCandidates } from '@/lib/api/schemas/admin/admin-cover.schemas';
+
+import { coverEditorKeys } from './coverEditorKeys';
+
+export function useCoverCandidates(gameId: string): UseQueryResult<CoverCandidates | null, Error> {
+  return useQuery({
+    queryKey: coverEditorKeys.candidates(gameId),
+    queryFn: () => api.admin.getCoverCandidates(gameId),
+    enabled: !!gameId,
+  });
+}

--- a/apps/web/src/hooks/admin/useRemoveCoverAssignment.ts
+++ b/apps/web/src/hooks/admin/useRemoveCoverAssignment.ts
@@ -1,0 +1,64 @@
+/**
+ * Admin Cover Picker (Epic #3470 — Slice 1d-c).
+ *
+ * Mutation hook: reset a UI context's cover to implicit precedence. Optimistically
+ * clears the cached per-context assignment, rolls back on error, and invalidates the
+ * candidates query + the shared-game detail on settle. Wraps `api.admin.removeCoverAssignment`.
+ */
+
+'use client';
+
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
+
+import { api } from '@/lib/api';
+import type { CoverCandidates, CoverContext } from '@/lib/api/schemas/admin/admin-cover.schemas';
+
+import { coverEditorKeys } from './coverEditorKeys';
+
+export interface UseRemoveCoverAssignmentVariables {
+  gameId: string;
+  context: CoverContext;
+}
+
+interface RemoveCoverMutationContext {
+  previous?: CoverCandidates;
+}
+
+/** Maps a `CoverContext` ("Card"/"Hero"/"Social") to its `assignments` object key. */
+function assignmentKey(context: CoverContext): keyof CoverCandidates['assignments'] {
+  return context.toLowerCase() as keyof CoverCandidates['assignments'];
+}
+
+export function useRemoveCoverAssignment(): UseMutationResult<
+  void,
+  Error,
+  UseRemoveCoverAssignmentVariables,
+  RemoveCoverMutationContext
+> {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, Error, UseRemoveCoverAssignmentVariables, RemoveCoverMutationContext>({
+    mutationFn: ({ gameId, context }) => api.admin.removeCoverAssignment(gameId, context),
+    onMutate: async ({ gameId, context }) => {
+      const key = coverEditorKeys.candidates(gameId);
+      await queryClient.cancelQueries({ queryKey: key });
+      const previous = queryClient.getQueryData<CoverCandidates>(key);
+      if (previous) {
+        queryClient.setQueryData<CoverCandidates>(key, {
+          ...previous,
+          assignments: { ...previous.assignments, [assignmentKey(context)]: null },
+        });
+      }
+      return { previous };
+    },
+    onError: (_error, { gameId }, mutationContext) => {
+      if (mutationContext?.previous) {
+        queryClient.setQueryData(coverEditorKeys.candidates(gameId), mutationContext.previous);
+      }
+    },
+    onSettled: (_data, _error, { gameId }) => {
+      queryClient.invalidateQueries({ queryKey: coverEditorKeys.candidates(gameId) });
+      queryClient.invalidateQueries({ queryKey: ['admin', 'shared-games', gameId] });
+    },
+  });
+}

--- a/apps/web/src/lib/api/clients/admin/__tests__/adminCoverClient.test.ts
+++ b/apps/web/src/lib/api/clients/admin/__tests__/adminCoverClient.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  CoverCandidatesSchema,
+  CoverAssignmentSchema,
+  type AssignCoverRequest,
+} from '@/lib/api/schemas/admin/admin-cover.schemas';
+
+import { createAdminCoverClient } from '../adminCoverClient';
+
+const GAME_ID = '550e8400-e29b-41d4-a716-446655440000';
+
+function makeHttp() {
+  return {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  };
+}
+
+describe('adminCoverClient', () => {
+  describe('getCoverCandidates', () => {
+    it('GETs the cover-candidates read shape with the CoverCandidatesSchema', async () => {
+      const http = makeHttp();
+      const payload = {
+        gameId: GAME_ID,
+        candidates: [],
+        assignments: { card: null, hero: null, social: null },
+      };
+      http.get.mockResolvedValue(payload);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const client = createAdminCoverClient(http as any);
+      const result = await client.getCoverCandidates(GAME_ID);
+
+      expect(http.get).toHaveBeenCalledWith(
+        `/api/v1/admin/shared-games/${GAME_ID}/cover-candidates`,
+        CoverCandidatesSchema
+      );
+      expect(result).toEqual(payload);
+    });
+  });
+
+  describe('assignCover', () => {
+    it('PUTs the pin to the per-context path with body + CoverAssignmentSchema', async () => {
+      const http = makeHttp();
+      const body: AssignCoverRequest = { source: 'Pdf', focalX: 0.25, focalY: 0.75 };
+      const assignment = { context: 'Hero', source: 'Pdf', focalX: 0.25, focalY: 0.75 };
+      http.put.mockResolvedValue(assignment);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const client = createAdminCoverClient(http as any);
+      const result = await client.assignCover(GAME_ID, 'Hero', body);
+
+      expect(http.put).toHaveBeenCalledWith(
+        `/api/v1/admin/shared-games/${GAME_ID}/cover-assignments/Hero`,
+        body,
+        CoverAssignmentSchema
+      );
+      expect(result).toEqual(assignment);
+    });
+  });
+
+  describe('removeCoverAssignment', () => {
+    it('DELETEs the per-context assignment path', async () => {
+      const http = makeHttp();
+      http.delete.mockResolvedValue(undefined);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const client = createAdminCoverClient(http as any);
+      await client.removeCoverAssignment(GAME_ID, 'Card');
+
+      expect(http.delete).toHaveBeenCalledWith(
+        `/api/v1/admin/shared-games/${GAME_ID}/cover-assignments/Card`
+      );
+    });
+  });
+});

--- a/apps/web/src/lib/api/clients/admin/adminCoverClient.ts
+++ b/apps/web/src/lib/api/clients/admin/adminCoverClient.ts
@@ -1,0 +1,58 @@
+/**
+ * Admin Cover Picker Client (Epic #3470 — Slice 1d-c)
+ *
+ * Read/write client for the admin cover-source picker. Wraps the merged backend
+ * endpoints under /admin/shared-games/{id}/cover-*. All three require the
+ * AdminOrEditorPolicy server-side (the FE role gate is progressive enhancement only).
+ */
+
+import {
+  CoverCandidatesSchema,
+  CoverAssignmentSchema,
+  type CoverCandidates,
+  type CoverAssignment,
+  type CoverContext,
+  type AssignCoverRequest,
+} from '../../schemas/admin/admin-cover.schemas';
+
+import type { HttpClient } from '../../core/httpClient';
+
+export function createAdminCoverClient(http: HttpClient) {
+  return {
+    /**
+     * GET the materialized cover source candidates (each with a presigned R2
+     * preview URL) plus the current per-context assignments. Returns null on 401.
+     */
+    async getCoverCandidates(gameId: string): Promise<CoverCandidates | null> {
+      return http.get(
+        `/api/v1/admin/shared-games/${encodeURIComponent(gameId)}/cover-candidates`,
+        CoverCandidatesSchema
+      );
+    },
+
+    /**
+     * PUT: pin a source (+ crop focal point) for a UI context. Returns the
+     * persisted assignment so the picker can reflect the new state without a round-trip.
+     */
+    async assignCover(
+      gameId: string,
+      context: CoverContext,
+      body: AssignCoverRequest
+    ): Promise<CoverAssignment> {
+      return http.put(
+        `/api/v1/admin/shared-games/${encodeURIComponent(gameId)}/cover-assignments/${encodeURIComponent(context)}`,
+        body,
+        CoverAssignmentSchema
+      );
+    },
+
+    /** DELETE: reset a context's cover to implicit precedence. Idempotent (204). */
+    async removeCoverAssignment(gameId: string, context: CoverContext): Promise<void> {
+      return http.delete(
+        `/api/v1/admin/shared-games/${encodeURIComponent(gameId)}/cover-assignments/${encodeURIComponent(context)}`
+      );
+    },
+  };
+}
+
+export type AdminCoverClient = ReturnType<typeof createAdminCoverClient>;

--- a/apps/web/src/lib/api/clients/admin/index.ts
+++ b/apps/web/src/lib/api/clients/admin/index.ts
@@ -20,3 +20,4 @@ export {
   type AdminMechanicMetricsClient,
   type MechanicMetricsFilters,
 } from './adminMechanicMetricsClient';
+export { createAdminCoverClient, type AdminCoverClient } from './adminCoverClient';

--- a/apps/web/src/lib/api/clients/adminClient.ts
+++ b/apps/web/src/lib/api/clients/adminClient.ts
@@ -17,6 +17,7 @@ import {
   createAdminMechanicExtractorValidationClient,
   createAdminProvidersClient,
   createAdminMechanicMetricsClient,
+  createAdminCoverClient,
 } from './admin';
 
 import type { HttpClient } from '../core/httpClient';
@@ -93,6 +94,7 @@ export function createAdminClient({ httpClient }: CreateAdminClientParams) {
     ...createAdminConfigClient(http),
     ...createAdminProvidersClient(http),
     ...createAdminMechanicMetricsClient(http),
+    ...createAdminCoverClient(http),
   };
 }
 

--- a/apps/web/src/lib/api/schemas/__tests__/admin-cover.schemas.test.ts
+++ b/apps/web/src/lib/api/schemas/__tests__/admin-cover.schemas.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Admin Cover Picker Schemas Tests (Epic #3470 — Slice 1d-c)
+ *
+ * Validates the Zod schemas parse the merged backend contract:
+ * - enums serialize as PascalCase names (JsonStringEnumConverter, no naming policy)
+ * - PropertyNamingPolicy=CamelCase, no DefaultIgnoreCondition → nulls ARE emitted
+ * - previewUrl/source/gameId/candidates/assignments/focalX/focalY required;
+ *   license/attribution/sourceUrl + assignments.card/hero/social nullable.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  CoverAssignmentSourceSchema,
+  CoverContextSchema,
+  CoverCandidateSchema,
+  CoverCandidatesSchema,
+  CoverAssignmentSchema,
+  AssignCoverRequestSchema,
+} from '../admin/admin-cover.schemas';
+
+// ── CoverAssignmentSourceSchema ─────────────────────────────────────────────
+
+describe('CoverAssignmentSourceSchema', () => {
+  it('accepts the 4 materialized sources (PascalCase from JsonStringEnumConverter)', () => {
+    ['Pdf', 'Bgg', 'Wikidata', 'Manual'].forEach(v => {
+      expect(CoverAssignmentSourceSchema.safeParse(v).success, `"${v}" should be valid`).toBe(true);
+    });
+  });
+
+  it('rejects lowercase, unknown, and non-string values', () => {
+    ['pdf', 'BGG', 'wikidata', 'Custom', 'User', '', null, 0].forEach(v => {
+      expect(CoverAssignmentSourceSchema.safeParse(v).success, `"${v}" should be invalid`).toBe(
+        false
+      );
+    });
+  });
+});
+
+// ── CoverContextSchema ──────────────────────────────────────────────────────
+
+describe('CoverContextSchema', () => {
+  it('accepts the 3 UI contexts (Card/Hero/Social)', () => {
+    ['Card', 'Hero', 'Social'].forEach(v => {
+      expect(CoverContextSchema.safeParse(v).success, `"${v}" should be valid`).toBe(true);
+    });
+  });
+
+  it('rejects lowercase and unknown contexts', () => {
+    ['card', 'HERO', 'Thumbnail', 'og', '', null].forEach(v => {
+      expect(CoverContextSchema.safeParse(v).success, `"${v}" should be invalid`).toBe(false);
+    });
+  });
+});
+
+// ── CoverCandidateSchema ────────────────────────────────────────────────────
+
+const validCandidate = {
+  source: 'Wikidata',
+  previewUrl: 'https://r2.example/cover-preview.webp',
+  license: 'CC BY-SA 4.0',
+  attribution: 'Jane Artist',
+  sourceUrl: 'https://commons.wikimedia.org/wiki/File:x.jpg',
+};
+
+describe('CoverCandidateSchema', () => {
+  it('parses a fully-populated candidate', () => {
+    const result = CoverCandidateSchema.safeParse(validCandidate);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.source).toBe('Wikidata');
+      expect(result.data.previewUrl).toBe('https://r2.example/cover-preview.webp');
+    }
+  });
+
+  it('accepts null license/attribution/sourceUrl (BE emits null, not omitted)', () => {
+    const result = CoverCandidateSchema.safeParse({
+      source: 'Pdf',
+      previewUrl: 'https://r2.example/pdf.webp',
+      license: null,
+      attribution: null,
+      sourceUrl: null,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.license).toBeNull();
+    }
+  });
+
+  it('accepts omitted optional metadata fields', () => {
+    const result = CoverCandidateSchema.safeParse({
+      source: 'Bgg',
+      previewUrl: 'https://r2.example/bgg.webp',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a missing source', () => {
+    const { source: _source, ...withoutSource } = validCandidate;
+    expect(CoverCandidateSchema.safeParse(withoutSource).success).toBe(false);
+  });
+
+  it('rejects a missing previewUrl (required, non-null in BE)', () => {
+    const { previewUrl: _previewUrl, ...withoutPreview } = validCandidate;
+    expect(CoverCandidateSchema.safeParse(withoutPreview).success).toBe(false);
+  });
+
+  it('rejects a null previewUrl', () => {
+    expect(CoverCandidateSchema.safeParse({ ...validCandidate, previewUrl: null }).success).toBe(
+      false
+    );
+  });
+});
+
+// ── CoverCandidatesSchema (the GET read shape) ──────────────────────────────
+
+const validCandidatesDto = {
+  gameId: '550e8400-e29b-41d4-a716-446655440000',
+  candidates: [validCandidate],
+  assignments: {
+    card: 'Wikidata',
+    hero: null,
+    social: null,
+  },
+};
+
+describe('CoverCandidatesSchema', () => {
+  it('parses the full read shape with a mix of assigned and null contexts', () => {
+    const result = CoverCandidatesSchema.safeParse(validCandidatesDto);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.assignments.card).toBe('Wikidata');
+      expect(result.data.assignments.hero).toBeNull();
+      expect(result.data.candidates).toHaveLength(1);
+    }
+  });
+
+  it('accepts an empty candidates array', () => {
+    const result = CoverCandidatesSchema.safeParse({ ...validCandidatesDto, candidates: [] });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts assignments with all contexts null (no explicit admin pin)', () => {
+    const result = CoverCandidatesSchema.safeParse({
+      ...validCandidatesDto,
+      assignments: { card: null, hero: null, social: null },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a missing assignments object', () => {
+    const { assignments: _assignments, ...withoutAssignments } = validCandidatesDto;
+    expect(CoverCandidatesSchema.safeParse(withoutAssignments).success).toBe(false);
+  });
+
+  it('rejects a non-uuid gameId', () => {
+    expect(CoverCandidatesSchema.safeParse({ ...validCandidatesDto, gameId: 'nope' }).success).toBe(
+      false
+    );
+  });
+
+  it('rejects an invalid enum inside assignments', () => {
+    const result = CoverCandidatesSchema.safeParse({
+      ...validCandidatesDto,
+      assignments: { card: 'custom', hero: null, social: null },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ── CoverAssignmentSchema (the PUT response) ────────────────────────────────
+
+describe('CoverAssignmentSchema', () => {
+  it('parses the persisted assignment returned by the write command', () => {
+    const result = CoverAssignmentSchema.safeParse({
+      context: 'Hero',
+      source: 'Pdf',
+      focalX: 0.42,
+      focalY: 0.5,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.context).toBe('Hero');
+      expect(result.data.focalX).toBe(0.42);
+    }
+  });
+
+  it('rejects a missing focal coordinate', () => {
+    expect(
+      CoverAssignmentSchema.safeParse({ context: 'Card', source: 'Pdf', focalX: 0.5 }).success
+    ).toBe(false);
+  });
+});
+
+// ── AssignCoverRequestSchema (the PUT body) ─────────────────────────────────
+
+describe('AssignCoverRequestSchema', () => {
+  it('parses a valid pin request with in-range focal point', () => {
+    const result = AssignCoverRequestSchema.safeParse({
+      source: 'Manual',
+      focalX: 0,
+      focalY: 1,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a focal coordinate outside 0..1', () => {
+    expect(
+      AssignCoverRequestSchema.safeParse({ source: 'Pdf', focalX: 1.5, focalY: 0.5 }).success
+    ).toBe(false);
+    expect(
+      AssignCoverRequestSchema.safeParse({ source: 'Pdf', focalX: 0.5, focalY: -0.1 }).success
+    ).toBe(false);
+  });
+
+  it('rejects a missing source', () => {
+    expect(AssignCoverRequestSchema.safeParse({ focalX: 0.5, focalY: 0.5 }).success).toBe(false);
+  });
+});

--- a/apps/web/src/lib/api/schemas/admin/admin-cover.schemas.ts
+++ b/apps/web/src/lib/api/schemas/admin/admin-cover.schemas.ts
@@ -1,0 +1,66 @@
+/**
+ * Admin Cover Picker Schemas (Epic #3470 — Slice 1d-c)
+ *
+ * Zod schemas for the admin cover-source picker read/write contract. Mirrors the
+ * merged backend records (CoverCandidatesDto, CoverAssignmentDto, AssignCoverRequest).
+ *
+ * Contract notes (verified against the API):
+ * - Enums serialize as PascalCase names (global JsonStringEnumConverter, no naming policy).
+ * - PropertyNamingPolicy=CamelCase; no DefaultIgnoreCondition → nullable fields are
+ *   emitted as `null` (not omitted). We still mark them `.nullable().optional()` to stay
+ *   robust against mocks and a future WhenWritingNull change.
+ * - `previewUrl` is a presigned R2 URL and is always non-null.
+ */
+
+import { z } from 'zod';
+
+/** The 4 materialized cover sources an admin may pin (CoverAssignmentSource). */
+export const CoverAssignmentSourceSchema = z.enum(['Pdf', 'Bgg', 'Wikidata', 'Manual']);
+export type CoverAssignmentSource = z.infer<typeof CoverAssignmentSourceSchema>;
+
+/** The 3 UI contexts a cover can be assigned for (CoverContext). */
+export const CoverContextSchema = z.enum(['Card', 'Hero', 'Social']);
+export type CoverContext = z.infer<typeof CoverContextSchema>;
+
+/** A single materialized cover source available to the picker (CoverCandidateDto). */
+export const CoverCandidateSchema = z.object({
+  source: CoverAssignmentSourceSchema,
+  previewUrl: z.string(),
+  license: z.string().nullable().optional(),
+  attribution: z.string().nullable().optional(),
+  sourceUrl: z.string().nullable().optional(),
+});
+export type CoverCandidate = z.infer<typeof CoverCandidateSchema>;
+
+/** Which source is currently pinned per context; null = implicit precedence (CoverContextAssignmentsDto). */
+export const CoverContextAssignmentsSchema = z.object({
+  card: CoverAssignmentSourceSchema.nullable().optional(),
+  hero: CoverAssignmentSourceSchema.nullable().optional(),
+  social: CoverAssignmentSourceSchema.nullable().optional(),
+});
+export type CoverContextAssignments = z.infer<typeof CoverContextAssignmentsSchema>;
+
+/** The cover-picker read shape (CoverCandidatesDto). */
+export const CoverCandidatesSchema = z.object({
+  gameId: z.string().uuid(),
+  candidates: z.array(CoverCandidateSchema),
+  assignments: CoverContextAssignmentsSchema,
+});
+export type CoverCandidates = z.infer<typeof CoverCandidatesSchema>;
+
+/** The persisted per-context assignment returned by the write command (CoverAssignmentDto). */
+export const CoverAssignmentSchema = z.object({
+  context: CoverContextSchema,
+  source: CoverAssignmentSourceSchema,
+  focalX: z.number(),
+  focalY: z.number(),
+});
+export type CoverAssignment = z.infer<typeof CoverAssignmentSchema>;
+
+/** Request body for the cover-picker upsert (AssignCoverRequest). Focal point is normalized 0..1. */
+export const AssignCoverRequestSchema = z.object({
+  source: CoverAssignmentSourceSchema,
+  focalX: z.number().min(0).max(1),
+  focalY: z.number().min(0).max(1),
+});
+export type AssignCoverRequest = z.infer<typeof AssignCoverRequestSchema>;

--- a/apps/web/src/lib/api/schemas/admin/index.ts
+++ b/apps/web/src/lib/api/schemas/admin/index.ts
@@ -10,3 +10,4 @@ export * from './admin-ai.schemas';
 export * from './admin-analytics.schemas';
 export * from './admin-system.schemas';
 export * from './admin-monitor.schemas';
+export * from './admin-cover.schemas';

--- a/docs/for-developers/specs/2026-08-02-slice-1dc-fe-cover-picker-design-delta.md
+++ b/docs/for-developers/specs/2026-08-02-slice-1dc-fe-cover-picker-design-delta.md
@@ -1,0 +1,79 @@
+# Slice 1d-c — FE admin cover picker: design-delta
+
+**Epic**: #3470 (admin cover editor su `/shared-games`)
+**Data**: 2026-08-02
+**Stato**: design ratificato, implementazione in corso (TDD, 4 PR)
+**Riferimento di partenza**: la spec di design dell'epic (`docs/for-developers/specs/2026-08-02-admin-cover-editor-design.md`, attualmente sul branch `docs/spec-admin-cover-editor`, non ancora in `main-dev`) — sezioni D3 (entry-point overlay inline role-gated su card/hero, nessuna nuova rotta), SD1 (contesti Card/Hero/Social), SD5 (pick tra sorgenti materializzate = AdminOrEditor).
+
+Questo documento riconcilia la spec D3 con la ricognizione del codice reale e ratifica le decisioni FE per l'ultima fetta rimasta (1d-c). Tutto il backend dell'epic è già mergiato in `main-dev` (1c-1 #3476, 1c-2 #3478, 1c-3 #3479, write #3481, 1d-a #3482, 1d-b #3483).
+
+## 1. Delta dalla ricognizione (assunzioni del handoff corrette)
+
+1. **La card pubblica è di fatto contract-locked.** `MeepleCardGame` è un adapter sottile su `MeepleCard`; con `href` presente `GridCard` renderizza **l'intera card come `<Link prefetch>`**. Un `<button>` interattivo dentro l'anchor viola `nested-interactive` (axe) e litiga con la navigazione. `MeepleCardProps` non ha `children`/slot. Due test di enforcement (`card-decision-table`, `no-inline-card-reimplementation` C4) + ESLint proteggono il componente.
+2. **L'hero del detail pubblico è montabile pulito.** Usa `detail-layout/hero.tsx` (NON `MeepleCard variant="hero"`): cover-div già `relative`, non link-wrapped. La pagina `(public)/shared-games/[id]/page-client.tsx` è già `'use client'`; sessione/ruolo raggiungibili.
+3. **`EditCoverOverlay` è solo il pulsante-matita**, non il modale. Il pattern a11y del modale (role=dialog, aria-modal, focus-trap, Escape) è il primitivo Radix `components/ui/overlays/dialog.tsx` (usato da `CustomCoverDialog`).
+4. **Niente riuso diretto per candidati/focal-point.** `CoverPagePicker` è un page-number picker propose→approve, **senza focal-point**. `CoverImagePicker` ha 3 tab placeholder/pdf/upload — concetto diverso dai candidati Pdf/Bgg/Wikidata/Manual — e **senza chip provenienza/licenza né griglia**. La griglia candidati e il focal-point control sono **new-build**.
+
+## 2. Decisioni ratificate
+
+- **Mount = hero + card** (scelta esplicita: coprire entrambe le superfici pubbliche di D3).
+- **Meccanica DS (card) = slot opzionale additivo, zero-diff quando assente.** Aggiungo `coverEditSlot?: ReactNode` a `MeepleCardProps` → `GridCard`. Quando assente (tutti i consumer attuali) l'output è byte-identico a oggi ⇒ zero blast radius, test verdi. Quando presente + `href`, `GridCard` avvolge `<Link>` + slot in un wrapper `relative` e monta lo slot come **sibling del Link** (fuori dall'anchor → niente nested-interactive); `group` e hover-lift si spostano sul wrapper così l'affordance traccia il sollevamento della card. `MeepleCardGame` inoltra il prop; l'iniezione avviene in `shared-games-grid.tsx`, che calcola `isEditorOrAbove` una volta sola e passa lo slot **solo agli admin** (non-admin ⇒ `undefined` ⇒ DOM invariato). I due test di enforcement non si attivano (nessun nuovo adapter `*Card`, nessuno star-glyph hand-rolled; `meeple-card/**` è escluso dagli scan).
+- **Meccanica DS (hero) = slot opzionale.** Aggiungo `coverOverlay?: ReactNode` a `detail-layout/hero.tsx`; iniezione role-gated in `page-client.tsx`.
+- **Affordance condivisa.** `AdminCoverEditAffordance(gameId, title)` possiede il `<button>` matita (stile `EditCoverOverlay`) + apre `AdminCoverSourceDialog`. Il DS (card/hero) espone solo uno slot cieco: non conosce admin/cover/dialog. Stesso nodo iniettato in entrambi gli slot.
+- **Gate = progressive enhancement, non boundary.** L'affordance è gated FE via `useAdminRole().isEditorOrAbove` (SD5), ma il server ri-autorizza ogni mutation (`AdminOrEditorPolicy`). `useCurrentUser` ha `staleTime:0` → l'affordance appare post-hydration (flash accettabile).
+- **Dialog.** Shell Radix `Dialog`; tab per-contesto Card/Hero/Social; candidati come thumbnail selezionabili con chip provenienza (`source`) + chip licenza; render **solo `previewUrl`** (R2 presigned, mai host BGG). `CoverFocalPointPicker`: dot draggabile normalizzato 0..1, keyboard-accessible, sopra l'anteprima del candidato scelto → alimenta `focalX/focalY`.
+
+## 3. Contratto BE (verificato sui record mergiati)
+
+Base FE via proxy Next: `/api/v1/admin/shared-games/{id}/...`. Enum serializzati come **nomi PascalCase** (`JsonStringEnumConverter` globale, nessuna naming policy sull'enum). `PropertyNamingPolicy=CamelCase`; **nessun `DefaultIgnoreCondition`** ⇒ i null sono emessi (campi nullable sempre presenti con valore `null`).
+
+**Enum**
+- `CoverAssignmentSource` = `"Pdf" | "Bgg" | "Wikidata" | "Manual"`.
+- `CoverContext` = `"Card" | "Hero" | "Social"`.
+
+**GET** `/admin/shared-games/{id}/cover-candidates` → 200 `CoverCandidatesDto`, 404 se gioco assente. Solo sorgenti MATERIALIZZATE.
+```
+CoverCandidatesDto {
+  gameId: string (guid)                       // req
+  candidates: CoverCandidateDto[]             // req (può essere vuoto)
+  assignments: {                              // req (oggetto sempre presente)
+    card:   "Pdf"|"Bgg"|"Wikidata"|"Manual" | null   // sempre presente, nullable
+    hero:   ... | null
+    social: ... | null
+  }
+}
+CoverCandidateDto {
+  source: "Pdf"|"Bgg"|"Wikidata"|"Manual"     // req
+  previewUrl: string                          // req, non-null (presigned R2)
+  license: string | null                      // nullable (emesso null)
+  attribution: string | null                  // nullable
+  sourceUrl: string | null                    // nullable
+}
+```
+
+**PUT** `/admin/shared-games/{id}/cover-assignments/{context}` (context path = `Card|Hero|Social`), body `{ source, focalX=0.5, focalY=0.5 }` → 200 `CoverAssignmentDto`, 400, 404. `AdminOrEditorPolicy`.
+```
+CoverAssignmentDto { context: CoverContext, source: CoverAssignmentSource, focalX: number, focalY: number }  // tutti req
+```
+
+**DELETE** `/admin/shared-games/{id}/cover-assignments/{context}` → 204 (idempotente).
+
+**Mappatura Zod (nullability):** `previewUrl`/`source`/`gameId`/`candidates`/`assignments`/`context`/`focalX`/`focalY` → required. `license`/`attribution`/`sourceUrl` e `assignments.card/hero/social` → `.nullable().optional()` (nullable-sempre-emessi; `.optional()` difensivo verso mock e futuri `WhenWritingNull`).
+
+## 4. Piano incrementi (4 PR mergeable → `main-dev`, TDD, review adversarial ciascuna)
+
+| PR | Contenuto | Rischio | Dipende da |
+|----|-----------|---------|------------|
+| 1 — data layer | Zod (`schemas/admin/admin-cover.schemas.ts`) + `clients/admin/adminCoverClient.ts` (get/assign/remove) + hook react-query (`hooks/admin/`: candidates query + assign/remove mutation, key factory, invalidate + optimistic) + unit test | Basso | — |
+| 2 — dialog+affordance | `components/features/cover-editor/`: `AdminCoverSourceDialog` + `CoverFocalPointPicker` + `AdminCoverEditAffordance` + test (MSW/hook mockati) + eventuale story | Medio | 1 |
+| 3 — hero mount | slot `coverOverlay` su `detail-layout/hero.tsx` + iniezione role-gated in `(public)/shared-games/[id]/page-client.tsx` + test | Basso-Medio | 2 |
+| 4 — card DS | `coverEditSlot` su `MeepleCard`/`GridCard` (+ forward `MeepleCardGame`) + iniezione in `shared-games-grid.tsx` + test (branch slot, href+slot no nested-interactive, non-admin no-wrapper) | Medio (isolato) | 2 |
+
+Sequenza 1 → 2 → 3 → 4: il valore hero atterra presto (PR3), il pezzo DS a rischio è isolato in coda (PR4).
+
+## 5. Vincoli (tutte le PR)
+
+- **BGG asset ban (#2123)**: solo `previewUrl`/`coverUrl`, mai host BGG (`cf.geekdo-images.com` ecc.); gate ESLint `local/no-bgg-host` + `pnpm lint:bgg`.
+- **Design token semantici**: `bg-background`/`bg-card`/`text-foreground`/entity utilities; mai colori hardcoded (ESLint `local/no-hardcoded-color-utility` = error).
+- **a11y AA blocking (axe)**: nessun fail color-contrast/ARIA; l'affordance sulla card DEVE restare fuori dall'anchor (no nested-interactive).
+- **TDD** (Vitest), un incremento mergeable per volta.


### PR DESCRIPTION
## Slice 1d-c PR 1/4 — FE cover picker data layer (epic #3470)

Last remaining slice of the admin cover editor (all backend merged). This PR is the **data layer** (Zod schemas + admin API client + react-query hooks); the dialog/affordance (PR2), hero mount (PR3), and card DS slot (PR4) follow.

### What's here
- **schemas/admin/admin-cover.schemas.ts** — `CoverAssignmentSource` (`Pdf|Bgg|Wikidata|Manual`) & `CoverContext` (`Card|Hero|Social`) enums, `CoverCandidate(s)`, `CoverAssignment`, `AssignCoverRequest`. Nullability verified field-by-field against the merged C# records (CamelCase, no `DefaultIgnoreCondition` → nulls emitted).
- **clients/admin/adminCoverClient.ts** — `getCoverCandidates` (GET, 401→null), `assignCover` (PUT + focal point), `removeCoverAssignment` (DELETE); wired into `api.admin`.
- **hooks/admin** — `useCoverCandidates` (query), `useAssignCover` / `useRemoveCoverAssignment` (optimistic per-context assignment update + rollback, invalidate candidates + admin detail).
- **34 unit tests** (schemas 21, client 3, hooks 10), TDD red→green. Toast-free by design — the picker dialog (PR2) owns user feedback.
- **docs**: Slice 1d-c FE design-delta spec reconciling the recon with D3 (card contract-lock → additive DS slot; focal-point/candidate picker are new-build; 4-PR plan).

### Verification
- 34/34 vitest green · `tsc --noEmit` clean · ESLint clean · adversarial subagent review (cross-checked every field vs the C# source) found no issues ≥80 confidence.

### Notes
- BGG asset ban (#2123) not implicated — no image hosts in the data layer.
- `AdminOrEditorPolicy` enforced server-side; the FE role gate is progressive enhancement (lands in PR3/PR4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
