### PR TITLE
feat(catalog): admin cover source picker overlay (#3470 Slice 1d-c)

### DIFF
--- a/apps/web/src/components/features/cover-editor/AdminCoverEditAffordance.tsx
+++ b/apps/web/src/components/features/cover-editor/AdminCoverEditAffordance.tsx
@@ -1,0 +1,60 @@
+/**
+ * AdminCoverEditAffordance (Epic #3470 — Slice 1d-c).
+ *
+ * The shared, self-positioning edit trigger injected into the card / hero cover
+ * slots on the PUBLIC shared-games surfaces (D3). Role-gated via useAdminRole:
+ * invisible to non-admins, so the `(public)` audience contract stays intact (#2118).
+ * Progressive enhancement only — the server re-authorizes every mutation.
+ *
+ * The button positions itself top-right of the (relative) cover slot and reveals on
+ * hover/focus (mockup #1824 pattern); it opens the AdminCoverSourceDialog overlay
+ * with no route/nav change.
+ */
+
+'use client';
+
+import { useState } from 'react';
+
+import { Pencil } from 'lucide-react';
+
+import { useAdminRole } from '@/hooks/useAdminRole';
+
+import { AdminCoverSourceDialog } from './AdminCoverSourceDialog';
+
+export interface AdminCoverEditAffordanceProps {
+  gameId: string;
+  title?: string;
+  className?: string;
+}
+
+export function AdminCoverEditAffordance({
+  gameId,
+  title,
+  className,
+}: AdminCoverEditAffordanceProps): React.JSX.Element | null {
+  const { isEditorOrAbove } = useAdminRole();
+  const [open, setOpen] = useState(false);
+
+  if (!isEditorOrAbove) return null;
+
+  return (
+    <>
+      <button
+        type="button"
+        aria-label="Modifica sorgente copertina"
+        onClick={() => setOpen(true)}
+        className={`absolute right-2 top-2 z-20 flex h-8 w-8 items-center justify-center rounded-md border border-border/50 bg-background/85 text-foreground shadow-sm backdrop-blur-md transition-opacity hover:bg-background focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring md:opacity-0 md:group-hover:opacity-100 ${
+          className ?? ''
+        }`}
+      >
+        <Pencil className="h-4 w-4" aria-hidden="true" />
+      </button>
+      <AdminCoverSourceDialog
+        gameId={gameId}
+        title={title}
+        open={open}
+        onClose={() => setOpen(false)}
+      />
+    </>
+  );
+}

--- a/apps/web/src/components/features/cover-editor/AdminCoverSourceDialog.tsx
+++ b/apps/web/src/components/features/cover-editor/AdminCoverSourceDialog.tsx
@@ -1,0 +1,258 @@
+/**
+ * AdminCoverSourceDialog (Epic #3470 — Slice 1d-c).
+ *
+ * The admin cover-source picker overlay (D3: no new route). Per-context tabs
+ * (Card/Hero/Social); each context lists the materialized source candidates as
+ * selectable thumbnails with a provenance + license chip, a focal-point control,
+ * and Apply / reset-to-implicit actions. Renders ONLY presigned previewUrl images
+ * (never a BGG host — #2123). Data/mutations come from the react-query hooks.
+ */
+
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/navigation/tabs';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/overlays/dialog';
+import { Button } from '@/components/ui/primitives/button';
+import { useAssignCover } from '@/hooks/admin/useAssignCover';
+import { useCoverCandidates } from '@/hooks/admin/useCoverCandidates';
+import { useRemoveCoverAssignment } from '@/hooks/admin/useRemoveCoverAssignment';
+import type {
+  CoverAssignmentSource,
+  CoverContext,
+} from '@/lib/api/schemas/admin/admin-cover.schemas';
+
+import { CoverFocalPointPicker } from './CoverFocalPointPicker';
+
+export interface AdminCoverSourceDialogProps {
+  gameId: string;
+  title?: string;
+  open: boolean;
+  onClose: () => void;
+}
+
+const CONTEXTS: readonly { value: CoverContext; label: string }[] = [
+  { value: 'Card', label: 'Card' },
+  { value: 'Hero', label: 'Hero' },
+  { value: 'Social', label: 'Social' },
+];
+
+const SOURCE_LABEL: Record<CoverAssignmentSource, string> = {
+  Pdf: 'PDF',
+  Bgg: 'BGG',
+  Wikidata: 'Wikidata',
+  Manual: 'Manuale',
+};
+
+const ASSIGN_KEY: Record<CoverContext, 'card' | 'hero' | 'social'> = {
+  Card: 'card',
+  Hero: 'hero',
+  Social: 'social',
+};
+
+const DEFAULT_FOCAL = { x: 0.5, y: 0.5 };
+
+export function AdminCoverSourceDialog({
+  gameId,
+  title,
+  open,
+  onClose,
+}: AdminCoverSourceDialogProps): React.JSX.Element {
+  // Gate the fetch on `open` so a mounted-but-closed dialog does not query.
+  const { data, isLoading, isError } = useCoverCandidates(open ? gameId : '');
+  const assign = useAssignCover();
+  const remove = useRemoveCoverAssignment();
+
+  const [activeContext, setActiveContext] = useState<CoverContext>('Card');
+  const [pendingSource, setPendingSource] = useState<CoverAssignmentSource | null>(null);
+  const [focal, setFocal] = useState(DEFAULT_FOCAL);
+  // The read shape carries no persisted focal, so the picker always starts at 0.5/0.5.
+  // Require an explicit change (candidate pick or focal move) before Applica is enabled,
+  // so a zero-interaction click can't silently re-center an already fine-tuned focal.
+  const [focalTouched, setFocalTouched] = useState(false);
+
+  const currentAssignment = data?.assignments[ASSIGN_KEY[activeContext]] ?? null;
+  const selectedSource = pendingSource ?? currentAssignment;
+  const selectedCandidate = data?.candidates.find(c => c.source === selectedSource) ?? null;
+  const dirty = pendingSource !== null || focalTouched;
+
+  const resetLocal = () => {
+    setPendingSource(null);
+    setFocal(DEFAULT_FOCAL);
+    setFocalTouched(false);
+  };
+
+  // Clear abandoned edit state when the dialog closes so it never resurfaces (and
+  // never becomes accidentally re-appliable) on the next open. The dialog component
+  // stays mounted across open/close, so this reset must be explicit.
+  useEffect(() => {
+    if (!open) {
+      setActiveContext('Card');
+      setPendingSource(null);
+      setFocal(DEFAULT_FOCAL);
+      setFocalTouched(false);
+    }
+  }, [open]);
+
+  const handleTabChange = (value: string) => {
+    setActiveContext(value as CoverContext);
+    resetLocal();
+  };
+
+  const handlePick = (source: CoverAssignmentSource) => {
+    setPendingSource(source);
+    setFocal(DEFAULT_FOCAL);
+    setFocalTouched(false);
+  };
+
+  const handleFocalChange = (next: { x: number; y: number }) => {
+    setFocal(next);
+    setFocalTouched(true);
+  };
+
+  const handleApply = () => {
+    if (!selectedSource) return;
+    assign.mutate({
+      gameId,
+      context: activeContext,
+      body: { source: selectedSource, focalX: focal.x, focalY: focal.y },
+    });
+  };
+
+  const handleReset = () => {
+    remove.mutate({ gameId, context: activeContext });
+    resetLocal();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={o => !o && onClose()}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Copertina{title ? ` — ${title}` : ''}</DialogTitle>
+          <DialogDescription>
+            Scegli la sorgente e il punto focale per ciascun contesto.
+          </DialogDescription>
+        </DialogHeader>
+
+        {isLoading && (
+          <p role="status" className="py-6 text-center text-sm text-muted-foreground">
+            Caricamento sorgenti…
+          </p>
+        )}
+        {isError && (
+          <p role="alert" className="py-6 text-center text-sm text-destructive">
+            Impossibile caricare le sorgenti copertina.
+          </p>
+        )}
+
+        {data && (
+          <Tabs value={activeContext} onValueChange={handleTabChange}>
+            <TabsList className="w-full">
+              {CONTEXTS.map(c => (
+                <TabsTrigger key={c.value} value={c.value} className="flex-1">
+                  {c.label}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+
+            {CONTEXTS.map(c => (
+              <TabsContent key={c.value} value={c.value} className="space-y-4">
+                {data.candidates.length === 0 ? (
+                  <p className="py-6 text-center text-sm text-muted-foreground">
+                    Nessuna sorgente copertina disponibile per questo gioco.
+                  </p>
+                ) : (
+                  <>
+                    <p className="text-sm text-muted-foreground">
+                      {currentAssignment
+                        ? `Attualmente: ${SOURCE_LABEL[currentAssignment]}`
+                        : 'Attualmente: automatico (precedenza implicita)'}
+                    </p>
+
+                    <ul className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+                      {data.candidates.map(cand => {
+                        const isSelected = cand.source === selectedSource;
+                        return (
+                          <li key={cand.source}>
+                            <button
+                              type="button"
+                              aria-pressed={isSelected}
+                              aria-label={`Copertina ${SOURCE_LABEL[cand.source]}${
+                                cand.license ? `, licenza ${cand.license}` : ''
+                              }`}
+                              onClick={() => handlePick(cand.source)}
+                              className={`flex w-full flex-col overflow-hidden rounded-lg border text-left transition-colors ${
+                                isSelected
+                                  ? 'border-primary ring-2 ring-primary'
+                                  : 'border-border hover:border-border-strong'
+                              }`}
+                            >
+                              {/* eslint-disable-next-line @next/next/no-img-element */}
+                              <img
+                                src={cand.previewUrl}
+                                alt={`Anteprima ${SOURCE_LABEL[cand.source]}`}
+                                loading="lazy"
+                                className="aspect-[2/3] w-full object-cover"
+                              />
+                              <span className="flex flex-wrap items-center gap-1 p-1.5">
+                                <span className="rounded bg-secondary px-1.5 py-0.5 text-xs font-medium text-secondary-foreground">
+                                  {SOURCE_LABEL[cand.source]}
+                                </span>
+                                {cand.license && (
+                                  <span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+                                    {cand.license}
+                                  </span>
+                                )}
+                              </span>
+                            </button>
+                          </li>
+                        );
+                      })}
+                    </ul>
+
+                    {selectedCandidate && (
+                      <div className="space-y-2">
+                        <p className="text-sm font-medium text-foreground">Punto focale</p>
+                        <CoverFocalPointPicker
+                          imageUrl={selectedCandidate.previewUrl}
+                          alt={`Anteprima ${SOURCE_LABEL[selectedCandidate.source]}`}
+                          x={focal.x}
+                          y={focal.y}
+                          onChange={handleFocalChange}
+                          label="Punto focale copertina"
+                        />
+                      </div>
+                    )}
+
+                    <div className="flex items-center justify-between gap-2">
+                      {currentAssignment ? (
+                        <Button variant="outline" onClick={handleReset} disabled={remove.isPending}>
+                          Reimposta ad automatico
+                        </Button>
+                      ) : (
+                        <span />
+                      )}
+                      <Button
+                        onClick={handleApply}
+                        disabled={!selectedSource || !dirty || assign.isPending}
+                      >
+                        Applica
+                      </Button>
+                    </div>
+                  </>
+                )}
+              </TabsContent>
+            ))}
+          </Tabs>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/features/cover-editor/CoverFocalPointPicker.tsx
+++ b/apps/web/src/components/features/cover-editor/CoverFocalPointPicker.tsx
@@ -1,0 +1,147 @@
+/**
+ * CoverFocalPointPicker (Epic #3470 — Slice 1d-c).
+ *
+ * A normalized (0..1) 2D focal-point control over a candidate cover preview. The
+ * draggable handle is a real <button> so it is keyboard-operable (arrow keys, one
+ * step per press) and screen-reader labeled; pointer drag on the area is a sighted-user
+ * convenience. Controlled: the parent owns { x, y } and receives updates via onChange.
+ */
+
+'use client';
+
+import {
+  useCallback,
+  useRef,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+} from 'react';
+
+export interface CoverFocalPointPickerProps {
+  imageUrl?: string | null;
+  alt?: string;
+  x: number;
+  y: number;
+  onChange: (next: { x: number; y: number }) => void;
+  disabled?: boolean;
+  label?: string;
+}
+
+const STEP = 0.05;
+const clamp01 = (n: number) => Math.max(0, Math.min(1, n));
+const round2 = (n: number) => Math.round(n * 100) / 100;
+const pct = (n: number) => `${round2(clamp01(n)) * 100}%`;
+
+export function CoverFocalPointPicker({
+  imageUrl,
+  alt,
+  x,
+  y,
+  onChange,
+  disabled = false,
+  label = 'Punto focale',
+}: CoverFocalPointPickerProps) {
+  const areaRef = useRef<HTMLDivElement>(null);
+
+  const emit = useCallback(
+    (nx: number, ny: number) => {
+      const next = { x: round2(clamp01(nx)), y: round2(clamp01(ny)) };
+      if (next.x !== x || next.y !== y) onChange(next);
+    },
+    [onChange, x, y]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: ReactKeyboardEvent<HTMLButtonElement>) => {
+      if (disabled) return;
+      switch (e.key) {
+        case 'ArrowLeft':
+          e.preventDefault();
+          emit(x - STEP, y);
+          break;
+        case 'ArrowRight':
+          e.preventDefault();
+          emit(x + STEP, y);
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          emit(x, y - STEP);
+          break;
+        case 'ArrowDown':
+          e.preventDefault();
+          emit(x, y + STEP);
+          break;
+        default:
+          break;
+      }
+    },
+    [disabled, emit, x, y]
+  );
+
+  const setFromPointer = useCallback(
+    (clientX: number, clientY: number) => {
+      const el = areaRef.current;
+      if (!el) return;
+      const rect = el.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) return;
+      emit((clientX - rect.left) / rect.width, (clientY - rect.top) / rect.height);
+    },
+    [emit]
+  );
+
+  const handlePointerDown = useCallback(
+    (e: ReactPointerEvent<HTMLDivElement>) => {
+      if (disabled) return;
+      e.currentTarget.setPointerCapture?.(e.pointerId);
+      setFromPointer(e.clientX, e.clientY);
+    },
+    [disabled, setFromPointer]
+  );
+
+  const handlePointerMove = useCallback(
+    (e: ReactPointerEvent<HTMLDivElement>) => {
+      if (disabled || e.buttons !== 1) return;
+      setFromPointer(e.clientX, e.clientY);
+    },
+    [disabled, setFromPointer]
+  );
+
+  const positionLabel = `${Math.round(clamp01(x) * 100)}% orizzontale, ${Math.round(
+    clamp01(y) * 100
+  )}% verticale`;
+
+  return (
+    // The keyboard-operable control is the <button> handle; the area's pointer handlers
+    // are a mouse/touch convenience only, so no static-element keyboard handler is needed.
+    <div
+      ref={areaRef}
+      data-testid="focal-area"
+      role="group"
+      aria-label={label}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      className={`relative aspect-video w-full overflow-hidden rounded-md border border-border bg-muted ${
+        disabled ? 'opacity-60' : 'cursor-crosshair'
+      }`}
+    >
+      {imageUrl ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={imageUrl} alt={alt ?? ''} className="h-full w-full object-cover" />
+      ) : (
+        <div
+          className="flex h-full w-full items-center justify-center text-sm text-muted-foreground"
+          aria-hidden="true"
+        >
+          Nessuna anteprima
+        </div>
+      )}
+      <button
+        type="button"
+        aria-label={`${label}: ${positionLabel}. Usa le frecce per regolare.`}
+        disabled={disabled}
+        onKeyDown={handleKeyDown}
+        style={{ left: pct(x), top: pct(y) }}
+        className="absolute z-10 h-5 w-5 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-background bg-primary shadow-md ring-offset-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none"
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/features/cover-editor/__tests__/AdminCoverEditAffordance.test.tsx
+++ b/apps/web/src/components/features/cover-editor/__tests__/AdminCoverEditAffordance.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/hooks/useAdminRole', () => ({ useAdminRole: vi.fn() }));
+
+// Stub the dialog so this unit test isolates the trigger + role gate + open/close.
+vi.mock('../AdminCoverSourceDialog', () => ({
+  AdminCoverSourceDialog: ({ open, onClose }: { open: boolean; onClose: () => void }) =>
+    open ? (
+      <div data-testid="cover-dialog">
+        <button type="button" onClick={onClose}>
+          close
+        </button>
+      </div>
+    ) : null,
+}));
+
+import { useAdminRole } from '@/hooks/useAdminRole';
+
+import { AdminCoverEditAffordance } from '../AdminCoverEditAffordance';
+
+const mockUseAdminRole = useAdminRole as unknown as ReturnType<typeof vi.fn>;
+const GID = '550e8400-e29b-41d4-a716-446655440000';
+
+function setRole(isEditorOrAbove: boolean) {
+  mockUseAdminRole.mockReturnValue({
+    user: null,
+    isSuperAdmin: false,
+    isAdminOrAbove: isEditorOrAbove,
+    isEditorOrAbove,
+    hasRole: () => false,
+    isLoading: false,
+  });
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('AdminCoverEditAffordance', () => {
+  it('renders nothing for a non-admin (invisible on public surfaces)', () => {
+    setRole(false);
+    const { container } = render(<AdminCoverEditAffordance gameId={GID} title="Catan" />);
+    expect(screen.queryByRole('button', { name: /copertina/i })).not.toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders a labeled edit trigger for an editor-or-above', () => {
+    setRole(true);
+    render(<AdminCoverEditAffordance gameId={GID} title="Catan" />);
+    expect(screen.getByRole('button', { name: /copertina/i })).toBeInTheDocument();
+    expect(screen.queryByTestId('cover-dialog')).not.toBeInTheDocument();
+  });
+
+  it('opens the source dialog on click and closes it via onClose', () => {
+    setRole(true);
+    render(<AdminCoverEditAffordance gameId={GID} title="Catan" />);
+
+    fireEvent.click(screen.getByRole('button', { name: /copertina/i }));
+    expect(screen.getByTestId('cover-dialog')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /close/i }));
+    expect(screen.queryByTestId('cover-dialog')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/features/cover-editor/__tests__/AdminCoverSourceDialog.test.tsx
+++ b/apps/web/src/components/features/cover-editor/__tests__/AdminCoverSourceDialog.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/hooks/admin/useCoverCandidates', () => ({ useCoverCandidates: vi.fn() }));
+vi.mock('@/hooks/admin/useAssignCover', () => ({ useAssignCover: vi.fn() }));
+vi.mock('@/hooks/admin/useRemoveCoverAssignment', () => ({ useRemoveCoverAssignment: vi.fn() }));
+
+import { useCoverCandidates } from '@/hooks/admin/useCoverCandidates';
+import { useAssignCover } from '@/hooks/admin/useAssignCover';
+import { useRemoveCoverAssignment } from '@/hooks/admin/useRemoveCoverAssignment';
+
+import { AdminCoverSourceDialog } from '../AdminCoverSourceDialog';
+
+const GID = '550e8400-e29b-41d4-a716-446655440000';
+
+const mockUseCandidates = useCoverCandidates as unknown as ReturnType<typeof vi.fn>;
+const mockUseAssign = useAssignCover as unknown as ReturnType<typeof vi.fn>;
+const mockUseRemove = useRemoveCoverAssignment as unknown as ReturnType<typeof vi.fn>;
+
+const candidatesData = {
+  gameId: GID,
+  candidates: [
+    {
+      source: 'Pdf',
+      previewUrl: 'https://r2.example/pdf.webp',
+      license: null,
+      attribution: null,
+      sourceUrl: null,
+    },
+    {
+      source: 'Wikidata',
+      previewUrl: 'https://r2.example/wiki.webp',
+      license: 'CC BY-SA 4.0',
+      attribution: 'Jane Artist',
+      sourceUrl: 'https://commons.wikimedia.org/wiki/File:x.jpg',
+    },
+  ],
+  assignments: { card: 'Pdf', hero: null, social: null },
+};
+
+let assignMutate: ReturnType<typeof vi.fn>;
+let removeMutate: ReturnType<typeof vi.fn>;
+
+function setCandidates(over: Partial<ReturnType<typeof mockUseCandidates>> = {}) {
+  mockUseCandidates.mockReturnValue({
+    data: candidatesData,
+    isLoading: false,
+    isError: false,
+    ...over,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  assignMutate = vi.fn();
+  removeMutate = vi.fn();
+  mockUseAssign.mockReturnValue({ mutate: assignMutate, isPending: false });
+  mockUseRemove.mockReturnValue({ mutate: removeMutate, isPending: false });
+  setCandidates();
+});
+
+function renderDialog(props: Partial<React.ComponentProps<typeof AdminCoverSourceDialog>> = {}) {
+  return render(
+    <AdminCoverSourceDialog gameId={GID} title="Catan" open onClose={vi.fn()} {...props} />
+  );
+}
+
+describe('AdminCoverSourceDialog', () => {
+  it('renders a titled dialog when open', () => {
+    renderDialog();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText(/Catan/)).toBeInTheDocument();
+  });
+
+  it('renders nothing when closed', () => {
+    renderDialog({ open: false });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('shows a loading state while candidates are fetching', () => {
+    setCandidates({ data: undefined, isLoading: true });
+    renderDialog();
+    expect(screen.getByText(/caricamento/i)).toBeInTheDocument();
+  });
+
+  it('renders the three UI-context tabs', () => {
+    renderDialog();
+    expect(screen.getByRole('tab', { name: /card/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /hero/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /social/i })).toBeInTheDocument();
+  });
+
+  it('renders candidate thumbnails from previewUrl with provenance + license chips', () => {
+    renderDialog();
+    const wikiCard = screen.getByRole('button', { name: /wikidata/i });
+    const img = within(wikiCard).getByRole('img');
+    expect(img).toHaveAttribute('src', 'https://r2.example/wiki.webp');
+    expect(within(wikiCard).getByText('CC BY-SA 4.0')).toBeInTheDocument();
+    // never a BGG host
+    expect(img.getAttribute('src')).not.toMatch(/geekdo|boardgamegeek/);
+  });
+
+  it('marks the currently-assigned source as pressed for the active context', () => {
+    renderDialog(); // default active = Card, assignments.card = 'Pdf'
+    expect(screen.getByRole('button', { name: /pdf/i })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: /wikidata/i })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+  });
+
+  it('assigns the selected source with the default focal point on Applica', () => {
+    renderDialog();
+    fireEvent.click(screen.getByRole('button', { name: /wikidata/i }));
+    fireEvent.click(screen.getByRole('button', { name: /applica/i }));
+    expect(assignMutate).toHaveBeenCalledWith({
+      gameId: GID,
+      context: 'Card',
+      body: { source: 'Wikidata', focalX: 0.5, focalY: 0.5 },
+    });
+  });
+
+  it('resets the active context to implicit precedence', () => {
+    renderDialog(); // Card has an assignment → reset available
+    fireEvent.click(screen.getByRole('button', { name: /automatico|reimposta/i }));
+    expect(removeMutate).toHaveBeenCalledWith({ gameId: GID, context: 'Card' });
+  });
+
+  it('shows an empty message when there are no candidates', () => {
+    setCandidates({ data: { ...candidatesData, candidates: [] } });
+    renderDialog();
+    expect(screen.getByText(/nessuna sorgente|nessun candidato/i)).toBeInTheDocument();
+  });
+
+  it('keeps Applica disabled until the admin picks a candidate or moves the focal', () => {
+    renderDialog(); // Card already assigned to Pdf, no interaction yet
+    expect(screen.getByRole('button', { name: /applica/i })).toBeDisabled();
+    fireEvent.click(screen.getByRole('button', { name: /wikidata/i }));
+    expect(screen.getByRole('button', { name: /applica/i })).toBeEnabled();
+  });
+
+  it('resets the pending selection when the dialog is closed and reopened', () => {
+    const onClose = vi.fn();
+    const { rerender } = render(
+      <AdminCoverSourceDialog gameId={GID} title="Catan" open onClose={onClose} />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /wikidata/i }));
+    expect(screen.getByRole('button', { name: /wikidata/i })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+
+    rerender(<AdminCoverSourceDialog gameId={GID} title="Catan" open={false} onClose={onClose} />);
+    rerender(<AdminCoverSourceDialog gameId={GID} title="Catan" open onClose={onClose} />);
+
+    // Stale pending pick cleared → the persisted assignment (Pdf) is selected again.
+    expect(screen.getByRole('button', { name: /pdf/i })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: /wikidata/i })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+  });
+});

--- a/apps/web/src/components/features/cover-editor/__tests__/CoverFocalPointPicker.test.tsx
+++ b/apps/web/src/components/features/cover-editor/__tests__/CoverFocalPointPicker.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { CoverFocalPointPicker } from '../CoverFocalPointPicker';
+
+function renderPicker(overrides: Partial<React.ComponentProps<typeof CoverFocalPointPicker>> = {}) {
+  const onChange = vi.fn();
+  const props = {
+    imageUrl: 'https://r2.example/preview.webp',
+    alt: 'Anteprima candidato',
+    x: 0.5,
+    y: 0.5,
+    onChange,
+    label: 'Punto focale copertina',
+    ...overrides,
+  };
+  const utils = render(<CoverFocalPointPicker {...props} />);
+  return { onChange, ...utils };
+}
+
+describe('CoverFocalPointPicker', () => {
+  it('renders the candidate preview image with its alt text', () => {
+    renderPicker();
+    expect(screen.getByRole('img', { name: 'Anteprima candidato' })).toHaveAttribute(
+      'src',
+      'https://r2.example/preview.webp'
+    );
+  });
+
+  it('positions the handle at the current focal value', () => {
+    renderPicker({ x: 0.25, y: 0.75 });
+    const handle = screen.getByRole('button', { name: /punto focale/i });
+    expect(handle.style.left).toBe('25%');
+    expect(handle.style.top).toBe('75%');
+  });
+
+  it('exposes the handle as a focusable button with an accessible name', () => {
+    renderPicker();
+    const handle = screen.getByRole('button', { name: /punto focale/i });
+    expect(handle.tabIndex).toBe(0);
+  });
+
+  it('moves the focal point right by one step on ArrowRight', () => {
+    const { onChange } = renderPicker({ x: 0.5, y: 0.5 });
+    fireEvent.keyDown(screen.getByRole('button', { name: /punto focale/i }), { key: 'ArrowRight' });
+    expect(onChange).toHaveBeenCalledWith({ x: 0.55, y: 0.5 });
+  });
+
+  it('moves the focal point down by one step on ArrowDown and up on ArrowUp', () => {
+    const { onChange } = renderPicker({ x: 0.5, y: 0.5 });
+    const handle = screen.getByRole('button', { name: /punto focale/i });
+    fireEvent.keyDown(handle, { key: 'ArrowDown' });
+    expect(onChange).toHaveBeenCalledWith({ x: 0.5, y: 0.55 });
+    onChange.mockClear();
+    fireEvent.keyDown(handle, { key: 'ArrowUp' });
+    expect(onChange).toHaveBeenCalledWith({ x: 0.5, y: 0.45 });
+  });
+
+  it('clamps at the boundary and does not emit when already at the edge', () => {
+    const { onChange } = renderPicker({ x: 0, y: 0 });
+    fireEvent.keyDown(screen.getByRole('button', { name: /punto focale/i }), { key: 'ArrowLeft' });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('sets the focal point from a pointer click, normalized by the area rect', () => {
+    const { onChange } = renderPicker();
+    const area = screen.getByTestId('focal-area');
+    vi.spyOn(area, 'getBoundingClientRect').mockReturnValue({
+      left: 0,
+      top: 0,
+      width: 200,
+      height: 300,
+      right: 200,
+      bottom: 300,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    fireEvent.pointerDown(area, { clientX: 150, clientY: 75 });
+
+    expect(onChange).toHaveBeenCalledWith({ x: 0.75, y: 0.25 });
+  });
+
+  it('does not emit when disabled', () => {
+    const { onChange } = renderPicker({ disabled: true });
+    fireEvent.keyDown(screen.getByRole('button', { name: /punto focale/i }), { key: 'ArrowRight' });
+    const area = screen.getByTestId('focal-area');
+    fireEvent.pointerDown(area, { clientX: 10, clientY: 10 });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/features/cover-editor/__tests__/cover-editor.axe.test.tsx
+++ b/apps/web/src/components/features/cover-editor/__tests__/cover-editor.axe.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * a11y (axe AA) coverage for the cover-editor overlay surfaces. The A11y gate is
+ * blocking (#2055 / a11y-baseline), so any ARIA/contrast violation here is a real
+ * regression. The Radix Dialog portals to document.body, so axe runs on the body.
+ */
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/hooks/admin/useCoverCandidates', () => ({ useCoverCandidates: vi.fn() }));
+vi.mock('@/hooks/admin/useAssignCover', () => ({ useAssignCover: vi.fn() }));
+vi.mock('@/hooks/admin/useRemoveCoverAssignment', () => ({ useRemoveCoverAssignment: vi.fn() }));
+
+import { useCoverCandidates } from '@/hooks/admin/useCoverCandidates';
+import { useAssignCover } from '@/hooks/admin/useAssignCover';
+import { useRemoveCoverAssignment } from '@/hooks/admin/useRemoveCoverAssignment';
+
+import { AdminCoverSourceDialog } from '../AdminCoverSourceDialog';
+import { CoverFocalPointPicker } from '../CoverFocalPointPicker';
+
+const GID = '550e8400-e29b-41d4-a716-446655440000';
+
+beforeEach(() => {
+  (useAssignCover as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+  });
+  (useRemoveCoverAssignment as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+  });
+  (useCoverCandidates as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+    isLoading: false,
+    isError: false,
+    data: {
+      gameId: GID,
+      candidates: [
+        {
+          source: 'Pdf',
+          previewUrl: 'https://r2.example/pdf.webp',
+          license: null,
+          attribution: null,
+          sourceUrl: null,
+        },
+        {
+          source: 'Wikidata',
+          previewUrl: 'https://r2.example/wiki.webp',
+          license: 'CC BY-SA 4.0',
+          attribution: 'Jane',
+          sourceUrl: 'https://commons.example/x',
+        },
+      ],
+      assignments: { card: 'Pdf', hero: null, social: null },
+    },
+  });
+});
+
+describe('cover-editor a11y (axe AA)', () => {
+  it('AdminCoverSourceDialog has no violations when open', async () => {
+    render(<AdminCoverSourceDialog gameId={GID} title="Catan" open onClose={vi.fn()} />);
+    expect(await axe(document.body)).toHaveNoViolations();
+  });
+
+  it('CoverFocalPointPicker has no violations', async () => {
+    const { container } = render(
+      <div className="relative">
+        <CoverFocalPointPicker
+          imageUrl="https://r2.example/wiki.webp"
+          alt="Anteprima Wikidata"
+          x={0.5}
+          y={0.5}
+          onChange={vi.fn()}
+          label="Punto focale copertina"
+        />
+      </div>
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/apps/web/src/components/features/cover-editor/index.ts
+++ b/apps/web/src/components/features/cover-editor/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Cover editor feature (Epic #3470 — Slice 1d-c). Admin cover-source picker
+ * overlay injected into the public shared-games card / hero cover slots.
+ */
+
+export {
+  AdminCoverEditAffordance,
+  type AdminCoverEditAffordanceProps,
+} from './AdminCoverEditAffordance';
+export { AdminCoverSourceDialog, type AdminCoverSourceDialogProps } from './AdminCoverSourceDialog';
+export { CoverFocalPointPicker, type CoverFocalPointPickerProps } from './CoverFocalPointPicker';


### PR DESCRIPTION
## Slice 1d-c PR 2/4 — admin cover-source picker overlay (epic #3470)

The admin cover-source picker UI (D3: no new route), consuming the PR1 (#3487) data layer. Injected into the public shared-games card/hero cover slots in PR3/PR4.

### Components (`apps/web/src/components/features/cover-editor/`)
- **CoverFocalPointPicker** — normalized 0..1 focal control. Keyboard (arrow-step + clamp, round-2) and pointer drag; the handle is a real `<button>` for keyboard/SR a11y.
- **AdminCoverSourceDialog** — Radix Dialog + per-context tabs (Card/Hero/Social); candidate thumbnails with provenance + license chips (renders `previewUrl` only, never a BGG host, #2123); focal picker; Applica/Reimposta wired to the assign/remove hooks.
- **AdminCoverEditAffordance** — role-gated pencil trigger (`useAdminRole.isEditorOrAbove`), invisible to non-admins; opens the dialog. Progressive enhancement (server re-authorizes every mutation).

### Correctness (adversarial review found & fixed 2 state-model bugs)
- **Dirty-guard**: Applica enables only after a real change → a zero-interaction click can't silently re-center an already fine-tuned focal point.
- **Reset on close**: local edit state clears when the dialog closes → an abandoned pick never resurfaces or becomes accidentally re-appliable on reopen.

### Verification
- 24 unit tests + axe AA (0 violations) · `tsc --noEmit` clean · ESLint `--max-warnings=0` clean · `pnpm lint:bgg` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
