### PR TITLE
refactor(ai): IGroundedAnswerService + tier-independent enhancement gate (#3490)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/AskGroundedSessionQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/AskGroundedSessionQueryHandler.cs
@@ -1,20 +1,9 @@
-using System.Diagnostics;
-using Api.BoundedContexts.KnowledgeBase.Application.Configuration;
 using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
-using Api.BoundedContexts.KnowledgeBase.Application.Models;
 using Api.BoundedContexts.KnowledgeBase.Application.Services;
-using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
-using Api.Models;
-using Api.Observability;
 using Api.Services;
 using Api.SharedKernel.Application.Interfaces;
-using Api.SharedKernel.Domain.Enums;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-// This file references both Api.Models.CitationDto (the wire shape) and Api.Models.CitationRegion;
-// the KnowledgeBase.Application.DTOs namespace also declares a CitationDto, so pin the wire one.
-using CitationDto = Api.Models.CitationDto;
 
 namespace Api.BoundedContexts.KnowledgeBase.Application.Queries;
 
@@ -30,19 +19,12 @@ public sealed class GroundedSessionGenerationException : Exception
 /// <summary>
 /// #3390 Slice 2 — produces a grounded, non-streaming answer for the in-session agent.
 ///
-/// Replicates the grounded pipeline of <c>ChatWithSessionAgentCommandHandler</c> (the SSE text
-/// path) without streaming/thread/session concerns: assemble RAG prompt under
-/// <c>RetrievalPolicy.LiveSession</c> → resolve copyright tiers → generate (text-only) →
-/// copyright leak guard (fail-open) → map to <see cref="CitationDto"/> → derive grounding from
-/// citation count. The vision board-state (<c>GameStateContext</c>) is injected as prompt
-/// context; pixels are NOT re-sent (they were already distilled by GameStateExtractor).
-///
-/// NOTE (#3390 Slice 5): the assemble→resolve→generate→guard→map sequence duplicates
-/// <c>ChatWithSessionAgentCommandHandler</c>. Consolidating both onto a shared grounded-generation
-/// service is the ownership-collapse work tracked for Slice 5; this slice accepts the controlled
-/// duplication to keep the boundary change reviewable.
-/// Paraphrase extraction for Protected-tier snippets is intentionally omitted here (Protected
-/// snippets are already null-gated in the citation map — no verbatim leak); it is a UX follow-up.
+/// Owns the retrieval + generation shape (assemble RAG prompt under <c>RetrievalPolicy.LiveSession</c>
+/// → resolve copyright tiers → generate text-only); delegates the shared finalize (copyright leak
+/// guard → paraphrase → citation mapping → grounding → confidence) to <see cref="IGroundedAnswerService"/>
+/// (#3490 / ADR-090), the same seam the SSE text path uses. The vision board-state
+/// (<c>GameStateContext</c>) is injected as prompt context; pixels are NOT re-sent (they were already
+/// distilled by GameStateExtractor).
 /// </summary>
 internal sealed class AskGroundedSessionQueryHandler
     : IQueryHandler<AskGroundedSessionQuery, GroundedSessionAnswerDto>
@@ -50,27 +32,18 @@ internal sealed class AskGroundedSessionQueryHandler
     private readonly IRagPromptAssemblyService _ragPromptService;
     private readonly ICopyrightTierResolver _copyrightTierResolver;
     private readonly ILlmService _llmService;
-    private readonly ICopyrightLeakGuard _copyrightLeakGuard;
-    private readonly ICopyrightFallbackMessageProvider _fallbackMessageProvider;
-    private readonly IOptions<CopyrightLeakGuardOptions> _copyrightOptions;
-    private readonly ILogger<AskGroundedSessionQueryHandler> _logger;
+    private readonly IGroundedAnswerService _groundedAnswerService;
 
     public AskGroundedSessionQueryHandler(
         IRagPromptAssemblyService ragPromptService,
         ICopyrightTierResolver copyrightTierResolver,
         ILlmService llmService,
-        ICopyrightLeakGuard copyrightLeakGuard,
-        ICopyrightFallbackMessageProvider fallbackMessageProvider,
-        IOptions<CopyrightLeakGuardOptions> copyrightOptions,
-        ILogger<AskGroundedSessionQueryHandler> logger)
+        IGroundedAnswerService groundedAnswerService)
     {
         _ragPromptService = ragPromptService ?? throw new ArgumentNullException(nameof(ragPromptService));
         _copyrightTierResolver = copyrightTierResolver ?? throw new ArgumentNullException(nameof(copyrightTierResolver));
         _llmService = llmService ?? throw new ArgumentNullException(nameof(llmService));
-        _copyrightLeakGuard = copyrightLeakGuard ?? throw new ArgumentNullException(nameof(copyrightLeakGuard));
-        _fallbackMessageProvider = fallbackMessageProvider ?? throw new ArgumentNullException(nameof(fallbackMessageProvider));
-        _copyrightOptions = copyrightOptions ?? throw new ArgumentNullException(nameof(copyrightOptions));
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _groundedAnswerService = groundedAnswerService ?? throw new ArgumentNullException(nameof(groundedAnswerService));
     }
 
     public async Task<GroundedSessionAnswerDto> Handle(AskGroundedSessionQuery request, CancellationToken cancellationToken)
@@ -124,77 +97,15 @@ internal sealed class AskGroundedSessionQueryHandler
             throw new GroundedSessionGenerationException("empty grounded answer");
         }
 
-        // 5. Copyright leak guard (#447). The SCAN is fail-open (a guard fault must not break the
-        //    answer), but leak HANDLING/sanitization runs OUTSIDE the try so a fault while sanitizing
-        //    can never ship the original verbatim-leaking text — the leak handling itself fails CLOSED.
-        var protectedCitations = resolvedCitations
-            .Where(c => c.CopyrightTier == CopyrightTier.Protected)
-            .ToList();
+        // 5. Shared finalize (#3490 / ADR-090): copyright leak guard (fail-open scan / fail-closed
+        //    sanitize) → paraphrase → citation mapping → grounding → confidence. Same seam as the SSE
+        //    text path, so the trust-critical logic lives in one place. Honors the caller's token
+        //    (a budget/client cancellation during the scan propagates so SessionTracking degrades).
+        var grounded = await _groundedAnswerService
+            .FinalizeAsync(responseText, resolvedCitations, request.Question, request.AgentLanguage, cancellationToken)
+            .ConfigureAwait(false);
 
-        CopyrightLeakResult? leakResult = null;
-        if (protectedCitations.Count > 0)
-        {
-            try
-            {
-                using var scanCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                scanCts.CancelAfter(TimeSpan.FromMilliseconds(_copyrightOptions.Value.ScanTimeoutMs));
-
-                var scanSw = Stopwatch.StartNew();
-                leakResult = await _copyrightLeakGuard
-                    .ScanAsync(responseText, protectedCitations, scanCts.Token)
-                    .ConfigureAwait(false);
-                scanSw.Stop();
-                MeepleAiMetrics.CopyrightScanDurationMs.Record(scanSw.ElapsedMilliseconds);
-            }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-            {
-                // The caller's latency budget / client cancellation fired — propagate so
-                // SessionTracking degrades, don't fail-open into a possibly-unscanned answer.
-                throw;
-            }
-            catch (Exception ex)
-            {
-                MeepleAiMetrics.CopyrightScanErrors.Add(1,
-                    new KeyValuePair<string, object?>("error_type", ex.GetType().Name));
-                _logger.LogError(ex,
-                    "Copyright leak guard failed for grounded session answer (game {GameId}), allowing response (fail-open on the scan)",
-                    request.GameId);
-                leakResult = null; // fail-open on the SCAN only
-            }
-        }
-
-        // Leak handling OUTSIDE the fail-open try: once a leak is detected, sanitize unconditionally.
-        if (leakResult?.HasLeak == true)
-        {
-            foreach (var match in leakResult.Matches)
-            {
-                MeepleAiMetrics.CopyrightVerbatimDetected.Add(1,
-                    new KeyValuePair<string, object?>("run_length", match.RunLength),
-                    new KeyValuePair<string, object?>("document_id", match.DocumentId));
-            }
-            _logger.LogWarning(
-                "Copyright leak detected in grounded session answer (game {GameId}): {MatchCount} matches, sanitizing",
-                request.GameId, leakResult.Matches.Count);
-            responseText = _fallbackMessageProvider.GetMessage(request.AgentLanguage);
-        }
-
-        // 6. Map to the wire CitationDto (tier-nulling identical to ChatWithSessionAgentCommandHandler).
-        var citationDtos = resolvedCitations.Select(c => new CitationDto(
-            c.DocumentId,
-            c.PageNumber,
-            c.RelevanceScore,
-            c.CopyrightTier == CopyrightTier.Full ? c.SnippetPreview : null,
-            c.CopyrightTier.ToString().ToLowerInvariant(),
-            c.ParaphrasedSnippet,
-            c.IsPublic,
-            Regions: c.CopyrightTier == CopyrightTier.Full ? CitationRegion.Parse(c.BoundingBoxesJson) : null,
-            CharStart: c.CopyrightTier == CopyrightTier.Full ? c.CharStart : null,
-            CharEnd: c.CopyrightTier == CopyrightTier.Full ? c.CharEnd : null)).ToList();
-
-        // 7. Grounding derived from citation count — the same invariant as the text path (#3388).
-        var grounding = citationDtos.Count > 0 ? GroundingStatus.Grounded : GroundingStatus.Ungrounded;
-        var confidence = RagPromptAssemblyService.ComputeConfidence(resolvedCitations.ToList(), responseText);
-
-        return new GroundedSessionAnswerDto(responseText, citationDtos, grounding, confidence);
+        return new GroundedSessionAnswerDto(
+            grounded.ResponseText, grounded.CitationDtos, grounded.GroundingStatus, grounded.Confidence);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/GroundedAnswerService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/GroundedAnswerService.cs
@@ -1,0 +1,143 @@
+using System.Diagnostics;
+using Api.BoundedContexts.KnowledgeBase.Application.Models;
+using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
+using Api.Models;
+using Api.Observability;
+using Api.SharedKernel.Domain.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using CitationDto = Api.Models.CitationDto;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Services;
+
+/// <summary>
+/// #3390 Slice 5 / #3490 (ADR-090) — the finalize half of the grounded-answer pipeline, shared by both
+/// in-session producers so the trust-critical logic lives in ONE place:
+///   - copyright leak guard (fail-OPEN scan; leak HANDLING/sanitize fails CLOSED — a fault while
+///     sanitizing can never ship the original verbatim-leaking text);
+///   - paraphrase extraction for Protected-tier citations;
+///   - <see cref="CitationDto"/> mapping with Full-gated tier-nulling (no Protected verbatim/region leak);
+///   - grounding derived from the citation count (#3388 invariant);
+///   - confidence.
+///
+/// Before this service the block was duplicated across <c>ChatWithSessionAgentCommandHandler</c> (SSE text)
+/// and <c>AskGroundedSessionQueryHandler</c> (one-shot image) — the Slice-2 review found a copyright
+/// fail-open/fail-closed defect that had to be fixed in one copy only. Consolidating removes that drift
+/// (ADR-090). The two handlers keep their own GENERATION shape (stream vs one-shot) and orchestration
+/// (thread/broadcast/persistence); they call <see cref="FinalizeAsync"/> for the shared computation.
+/// </summary>
+internal sealed class GroundedAnswerService : IGroundedAnswerService
+{
+    private readonly ICopyrightLeakGuard _copyrightLeakGuard;
+    private readonly ICopyrightFallbackMessageProvider _fallbackMessageProvider;
+    private readonly IOptions<CopyrightLeakGuardOptions> _copyrightOptions;
+    private readonly ILogger<GroundedAnswerService> _logger;
+
+    public GroundedAnswerService(
+        ICopyrightLeakGuard copyrightLeakGuard,
+        ICopyrightFallbackMessageProvider fallbackMessageProvider,
+        IOptions<CopyrightLeakGuardOptions> copyrightOptions,
+        ILogger<GroundedAnswerService> logger)
+    {
+        _copyrightLeakGuard = copyrightLeakGuard ?? throw new ArgumentNullException(nameof(copyrightLeakGuard));
+        _fallbackMessageProvider = fallbackMessageProvider ?? throw new ArgumentNullException(nameof(fallbackMessageProvider));
+        _copyrightOptions = copyrightOptions ?? throw new ArgumentNullException(nameof(copyrightOptions));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<GroundedAnswer> FinalizeAsync(
+        string responseText,
+        IReadOnlyList<ChunkCitation> resolvedCitations,
+        string userQuestion,
+        string agentLanguage,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(responseText);
+        ArgumentNullException.ThrowIfNull(resolvedCitations);
+
+        // 1. Copyright leak guard. SCAN is fail-open (a guard fault must not break the answer), but leak
+        //    HANDLING/sanitization runs OUTSIDE the try so a fault while sanitizing can never ship the
+        //    original verbatim-leaking text (Slice-2 review fix).
+        var protectedCitations = resolvedCitations
+            .Where(c => c.CopyrightTier == CopyrightTier.Protected)
+            .ToList();
+
+        CopyrightLeakResult? leakResult = null;
+        if (protectedCitations.Count > 0)
+        {
+            try
+            {
+                using var scanCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                scanCts.CancelAfter(TimeSpan.FromMilliseconds(_copyrightOptions.Value.ScanTimeoutMs));
+
+                var scanSw = Stopwatch.StartNew();
+                leakResult = await _copyrightLeakGuard
+                    .ScanAsync(responseText, protectedCitations, scanCts.Token)
+                    .ConfigureAwait(false);
+                scanSw.Stop();
+                MeepleAiMetrics.CopyrightScanDurationMs.Record(scanSw.ElapsedMilliseconds);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                // The caller's budget / client cancellation fired — propagate, don't fail-open into a
+                // possibly-unscanned answer.
+                throw;
+            }
+            catch (Exception ex)
+            {
+                MeepleAiMetrics.CopyrightScanErrors.Add(1,
+                    new KeyValuePair<string, object?>("error_type", ex.GetType().Name));
+                _logger.LogError(ex,
+                    "Copyright leak guard failed for grounded answer, allowing response (fail-open on the scan)");
+                leakResult = null; // fail-open on the SCAN only
+            }
+        }
+
+        var finalText = responseText;
+        var leakMatchCount = leakResult?.Matches.Count ?? 0;
+        if (leakResult?.HasLeak == true)
+        {
+            foreach (var match in leakResult.Matches)
+            {
+                MeepleAiMetrics.CopyrightVerbatimDetected.Add(1,
+                    new KeyValuePair<string, object?>("run_length", match.RunLength),
+                    new KeyValuePair<string, object?>("document_id", match.DocumentId));
+            }
+            _logger.LogWarning(
+                "Copyright leak detected in grounded answer: {MatchCount} matches, sanitizing",
+                leakResult.Matches.Count);
+            finalText = _fallbackMessageProvider.GetMessage(agentLanguage);
+        }
+
+        // 2. Paraphrase extraction for Protected-tier citations (from the possibly-sanitized text).
+        var finalCitations = resolvedCitations.Select(c =>
+        {
+            if (c.CopyrightTier == CopyrightTier.Protected)
+            {
+                var paraphrase = ParaphraseExtractor.Extract(
+                    finalText, c.DocumentId, c.PageNumber, c.SnippetPreview, userQuestion);
+                return c with { ParaphrasedSnippet = paraphrase };
+            }
+            return c;
+        }).ToList();
+
+        // 3. Map to the wire CitationDto with Full-gated tier-nulling (identical to both former handlers).
+        var citationDtos = finalCitations.Select(c => new CitationDto(
+            c.DocumentId,
+            c.PageNumber,
+            c.RelevanceScore,
+            c.CopyrightTier == CopyrightTier.Full ? c.SnippetPreview : null,
+            c.CopyrightTier.ToString().ToLowerInvariant(),
+            c.ParaphrasedSnippet,
+            c.IsPublic,
+            Regions: c.CopyrightTier == CopyrightTier.Full ? CitationRegion.Parse(c.BoundingBoxesJson) : null,
+            CharStart: c.CopyrightTier == CopyrightTier.Full ? c.CharStart : null,
+            CharEnd: c.CopyrightTier == CopyrightTier.Full ? c.CharEnd : null)).ToList();
+
+        // 4. Grounding from citation count (#3388) + confidence.
+        var grounding = citationDtos.Count > 0 ? GroundingStatus.Grounded : GroundingStatus.Ungrounded;
+        var confidence = RagPromptAssemblyService.ComputeConfidence(resolvedCitations.ToList(), finalText);
+
+        return new GroundedAnswer(finalText, finalCitations, citationDtos, grounding, confidence, leakMatchCount);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/IGroundedAnswerService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/IGroundedAnswerService.cs
@@ -1,0 +1,44 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Models;
+using Api.SharedKernel.Domain.Enums;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Services;
+
+/// <summary>
+/// #3490 (ADR-090) — the shared finalize half of the grounded-answer pipeline. See
+/// <see cref="GroundedAnswerService"/> for rationale. Both in-session producers call
+/// <see cref="FinalizeAsync"/> so the copyright leak guard, citation tier-nulling, and grounding
+/// derivation live in one place (removing the drift ADR-090 flagged).
+/// </summary>
+internal interface IGroundedAnswerService
+{
+    /// <summary>
+    /// Finalizes a generated grounded answer: copyright leak guard (fail-open scan / fail-closed sanitize)
+    /// → paraphrase for Protected citations → <see cref="Api.Models.CitationDto"/> mapping with Full-gated
+    /// tier-nulling → grounding from citation count (#3388) → confidence. The caller owns generation
+    /// (stream vs one-shot) and orchestration (yields/persistence/broadcast).
+    /// </summary>
+    /// <param name="responseText">The generated answer text.</param>
+    /// <param name="resolvedCitations">Citations after copyright-tier resolution.</param>
+    /// <param name="userQuestion">The user question (used to reject paraphrase prompt-injection).</param>
+    /// <param name="agentLanguage">ISO 639-1 language for the copyright fallback message.</param>
+    /// <param name="ct">Cancellation token; a cancellation during the copyright scan propagates.</param>
+    Task<GroundedAnswer> FinalizeAsync(
+        string responseText,
+        IReadOnlyList<ChunkCitation> resolvedCitations,
+        string userQuestion,
+        string agentLanguage,
+        CancellationToken ct);
+}
+
+/// <summary>
+/// Result of <see cref="IGroundedAnswerService.FinalizeAsync"/>. Carries the possibly-sanitized text,
+/// the wire citations, grounding, confidence, and the leak-match count (so a streaming caller can emit
+/// its CopyrightSanitized event without re-scanning).
+/// </summary>
+internal sealed record GroundedAnswer(
+    string ResponseText,
+    IReadOnlyList<ChunkCitation> FinalCitations,
+    IReadOnlyList<Api.Models.CitationDto> CitationDtos,
+    GroundingStatus GroundingStatus,
+    double? Confidence,
+    int LeakMatchCount);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyService.cs
@@ -180,10 +180,17 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
             // a null tier no longer silently means "Default profile + all enhancements off": the profile is
             // an explicit named choice and enhancements are explicitly gated off (wiring deferred to #3390).
             var profile = retrievalPolicy?.BaseProfile ?? RetrievalProfile.Default;
-            var enhancementsAllowed = retrievalPolicy?.EnhancementsEnabled ?? true;
             var activeEnhancements = RagEnhancement.None;
-            if (enhancementsAllowed && userTier != null)
+            if (retrievalPolicy?.EnabledEnhancements is { } explicitEnhancements)
             {
+                // #3390 Slice 4 (D1): explicit, tier-independent enhancement set. Used directly — the live
+                // path resolves enhancements from the global rag.enhancement.* flags at the boundary, not
+                // from the user's tier (grounding is a correctness property, not a tier perk).
+                activeEnhancements = explicitEnhancements;
+            }
+            else if ((retrievalPolicy?.EnhancementsEnabled ?? true) && userTier != null)
+            {
+                // Legacy: enhancements gated by tier presence (classic QA paths, admin debug).
                 activeEnhancements = await _ragEnhancementService
                     .GetActiveEnhancementsAsync(userTier, ct).ConfigureAwait(false);
             }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/ValueObjects/RetrievalPolicy.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/ValueObjects/RetrievalPolicy.cs
@@ -1,3 +1,5 @@
+using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
+
 namespace Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
 
 /// <summary>
@@ -10,7 +12,17 @@ namespace Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
 /// When <c>false</c>, tier-derived enhancements (AdaptiveRouting/CRAG/RAPTOR/Fusion/Graph) are NOT activated,
 /// even if a user tier is supplied. The live path uses <c>false</c> until a golden eval set exists (#3390).
 /// </param>
-internal sealed record RetrievalPolicy(RetrievalProfile BaseProfile, bool EnhancementsEnabled)
+/// <param name="EnabledEnhancements">
+/// #3390 Slice 4 (D1): an EXPLICIT, tier-independent set of enhancements to activate. When non-null it is used
+/// directly by the assembly gate, bypassing the <c>EnhancementsEnabled &amp;&amp; userTier != null</c> legacy gate —
+/// grounding is a correctness property, not a tier perk, so the in-session live path resolves enhancements from
+/// the GLOBAL <c>rag.enhancement.*</c> flags at the boundary rather than from the user's tier. When null, the
+/// legacy tier-gated behaviour is preserved (classic QA paths, admin debug). Default null.
+/// </param>
+internal sealed record RetrievalPolicy(
+    RetrievalProfile BaseProfile,
+    bool EnhancementsEnabled,
+    RagEnhancement? EnabledEnhancements = null)
 {
     /// <summary>Legacy behaviour: Default profile; enhancements gated only by the presence of a tier.</summary>
     public static RetrievalPolicy Default => new(RetrievalProfile.Default, EnhancementsEnabled: true);
@@ -21,4 +33,12 @@ internal sealed record RetrievalPolicy(RetrievalProfile BaseProfile, bool Enhanc
     /// and CRAG web-fallback disabled on the closed rulebook domain — deferred, not silently dormant.
     /// </summary>
     public static RetrievalPolicy LiveSession => new(RetrievalProfile.LiveSession, EnhancementsEnabled: false);
+
+    /// <summary>
+    /// #3390 Slice 4 (D1): LiveSession profile with an EXPLICIT, tier-independent enhancement set. Slice 4 builds
+    /// the set from the global <c>rag.enhancement.*</c> flags at the boundary and passes it here; the assembly
+    /// gate uses it directly (no tier required). The mechanism lands in #3490; activation is Slice 4.
+    /// </summary>
+    public static RetrievalPolicy LiveSessionWith(RagEnhancement enhancements) =>
+        new(RetrievalProfile.LiveSession, EnhancementsEnabled: true, EnabledEnhancements: enhancements);
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/DependencyInjection/KnowledgeBaseServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/DependencyInjection/KnowledgeBaseServiceExtensions.cs
@@ -94,6 +94,7 @@ internal static class KnowledgeBaseServiceExtensions
         services.AddScoped<IConversationSummarizer, Application.Services.ConversationSummarizer>(); // Issue #5259: Progressive conversation summarization
         services.AddSingleton<ChunkingStrategySelector>(); // ISSUE-1903: ADR-016 Phase 1 - Chunking strategy selection
         services.AddScoped<IRagPromptAssemblyService, RagPromptAssemblyService>(); // Replaces AgentPromptBuilder: RAG context + chat history + token budget
+        services.AddScoped<IGroundedAnswerService, GroundedAnswerService>(); // #3490 (ADR-090): shared grounded finalize (leak guard + citation map + grounding)
         services.AddScoped<IExpansionGameResolver, Infrastructure.Services.ExpansionGameResolver>(); // Issue #5588: Expansion priority in RAG search
         services.AddScoped<ITextChunkSearchService, Infrastructure.Services.TextChunkSearchService>(); // Phase 2: PostgreSQL FTS + adjacent chunk retrieval
         services.AddSingleton<IModelConfigurationService, ModelConfigurationService>(); // Issue #3377: Models tier endpoint

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/AskGroundedSessionQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/AskGroundedSessionQueryHandlerTests.cs
@@ -151,13 +151,18 @@ public sealed class AskGroundedSessionQueryHandlerTests
         var fallbackProvider = new Mock<ICopyrightFallbackMessageProvider>();
         fallbackProvider.Setup(f => f.GetMessage(It.IsAny<string>())).Returns("[copyright fallback]");
 
+        // #3490: the handler delegates finalize to the shared GroundedAnswerService — use the REAL
+        // service (with mocked leak guard / fallback) so the finalize logic stays exercised end-to-end.
+        var groundedAnswerService = new GroundedAnswerService(
+            leakGuard.Object,
+            fallbackProvider.Object,
+            Options.Create(new CopyrightLeakGuardOptions()),
+            NullLogger<GroundedAnswerService>.Instance);
+
         return new AskGroundedSessionQueryHandler(
             ragPrompt.Object,
             tierResolver.Object,
             llm.Object,
-            leakGuard.Object,
-            fallbackProvider.Object,
-            Options.Create(new CopyrightLeakGuardOptions()),
-            NullLogger<AskGroundedSessionQueryHandler>.Instance);
+            groundedAnswerService);
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/GroundedAnswerServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/GroundedAnswerServiceTests.cs
@@ -1,0 +1,143 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Models;
+using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
+using Api.SharedKernel.Domain.Enums;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Services;
+
+/// <summary>
+/// #3490 (ADR-090): the shared grounded finalize. Pins the trust-critical invariants that used to be
+/// duplicated across the two in-session handlers — copyright leak guard (fail-open scan / fail-closed
+/// sanitize), Full-gated tier-nulling, grounding from citation count (#3388), and cancellation propagation.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Issue", "3490")]
+public sealed class GroundedAnswerServiceTests
+{
+    private readonly Mock<ICopyrightLeakGuard> _leakGuard = new();
+    private readonly Mock<ICopyrightFallbackMessageProvider> _fallback = new();
+
+    public GroundedAnswerServiceTests()
+    {
+        _fallback.Setup(f => f.GetMessage(It.IsAny<string>())).Returns("[copyright fallback]");
+        // Default: no leak.
+        _leakGuard
+            .Setup(g => g.ScanAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<ChunkCitation>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CopyrightLeakResult(HasLeak: false, Matches: Array.Empty<LeakMatch>()));
+    }
+
+    private GroundedAnswerService BuildService() => new(
+        _leakGuard.Object,
+        _fallback.Object,
+        Options.Create(new CopyrightLeakGuardOptions()),
+        NullLogger<GroundedAnswerService>.Instance);
+
+    private static ChunkCitation Cite(CopyrightTier tier, string doc = "doc-1", string preview = "snippet") =>
+        new(DocumentId: doc, PageNumber: 3, RelevanceScore: 0.9f, SnippetPreview: preview, CopyrightTier: tier, IsPublic: true);
+
+    [Fact]
+    public async Task Finalize_FullTierCitation_MapsPreviewAndGrounded()
+    {
+        var svc = BuildService();
+
+        var result = await svc.FinalizeAsync(
+            "You score at game end. [Page 3]",
+            new List<ChunkCitation> { Cite(CopyrightTier.Full, preview: "Score at game end.") },
+            "How do I score?", "en", CancellationToken.None);
+
+        result.GroundingStatus.Should().Be(GroundingStatus.Grounded);
+        result.CitationDtos.Should().ContainSingle();
+        result.CitationDtos[0].SnippetPreview.Should().Be("Score at game end.", "Full tier keeps the preview");
+        result.Confidence.Should().NotBeNull();
+        result.LeakMatchCount.Should().Be(0);
+        result.ResponseText.Should().Contain("[Page 3]");
+    }
+
+    [Fact]
+    public async Task Finalize_ProtectedTierCitation_NullsPreviewInDto()
+    {
+        var svc = BuildService();
+
+        var result = await svc.FinalizeAsync(
+            "answer", new List<ChunkCitation> { Cite(CopyrightTier.Protected, preview: "verbatim protected text") },
+            "q", "en", CancellationToken.None);
+
+        result.CitationDtos.Should().ContainSingle();
+        result.CitationDtos[0].SnippetPreview.Should().BeNull("Protected tier must not leak the preview verbatim");
+    }
+
+    [Fact]
+    public async Task Finalize_NoCitations_Ungrounded()
+    {
+        var svc = BuildService();
+
+        var result = await svc.FinalizeAsync("no match", new List<ChunkCitation>(), "q", "en", CancellationToken.None);
+
+        result.GroundingStatus.Should().Be(GroundingStatus.Ungrounded);
+        result.CitationDtos.Should().BeEmpty();
+        result.Confidence.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Finalize_LeakDetected_SanitizesAndReportsMatchCount()
+    {
+        // Arrange — a Protected citation and a leak match.
+        _leakGuard
+            .Setup(g => g.ScanAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<ChunkCitation>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CopyrightLeakResult(
+                HasLeak: true,
+                Matches: new List<LeakMatch> { new("doc-1", 3, 12, 0, "verbatim run") }));
+        var svc = BuildService();
+
+        var result = await svc.FinalizeAsync(
+            "a verbatim run leaked here",
+            new List<ChunkCitation> { Cite(CopyrightTier.Protected) },
+            "q", "en", CancellationToken.None);
+
+        result.ResponseText.Should().Be("[copyright fallback]", "leaked text must be replaced by the fallback");
+        result.LeakMatchCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Finalize_ScanThrowsNonCancel_FailsOpen()
+    {
+        // Arrange — the scan faults (not a cancellation). Must fail-open: allow the response, no sanitize.
+        _leakGuard
+            .Setup(g => g.ScanAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<ChunkCitation>>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("guard boom"));
+        var svc = BuildService();
+
+        var result = await svc.FinalizeAsync(
+            "original answer",
+            new List<ChunkCitation> { Cite(CopyrightTier.Protected) },
+            "q", "en", CancellationToken.None);
+
+        result.ResponseText.Should().Be("original answer", "fail-open on a scan fault: ship the answer unsanitized");
+        result.LeakMatchCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Finalize_CallerCancelledDuringScan_Propagates()
+    {
+        // Arrange — the caller's token is cancelled and the scan throws OCE. Must propagate (so a
+        // budget/client cancellation degrades) rather than fail-open into a possibly-unscanned answer.
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        _leakGuard
+            .Setup(g => g.ScanAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<ChunkCitation>>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+        var svc = BuildService();
+
+        var act = () => svc.FinalizeAsync(
+            "answer", new List<ChunkCitation> { Cite(CopyrightTier.Protected) }, "q", "en", cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/GroundedAnswerServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/GroundedAnswerServiceTests.cs
@@ -74,6 +74,25 @@ public sealed class GroundedAnswerServiceTests
     }
 
     [Fact]
+    public async Task Finalize_ProtectedTier_PopulatesParaphraseFromMarker()
+    {
+        // #3490 convergence: FinalizeAsync wires ParaphraseExtractor for Protected citations (the
+        // one-shot path gained this via the consolidation onto streaming's behaviour). Given a
+        // [ref:doc:page] marker + distinct text, ParaphrasedSnippet is populated while SnippetPreview
+        // stays null (no verbatim leak).
+        var svc = BuildService();
+
+        var result = await svc.FinalizeAsync(
+            "According to the rules, [ref:doc-1:3] you gain one victory point per settlement.",
+            new List<ChunkCitation> { Cite(CopyrightTier.Protected, doc: "doc-1", preview: "verbatim protected text") },
+            "How do I score?", "en", CancellationToken.None);
+
+        result.CitationDtos.Should().ContainSingle();
+        result.CitationDtos[0].SnippetPreview.Should().BeNull("Protected must not leak the verbatim preview");
+        result.CitationDtos[0].ParaphrasedSnippet.Should().NotBeNull("FinalizeAsync extracts a paraphrase for Protected citations");
+    }
+
+    [Fact]
     public async Task Finalize_NoCitations_Ungrounded()
     {
         var svc = BuildService();

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Unit/RagPromptAssemblyEnhancementsTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Unit/RagPromptAssemblyEnhancementsTests.cs
@@ -531,6 +531,35 @@ public class RagPromptAssemblyEnhancementsTests
     }
 
     [Fact]
+    public async Task WhenEnabledEnhancementsNone_BypassesLegacyTierPath()
+    {
+        // #3390 D1 edge: an EXPLICIT empty set (RagEnhancement.None) takes the explicit branch (is {}
+        // matches any non-null enum value, including None) and bypasses enhancements entirely — it must
+        // NOT fall into the legacy tier path, even with a tier that would otherwise enable one.
+        var tier = UserTier.Premium;
+        _ragEnhancementMock
+            .Setup(r => r.GetActiveEnhancementsAsync(tier, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RagEnhancement.AdaptiveRouting);
+        SetupTextSearchResults(CreateChunk("doc1", 0, 0.90f, "Pawns move forward."));
+        SetupRerankerPassthrough();
+        var service = CreateService();
+
+        // Act — explicit None set + a tier that WOULD otherwise enable AdaptiveRouting
+        await service.AssemblePromptAsync(
+            "tutor", "Chess", null, "How do pawns move?",
+            TestGameId, null, tier, "it", CancellationToken.None,
+            retrievalPolicy: RetrievalPolicy.LiveSessionWith(RagEnhancement.None));
+
+        // Assert — no tier lookup, no enhancement ran
+        _ragEnhancementMock.Verify(
+            r => r.GetActiveEnhancementsAsync(It.IsAny<UserTier>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _complexityClassifierMock.Verify(
+            c => c.ClassifyAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
     public async Task WhenEnabledEnhancementsNull_LegacyTierPathUnchanged()
     {
         // #3390 D1 backward-compat: a policy with EnabledEnhancements=null keeps the legacy behaviour —

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Unit/RagPromptAssemblyEnhancementsTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Unit/RagPromptAssemblyEnhancementsTests.cs
@@ -464,6 +464,100 @@ public class RagPromptAssemblyEnhancementsTests
 
     #endregion
 
+    #region Tier-independent EnabledEnhancements set (#3390 Slice 4 / D1)
+
+    [Fact]
+    public async Task WhenEnabledEnhancementsSet_ActivatesWithoutTier()
+    {
+        // #3390 D1: an explicit EnabledEnhancements set activates enhancements with NO tier at all —
+        // grounding is a correctness property, not a tier perk. Here AdaptiveRouting is requested via
+        // the policy set (userTier=null); the complexity classifier must run.
+        _complexityClassifierMock
+            .Setup(c => c.ClassifyAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(QueryComplexity.Simple("Greeting query", 0.95f));
+        SetupTextSearchResults(CreateChunk("doc1", 0, 0.90f, "Pawns move forward."));
+        SetupRerankerPassthrough();
+        var service = CreateService();
+
+        // Act — explicit set, tier null
+        await service.AssemblePromptAsync(
+            "tutor", "Chess", null, "Hello!",
+            TestGameId, null, userTier: null, "it", CancellationToken.None,
+            retrievalPolicy: RetrievalPolicy.LiveSessionWith(RagEnhancement.AdaptiveRouting));
+
+        // Assert — the enhancement activated from the explicit set, without any tier lookup
+        _complexityClassifierMock.Verify(
+            c => c.ClassifyAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _ragEnhancementMock.Verify(
+            r => r.GetActiveEnhancementsAsync(It.IsAny<UserTier>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task WhenEnabledEnhancementsSet_BypassesTierLookup()
+    {
+        // #3390 D1: the explicit set wins over the tier path — GetActiveEnhancementsAsync is never
+        // consulted even when a tier is present. Here CRAG is requested via the set; its evaluator runs.
+        var tier = UserTier.Premium;
+        _relevanceEvaluatorMock
+            .Setup(e => e.EvaluateAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<ScoredChunk>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RelevanceEvaluation(RelevanceVerdict.Correct, 0.9f, "Relevant"));
+        var docId = Guid.NewGuid();
+        _textSearchMock
+            .Setup(t => t.FullTextSearchAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<TextChunkMatch>
+            {
+                new(docId, "Initial chunk text", 0, 1, 0.90f),
+                new(docId, "Initial chunk text", 0, 1, 0.85f), // duplicate boosts RRF above threshold
+            });
+        SetupRerankerPassthrough();
+        var service = CreateService();
+
+        // Act — explicit CRAG set AND a tier that would otherwise drive the tier path
+        await service.AssemblePromptAsync(
+            "tutor", "Chess", null, "How does castling work?",
+            TestGameId, null, tier, "it", CancellationToken.None,
+            retrievalPolicy: RetrievalPolicy.LiveSessionWith(RagEnhancement.CragEvaluation));
+
+        // Assert — CRAG ran from the explicit set; the tier lookup was bypassed entirely
+        _relevanceEvaluatorMock.Verify(
+            e => e.EvaluateAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<ScoredChunk>>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _ragEnhancementMock.Verify(
+            r => r.GetActiveEnhancementsAsync(It.IsAny<UserTier>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task WhenEnabledEnhancementsNull_LegacyTierPathUnchanged()
+    {
+        // #3390 D1 backward-compat: a policy with EnabledEnhancements=null keeps the legacy behaviour —
+        // enhancements resolved from the tier via GetActiveEnhancementsAsync. RetrievalPolicy.Default
+        // carries EnhancementsEnabled=true and no explicit set, so the tier path runs.
+        var tier = UserTier.Premium;
+        _ragEnhancementMock
+            .Setup(r => r.GetActiveEnhancementsAsync(tier, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RagEnhancement.None);
+        SetupTextSearchResults(CreateChunk("doc1", 0, 0.90f, "Pawns move forward."));
+        SetupRerankerPassthrough();
+        var service = CreateService();
+
+        // Act — explicit-null set + a tier → legacy tier path
+        await service.AssemblePromptAsync(
+            "tutor", "Chess", null, "How do pawns move?",
+            TestGameId, null, tier, "it", CancellationToken.None,
+            retrievalPolicy: RetrievalPolicy.Default);
+
+        // Assert — the tier lookup ran (legacy path preserved)
+        _ragEnhancementMock.Verify(
+            r => r.GetActiveEnhancementsAsync(tier, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    #endregion
+
     #region CRAG web-fallback OFF on the closed rulebook domain (#3467)
 
     [Fact]


### PR DESCRIPTION
## #3490 (ADR-090) — parte 1: meccanismo Slice 4 + consolidamento one-shot

Sblocca #3390 Slice 4. Due pezzi:

### 1. `RetrievalPolicy.EnabledEnhancements` (D1 — l'abilitatore di Slice 4)
Set esplicito, **tier-independent**, di enhancement su `RetrievalPolicy`. Il gate (`RagPromptAssemblyService.cs:184`) lo usa direttamente quando presente, bypassando il gate legacy `EnhancementsEnabled && userTier != null` — il grounding è una **proprietà di correttezza, non un perk di tier**. Set null → path legacy invariato (QA classico / admin debug). Factory `RetrievalPolicy.LiveSessionWith(enhancements)` per Slice 4. **Solo meccanismo**: il live path passa ancora `LiveSession` (nessun enhancement) → comportamento invariato.

### 2. `IGroundedAnswerService` (consolidamento ADR-090)
Estrae il **finalize** grounded security-critical (copyright leak guard fail-open-scan/**fail-closed-sanitize** → paraphrase → tier-nulling `CitationDto` → grounding da citation count #3388 → confidence) — il blocco dove la review di Slice 2 trovò il bug del leak-guard, duplicato tra i due handler in-sessione. `AskGroundedSessionQueryHandler` (one-shot, path immagine) ora **delega** al servizio (e guadagna la paraphrase che gli mancava). Ogni handler mantiene la propria forma di generazione.

## Deferito (follow-up tracciato su #3490)
Il wiring del **handler streaming** (`ChatWithSessionAgentCommandHandler`) al servizio: il suo blocco post-gen è iterator-constrained e ha una sfumatura di cancellazione (fail-open scan → persist+broadcast su client-disconnect vs propagazione di `FinalizeAsync`) sul path di produzione più trafficato — merita una PR revisionabile a sé. Il handler streaming mantiene intanto il suo finalize inline corretto; il residuo di drift è documentato.

## Code review (finder avversariale) — 0 blocker
Estrazione **fedele, nessun bug di correttezza**. Verificati: fail-open/fail-closed ordering, paraphrase-dopo-sanitize, `is { }` su `None` prende il ramo esplicito (bypassa, non cade nel legacy), ComputeConfidence senza divergenza, DI ok. 2 osservazioni azionabili → fixate con test (edge `None`, paraphrase Protected).

## Test
3 test gate tier-independent + edge `None` · 7 unit `GroundedAnswerService` (fail-closed sanitize, tier-nulling, grounding, cancellation-propagation, paraphrase) · one-shot handler usa il servizio reale. **21/21 mirati + 110/110 regressione streaming** verdi. Build 0 errori.

Part of #3490. Ref ADR-090, spec `2026-08-02-rag-enhancement-live-path-validation.md`, epic #3390/#3397.

🤖 Generated with [Claude Code](https://claude.com/claude-code)