### PR TITLE
feat(catalog): cover editor on shared-games card (#3470 Slice 1d-c)

### DIFF
--- a/apps/web/src/components/ui/data-display/meeple-card/types.ts
+++ b/apps/web/src/components/ui/data-display/meeple-card/types.ts
@@ -157,6 +157,13 @@ export interface MeepleCardProps {
   /** Optional test id forwarded to the root wrapper element. */
   'data-testid'?: string;
   /**
+   * Issue #3470 Slice 1d-c — optional cover-edit affordance (admin only) rendered
+   * OUTSIDE the card's anchor/button root (to avoid axe nested-interactive) over the
+   * cover. Currently honored by GridCard only. When omitted the card renders unchanged,
+   * so existing consumers are unaffected.
+   */
+  coverEditSlot?: ReactNode;
+  /**
    * Issue #1823 Wave 3 M14 — license + attribution metadata for the cover
    * image. Renders a small footer chip under the title when present
    * (typically Wikidata-sourced covers per ADR DEC-3c whitelist).

--- a/apps/web/src/components/ui/data-display/meeple-card/variants/GridCard.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/variants/GridCard.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import type { ReactElement } from 'react';
+
 import Link from 'next/link';
 
 import { useConnectionSource } from '../hooks/useConnectionSource';
@@ -41,6 +43,7 @@ export function GridCard(props: MeepleCardProps) {
     href,
     className = '',
     attribution,
+    coverEditSlot,
   } = props;
   const testId = props['data-testid'];
 
@@ -48,7 +51,10 @@ export function GridCard(props: MeepleCardProps) {
 
   const glowColor = entityHsl(entity, 0.4);
 
-  const rootClassName = `group relative flex cursor-pointer flex-col overflow-hidden rounded-2xl border border-[var(--mc-border)] bg-[var(--mc-bg-card)] shadow-[var(--mc-shadow-sm)] outline-2 outline-offset-2 outline-transparent backdrop-blur-[12px] backdrop-saturate-[180%] transition-all duration-[350ms] [transition-timing-function:cubic-bezier(0.4,0,0.2,1)] hover:-translate-y-1.5 hover:shadow-[var(--mc-shadow-xl)] hover:outline-[var(--mc-glow)] ${className}`;
+  // With a coverEditSlot the hover-lift moves to the wrapper (see withSlot below) so the
+  // card and its sibling affordance lift together; stripping it here avoids a double lift.
+  const liftClass = coverEditSlot ? '' : 'hover:-translate-y-1.5';
+  const rootClassName = `group relative flex cursor-pointer flex-col overflow-hidden rounded-2xl border border-[var(--mc-border)] bg-[var(--mc-bg-card)] shadow-[var(--mc-shadow-sm)] outline-2 outline-offset-2 outline-transparent backdrop-blur-[12px] backdrop-saturate-[180%] transition-all duration-[350ms] [transition-timing-function:cubic-bezier(0.4,0,0.2,1)] ${liftClass} hover:shadow-[var(--mc-shadow-xl)] hover:outline-[var(--mc-glow)] ${className}`;
   const rootStyle = { '--mc-glow': glowColor } as React.CSSProperties;
 
   const content = (
@@ -100,8 +106,26 @@ export function GridCard(props: MeepleCardProps) {
     </>
   );
 
+  // #3470 Slice 1d-c — an optional cover-edit affordance renders OUTSIDE the anchor/button
+  // root (avoids axe nested-interactive) inside a `group relative` wrapper that supplies the
+  // hover + positioning context for a hover-revealed absolute affordance. When the slot is
+  // absent the card root is returned unchanged, so every existing consumer is byte-identical.
+  const withSlot = (card: ReactElement): ReactElement =>
+    coverEditSlot ? (
+      // `grid` makes the single in-flow child (the card) stretch to the row height like the
+      // card did before (CSS Grid `align-items: stretch`), preserving equal-height rows.
+      // The hover-lift lives here (not on the card) so the card + its absolutely-positioned
+      // sibling affordance lift together — no detachment on hover.
+      <div className="group relative grid transition-transform duration-[350ms] [transition-timing-function:cubic-bezier(0.4,0,0.2,1)] hover:-translate-y-1.5">
+        {card}
+        {coverEditSlot}
+      </div>
+    ) : (
+      card
+    );
+
   if (href) {
-    return (
+    return withSlot(
       <Link
         href={href}
         prefetch
@@ -115,7 +139,7 @@ export function GridCard(props: MeepleCardProps) {
     );
   }
 
-  return (
+  return withSlot(
     <div
       className={rootClassName}
       style={rootStyle}

--- a/apps/web/src/components/ui/data-display/meeple-card/variants/__tests__/GridCard.coverEditSlot.test.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/variants/__tests__/GridCard.coverEditSlot.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { describe, expect, it, vi } from 'vitest';
+
+import { GridCard } from '../GridCard';
+
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    prefetch: _prefetch,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+    prefetch?: boolean;
+  } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+describe('GridCard coverEditSlot (#3470 Slice 1d-c)', () => {
+  it('renders the slot OUTSIDE the anchor (no nested interactive) when href + slot are present', () => {
+    render(
+      <GridCard
+        entity="game"
+        variant="grid"
+        title="Catan"
+        href="/shared-games/1"
+        data-testid="card"
+        coverEditSlot={<button type="button">edit-cover</button>}
+      />
+    );
+
+    const anchor = screen.getByRole('link');
+    const editBtn = screen.getByRole('button', { name: 'edit-cover' });
+
+    expect(anchor).toBeInTheDocument();
+    expect(editBtn).toBeInTheDocument();
+    // The interactive slot must NOT be nested inside the anchor (axe nested-interactive).
+    expect(anchor.contains(editBtn)).toBe(false);
+    // The testid stays on the anchor root.
+    expect(screen.getByTestId('card').tagName).toBe('A');
+  });
+
+  it('renders the anchor directly (no slot) when coverEditSlot is absent', () => {
+    render(<GridCard entity="game" variant="grid" title="Catan" href="/x" data-testid="card" />);
+    expect(screen.getByTestId('card').tagName).toBe('A');
+    expect(screen.queryByRole('button', { name: 'edit-cover' })).toBeNull();
+  });
+
+  it('renders the slot OUTSIDE the button root when no href (onClick) + slot are present', () => {
+    render(
+      <GridCard
+        entity="game"
+        variant="grid"
+        title="Catan"
+        onClick={() => {}}
+        data-testid="card"
+        coverEditSlot={<button type="button">edit-cover</button>}
+      />
+    );
+    const rootButton = screen.getByRole('button', { name: /catan/i });
+    const editBtn = screen.getByRole('button', { name: 'edit-cover' });
+    expect(rootButton.contains(editBtn)).toBe(false);
+  });
+
+  it('has no axe AA violations with an interactive cover-edit slot (no nested interactive)', async () => {
+    const { container } = render(
+      <GridCard
+        entity="game"
+        variant="grid"
+        title="Catan"
+        href="/shared-games/1"
+        coverEditSlot={
+          <button type="button" aria-label="Modifica copertina">
+            edit
+          </button>
+        }
+      />
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/apps/web/src/components/ui/shared-games/meeple-card-game.tsx
+++ b/apps/web/src/components/ui/shared-games/meeple-card-game.tsx
@@ -16,7 +16,7 @@
  * interface (to avoid churning /shared-games page-client) but are no longer
  * consumed by the canonical render; a follow-up may prune them.
  */
-import type { JSX } from 'react';
+import type { JSX, ReactNode } from 'react';
 
 import { MeepleCard } from '@/components/ui/data-display/meeple-card/MeepleCard';
 import type { ConnectionChipProps } from '@/components/ui/data-display/meeple-card/types';
@@ -55,6 +55,12 @@ export interface MeepleCardGameProps {
   readonly wikidataCoverLicense?: string | null;
   readonly wikidataCoverAttribution?: string | null;
   readonly wikidataCoverSourceUrl?: string | null;
+  /**
+   * Issue #3470 Slice 1d-c — optional admin cover-edit affordance forwarded to the
+   * canonical MeepleCard cover slot (rendered outside the card anchor). Omitted for
+   * non-admins so the tile renders unchanged.
+   */
+  readonly coverEditSlot?: ReactNode;
 }
 
 export function MeepleCardGame({
@@ -72,6 +78,7 @@ export function MeepleCardGame({
   wikidataCoverLicense = null,
   wikidataCoverAttribution = null,
   wikidataCoverSourceUrl = null,
+  coverEditSlot,
 }: MeepleCardGameProps): JSX.Element {
   const connections: ConnectionChipProps[] = [];
   if (toolkitsCount > 0) {
@@ -114,6 +121,7 @@ export function MeepleCardGame({
       wikidataCoverLicense={wikidataCoverLicense}
       wikidataCoverAttribution={wikidataCoverAttribution}
       wikidataCoverSourceUrl={wikidataCoverSourceUrl}
+      coverEditSlot={coverEditSlot}
     />
   );
 }

--- a/apps/web/src/components/ui/shared-games/shared-games-grid.test.tsx
+++ b/apps/web/src/components/ui/shared-games/shared-games-grid.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { type MeepleCardGameLabels } from './meeple-card-game';
 import {
@@ -24,6 +24,28 @@ vi.mock('next/link', () => ({
     </a>
   ),
 }));
+
+vi.mock('@/hooks/useAdminRole', () => ({ useAdminRole: vi.fn() }));
+vi.mock('@/components/features/cover-editor', () => ({
+  AdminCoverEditAffordance: ({ gameId }: { gameId: string }) => (
+    <div data-testid="cover-affordance" data-game-id={gameId} />
+  ),
+}));
+
+import { useAdminRole } from '@/hooks/useAdminRole';
+
+const mockUseAdminRole = useAdminRole as unknown as ReturnType<typeof vi.fn>;
+
+function setRole(isEditorOrAbove: boolean) {
+  mockUseAdminRole.mockReturnValue({
+    user: null,
+    isSuperAdmin: false,
+    isAdminOrAbove: isEditorOrAbove,
+    isEditorOrAbove,
+    hasRole: () => false,
+    isLoading: false,
+  });
+}
 
 const cardLabels: MeepleCardGameLabels = {
   ratingAriaLabel: 'Voto',
@@ -65,6 +87,26 @@ function build(overrides: Partial<SharedGamesGridProps> = {}): SharedGamesGridPr
 }
 
 describe('SharedGamesGrid (v2)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setRole(false);
+  });
+
+  it('does not render cover-edit affordances for a non-admin', () => {
+    setRole(false);
+    render(<SharedGamesGrid {...build()} />);
+    expect(screen.queryAllByTestId('cover-affordance')).toHaveLength(0);
+  });
+
+  it('renders a role-gated cover-edit affordance per card for an editor-or-above', () => {
+    setRole(true);
+    render(<SharedGamesGrid {...build()} />);
+    const affordances = screen.getAllByTestId('cover-affordance');
+    expect(affordances).toHaveLength(2);
+    expect(affordances[0]).toHaveAttribute('data-game-id', games[0].id);
+    expect(affordances[1]).toHaveAttribute('data-game-id', games[1].id);
+  });
+
   it('emits data-state matching the state prop', () => {
     const { container, rerender } = render(<SharedGamesGrid {...build({ state: 'default' })} />);
     expect(container.querySelector('[data-slot="shared-games-grid"]')).toHaveAttribute(

--- a/apps/web/src/components/ui/shared-games/shared-games-grid.tsx
+++ b/apps/web/src/components/ui/shared-games/shared-games-grid.tsx
@@ -15,23 +15,23 @@
  * same outer spacing and visual rhythm.
  */
 
+'use client';
+
 import type { JSX, ReactNode } from 'react';
 
 import clsx from 'clsx';
 
+import { AdminCoverEditAffordance } from '@/components/features/cover-editor';
 import {
   MeepleCardGame,
   type MeepleCardGameLabels,
   type MeepleCardGameProps,
 } from '@/components/ui/shared-games/meeple-card-game';
 import { SkeletonCard } from '@/components/ui/shared-games/skeleton-card';
+import { useAdminRole } from '@/hooks/useAdminRole';
 
 export type SharedGamesGridState =
-  | 'default'
-  | 'loading'
-  | 'error'
-  | 'empty-search'
-  | 'filtered-empty';
+  'default' | 'loading' | 'error' | 'empty-search' | 'filtered-empty';
 
 export type SharedGamesGridGame = Omit<MeepleCardGameProps, 'labels' | 'className'>;
 
@@ -58,6 +58,10 @@ export function SharedGamesGrid({
   compact = false,
   className,
 }: SharedGamesGridProps): JSX.Element {
+  // #3470 Slice 1d-c — role gate computed once (not per card). Non-admins get no slot,
+  // so the tile DOM is unchanged for the public audience; admins get an inline editor.
+  const { isEditorOrAbove } = useAdminRole();
+
   const gridClasses = clsx(
     'grid grid-cols-2 gap-3 md:grid-cols-3 md:gap-4 lg:grid-cols-4',
     className
@@ -92,7 +96,17 @@ export function SharedGamesGrid({
   return (
     <div data-slot="shared-games-grid" data-state="default" className={gridClasses}>
       {games.map(game => (
-        <MeepleCardGame key={game.id} {...game} labels={cardLabels} />
+        <MeepleCardGame
+          key={game.id}
+          {...game}
+          labels={cardLabels}
+          coverEditSlot={
+            // Title is intentionally omitted here: useGameTitle is a hook (illegal in
+            // this map callback), and the picker dialog identifies the game by the card
+            // the admin clicked. The hero surface passes the locale-resolved title.
+            isEditorOrAbove ? <AdminCoverEditAffordance gameId={game.id} /> : undefined
+          }
+        />
       ))}
     </div>
   );


### PR DESCRIPTION
## Slice 1d-c PR 4/4 — cover editor on the shared-games card (epic #3470)

The final surface of the FE cover picker: the design-system card-grid mount (D3 card). Completes Slice 1d-c (PRs #3487 data layer, #3488 dialog+affordance, #3491 hero, and this one).

### Changes
- **meeple-card/types.ts + GridCard.tsx**: optional `coverEditSlot` prop. When present, GridCard wraps the card root + slot in a `group relative grid` div so the interactive affordance renders OUTSIDE the anchor/button (no axe nested-interactive), the card stretches to equal-height rows, and the hover-lift moves to the wrapper (card + affordance lift together). Absent → the card root is **byte-identical** (zero-diff for every existing MeepleCard consumer).
- **meeple-card-game.tsx**: forwards `coverEditSlot` to the canonical MeepleCard.
- **shared-games-grid.tsx** (`'use client'`): computes `useAdminRole()` once and injects `<AdminCoverEditAffordance>` only for editor-or-above → non-admins get the unchanged tile DOM (progressive enhancement; server re-authorizes).

### Verification
- 399 meeple-card/shared-games tests green, incl. `card-decision-table` + `no-inline-card-reimplementation` enforcement gates and a jest-axe no-nested-interactive check · `tsc --noEmit` clean · ESLint `--max-warnings=0` clean · `pnpm lint:bgg` clean.
- Adversarial review found & fixed 2 admin-only layout regressions (CSS-grid stretch parity; hover-lift detachment) that jsdom's layout-less tests can't catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
