### PR TITLE
feat(catalog): cover editor on shared-game hero (#3470 Slice 1d-c)

### DIFF
--- a/apps/web/src/app/(public)/shared-games/[id]/page-client.tsx
+++ b/apps/web/src/app/(public)/shared-games/[id]/page-client.tsx
@@ -21,6 +21,7 @@ import { useMemo, type JSX } from 'react';
 
 import { useSearchParams } from 'next/navigation';
 
+import { AdminCoverEditAffordance } from '@/components/features/cover-editor';
 import { ContributorsSection } from '@/components/shared-games/ContributorsSection';
 import {
   AgentListItem,
@@ -351,6 +352,10 @@ export function SharedGameDetailPageClient({
           agentsCount={game.agentsCount}
           kbsCount={game.kbsCount}
           labels={heroLabels}
+          // #3470 Slice 1d-c — admin-only cover-source editor over the hero cover.
+          // Self-gated via useAdminRole (renders null for non-admins), so the public
+          // audience contract is untouched (#2118).
+          coverOverlay={<AdminCoverEditAffordance gameId={game.id} title={resolvedTitle} />}
         />
 
         <Tabs

--- a/apps/web/src/components/ui/detail-layout/hero.test.tsx
+++ b/apps/web/src/components/ui/detail-layout/hero.test.tsx
@@ -229,6 +229,28 @@ describe('Hero (Wave A.4)', () => {
     expect(screen.getByRole('group', { name: 'Connections' })).toBeInTheDocument();
   });
 
+  it('renders the coverOverlay slot inside the cover region when provided', () => {
+    const { container } = render(
+      <Hero
+        title="Catan"
+        toolkitsCount={0}
+        agentsCount={0}
+        kbsCount={0}
+        labels={labels}
+        coverOverlay={<button type="button">edit-cover</button>}
+      />
+    );
+    const btn = screen.getByRole('button', { name: 'edit-cover' });
+    const cover = container.querySelector('[data-slot="hero-cover"]');
+    expect(cover).not.toBeNull();
+    expect(cover?.contains(btn)).toBe(true);
+  });
+
+  it('renders no overlay content when coverOverlay is omitted', () => {
+    render(<Hero title="Catan" toolkitsCount={0} agentsCount={0} kbsCount={0} labels={labels} />);
+    expect(screen.queryByRole('button', { name: 'edit-cover' })).toBeNull();
+  });
+
   it('passes through optional className', () => {
     const { container } = render(
       <Hero

--- a/apps/web/src/components/ui/detail-layout/hero.tsx
+++ b/apps/web/src/components/ui/detail-layout/hero.tsx
@@ -18,7 +18,7 @@
  * viewports / preview cards in future waves.
  */
 
-import type { JSX } from 'react';
+import type { JSX, ReactNode } from 'react';
 
 import clsx from 'clsx';
 
@@ -61,6 +61,12 @@ export interface HeroProps {
   readonly labels: HeroLabels;
   readonly compact?: boolean;
   readonly className?: string;
+  /**
+   * Optional overlay rendered over the (relative) cover region — used by the admin
+   * cover-edit affordance on public surfaces (#3470 Slice 1d-c). The cover region is
+   * a `group` so a hover-revealed affordance can react to cover hover.
+   */
+  readonly coverOverlay?: ReactNode;
 }
 
 function Stars({
@@ -156,6 +162,7 @@ export function Hero({
   labels,
   compact = false,
   className,
+  coverOverlay,
 }: HeroProps): JSX.Element {
   const coverH = compact ? 'h-[160px]' : 'h-[220px]';
   const titleSize = compact ? 'text-[22px]' : 'text-[30px]';
@@ -189,7 +196,8 @@ export function Hero({
     >
       {/* Cover */}
       <div
-        className={clsx('relative flex items-center justify-center overflow-hidden', coverH)}
+        data-slot="hero-cover"
+        className={clsx('group relative flex items-center justify-center overflow-hidden', coverH)}
         style={{
           backgroundColor: entityHsl('game', 0.12),
         }}
@@ -206,6 +214,7 @@ export function Hero({
           aria-hidden="true"
           className="absolute inset-x-0 bottom-0 h-1/2 bg-gradient-to-t from-black/35 to-transparent"
         />
+        {coverOverlay}
       </div>
 
       {/* Body */}


### PR DESCRIPTION
## Slice 1d-c PR 3/4 — cover editor on the shared-game hero (epic #3470)

Mounts the admin cover-source picker (PR2 #3488) on the public shared-game detail hero (D3).

### Changes
- **detail-layout/hero.tsx**: optional `coverOverlay` slot rendered over the cover region (now `relative group`). Additive — undefined for existing consumers, so **zero behavioral change** (19/19 hero tests green; `group` is inert since no hero child uses `group-hover`).
- **(public)/shared-games/[id]/page-client.tsx**: injects `<AdminCoverEditAffordance gameId={game.id} title={resolvedTitle} />` into the hero `coverOverlay`. Self-gated via `useAdminRole` → invisible to non-admins, so the `(public)` audience contract (#2118) stays intact.
- **hero.test.tsx**: coverOverlay renders inside the cover region; omitted → nothing.

### On the page-client wiring test
The detail page-client render pulls in data-shape-dependent children that make a bespoke unit harness fragile (an obscure "object as React child" error surfaced from a minimal fixture, unrelated to the wiring). Rather than over-fit a brittle mock harness, the wiring is covered by the hero-slot unit test + the affordance unit tests (PR2) + typecheck (`game.id` / `resolvedTitle` / affordance props) + the E2E axe/Playwright gate that renders the real page. Happy to add a dedicated test if preferred.

### Verification
- 19/19 hero tests · `tsc --noEmit` clean · ESLint `--max-warnings=0` clean.

The card-grid mount (the DS slot on MeepleCard/GridCard) follows in PR4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
