### PR TITLE
refactor(ai): migrate streaming handler to IGroundedAnswerService (#3490)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentCommandHandler.cs
@@ -53,9 +53,7 @@ internal sealed class ChatWithSessionAgentCommandHandler : IStreamingQueryHandle
     private readonly ICircuitBreakerRegistry _circuitBreakerRegistry;
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<ChatWithSessionAgentCommandHandler> _logger;
-    private readonly ICopyrightLeakGuard _copyrightLeakGuard;
-    private readonly ICopyrightFallbackMessageProvider _fallbackMessageProvider;
-    private readonly IOptions<CopyrightLeakGuardOptions> _copyrightOptions;
+    private readonly IGroundedAnswerService _groundedAnswerService;
     private readonly ILiveSessionStreamGateway _liveSessionStreamGateway;
     private readonly IOptions<SessionAgentOptions> _sessionAgentOptions;
 
@@ -86,9 +84,7 @@ internal sealed class ChatWithSessionAgentCommandHandler : IStreamingQueryHandle
         ICircuitBreakerRegistry circuitBreakerRegistry,
         IServiceScopeFactory scopeFactory,
         ILogger<ChatWithSessionAgentCommandHandler> logger,
-        ICopyrightLeakGuard copyrightLeakGuard,
-        ICopyrightFallbackMessageProvider fallbackMessageProvider,
-        IOptions<CopyrightLeakGuardOptions> copyrightOptions,
+        IGroundedAnswerService groundedAnswerService,
         ILiveSessionStreamGateway liveSessionStreamGateway,
         IOptions<SessionAgentOptions>? sessionAgentOptions = null)
     {
@@ -106,9 +102,7 @@ internal sealed class ChatWithSessionAgentCommandHandler : IStreamingQueryHandle
         _circuitBreakerRegistry = circuitBreakerRegistry ?? throw new ArgumentNullException(nameof(circuitBreakerRegistry));
         _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _copyrightLeakGuard = copyrightLeakGuard ?? throw new ArgumentNullException(nameof(copyrightLeakGuard));
-        _fallbackMessageProvider = fallbackMessageProvider ?? throw new ArgumentNullException(nameof(fallbackMessageProvider));
-        _copyrightOptions = copyrightOptions ?? throw new ArgumentNullException(nameof(copyrightOptions));
+        _groundedAnswerService = groundedAnswerService ?? throw new ArgumentNullException(nameof(groundedAnswerService));
         _liveSessionStreamGateway = liveSessionStreamGateway ?? throw new ArgumentNullException(nameof(liveSessionStreamGateway));
         _sessionAgentOptions = sessionAgentOptions ?? Options.Create(new SessionAgentOptions());
     }
@@ -500,74 +494,36 @@ internal sealed class ChatWithSessionAgentCommandHandler : IStreamingQueryHandle
         var responseText = fullResponse.ToString();
         var totalTokens = finalUsage?.TotalTokens ?? 0;
 
-        // #447: Copyright leak guard (fail-open)
-        var protectedCitations = resolvedCitations
-            .Where(c => c.CopyrightTier == CopyrightTier.Protected)
-            .ToList();
+        // #447 / #3490 (ADR-090): shared grounded finalize — copyright leak guard (fail-open scan /
+        // fail-closed sanitize) → paraphrase (Protected) → CitationDto mapping (Full-gated tier-nulling)
+        // → grounding (#3388) → confidence. Same seam as the one-shot path (GroundedAnswerService), so
+        // the trust-critical logic lives in ONE place (removes the ADR-090 drift). FinalizeAsync emits
+        // the copyright scan/verbatim metrics internally — the handler must NOT re-emit them.
+        //
+        // Cancellation: FinalizeAsync PROPAGATES an OperationCanceledException on the caller's token
+        // (a client-disconnect during the scan). The previous inline code fail-opened the scan but then
+        // aborted at the following SaveChangesAsync(cancellationToken) anyway — so the net user outcome
+        // (no persist, no broadcast) is IDENTICAL; propagating just drops the spurious "fail-open" log +
+        // CopyrightScanErrors metric that a mere cancel should never have produced.
+        var grounded = await _groundedAnswerService
+            .FinalizeAsync(responseText, resolvedCitations, command.UserQuestion, agentLanguage, cancellationToken)
+            .ConfigureAwait(false);
 
-        CopyrightLeakResult? leakResult = null;
+        responseText = grounded.ResponseText;
+        var finalCitations = grounded.FinalCitations;
 
-        if (protectedCitations.Count > 0)
+        // Copyright sanitize event kept in the handler: the C# iterator method forbids `yield` inside a
+        // try/catch, so FinalizeAsync does the scan/sanitize and returns LeakMatchCount for the yield.
+        if (grounded.LeakMatchCount > 0)
         {
-            try
-            {
-                using var scanCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                scanCts.CancelAfter(TimeSpan.FromMilliseconds(_copyrightOptions.Value.ScanTimeoutMs));
-
-                var scanSw = Stopwatch.StartNew();
-                leakResult = await _copyrightLeakGuard
-                    .ScanAsync(responseText, protectedCitations, scanCts.Token)
-                    .ConfigureAwait(false);
-                scanSw.Stop();
-
-                MeepleAiMetrics.CopyrightScanDurationMs.Record(scanSw.ElapsedMilliseconds);
-            }
-            catch (Exception ex)
-            {
-                MeepleAiMetrics.CopyrightScanErrors.Add(1,
-                    new KeyValuePair<string, object?>("error_type", ex.GetType().Name));
-                _logger.LogError(ex,
-                    "Copyright leak guard failed for session {SessionId}, allowing response (fail-open)",
-                    command.AgentSessionId);
-                leakResult = null;  // fail-open
-            }
-        }
-
-        // #447: Leak detection result handling (placed here due to C# iterator method constraints)
-        if (leakResult?.HasLeak == true)
-        {
-            foreach (var match in leakResult.Matches)
-            {
-                MeepleAiMetrics.CopyrightVerbatimDetected.Add(1,
-                    new KeyValuePair<string, object?>("run_length", match.RunLength),
-                    new KeyValuePair<string, object?>("document_id", match.DocumentId));
-            }
-
             _logger.LogWarning(
-                "Copyright leak detected in session {SessionId}: {MatchCount} matches, sanitizing response",
-                command.AgentSessionId, leakResult.Matches.Count);
-
-            var fallbackMessage = _fallbackMessageProvider.GetMessage(agentLanguage);
+                "Copyright leak detected in session {SessionId}: {MatchCount} matches, response sanitized",
+                command.AgentSessionId, grounded.LeakMatchCount);
 
             yield return CreateEvent(
                 StreamingEventType.CopyrightSanitized,
-                new StreamingCopyrightSanitized(fallbackMessage, leakResult.Matches.Count));
-
-            responseText = fallbackMessage;
+                new StreamingCopyrightSanitized(responseText, grounded.LeakMatchCount));
         }
-
-        // Extract paraphrased snippets for Protected-tier citations
-        var finalCitations = resolvedCitations.Select(c =>
-        {
-            if (c.CopyrightTier == CopyrightTier.Protected)
-            {
-                var paraphrase = ParaphraseExtractor.Extract(
-                    responseText, c.DocumentId, c.PageNumber,
-                    c.SnippetPreview, command.UserQuestion);
-                return c with { ParaphrasedSnippet = paraphrase };
-            }
-            return c;
-        }).ToList();
 
         // Persist assistant response with citations
         var citationsJson = JsonSerializer.Serialize(finalCitations);
@@ -647,20 +603,9 @@ internal sealed class ChatWithSessionAgentCommandHandler : IStreamingQueryHandle
             _ = GenerateConversationSummaryAsync(thread.Id);
         }
 
-        // Build citation DTOs for SSE response (reused for both StreamingComplete and session:chat broadcast).
-        var citationDtos = finalCitations.Select(c => new CitationDto(
-            c.DocumentId,
-            c.PageNumber,
-            c.RelevanceScore,
-            c.CopyrightTier == CopyrightTier.Full ? c.SnippetPreview : null,
-            c.CopyrightTier.ToString().ToLowerInvariant(),
-            c.ParaphrasedSnippet,
-            c.IsPublic,
-            // SP-C (#3407): region overlay + char offsets are Full-gated (same rule as SnippetPreview) —
-            // parsed from the raw bbox JSON only for Full-tier citations (DA-4: no verbatim highlight leak).
-            Regions: c.CopyrightTier == CopyrightTier.Full ? CitationRegion.Parse(c.BoundingBoxesJson) : null,
-            CharStart: c.CopyrightTier == CopyrightTier.Full ? c.CharStart : null,
-            CharEnd: c.CopyrightTier == CopyrightTier.Full ? c.CharEnd : null)).ToList();
+        // Citation DTOs for the SSE response + session:chat broadcast — built by the shared finalize
+        // (Full-gated tier-nulling; SP-C #3407 region/offset gating inherited, no Protected verbatim leak).
+        var citationDtos = grounded.CitationDtos;
 
         // SP5-b T2: record citations-per-answer ONCE, post-stream, using citationDtos.Count
         // (the broadcast-authoritative list — NOT the earlier assembled.Citations or resolvedCitations).
@@ -712,7 +657,9 @@ internal sealed class ChatWithSessionAgentCommandHandler : IStreamingQueryHandle
             }
         }
 
-        var groundingStatus = citationDtos.Count > 0 ? "Grounded" : "Ungrounded";
+        // Wire grounding string (#3388) from the shared finalize enum (Grounded/Ungrounded — derived
+        // from citation count, never Partial). SSE serializes enums numerically, so send the name.
+        var groundingStatus = grounded.GroundingStatus.ToString();
 
         // #3390 Slice 1: structured grounding observability (text path -> RAG, LiveSession profile).
         // Wrapped so a metrics fault can never break the user's stream (mirrors the broadcast guard above).
@@ -736,7 +683,7 @@ internal sealed class ChatWithSessionAgentCommandHandler : IStreamingQueryHandle
                 promptTokens: finalUsage?.PromptTokens ?? 0,
                 completionTokens: finalUsage?.CompletionTokens ?? 0,
                 totalTokens: totalTokens,
-                confidence: RagPromptAssemblyService.ComputeConfidence(assembled.Citations, responseText),
+                confidence: grounded.Confidence,
                 chatThreadId: thread.Id,
                 Citations: citationDtos,
                 GroundingStatus: groundingStatus));

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatSessionAgentBroadcastTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatSessionAgentBroadcastTests.cs
@@ -494,9 +494,10 @@ public class ChatSessionAgentBroadcastTests
             circuitBreakerRegistry: registry.Object,
             scopeFactory: scopeFactory.Object,
             logger: NullLogger<ChatWithSessionAgentCommandHandler>.Instance,
-            copyrightLeakGuard: leakGuard.Object,
-            fallbackMessageProvider: fallbackProvider.Object,
-            copyrightOptions: Options.Create(new CopyrightLeakGuardOptions()),
+            groundedAnswerService: new GroundedAnswerService(
+                leakGuard.Object, fallbackProvider.Object,
+                Options.Create(new CopyrightLeakGuardOptions()),
+                NullLogger<GroundedAnswerService>.Instance),
             liveSessionStreamGateway: gateway);
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentFallbackTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentFallbackTests.cs
@@ -145,9 +145,10 @@ public class ChatWithSessionAgentFallbackTests
             circuitBreakerRegistry: registry,
             scopeFactory: Mock.Of<IServiceScopeFactory>(),
             logger: NullLogger<ChatWithSessionAgentCommandHandler>.Instance,
-            copyrightLeakGuard: Mock.Of<ICopyrightLeakGuard>(),
-            fallbackMessageProvider: Mock.Of<ICopyrightFallbackMessageProvider>(),
-            copyrightOptions: Options.Create(new CopyrightLeakGuardOptions()),
+            groundedAnswerService: new GroundedAnswerService(
+                Mock.Of<ICopyrightLeakGuard>(), Mock.Of<ICopyrightFallbackMessageProvider>(),
+                Options.Create(new CopyrightLeakGuardOptions()),
+                NullLogger<GroundedAnswerService>.Instance),
             liveSessionStreamGateway: Mock.Of<ILiveSessionStreamGateway>());
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentMemoryContextTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentMemoryContextTests.cs
@@ -256,9 +256,10 @@ public class ChatWithSessionAgentMemoryContextTests
             circuitBreakerRegistry: registry.Object,
             scopeFactory: scopeFactory.Object,
             logger: NullLogger<ChatWithSessionAgentCommandHandler>.Instance,
-            copyrightLeakGuard: leakGuard.Object,
-            fallbackMessageProvider: fallbackProvider.Object,
-            copyrightOptions: Options.Create(new CopyrightLeakGuardOptions()),
+            groundedAnswerService: new GroundedAnswerService(
+                leakGuard.Object, fallbackProvider.Object,
+                Options.Create(new CopyrightLeakGuardOptions()),
+                NullLogger<GroundedAnswerService>.Instance),
             liveSessionStreamGateway: gateway.Object);
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentMetricsTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentMetricsTests.cs
@@ -381,10 +381,49 @@ public sealed class ChatWithSessionAgentMetricsTests
             Times.Once);
     }
 
+    // ──────────────────────────────────────────────────────────────────────────
+    // #3490: streaming handler delegates finalize to IGroundedAnswerService; the
+    // CopyrightSanitized yield is driven by the returned LeakMatchCount (the one
+    // handler-specific behavior the shared-service tests cannot cover — the yield).
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "#3490: streaming path yields CopyrightSanitized when the shared finalize detects a leak")]
+    public async Task Handle_LeakDetected_YieldsCopyrightSanitizedEvent()
+    {
+        // Arrange — a Protected citation (so the finalize scans) + a leaking scan result.
+        var protectedCitation = new ChunkCitation(
+            DocumentId: "doc-1", PageNumber: 1, RelevanceScore: 0.9f,
+            SnippetPreview: "verbatim", CopyrightTier: CopyrightTier.Protected, IsPublic: false);
+        var leak = new CopyrightLeakResult(
+            HasLeak: true,
+            Matches: new List<LeakMatch> { new("doc-1", 1, 12, 0, "verbatim run") });
+        var handler = BuildHandler(
+            resolvedCitations: new List<ChunkCitation> { protectedCitation },
+            ragPromptMock: out _,
+            tokenContent: "a verbatim run leaked",
+            leakResult: leak);
+
+        // Act — capture the CopyrightSanitized event
+        StreamingCopyrightSanitized? sanitized = null;
+        await foreach (var evt in handler.Handle(BuildCommand(), CancellationToken.None))
+        {
+            if (evt.Type == StreamingEventType.CopyrightSanitized)
+            {
+                sanitized = evt.Data as StreamingCopyrightSanitized;
+            }
+        }
+
+        // Assert — the handler yielded the sanitize event with the fallback body + match count
+        sanitized.Should().NotBeNull("the shared finalize detected a leak → the handler must yield CopyrightSanitized");
+        sanitized!.MatchCount.Should().Be(1);
+        sanitized.SanitizedBody.Should().Be("[copyright sanitized]");
+    }
+
     private static ChatWithSessionAgentCommandHandler BuildHandler(
         IReadOnlyList<ChunkCitation> resolvedCitations,
         out Mock<IRagPromptAssemblyService> ragPromptMock,
-        string tokenContent = "Hello world")
+        string tokenContent = "Hello world",
+        CopyrightLeakResult? leakResult = null)
     {
         // --- AgentSession repo ---
         var playerId = Guid.NewGuid();
@@ -508,16 +547,17 @@ public sealed class ChatWithSessionAgentMetricsTests
         // --- ServiceScopeFactory (chunk usage increment fire-and-forget) ---
         var scopeFactory = new Mock<IServiceScopeFactory>();
 
-        // --- Copyright leak guard (no leak) ---
-        var noLeak = new CopyrightLeakResult(HasLeak: false, Matches: Array.Empty<LeakMatch>());
+        // --- Copyright leak guard (no leak by default; a leaking result exercises the sanitize path) ---
+        var scanResult = leakResult ?? new CopyrightLeakResult(HasLeak: false, Matches: Array.Empty<LeakMatch>());
         var leakGuard = new Mock<ICopyrightLeakGuard>();
         leakGuard
             .Setup(g => g.ScanAsync(
                 It.IsAny<string>(), It.IsAny<IReadOnlyList<ChunkCitation>>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(noLeak);
+            .ReturnsAsync(scanResult);
 
         var fallbackProvider = new Mock<ICopyrightFallbackMessageProvider>();
+        fallbackProvider.Setup(f => f.GetMessage(It.IsAny<string>())).Returns("[copyright sanitized]");
 
         var gateway = new Mock<ILiveSessionStreamGateway>();
 
@@ -536,9 +576,10 @@ public sealed class ChatWithSessionAgentMetricsTests
             circuitBreakerRegistry: registry.Object,
             scopeFactory: scopeFactory.Object,
             logger: NullLogger<ChatWithSessionAgentCommandHandler>.Instance,
-            copyrightLeakGuard: leakGuard.Object,
-            fallbackMessageProvider: fallbackProvider.Object,
-            copyrightOptions: Options.Create(new CopyrightLeakGuardOptions()),
+            groundedAnswerService: new GroundedAnswerService(
+                leakGuard.Object, fallbackProvider.Object,
+                Options.Create(new CopyrightLeakGuardOptions()),
+                NullLogger<GroundedAnswerService>.Instance),
             liveSessionStreamGateway: gateway.Object);
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentPerChunkTimeoutTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentPerChunkTimeoutTests.cs
@@ -450,9 +450,10 @@ public sealed class ChatWithSessionAgentPerChunkTimeoutTests
             circuitBreakerRegistry: registry.Object,
             scopeFactory: scopeFactory.Object,
             logger: NullLogger<ChatWithSessionAgentCommandHandler>.Instance,
-            copyrightLeakGuard: leakGuard.Object,
-            fallbackMessageProvider: fallbackProvider.Object,
-            copyrightOptions: Options.Create(new CopyrightLeakGuardOptions()),
+            groundedAnswerService: new GroundedAnswerService(
+                leakGuard.Object, fallbackProvider.Object,
+                Options.Create(new CopyrightLeakGuardOptions()),
+                NullLogger<GroundedAnswerService>.Instance),
             liveSessionStreamGateway: gateway.Object,
             sessionAgentOptions: sessionAgentOptions);
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentStreamingSafetyTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentStreamingSafetyTests.cs
@@ -420,9 +420,10 @@ public sealed class ChatWithSessionAgentStreamingSafetyTests
             circuitBreakerRegistry: registry.Object,
             scopeFactory: scopeFactory.Object,
             logger: NullLogger<ChatWithSessionAgentCommandHandler>.Instance,
-            copyrightLeakGuard: leakGuard.Object,
-            fallbackMessageProvider: fallbackProvider.Object,
-            copyrightOptions: Options.Create(new CopyrightLeakGuardOptions()),
+            groundedAnswerService: new GroundedAnswerService(
+                leakGuard.Object, fallbackProvider.Object,
+                Options.Create(new CopyrightLeakGuardOptions()),
+                NullLogger<GroundedAnswerService>.Instance),
             liveSessionStreamGateway: gateway.Object);
     }
 


### PR DESCRIPTION
## #3490 — completa il consolidamento ADR-090

Migra il **handler streaming** `ChatWithSessionAgentCommandHandler` (path testo SSE) a delegare il finalize grounded a `IGroundedAnswerService.FinalizeAsync` — lo stesso seam già usato dal handler one-shot. La logica trust-critical (copyright leak guard, paraphrase, tier-nulling `CitationDto`, grounding da citation count #3388, confidence) vive ora in **un solo posto**. La copia inline (~110 righe) sparisce; entrambi i produttori in-sessione condividono il seam → **elimina il drift che ADR-090 mirava a rimuovere**.

## Parità di comportamento (verificata da recon + review)

- **`yield CopyrightSanitized`** resta nel handler (il C# iterator vieta `yield` dentro try/catch), pilotato dal `LeakMatchCount` ritornato. Ordine eventi SSE invariato (Sanitized prima di Complete).
- **Cancellazione**: `FinalizeAsync` **propaga** l'OCE sul token del caller invece del vecchio fail-open inline. **Outcome utente IDENTICO** — il vecchio codice fail-opennava lo scan ma poi abortiva comunque alla `SaveChangesAsync(cancellationToken)` successiva, quindi un client-disconnect mid-scan produceva niente-persist/niente-broadcast in entrambi i casi. La migrazione elimina solo il log "fail-open" spurio + la metrica `CopyrightScanErrors` che un semplice cancel non doveva mai emettere. Rimuove anche la stessa fail-open-su-OCE che la review di Slice 2 aveva segnalato.
- **ComputeConfidence** invariato (`resolvedCitations` vs `assembled.Citations` sono count- e RelevanceScore-identici). Wire grounding string da `enum.ToString()`.
- **Metriche copyright** emesse ora solo dal servizio (nessun doppio conteggio).

## Costruttore + test

3 deps copyright rimpiazzate da `IGroundedAnswerService`; 6 call-site di test rewired a un `GroundedAnswerService` reale (mantengono i loro mock leak-guard). **Nuova copertura**: `Handle_LeakDetected_YieldsCopyrightSanitizedEvent` pinna il sanitize-yield dello streaming — branch prima **non testata** a livello handler.

## Code review avversariale — **CLEAN, 0 bug**
Ogni punto di parità verificato (wiring a valle, iterator constraint, no-doppio-conteggio, claim cancellazione, confidence-input-swap benigno, no dead-code).

## Test
**71/71** mirati verdi. Build 0 errori. (Il flake `RagPromptAssembly*Metrics` sotto `--filter` largo è una race MeterListener sul Meter globale pre-esistente, isolation-pass confermato, non toccato da questo change.)

Closes #3490. Ref ADR-090, sblocca #3390 Slice 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)