### PR TITLE
fix(catalog): SSRF connect-pin egress client + Bgg size cap (#3495 fix 2/N)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloader.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloader.cs
@@ -9,6 +9,11 @@ internal sealed class BggCoverDownloader : IBggCoverDownloader
     private readonly IBggCoverUploadPipeline _uploadPipeline;
     private readonly ILogger<BggCoverDownloader> _logger;
 
+    // #3495 (finding C5): stream-and-cap the image body to bound memory. The HttpClient-level
+    // MaxResponseContentBufferSize belt is a no-op under ResponseHeadersRead, so the ceiling is
+    // enforced here during the read.
+    private const long MaxImageSizeBytes = 10 * 1024 * 1024;
+
     public BggCoverDownloader(
         HttpClient httpClient,
         IBggCoverUploadPipeline uploadPipeline,
@@ -59,7 +64,37 @@ internal sealed class BggCoverDownloader : IBggCoverDownloader
                 return null;
             }
 
-            var imageBytes = await response.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+            // Reject early on an advertised over-cap length; Content-Length is spoofable/absent
+            // (chunked), so the ceiling is ALSO enforced during the streamed read below.
+            if (response.Content.Headers.ContentLength > MaxImageSizeBytes)
+            {
+                _logger.LogWarning("BGG cover exceeds size cap (Content-Length): BggId={BggId}", bggId);
+                return null;
+            }
+
+            byte[] imageBytes;
+            using (var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false))
+            using (var buffer = new MemoryStream())
+            {
+                var chunk = new byte[81920];
+                long total = 0;
+                int read;
+                while ((read = await stream.ReadAsync(chunk, cancellationToken).ConfigureAwait(false)) > 0)
+                {
+                    total += read;
+                    if (total > MaxImageSizeBytes)
+                    {
+                        _logger.LogWarning(
+                            "BGG cover exceeds {Cap}-byte cap mid-stream: BggId={BggId}", MaxImageSizeBytes, bggId);
+                        return null;
+                    }
+
+                    await buffer.WriteAsync(chunk.AsMemory(0, read), cancellationToken).ConfigureAwait(false);
+                }
+
+                imageBytes = buffer.ToArray();
+            }
+
             if (imageBytes.Length == 0)
             {
                 _logger.LogWarning("BGG cover download returned empty body: BggId={BggId}", bggId);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
@@ -1,3 +1,4 @@
+using System.Net.Http;
 using Api.SharedKernel.Constants;
 using Api.BoundedContexts.SharedGameCatalog.Application.Configuration;
 using Api.BoundedContexts.SharedGameCatalog.Application.Jobs;
@@ -15,6 +16,7 @@ using Api.Services.Pdf;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Quartz;
 
@@ -190,11 +192,23 @@ internal static class SharedGameCatalogServiceExtensions
                 .WithDescription("Runs every 15 min to evict shared-game detail tags for top-N most-viewed games and the search-games list tag"));
         });
 
-        // Gap G2: BGG cover re-upload service (typed HttpClient pattern).
-        // 10s timeout — BGG CDN images are typically < 500 KB.
+        // #3495 fix 2/N: DNS-resolution seam shared by the SSRF connect pin.
+        services.TryAddSingleton<IDnsResolver, SystemDnsResolver>();
+
+        // Gap G2: BGG cover re-upload service (typed HttpClient pattern). 10s timeout — BGG CDN
+        // images are typically < 500 KB (BggCoverDownloader stream-caps the body at 10MB).
+        // #3495 fix 2/N: the SSRF-pinned ConnectCallback resolves once and dials the validated
+        // IP, so DNS-rebinding and redirect-to-internal are closed by construction on EVERY
+        // connection (the initial request and each of the ≤5 auto-redirect hops).
         services.AddHttpClient<IBggCoverDownloader, BggCoverDownloader>(client =>
         {
             client.Timeout = TimeSpan.FromSeconds(10);
+        })
+        .ConfigurePrimaryHttpMessageHandler(static sp => new SocketsHttpHandler
+        {
+            ConnectCallback = SsrfPinnedConnect.Create(sp.GetRequiredService<IDnsResolver>()),
+            AllowAutoRedirect = true,
+            MaxAutomaticRedirections = 5,
         });
 
         // Issue #1903 M5.2: register HttpClients, keyed catalog providers,

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/IDnsResolver.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/IDnsResolver.cs
@@ -1,0 +1,20 @@
+using System.Net;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+
+/// <summary>
+/// Seam over DNS resolution (issue #3495, finding H4). Injecting it lets the SSRF connect pin
+/// resolve once and connect to that exact address in a unit-testable way, and lets tests inject
+/// a resolver that returns public-then-private to prove the pin (not just the validation).
+/// </summary>
+internal interface IDnsResolver
+{
+    Task<IReadOnlyList<IPAddress>> ResolveAsync(string host, CancellationToken ct);
+}
+
+/// <summary>Production resolver backed by the OS resolver.</summary>
+internal sealed class SystemDnsResolver : IDnsResolver
+{
+    public async Task<IReadOnlyList<IPAddress>> ResolveAsync(string host, CancellationToken ct)
+        => await Dns.GetHostAddressesAsync(host, ct).ConfigureAwait(false);
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfPinnedConnect.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfPinnedConnect.cs
@@ -1,0 +1,75 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+
+/// <summary>
+/// SSRF-safe connect pin (issue #3495, findings C1/C2/H4). Used as a
+/// <see cref="SocketsHttpHandler.ConnectCallback"/> so that EVERY connection an egress
+/// <c>HttpClient</c> makes — the initial request AND every auto-redirect hop — resolves the
+/// host once, fails closed if any resolved address is private/reserved (per
+/// <see cref="SsrfPolicy"/>), and dials the validated IP directly. Because the socket connects
+/// to a fixed <see cref="IPEndPoint"/> (never the hostname), there is no second resolution:
+/// DNS-rebinding and redirect-to-internal are closed by construction. The original host is left
+/// on the request so TLS SNI / the Host header stay correct.
+/// </summary>
+internal static class SsrfPinnedConnect
+{
+    /// <summary>
+    /// Resolves <paramref name="host"/> exactly once and returns the pinned validated address.
+    /// Fails closed (throws) if resolution is empty or if ANY resolved address is blocked.
+    /// </summary>
+    internal static async Task<IPAddress> ResolveAndValidateAsync(
+        IDnsResolver dns,
+        string host,
+        CancellationToken ct)
+    {
+        IReadOnlyList<IPAddress> addresses = await dns.ResolveAsync(host, ct).ConfigureAwait(false);
+
+        if (addresses.Count == 0)
+        {
+            throw new InvalidOperationException($"SSRF: host '{host}' did not resolve to any address");
+        }
+
+        IPAddress? pinned = null;
+        foreach (IPAddress ip in addresses)
+        {
+            if (SsrfPolicy.IsBlocked(ip))
+            {
+                throw new InvalidOperationException($"SSRF: host '{host}' resolves to blocked address {ip}");
+            }
+
+            pinned ??= ip;
+        }
+
+        return pinned!;
+    }
+
+    /// <summary>
+    /// Builds a <see cref="SocketsHttpHandler.ConnectCallback"/> that pins to the validated IP.
+    /// </summary>
+    public static Func<SocketsHttpConnectionContext, CancellationToken, ValueTask<Stream>> Create(IDnsResolver dns)
+    {
+        ArgumentNullException.ThrowIfNull(dns);
+
+        return async (context, ct) =>
+        {
+            IPAddress pinned = await ResolveAndValidateAsync(dns, context.DnsEndPoint.Host, ct)
+                .ConfigureAwait(false);
+
+            var socket = new Socket(SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
+            try
+            {
+                await socket.ConnectAsync(new IPEndPoint(pinned, context.DnsEndPoint.Port), ct)
+                    .ConfigureAwait(false);
+                return new NetworkStream(socket, ownsSocket: true);
+            }
+            catch
+            {
+                socket.Dispose();
+                throw;
+            }
+        };
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Infrastructure/External/SlackWebhookClientTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Infrastructure/External/SlackWebhookClientTests.cs
@@ -19,10 +19,12 @@ namespace Api.Tests.BoundedContexts.Administration.Infrastructure.External;
 [Trait("Issue", "1840")]
 public class SlackWebhookClientTests
 {
-    // A public, non-private IP literal (RFC 5737 TEST-NET-3). Using an IP literal keeps the SSRF
-    // guard's DNS resolution offline/deterministic in unit tests (Dns.GetHostAddressesAsync on a
-    // literal returns it without a DNS query), while still passing the private-IP check.
-    private const string PublicWebhookUrl = "https://203.0.113.10/services/T1/B1/abc";
+    // A genuinely-public IP literal. An IP literal keeps the SSRF guard's DNS resolution
+    // offline/deterministic in unit tests (Dns.GetHostAddressesAsync on a literal returns it
+    // without a DNS query). NB: RFC 5737 TEST-NET ranges are NOT usable here — the IANA-driven
+    // SsrfPolicy (#3495) correctly blocks them as reserved; 8.8.8.8 is public and, with the mock
+    // handler below, is never actually dialed.
+    private const string PublicWebhookUrl = "https://8.8.8.8/services/T1/B1/abc";
 
     private static SlackWebhookClient CreateClient(Mock<HttpMessageHandler> handler)
     {

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloaderTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloaderTests.cs
@@ -13,8 +13,10 @@ public sealed class BggCoverDownloaderTests
     private readonly Mock<IBggCoverUploadPipeline> _pipelineMock = new();
     private readonly Mock<ILogger<BggCoverDownloader>> _loggerMock = new();
 
-    // RFC 5737 TEST-NET-3 literal keeps the SSRF DNS check offline/deterministic.
-    private const string PublicHttpsUrl = "https://203.0.113.10/abc.jpg";
+    // A genuinely-public IP literal keeps the SSRF DNS check offline/deterministic (a literal
+    // resolves to itself without a DNS query). RFC 5737 TEST-NET ranges can't be used here — the
+    // IANA-driven SsrfPolicy (#3495) correctly blocks them as reserved; 8.8.8.8 is never dialed.
+    private const string PublicHttpsUrl = "https://8.8.8.8/abc.jpg";
 
     [Fact]
     public async Task DownloadAndUploadAsync_OnSuccess_ReturnsPipelineKey()
@@ -42,7 +44,7 @@ public sealed class BggCoverDownloaderTests
 
         var sut = new BggCoverDownloader(httpClient, _pipelineMock.Object, _loggerMock.Object);
 
-        var result = await sut.DownloadAndUploadAsync(99, "https://203.0.113.10/image.PNG", CancellationToken.None);
+        var result = await sut.DownloadAndUploadAsync(99, "https://8.8.8.8/image.PNG", CancellationToken.None);
 
         result.Should().Be("bgg-covers/99/cover.png");
         _pipelineMock.Verify(p => p.UploadAsync(99, It.IsAny<byte[]>(), ".png", It.IsAny<CancellationToken>()), Times.Once);
@@ -105,6 +107,24 @@ public sealed class BggCoverDownloaderTests
 
         result.Should().BeNull("a URL resolving to a private/reserved IP must be blocked by the SSRF guard");
         VerifyNoHttpCall(handler);
+    }
+
+    [Fact]
+    public async Task DownloadAndUploadAsync_BodyExceedsSizeCap_ReturnsNullWithoutUploading()
+    {
+        // 11 MB body — over the 10 MB image cap (#3495 C5). ByteArrayContent advertises a
+        // Content-Length, so this exercises the pre-read rejection; the streamed ceiling covers
+        // the chunked/absent-Content-Length case.
+        var oversized = new byte[(11 * 1024 * 1024)];
+        var httpClient = BuildHttpClient(HttpStatusCode.OK, oversized);
+        var sut = new BggCoverDownloader(httpClient, _pipelineMock.Object, _loggerMock.Object);
+
+        var result = await sut.DownloadAndUploadAsync(7, PublicHttpsUrl, CancellationToken.None);
+
+        result.Should().BeNull();
+        _pipelineMock.Verify(
+            p => p.UploadAsync(It.IsAny<int>(), It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     private static HttpClient BuildHttpClient(HttpStatusCode statusCode, byte[]? content = null)

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfPinnedConnectTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfPinnedConnectTests.cs
@@ -1,0 +1,86 @@
+using System.Net;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+
+/// <summary>
+/// The SSRF connect pin's security decision (issue #3495, findings C1/H4/M4/M5). Resolve
+/// exactly once, fail closed if ANY resolved address is blocked or if none resolve, and pin
+/// the validated public address — so the socket dials the validated IP with no second
+/// resolution (DNS-rebinding closed by construction).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public class SsrfPinnedConnectTests
+{
+    private sealed class FakeDnsResolver : IDnsResolver
+    {
+        private readonly IReadOnlyList<IPAddress> _addresses;
+        public int ResolveCalls { get; private set; }
+
+        public FakeDnsResolver(params string[] ips)
+            => _addresses = ips.Select(IPAddress.Parse).ToArray();
+
+        public Task<IReadOnlyList<IPAddress>> ResolveAsync(string host, CancellationToken ct)
+        {
+            ResolveCalls++;
+            return Task.FromResult(_addresses);
+        }
+    }
+
+    [Fact]
+    public async Task ResolveAndValidate_PublicHost_PinsFirstAddress_ResolvingExactlyOnce()
+    {
+        var dns = new FakeDnsResolver("8.8.8.8");
+
+        var pinned = await SsrfPinnedConnect.ResolveAndValidateAsync(dns, "cdn.example.com", CancellationToken.None);
+
+        pinned.Should().Be(IPAddress.Parse("8.8.8.8"));
+        dns.ResolveCalls.Should().Be(1, "the pin must not re-resolve after validation");
+    }
+
+    [Fact]
+    public async Task ResolveAndValidate_PrivateAddress_FailsClosed()
+    {
+        var dns = new FakeDnsResolver("10.0.0.5");
+
+        var act = () => SsrfPinnedConnect.ResolveAndValidateAsync(dns, "evil.example.com", CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*blocked*");
+    }
+
+    [Fact]
+    public async Task ResolveAndValidate_MetadataAddress_FailsClosed()
+    {
+        var dns = new FakeDnsResolver("169.254.169.254");
+
+        var act = () => SsrfPinnedConnect.ResolveAndValidateAsync(dns, "meta.example.com", CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task ResolveAndValidate_MixedPublicThenPrivate_FailsClosed()
+    {
+        // Rebinding-style multi-record: a single lookup returning both a public and a private
+        // address must be rejected (never pin the public one and ignore the private).
+        var dns = new FakeDnsResolver("8.8.8.8", "169.254.169.254");
+
+        var act = () => SsrfPinnedConnect.ResolveAndValidateAsync(dns, "rebind.example.com", CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task ResolveAndValidate_EmptyResolution_FailsClosed()
+    {
+        var dns = new FakeDnsResolver();
+
+        var act = () => SsrfPinnedConnect.ResolveAndValidateAsync(dns, "void.example.com", CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*resolve*");
+    }
+}


### PR DESCRIPTION
## SSRF egress hardening — fix 2/N: connect-pin (issue #3495)

The core TOCTOU/DNS-rebinding fix. Moves the SSRF guard to a `SocketsHttpHandler.ConnectCallback` pin on the live `BggCoverDownloader` egress + caps the body.

- **`IDnsResolver` + `SsrfPinnedConnect`**: resolve once, fail closed if any resolved address is blocked (`SsrfPolicy`) or none resolve, dial the validated `IPAddress` directly (never the hostname). Every connection (initial + each ≤5 redirect hop) is validated → DNS-rebinding + redirect-to-internal closed **by construction**; Host/TLS SNI preserved (raw `NetworkStream` → handler does its own TLS).
- **`BggCoverDownloader`**: stream-and-cap the body at 10MB (mid-read abort) + Content-Length pre-check (finding **C5** — the HttpClient `MaxResponseContentBufferSize` belt is a no-op under `ResponseHeadersRead`, so the ceiling is enforced in the read).
- Fixes 2 pre-existing tests (Bgg + Slack) that used RFC 5737 TEST-NET (`203.0.113.10`) as a "public" URL — `SsrfPolicy` (fix 1/N) now correctly blocks TEST-NET → `8.8.8.8`.

### Verification
- **107 tests green** (Ssrf/Bgg/Slack scope), incl. the pin's fail-closed decision (private/mixed/empty) + the Bgg size cap. Adversarial review confirmed the pin mechanism is sound (no bypass).

### Deferred to fix 3/N (per the hardened DoD in #3495)
Migrate `SlackWebhookClient` onto the pinned client (still TOCTOU today, admin-only), delete the static validators, per-hop redirect **scheme** re-check, bring Wikimedia into scope, per-sink circuit breaker + egress-blocked metric, a dial-by-IP test seam for `SsrfPinnedConnect.Create()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
