### PR TITLE
feat(rag-eval): grounded eval seam for enhancements (#3390 Step 1)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Evaluation/Commands/RunEvaluationCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Evaluation/Commands/RunEvaluationCommand.cs
@@ -32,4 +32,15 @@ internal sealed record RunEvaluationCommand : IRequest<EvaluationResult>
     /// Number of top results to retrieve per query.
     /// </summary>
     public int TopK { get; init; } = 10;
+
+    /// <summary>
+    /// #3390 Slice 4 Step 1: RAG enhancement identifiers to activate on the grounded eval seam
+    /// (e.g. <c>["crag-evaluation"]</c>, or <c>["rag.enhancement.raptor-retrieval"]</c>). When
+    /// <b>non-null</b> the eval runs through <c>AssemblePromptAsync</c> under
+    /// <c>RetrievalPolicy.LiveSessionWith(parsedSet)</c> — an <b>empty</b> list is the grounded
+    /// baseline (no enhancements). When <b>null</b>, the legacy <c>AskWithHybridSearchAsync</c> path
+    /// runs (preserves the #3477 baseline). Parsed via <c>RagEnhancementExtensions.ParseFlags</c>
+    /// (fail-loud on an unknown identifier).
+    /// </summary>
+    public IReadOnlyList<string>? Enhancements { get; init; }
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Evaluation/Commands/RunEvaluationCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Evaluation/Commands/RunEvaluationCommandHandler.cs
@@ -61,13 +61,22 @@ internal sealed class RunEvaluationCommandHandler : IRequestHandler<RunEvaluatio
                 string.Join("; ", errors));
         }
 
+        // #3390 Slice 4 Step 1: null Enhancements → legacy hybrid path; non-null (incl. empty) → the
+        // grounded seam with the parsed enhancement set (empty = grounded baseline). ParseFlags is
+        // fail-loud on a typo, so a bad identifier surfaces as a 4xx rather than a silent wrong-set run.
+        Api.BoundedContexts.KnowledgeBase.Domain.Enums.RagEnhancement? groundedEnhancements =
+            request.Enhancements is null
+                ? null
+                : Api.BoundedContexts.KnowledgeBase.Domain.Enums.RagEnhancementExtensions.ParseFlags(request.Enhancements);
+
         // Create evaluation options
         var options = new EvaluationOptions
         {
             Configuration = request.Configuration,
             TopK = request.TopK,
             EvaluateAnswerCorrectness = request.EvaluateAnswerCorrectness,
-            MaxSamples = request.MaxSamples
+            MaxSamples = request.MaxSamples,
+            GroundedEnhancements = groundedEnhancements
         };
 
         // Run evaluation

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Evaluation/Services/DatasetEvaluationService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Evaluation/Services/DatasetEvaluationService.cs
@@ -1,8 +1,14 @@
 using System.Diagnostics;
+using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
 using Api.BoundedContexts.KnowledgeBase.Domain.Evaluation;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
 using Api.Services;
 using Microsoft.Extensions.Logging;
+// Api.Models also declares an EvaluationMetrics; pin only the two wire types we need to avoid ambiguity.
+using Snippet = Api.Models.Snippet;
+using QaResponse = Api.Models.QaResponse;
 
 namespace Api.BoundedContexts.KnowledgeBase.Application.Evaluation.Services;
 
@@ -14,17 +20,23 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Evaluation.Services;
 internal sealed class DatasetEvaluationService : IDatasetEvaluationService
 {
     private readonly IRagService _ragService;
+    private readonly IRagPromptAssemblyService _ragPromptService;
+    private readonly ILlmService _llmService;
     private readonly InlineCitationMatcherService _citationMatcher;
     private readonly ICitationValidationService _citationValidation;
     private readonly ILogger<DatasetEvaluationService> _logger;
 
     public DatasetEvaluationService(
         IRagService ragService,
+        IRagPromptAssemblyService ragPromptService,
+        ILlmService llmService,
         InlineCitationMatcherService citationMatcher,
         ICitationValidationService citationValidation,
         ILogger<DatasetEvaluationService> logger)
     {
         _ragService = ragService ?? throw new ArgumentNullException(nameof(ragService));
+        _ragPromptService = ragPromptService ?? throw new ArgumentNullException(nameof(ragPromptService));
+        _llmService = llmService ?? throw new ArgumentNullException(nameof(llmService));
         _citationMatcher = citationMatcher ?? throw new ArgumentNullException(nameof(citationMatcher));
         _citationValidation = citationValidation ?? throw new ArgumentNullException(nameof(citationValidation));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -104,17 +116,21 @@ internal sealed class DatasetEvaluationService : IDatasetEvaluationService
 
         try
         {
-            // Query the RAG system via the canonical hybrid retrieval path. IRagService.AskAsync's legacy
-            // vector path is deprecated and returns empty results (RagService.ExecuteRetrievalPhaseAsync),
-            // so the eval must use AskWithHybridSearchAsync to exercise the real production retrieval.
-            // bypassCache: true so each run measures fresh retrieval, not a possibly-stale cached response.
-            var ragResponse = await _ragService.AskWithHybridSearchAsync(
-                sample.GameId ?? "",
-                sample.Question,
-                SearchMode.Hybrid,
-                language: null,
-                bypassCache: true,
-                cancellationToken).ConfigureAwait(false);
+            // Retrieval. Two paths, selected by options.GroundedEnhancements (#3390 Step 1):
+            //  - non-null → the SAME grounded seam the in-session live path uses (AssemblePromptAsync)
+            //    under RetrievalPolicy.LiveSessionWith(set), so enhancements are actually exercised and
+            //    the eval can measure them (closes the #3475-class wrong-path gap).
+            //  - null → legacy AskWithHybridSearchAsync (backward-compatible; preserves #3477 baseline).
+            //    bypassCache: true so each run measures fresh retrieval, not a possibly-stale cache.
+            var ragResponse = options.GroundedEnhancements is { } groundedEnhancements
+                ? await RunGroundedRetrievalAsync(sample, groundedEnhancements, cancellationToken).ConfigureAwait(false)
+                : await _ragService.AskWithHybridSearchAsync(
+                    sample.GameId ?? "",
+                    sample.Question,
+                    SearchMode.Hybrid,
+                    language: null,
+                    bypassCache: true,
+                    cancellationToken).ConfigureAwait(false);
 
             stopwatch.Stop();
 
@@ -209,6 +225,61 @@ internal sealed class DatasetEvaluationService : IDatasetEvaluationService
             };
         }
 #pragma warning restore CA1031
+    }
+
+    /// <summary>
+    /// #3390 Slice 4 Step 1: retrieval through the SAME grounded seam the in-session live path uses
+    /// (<c>AssemblePromptAsync</c>), under <c>RetrievalPolicy.LiveSessionWith(enhancements)</c>, then
+    /// generation. Produces a <see cref="QaResponse"/> whose <c>snippets</c> have the identical shape
+    /// <c>AskWithHybridSearchAsync</c> emits (<c>source = "PDF:{documentId}"</c>, <c>page</c>), so the
+    /// downstream metrics are unchanged — only the retrieval PATH changes, which is the whole point:
+    /// enhancements now affect the measured numbers.
+    /// </summary>
+    private async Task<QaResponse> RunGroundedRetrievalAsync(
+        EvaluationSample sample,
+        RagEnhancement enhancements,
+        CancellationToken cancellationToken)
+    {
+        if (!Guid.TryParse(sample.GameId, out var gameGuid))
+        {
+            // The grounded seam needs a UUID GameId; the golden set is UUID-resolved. A slug here is a
+            // data error — surface it (the caller's catch records a failed sample, not a silent zero).
+            throw new InvalidOperationException(
+                $"Grounded eval requires a UUID GameId; sample '{sample.Id}' has '{sample.GameId}'.");
+        }
+
+        var assembled = await _ragPromptService.AssemblePromptAsync(
+            agentTypology: "tutor",
+            gameTitle: string.Empty,
+            gameState: null,
+            userQuestion: sample.Question,
+            gameId: gameGuid,
+            chatThread: null,
+            userTier: null,
+            agentLanguage: "en",
+            cancellationToken,
+            retrievalPolicy: RetrievalPolicy.LiveSessionWith(enhancements)).ConfigureAwait(false);
+
+        var completion = await _llmService.GenerateCompletionAsync(
+            assembled.SystemPrompt, assembled.UserPrompt, RequestSource.RagPipeline, cancellationToken)
+            .ConfigureAwait(false);
+
+        var answer = completion.Success ? completion.Response : string.Empty;
+
+        // Map ChunkCitation → Snippet with the same shape the hybrid path emits (source "PDF:{guid}",
+        // page). Metrics read only source/page from snippets + the answer text; text is used solely by
+        // the inline citation matcher.
+        var snippets = assembled.Citations
+            .Select(c => new Snippet(
+                c.FullText ?? c.SnippetPreview,
+                $"PDF:{c.DocumentId}",
+                c.PageNumber,
+                0,
+                c.RelevanceScore))
+            .ToList();
+
+        var confidence = RagPromptAssemblyService.ComputeConfidence(assembled.Citations, answer);
+        return new QaResponse(answer, snippets, confidence: confidence);
     }
 
     /// <inheritdoc/>

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Evaluation/Services/IDatasetEvaluationService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Evaluation/Services/IDatasetEvaluationService.cs
@@ -78,6 +78,17 @@ internal sealed record EvaluationOptions
     public string? GameIdFilter { get; init; }
 
     /// <summary>
+    /// #3390 Slice 4 Step 1: when non-null, the eval exercises the SAME grounded retrieval seam the
+    /// in-session live path uses (<c>AssemblePromptAsync</c>) under a <c>RetrievalPolicy</c> carrying
+    /// this explicit enhancement set — so flipping an enhancement actually changes retrieval and the
+    /// eval can measure it. <c>None</c> = grounded baseline (no enhancements). When <b>null</b>, the
+    /// legacy <c>AskWithHybridSearchAsync</c> path is used (backward-compatible; preserves the #3477
+    /// baseline's reproducibility). Note: the legacy path never touches the enhancement gate, so
+    /// per-enhancement measurement REQUIRES this to be non-null (#3390 R1 / #3475-class gap).
+    /// </summary>
+    public Api.BoundedContexts.KnowledgeBase.Domain.Enums.RagEnhancement? GroundedEnhancements { get; init; }
+
+    /// <summary>
     /// Default options for baseline evaluation.
     /// </summary>
     public static EvaluationOptions Default => new();

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Enums/RagEnhancement.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Enums/RagEnhancement.cs
@@ -53,4 +53,44 @@ public static class RagEnhancementExtensions
                 yield return flag;
         }
     }
+
+    /// <summary>
+    /// #3390 Slice 4 Step 1: parses enhancement identifiers (feature-flag key
+    /// <c>rag.enhancement.crag-evaluation</c>, its suffix <c>crag-evaluation</c>, or the enum name
+    /// <c>CragEvaluation</c>) into a combined <see cref="RagEnhancement"/> set. Empty input → None
+    /// (grounded baseline). Fail-loud on an unknown identifier — a typo in an eval request must not
+    /// silently degrade to a different enhancement set (mirrors the eval's fail-loud policy parsing).
+    /// </summary>
+    public static RagEnhancement ParseFlags(IEnumerable<string> identifiers)
+    {
+        ArgumentNullException.ThrowIfNull(identifiers);
+        const string prefix = "rag.enhancement.";
+        var result = RagEnhancement.None;
+        foreach (var raw in identifiers)
+        {
+            if (string.IsNullOrWhiteSpace(raw)) continue;
+            var id = raw.Trim();
+            RagEnhancement? matched = null;
+            foreach (var flag in AllFlags)
+            {
+                var key = flag.ToFeatureFlagKey();
+                var suffix = key[prefix.Length..];
+                if (key.Equals(id, StringComparison.OrdinalIgnoreCase)
+                    || suffix.Equals(id, StringComparison.OrdinalIgnoreCase)
+                    || flag.ToString().Equals(id, StringComparison.OrdinalIgnoreCase))
+                {
+                    matched = flag;
+                    break;
+                }
+            }
+            if (matched is null)
+            {
+                var valid = string.Join(", ", AllFlags.Select(f => f.ToFeatureFlagKey()[prefix.Length..]));
+                throw new ArgumentException(
+                    $"Unknown RAG enhancement '{raw}'. Valid values: {valid}.", nameof(identifiers));
+            }
+            result |= matched.Value;
+        }
+        return result;
+    }
 }

--- a/apps/api/src/Api/Routing/KnowledgeBase/AdminEvalEndpoints.cs
+++ b/apps/api/src/Api/Routing/KnowledgeBase/AdminEvalEndpoints.cs
@@ -55,7 +55,12 @@ internal static class AdminEvalEndpoints
             new LoadDatasetCommand { FilePath = request.DatasetPath }, ct).ConfigureAwait(false);
 
         var result = await mediator.Send(
-            new RunEvaluationCommand { DatasetPath = request.DatasetPath, MaxSamples = request.MaxSamples },
+            new RunEvaluationCommand
+            {
+                DatasetPath = request.DatasetPath,
+                MaxSamples = request.MaxSamples,
+                Enhancements = request.Enhancements
+            },
             ct).ConfigureAwait(false);
 
         var byLanguage = EvaluationReportFormatter.MetricsByLanguage(result, dataset);
@@ -131,6 +136,9 @@ internal static class AdminEvalEndpoints
     }
 }
 
-internal sealed record RunRetrievalEvaluationRequest(string DatasetPath, int? MaxSamples = null);
+// #3390 Slice 4 Step 1: Enhancements null → legacy hybrid eval; non-null (incl. empty) → grounded seam
+// with the parsed enhancement set (empty = grounded baseline). Identifiers: "crag-evaluation" etc.
+internal sealed record RunRetrievalEvaluationRequest(
+    string DatasetPath, int? MaxSamples = null, IReadOnlyList<string>? Enhancements = null);
 internal sealed record GenerateLabelingCandidatesRequest(string DatasetPath, int? TopN = null);
 internal sealed record MergeLabelsRequest(string DatasetPath, LabelingReview Review, string? OutputPath = null);

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Evaluation/Services/DatasetEvaluationServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Evaluation/Services/DatasetEvaluationServiceTests.cs
@@ -1,6 +1,11 @@
 using Api.BoundedContexts.KnowledgeBase.Application.Evaluation.Services;
+using Api.BoundedContexts.KnowledgeBase.Application.Models;
+using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
 using Api.BoundedContexts.KnowledgeBase.Domain.Evaluation;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
 using Api.Models;
 using Api.Services;
 using Microsoft.Extensions.Logging;
@@ -8,6 +13,7 @@ using Moq;
 using Xunit;
 using FluentAssertions;
 using Api.Tests.Constants;
+using SharedUserTier = Api.SharedKernel.Domain.ValueObjects.UserTier;
 
 namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Evaluation.Services;
 
@@ -19,6 +25,8 @@ namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Evaluation.Service
 public class DatasetEvaluationServiceTests
 {
     private readonly Mock<IRagService> _mockRagService;
+    private readonly Mock<IRagPromptAssemblyService> _mockRagPromptService;
+    private readonly Mock<ILlmService> _mockLlmService;
     private readonly Mock<ICitationValidationService> _mockCitationValidation;
     private readonly InlineCitationMatcherService _citationMatcher;
     private readonly Mock<ILogger<DatasetEvaluationService>> _mockLogger;
@@ -27,6 +35,8 @@ public class DatasetEvaluationServiceTests
     public DatasetEvaluationServiceTests()
     {
         _mockRagService = new Mock<IRagService>();
+        _mockRagPromptService = new Mock<IRagPromptAssemblyService>();
+        _mockLlmService = new Mock<ILlmService>();
         _mockCitationValidation = new Mock<ICitationValidationService>();
         _citationMatcher = new InlineCitationMatcherService();
         _mockLogger = new Mock<ILogger<DatasetEvaluationService>>();
@@ -45,7 +55,8 @@ public class DatasetEvaluationServiceTests
             });
 
         _service = new DatasetEvaluationService(
-            _mockRagService.Object, _citationMatcher, _mockCitationValidation.Object, _mockLogger.Object);
+            _mockRagService.Object, _mockRagPromptService.Object, _mockLlmService.Object,
+            _citationMatcher, _mockCitationValidation.Object, _mockLogger.Object);
     }
 
     private static EvaluationSample CreateSample(
@@ -75,39 +86,182 @@ public class DatasetEvaluationServiceTests
             snippets: snippets ?? [],
             confidence: confidence);
     }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // #3390 Slice 4 Step 1: grounded eval seam (options.GroundedEnhancements)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    private const string GroundedGameGuid = "9a3d0250-dc8b-4c35-96a2-716fe08cff08";
+
+    private void SetupGroundedSeam(RetrievalPolicy? capturedInto = null, string answer = "Grounded answer. [Page 3]")
+    {
+        var assembled = new AssembledPrompt(
+            SystemPrompt: "You are a tutor.",
+            UserPrompt: "Question",
+            Citations: new List<ChunkCitation>
+            {
+                new(DocumentId: "doc-1", PageNumber: 3, RelevanceScore: 0.9f, SnippetPreview: "settlements score",
+                    CopyrightTier: CopyrightTier.Full, IsPublic: true),
+            },
+            EstimatedTokens: 100);
+
+        _mockRagPromptService
+            .Setup(r => r.AssemblePromptAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<GameState?>(),
+                It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<ChatThread?>(),
+                It.IsAny<SharedUserTier?>(), It.IsAny<string>(), It.IsAny<CancellationToken>(),
+                It.IsAny<IRagDebugEventCollector?>(), It.IsAny<RetrievalProfile?>(), It.IsAny<RetrievalPolicy?>()))
+            .ReturnsAsync(assembled);
+
+        _mockLlmService
+            .Setup(l => l.GenerateCompletionAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(LlmCompletionResult.CreateSuccess(answer));
+    }
+
+    [Fact]
+    public async Task EvaluateSample_GroundedSeam_PassesEnabledEnhancementsToAssemble_R1aCanary()
+    {
+        // #3390 R1a: the self-verifying wiring canary — when the eval runs the grounded seam, it MUST
+        // invoke AssemblePromptAsync (the enhancement-gated path) with a RetrievalPolicy carrying the
+        // requested EnabledEnhancements set. If this ever routes elsewhere, per-enhancement measurement
+        // is measuring the wrong path (#3475 class) — this test goes red.
+        SetupGroundedSeam();
+        var sample = new EvaluationSample
+        {
+            Id = "g-1", Question = "How do I score?", ExpectedAnswer = "settlements",
+            GameId = GroundedGameGuid, ExpectedKeywords = [], RelevantChunkIds = []
+        };
+        var options = new EvaluationOptions { GroundedEnhancements = RagEnhancement.CragEvaluation };
+
+        await _service.EvaluateSampleAsync(sample, options);
+
+        _mockRagPromptService.Verify(r => r.AssemblePromptAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<GameState?>(),
+            It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<ChatThread?>(),
+            It.IsAny<SharedUserTier?>(), It.IsAny<string>(), It.IsAny<CancellationToken>(),
+            It.IsAny<IRagDebugEventCollector?>(), It.IsAny<RetrievalProfile?>(),
+            It.Is<RetrievalPolicy?>(p => p != null && p.EnabledEnhancements == RagEnhancement.CragEvaluation)),
+            Times.Once);
+        // and the legacy hybrid path is NOT taken
+        _mockRagService.Verify(r => r.AskWithHybridSearchAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SearchMode>(), It.IsAny<string?>(),
+            It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task EvaluateSample_GroundedSeam_MapsCitationsToSnippets()
+    {
+        // The grounded citations become snippets with source "PDF:{documentId}" (the metric key), so
+        // retrievedChunkIds reflect the grounded retrieval.
+        SetupGroundedSeam();
+        var sample = new EvaluationSample
+        {
+            Id = "g-2", Question = "How do I score?", ExpectedAnswer = "settlements",
+            GameId = GroundedGameGuid, ExpectedKeywords = [], RelevantChunkIds = ["PDF:doc-1"]
+        };
+        var options = new EvaluationOptions { GroundedEnhancements = RagEnhancement.None };
+
+        var result = await _service.EvaluateSampleAsync(sample, options);
+
+        result.RetrievedChunkIds.Should().ContainSingle().Which.Should().Be("PDF:doc-1");
+        result.GeneratedAnswer.Should().Contain("[Page 3]");
+    }
+
+    [Fact]
+    public async Task EvaluateSample_NullGroundedEnhancements_UsesLegacyHybridPath()
+    {
+        // Backward-compat: null → legacy AskWithHybridSearchAsync (preserves the #3477 baseline path);
+        // the grounded seam is NOT invoked.
+        _mockRagService
+            .Setup(r => r.AskWithHybridSearchAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SearchMode>(), It.IsAny<string?>(),
+                It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateQaResponse());
+        var sample = new EvaluationSample
+        {
+            Id = "l-1", Question = "Q", ExpectedAnswer = "a",
+            GameId = GroundedGameGuid, ExpectedKeywords = [], RelevantChunkIds = []
+        };
+        var options = new EvaluationOptions { GroundedEnhancements = null };
+
+        await _service.EvaluateSampleAsync(sample, options);
+
+        _mockRagService.Verify(r => r.AskWithHybridSearchAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SearchMode>(), It.IsAny<string?>(),
+            It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once);
+        _mockRagPromptService.Verify(r => r.AssemblePromptAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<GameState?>(),
+            It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<ChatThread?>(),
+            It.IsAny<SharedUserTier?>(), It.IsAny<string>(), It.IsAny<CancellationToken>(),
+            It.IsAny<IRagDebugEventCollector?>(), It.IsAny<RetrievalProfile?>(), It.IsAny<RetrievalPolicy?>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task EvaluateSample_GroundedSeam_NonUuidGameId_RecordsFailedSample()
+    {
+        // The grounded seam needs a UUID GameId; a slug is a data error surfaced as a failed sample
+        // (the batch is not aborted).
+        SetupGroundedSeam();
+        var sample = new EvaluationSample
+        {
+            Id = "g-3", Question = "Q", ExpectedAnswer = "a",
+            GameId = "catan-slug-not-a-guid", ExpectedKeywords = [], RelevantChunkIds = []
+        };
+        var options = new EvaluationOptions { GroundedEnhancements = RagEnhancement.None };
+
+        var result = await _service.EvaluateSampleAsync(sample, options);
+
+        result.ErrorMessage.Should().NotBeNullOrEmpty();
+        result.GeneratedAnswer.Should().BeNull();
+    }
+
     [Fact]
     public void Constructor_WithNullRagService_ThrowsArgumentNullException()
     {
-        // Act & Assert
         Action act = () =>
-            new DatasetEvaluationService(null!, _citationMatcher, _mockCitationValidation.Object, _mockLogger.Object);
+            new DatasetEvaluationService(null!, _mockRagPromptService.Object, _mockLlmService.Object, _citationMatcher, _mockCitationValidation.Object, _mockLogger.Object);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Constructor_WithNullRagPromptService_ThrowsArgumentNullException()
+    {
+        Action act = () =>
+            new DatasetEvaluationService(_mockRagService.Object, null!, _mockLlmService.Object, _citationMatcher, _mockCitationValidation.Object, _mockLogger.Object);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Constructor_WithNullLlmService_ThrowsArgumentNullException()
+    {
+        Action act = () =>
+            new DatasetEvaluationService(_mockRagService.Object, _mockRagPromptService.Object, null!, _citationMatcher, _mockCitationValidation.Object, _mockLogger.Object);
         act.Should().Throw<ArgumentNullException>();
     }
 
     [Fact]
     public void Constructor_WithNullCitationMatcher_ThrowsArgumentNullException()
     {
-        // Act & Assert
         Action act = () =>
-            new DatasetEvaluationService(_mockRagService.Object, null!, _mockCitationValidation.Object, _mockLogger.Object);
+            new DatasetEvaluationService(_mockRagService.Object, _mockRagPromptService.Object, _mockLlmService.Object, null!, _mockCitationValidation.Object, _mockLogger.Object);
         act.Should().Throw<ArgumentNullException>();
     }
 
     [Fact]
     public void Constructor_WithNullCitationValidation_ThrowsArgumentNullException()
     {
-        // Act & Assert
         Action act = () =>
-            new DatasetEvaluationService(_mockRagService.Object, _citationMatcher, null!, _mockLogger.Object);
+            new DatasetEvaluationService(_mockRagService.Object, _mockRagPromptService.Object, _mockLlmService.Object, _citationMatcher, null!, _mockLogger.Object);
         act.Should().Throw<ArgumentNullException>();
     }
 
     [Fact]
     public void Constructor_WithNullLogger_ThrowsArgumentNullException()
     {
-        // Act & Assert
         Action act = () =>
-            new DatasetEvaluationService(_mockRagService.Object, _citationMatcher, _mockCitationValidation.Object, null!);
+            new DatasetEvaluationService(_mockRagService.Object, _mockRagPromptService.Object, _mockLlmService.Object, _citationMatcher, _mockCitationValidation.Object, null!);
         act.Should().Throw<ArgumentNullException>();
     }
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Unit/RagEnhancementTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Unit/RagEnhancementTests.cs
@@ -118,4 +118,36 @@ public class RagEnhancementTests
         var flags = all.GetIndividualFlags().ToList();
         flags.Count.Should().Be(5);
     }
+
+    // ── #3390 Slice 4 Step 1: ParseFlags ──
+
+    [Theory]
+    [InlineData("rag.enhancement.crag-evaluation")]  // full feature-flag key
+    [InlineData("crag-evaluation")]                   // suffix
+    [InlineData("CragEvaluation")]                    // enum name
+    [InlineData("cragevaluation")]                    // case-insensitive
+    public void ParseFlags_AcceptsKeyFormats(string id)
+    {
+        RagEnhancementExtensions.ParseFlags(new[] { id }).Should().Be(RagEnhancement.CragEvaluation);
+    }
+
+    [Fact]
+    public void ParseFlags_CombinesMultiple()
+    {
+        var result = RagEnhancementExtensions.ParseFlags(new[] { "crag-evaluation", "raptor-retrieval" });
+        result.Should().Be(RagEnhancement.CragEvaluation | RagEnhancement.RaptorRetrieval);
+    }
+
+    [Fact]
+    public void ParseFlags_Empty_ReturnsNone()
+    {
+        RagEnhancementExtensions.ParseFlags(Array.Empty<string>()).Should().Be(RagEnhancement.None);
+    }
+
+    [Fact]
+    public void ParseFlags_UnknownIdentifier_ThrowsFailLoud()
+    {
+        var act = () => RagEnhancementExtensions.ParseFlags(new[] { "crag-evaluatino" }); // typo
+        act.Should().Throw<ArgumentException>().WithMessage("*Unknown RAG enhancement*");
+    }
 }

--- a/apps/api/tests/Api.Tests/Unit/KnowledgeBase/Evaluation/DatasetEvaluationServiceMetricTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/KnowledgeBase/Evaluation/DatasetEvaluationServiceMetricTests.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.KnowledgeBase.Application.Evaluation.Services;
+using Api.BoundedContexts.KnowledgeBase.Application.Services;
 using Api.BoundedContexts.KnowledgeBase.Domain.Evaluation;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services;
 using Api.Services;
@@ -24,10 +25,13 @@ public sealed class DatasetEvaluationServiceMetricTests
     public DatasetEvaluationServiceMetricTests()
     {
         var ragService = new Mock<IRagService>();
+        var ragPromptService = new Mock<IRagPromptAssemblyService>();
+        var llmService = new Mock<ILlmService>();
         var citationValidation = new Mock<ICitationValidationService>();
         var logger = new Mock<ILogger<DatasetEvaluationService>>();
         _service = new DatasetEvaluationService(
-            ragService.Object, new InlineCitationMatcherService(), citationValidation.Object, logger.Object);
+            ragService.Object, ragPromptService.Object, llmService.Object,
+            new InlineCitationMatcherService(), citationValidation.Object, logger.Object);
     }
 
     #region CalculateRecallAtK Tests


### PR DESCRIPTION
## Slice 4 Step 1 — l'eval harness può ora misurare gli enhancement

Sblocca la misura per-enhancement di Slice 4. **Root cause provata sul codice deployato**: l'eval usava `RagService.AskWithHybridSearchAsync` → `_hybridSearchService.SearchAsync` **diretto**, che **non tocca mai** il gate enhancement (`RagPromptAssemblyService:185`). Flippare `rag.enhancement.*` aveva **effetto zero** sui numeri dell'eval — un gap wrong-path in stile #3475. Delta per-enhancement misurati così sarebbero **fasulli**.

## Cosa fa

- **Grounded eval path**: quando `EvaluationOptions.GroundedEnhancements` è non-null, `EvaluateSampleAsync` passa per `AssemblePromptAsync` (il seam enhancement-gated) sotto `RetrievalPolicy.LiveSessionWith(set)` + `GenerateCompletionAsync`, poi mappa `ChunkCitation` → `Snippet` con la **shape identica** che il path hybrid emette (`source="PDF:{documentId}"`, `page`) → **metriche a valle invariate**. Null (default) = path legacy → il baseline #3477 resta riproducibile.
- **Plumbing**: `RunRetrievalEvaluationRequest.Enhancements` (string[]) → `RunEvaluationCommand` → `EvaluationOptions.GroundedEnhancements`. `RagEnhancementExtensions.ParseFlags` (chiavi flag / suffix / enum-name, **fail-loud** sui typo). Lista vuota = baseline grounded (`None`): baseline-grounded vs enhancement-grounded diventa un confronto **stesso-path, stesso-run** (spec §6).
- **Canary auto-verificante (R1a)**: un test asserisce che il grounded seam passa il set `EnabledEnhancements` richiesto ad `AssemblePromptAsync` e **non** chiama il legacy → un futuro re-fork della pipeline va rosso invece di misurare silenziosamente il path sbagliato.

## Come usarlo (dopo il deploy)

```
POST /api/v1/admin/eval/retrieval
{ "datasetPath": "tests/evaluation-datasets/meepleai-en-seed.json", "enhancements": [] }          # baseline grounded
{ "datasetPath": "...", "enhancements": ["crag-evaluation"] }                                      # CRAG on
```

## Code review avversariale — 0 bug di correttezza
Verificati: identità shape Snippet (field-by-field vs `RagService.cs:702-708`), compatibilità metriche, ParseFlags (formati/fail-loud/no-partial-match), guid-parse→failed-sample, ComputeConfidence accessibile+null-safe, gen-failure safe, DI, retro-compatibilità (null default), canary valido. 3 osservazioni non-bloccanti (answer su gen-failure cosmetico; `TopK` non-wired pre-esistente su entrambi i path; **CRAG web-fallback**: sul seam `AssemblePromptAsync` CRAG è **corpus-interno, nessun collaboratore web** — asserito dal test negative-space `RagPromptAssemblyService_HasNoWebRetrievalDependency` del #3390, quindi nessuna chiamata esterna durante l'eval, coerente col freeze BGG #2123).

## Test
Canary R1a + citation→snippet mapping + legacy-path + non-UUID-gameId→failed-sample + ParseFlags (formati/combine/empty/fail-loud). **98/98 unit mirati** verdi. Build 0 errori. (AdminEvalEndpoints integration = Testcontainers → CI; nuovo campo request opzionale/retro-compatibile.)

Part of #3390 Slice 4 (spec `2026-08-02-rag-enhancement-live-path-validation.md`, Step 1 / R1). Epic #3397.

🤖 Generated with [Claude Code](https://claude.com/claude-code)