### PR TITLE
fix(security): SSRF connect-pin boundary + Slack egress (#3495 fix 3/N)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/DependencyInjection/AdministrationServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/DependencyInjection/AdministrationServiceExtensions.cs
@@ -15,9 +15,11 @@ using Api.Infrastructure.Seeders.Catalog;
 using Api.Infrastructure.Seeders.Core;
 using Api.Infrastructure.Seeders.LivedIn;
 using Api.Infrastructure.Seeders.MechanicValidation;
+using Api.SharedKernel.Infrastructure.Http;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using Polly;
 using Polly.CircuitBreaker;
@@ -156,15 +158,20 @@ internal static class AdministrationServiceExtensions
             .AddPolicyHandler((sp, _) => GetCircuitBreakerPolicy(
                 "Prometheus", sp.GetService<ICircuitBreakerStateTracker>()));
 
+        // #3495 fix 3/N: DNS-resolution seam for the SSRF connect pin. TryAdd — SharedGameCatalog
+        // registers the same singleton; whichever context initializes first wins and both share
+        // the one SystemDnsResolver.
+        services.TryAddSingleton<IDnsResolver, SystemDnsResolver>();
+
         // Issue #1840 SP5 F4-C7: Slack webhook client for per-channel alert dispatch.
         // Separate from the legacy IAlertChannel-based SlackAlertChannel (OPS-07) — this
         // client accepts the webhook URL as an argument so configuration can come from
         // the AlertChannel aggregate rather than appsettings.json. Retry/CB policies
         // mirror the Prometheus client.
-        services.AddHttpClient<ISlackWebhookClient, SlackWebhookClient>(client =>
-            {
-                client.Timeout = TimeSpan.FromSeconds(10);
-            })
+        // #3495 fix 3/N: the webhook URL is admin-controlled config, so the egress is SSRF-pinned
+        // (ConfigureSsrfPin, factored into AddSlackWebhookClient so the prod pipeline and the DI
+        // test seam share the EXACT pin wiring). Retry/CB policies wrap the pinned primary handler.
+        AddSlackWebhookClient(services)
             .AddPolicyHandler(GetRetryPolicy())
             .AddPolicyHandler((sp, _) => GetCircuitBreakerPolicy(
                 "SlackWebhook", sp.GetService<ICircuitBreakerStateTracker>()));
@@ -295,6 +302,34 @@ internal static class AdministrationServiceExtensions
         });
 
         return services;
+    }
+
+    /// <summary>
+    /// Issue #3495 fix 3/N — registers the Slack webhook typed <see cref="HttpClient"/> with the
+    /// SSRF connect-pin (<c>ConfigureSsrfPin</c>) as its primary handler. Extracted so the prod
+    /// pipeline (which additionally wraps it in Polly retry/CB) and the DI test seam
+    /// (<see cref="AddSlackWebhookClientForTests"/>) share the exact same pin wiring — if the pin
+    /// is ever dropped here, both prod and the fail-closed test lose it together.
+    /// </summary>
+    private static IHttpClientBuilder AddSlackWebhookClient(IServiceCollection services) =>
+        services.AddHttpClient<ISlackWebhookClient, SlackWebhookClient>(client =>
+            {
+                client.Timeout = TimeSpan.FromSeconds(10);
+            })
+            .ConfigureSsrfPin();
+
+    /// <summary>
+    /// Test seam (issue #3495 fix 3/N): registers ONLY the SSRF-pinned Slack webhook client so a
+    /// DI-resolution test can prove a private-resolving webhook fails closed at the connect-pin.
+    /// Omits the Polly retry/CB handlers on purpose — retrying a fail-closed pin would add the
+    /// 2+4+8s backoff to the test for no added coverage (Polly is exercised separately). The caller
+    /// MUST register an <see cref="IDnsResolver"/> on the same collection before resolving the client.
+    /// </summary>
+    internal static void AddSlackWebhookClientForTests(IServiceCollection services)
+    {
+        services.AddLogging();
+        services.TryAddSingleton<IDnsResolver, SystemDnsResolver>();
+        AddSlackWebhookClient(services);
     }
 
     private static AsyncRetryPolicy<HttpResponseMessage> GetRetryPolicy()

--- a/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/External/SlackWebhookClient.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/External/SlackWebhookClient.cs
@@ -1,5 +1,4 @@
 using System.Net.Http.Json;
-using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 using Api.Helpers;
 
 namespace Api.BoundedContexts.Administration.Infrastructure.External;
@@ -46,19 +45,16 @@ internal sealed class SlackWebhookClient : ISlackWebhookClient
             return new SlackSendResult(false, "Webhook URL is not a valid absolute URI.");
         }
 
-        // SSRF guard (#2655 finding #11): a compromised/misconfigured webhook URL must not be able
-        // to reach internal services or the cloud metadata endpoint. Only HTTPS URLs resolving to
-        // public IPs are allowed. The response message stays generic (no resolved IP) and the URL is
-        // never logged (it embeds the webhook secret).
-        try
+        // SSRF guard (#2655 finding #11 / #3495 fix 3/N): reject non-HTTPS schemes up front, then
+        // let the SSRF connect-pin on this client's handler (ConfigureSsrfPin) enforce the public-IP
+        // guarantee at connect time. The pin — unlike a pre-connect DNS check — is not TOCTOU: every
+        // connection (and redirect hop) dials only a validated public address, so a compromised or
+        // misconfigured webhook cannot reach internal services or the cloud metadata endpoint. The
+        // URL is never logged (it embeds the webhook secret).
+        if (!string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
         {
-            SsrfSafeHttpClient.ValidateUrlScheme(webhookUrl);
-            await SsrfSafeHttpClient.ValidateResolvedIpAsync(webhookUrl, cancellationToken).ConfigureAwait(false);
-        }
-        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
-        {
-            _logger.LogWarning(ex, "Slack webhook blocked by SSRF guard");
-            return new SlackSendResult(false, "Webhook URL is not allowed (must be HTTPS to a public host).");
+            _logger.LogWarning("Slack webhook blocked by SSRF guard: non-HTTPS scheme");
+            return new SlackSendResult(false, "Webhook URL is not allowed (must be HTTPS).");
         }
 
         var payload = BuildPayload(message);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloader.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloader.cs
@@ -34,14 +34,15 @@ internal sealed class BggCoverDownloader : IBggCoverDownloader
             return null;
         }
 
-        // SSRF guard (#2655 finding #10): only fetch HTTPS URLs that resolve to public IPs.
-        // Fails closed — an invalid scheme or a private/reserved target aborts the download.
+        // SSRF guard: reject non-HTTPS / malformed URLs up front (fail-fast). The public-IP
+        // guarantee is enforced at connect time by the SSRF connect-pin on this client's handler
+        // (ConfigureSsrfPin, #3495) — which, unlike a pre-connect DNS check, is not TOCTOU: every
+        // connection (and each redirect hop) dials only a validated public address.
         try
         {
             SsrfSafeHttpClient.ValidateUrlScheme(remoteImageUrl);
-            await SsrfSafeHttpClient.ValidateResolvedIpAsync(remoteImageUrl, cancellationToken).ConfigureAwait(false);
         }
-        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
+        catch (ArgumentException ex)
         {
             _logger.LogWarning(
                 ex,

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
@@ -1,4 +1,3 @@
-using System.Net.Http;
 using Api.SharedKernel.Constants;
 using Api.BoundedContexts.SharedGameCatalog.Application.Configuration;
 using Api.BoundedContexts.SharedGameCatalog.Application.Jobs;
@@ -13,6 +12,7 @@ using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Resilience;
 using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 using Api.Services.Pdf;
+using Api.SharedKernel.Infrastructure.Http;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -192,24 +192,16 @@ internal static class SharedGameCatalogServiceExtensions
                 .WithDescription("Runs every 15 min to evict shared-game detail tags for top-N most-viewed games and the search-games list tag"));
         });
 
-        // #3495 fix 2/N: DNS-resolution seam shared by the SSRF connect pin.
+        // #3495: DNS-resolution seam shared by the SSRF connect pin (promoted to
+        // Api.SharedKernel.Infrastructure.Http in fix 3/N so every egress sink can share it).
         services.TryAddSingleton<IDnsResolver, SystemDnsResolver>();
 
         // Gap G2: BGG cover re-upload service (typed HttpClient pattern). 10s timeout — BGG CDN
         // images are typically < 500 KB (BggCoverDownloader stream-caps the body at 10MB).
-        // #3495 fix 2/N: the SSRF-pinned ConnectCallback resolves once and dials the validated
-        // IP, so DNS-rebinding and redirect-to-internal are closed by construction on EVERY
-        // connection (the initial request and each of the ≤5 auto-redirect hops).
-        services.AddHttpClient<IBggCoverDownloader, BggCoverDownloader>(client =>
-        {
-            client.Timeout = TimeSpan.FromSeconds(10);
-        })
-        .ConfigurePrimaryHttpMessageHandler(static sp => new SocketsHttpHandler
-        {
-            ConnectCallback = SsrfPinnedConnect.Create(sp.GetRequiredService<IDnsResolver>()),
-            AllowAutoRedirect = true,
-            MaxAutomaticRedirections = 5,
-        });
+        // #3495: ConfigureSsrfPin resolves once and dials the validated IP, so DNS-rebinding and
+        // redirect-to-internal are closed by construction on EVERY connection (the initial
+        // request and each of the ≤5 auto-redirect hops).
+        AddBggCoverDownloader(services);
 
         // Issue #1903 M5.2: register HttpClients, keyed catalog providers,
         // aggregator, and Quartz CatalogSeedFetchJob.
@@ -390,6 +382,32 @@ internal static class SharedGameCatalogServiceExtensions
     {
         services.AddLogging();
         RegisterBggCoverUploadPipeline(services);
+    }
+
+    /// <summary>
+    /// Issue #3495 fix 3/N — registers the BGG cover-download typed <see cref="HttpClient"/> with
+    /// the SSRF connect-pin (<c>ConfigureSsrfPin</c>) as its primary handler. Extracted so the prod
+    /// registration and the DI test seam (<see cref="AddBggCoverDownloaderForTests"/>) share the
+    /// exact same pin wiring — drop the pin here and both prod and the fail-closed test lose it.
+    /// </summary>
+    private static void AddBggCoverDownloader(IServiceCollection services) =>
+        services.AddHttpClient<IBggCoverDownloader, BggCoverDownloader>(client =>
+        {
+            client.Timeout = TimeSpan.FromSeconds(10);
+        })
+        .ConfigureSsrfPin();
+
+    /// <summary>
+    /// Test seam (issue #3495 fix 3/N): registers ONLY the SSRF-pinned BGG cover-download client so
+    /// a DI-resolution test can prove a private-resolving cover host fails closed at the connect-pin.
+    /// The caller MUST register an <see cref="IBggCoverUploadPipeline"/> + <see cref="IDnsResolver"/>
+    /// on the same collection before resolving <see cref="IBggCoverDownloader"/>.
+    /// </summary>
+    internal static void AddBggCoverDownloaderForTests(IServiceCollection services)
+    {
+        services.AddLogging();
+        services.TryAddSingleton<IDnsResolver, SystemDnsResolver>();
+        AddBggCoverDownloader(services);
     }
 
     private static BggCoverUploadPipeline BuildBggCoverUploadPipeline(

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfSafeHttpClient.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfSafeHttpClient.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using Api.SharedKernel.Infrastructure.Http;
 
 namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 
@@ -76,8 +77,16 @@ internal sealed class SsrfSafeHttpClient
 
     /// <summary>
     /// Validates that the URL does not resolve to a private or reserved IP address.
+    /// <para>
+    /// PRIVATE (issue #3495 fix 3/N): this pre-connect DNS check is inherently TOCTOU
+    /// (DNS-rebinding). It is NOT a security boundary for live egress — the connect-pin
+    /// (<see cref="Api.SharedKernel.Infrastructure.Http.SsrfPinnedConnect"/>, applied via
+    /// <c>ConfigureSsrfPin</c>) is. It survives only as an internal fail-fast pre-check for the
+    /// not-yet-wired <see cref="DownloadPdfAsync"/> path; when that path is integrated into the
+    /// DocumentProcessing BC its HttpClient MUST be registered with the pin.
+    /// </para>
     /// </summary>
-    internal static async Task ValidateResolvedIpAsync(string url, CancellationToken ct)
+    private static async Task ValidateResolvedIpAsync(string url, CancellationToken ct)
     {
         var uri = new Uri(url);
         var addresses = await Dns.GetHostAddressesAsync(uri.Host, ct).ConfigureAwait(false);

--- a/apps/api/src/Api/SharedKernel/Infrastructure/Http/IDnsResolver.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/Http/IDnsResolver.cs
@@ -1,6 +1,6 @@
 using System.Net;
 
-namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+namespace Api.SharedKernel.Infrastructure.Http;
 
 /// <summary>
 /// Seam over DNS resolution (issue #3495, finding H4). Injecting it lets the SSRF connect pin

--- a/apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPinnedConnect.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPinnedConnect.cs
@@ -2,7 +2,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Sockets;
 
-namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+namespace Api.SharedKernel.Infrastructure.Http;
 
 /// <summary>
 /// SSRF-safe connect pin (issue #3495, findings C1/C2/H4). Used as a

--- a/apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPinnedHttpClientBuilderExtensions.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPinnedHttpClientBuilderExtensions.cs
@@ -1,0 +1,35 @@
+using System.Net.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Api.SharedKernel.Infrastructure.Http;
+
+/// <summary>
+/// Applies the SSRF connect-pin (<see cref="SsrfPinnedConnect"/>) to a typed
+/// <see cref="HttpClient"/> egress so that EVERY connection — the initial request AND every
+/// ≤5 auto-redirect hop — resolves the host once, fails closed if any resolved address is
+/// private/reserved (per <see cref="SsrfPolicy"/>), and dials the validated public IP directly.
+/// DNS-rebinding and redirect-to-internal are closed by construction.
+/// <para>
+/// Shared by all outbound sinks (BGG cover download, Slack webhook) so the pin configuration
+/// lives in exactly one place — the drift-sensitive security wiring is DRY (issue #3495 fix 3/N).
+/// </para>
+/// </summary>
+internal static class SsrfPinnedHttpClientBuilderExtensions
+{
+    /// <summary>
+    /// Configures the client's primary handler as a <see cref="SocketsHttpHandler"/> whose
+    /// <see cref="SocketsHttpHandler.ConnectCallback"/> pins to the validated address. Requires an
+    /// <see cref="IDnsResolver"/> to be registered in the same container.
+    /// </summary>
+    public static IHttpClientBuilder ConfigureSsrfPin(this IHttpClientBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        return builder.ConfigurePrimaryHttpMessageHandler(static sp => new SocketsHttpHandler
+        {
+            ConnectCallback = SsrfPinnedConnect.Create(sp.GetRequiredService<IDnsResolver>()),
+            AllowAutoRedirect = true,
+            MaxAutomaticRedirections = 5,
+        });
+    }
+}

--- a/apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPolicy.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPolicy.cs
@@ -1,7 +1,7 @@
 using System.Net;
 using System.Net.Sockets;
 
-namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+namespace Api.SharedKernel.Infrastructure.Http;
 
 /// <summary>
 /// SSRF IP classifier (issue #3495, finding H3). Pure, fail-closed classification of an

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Infrastructure/External/SlackWebhookClientPinIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Infrastructure/External/SlackWebhookClientPinIntegrationTests.cs
@@ -24,18 +24,24 @@ public sealed class SlackWebhookClientPinIntegrationTests
     private sealed class StubDnsResolver : IDnsResolver
     {
         private readonly IPAddress _address;
+        public int ResolveCalls { get; private set; }
+
         public StubDnsResolver(string ip) => _address = IPAddress.Parse(ip);
 
         public Task<IReadOnlyList<IPAddress>> ResolveAsync(string host, CancellationToken ct)
-            => Task.FromResult<IReadOnlyList<IPAddress>>(new[] { _address });
+        {
+            ResolveCalls++;
+            return Task.FromResult<IReadOnlyList<IPAddress>>(new[] { _address });
+        }
     }
 
     [Fact]
     public async Task Slack_WebhookResolvingToPrivateIp_FailsClosedAtConnectPin()
     {
+        var dns = new StubDnsResolver("10.0.0.5");
         var services = new ServiceCollection();
         // Registered BEFORE the seam so its TryAddSingleton<IDnsResolver> does not override this stub.
-        services.AddSingleton<IDnsResolver>(new StubDnsResolver("10.0.0.5"));
+        services.AddSingleton<IDnsResolver>(dns);
         AdministrationServiceExtensions.AddSlackWebhookClientForTests(services);
         using var provider = services.BuildServiceProvider();
 
@@ -49,5 +55,10 @@ public sealed class SlackWebhookClientPinIntegrationTests
             CancellationToken.None);
 
         result.Success.Should().BeFalse("the SSRF connect-pin must block a private-resolving webhook host");
+        // The stub is consulted ONLY by the pin's ConnectCallback — a non-zero count proves
+        // ConfigureSsrfPin is actually wired. Without the pin the default handler would do its own
+        // DNS (8.8.8.8, public) and never touch this stub, so this assertion fails deterministically
+        // if the pin is ever silently dropped from AddSlackWebhookClient.
+        dns.ResolveCalls.Should().BeGreaterThan(0, "the connect-pin must consult the injected resolver");
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Infrastructure/External/SlackWebhookClientPinIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Infrastructure/External/SlackWebhookClientPinIntegrationTests.cs
@@ -1,0 +1,53 @@
+using System.Net;
+using Api.BoundedContexts.Administration.Infrastructure.DependencyInjection;
+using Api.BoundedContexts.Administration.Infrastructure.External;
+using Api.SharedKernel.Infrastructure.Http;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Administration.Infrastructure.External;
+
+/// <summary>
+/// Proves the Slack webhook egress is actually wired to the SSRF connect-pin (issue #3495 fix 3/N):
+/// a webhook whose host resolves to a private/reserved address must fail closed at connect time —
+/// WITHOUT the removed pre-connect DNS check. Resolving through the real DI registration
+/// (<see cref="AdministrationServiceExtensions.AddSlackWebhookClientForTests"/>) guards against the
+/// pin being silently dropped from the pipeline; the pin's own fail-closed decision is covered by
+/// SsrfPinnedConnectTests.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Administration")]
+public sealed class SlackWebhookClientPinIntegrationTests
+{
+    private sealed class StubDnsResolver : IDnsResolver
+    {
+        private readonly IPAddress _address;
+        public StubDnsResolver(string ip) => _address = IPAddress.Parse(ip);
+
+        public Task<IReadOnlyList<IPAddress>> ResolveAsync(string host, CancellationToken ct)
+            => Task.FromResult<IReadOnlyList<IPAddress>>(new[] { _address });
+    }
+
+    [Fact]
+    public async Task Slack_WebhookResolvingToPrivateIp_FailsClosedAtConnectPin()
+    {
+        var services = new ServiceCollection();
+        // Registered BEFORE the seam so its TryAddSingleton<IDnsResolver> does not override this stub.
+        services.AddSingleton<IDnsResolver>(new StubDnsResolver("10.0.0.5"));
+        AdministrationServiceExtensions.AddSlackWebhookClientForTests(services);
+        using var provider = services.BuildServiceProvider();
+
+        var client = provider.GetRequiredService<ISlackWebhookClient>();
+
+        // The host literal (8.8.8.8) is public, but the pinned resolver returns a private address,
+        // so the pin throws at connect and SendAsync surfaces a failure rather than dialing out.
+        var result = await client.SendAsync(
+            "https://8.8.8.8/services/T1/B1/abc",
+            new SlackMessage("Hello"),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse("the SSRF connect-pin must block a private-resolving webhook host");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Infrastructure/External/SlackWebhookClientTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Infrastructure/External/SlackWebhookClientTests.cs
@@ -183,19 +183,9 @@ public class SlackWebhookClientTests
             "SendAsync", Times.Never(), ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
     }
 
-    [Theory]
-    [InlineData("https://127.0.0.1/services/T1/B1/abc")]     // loopback
-    [InlineData("https://169.254.169.254/latest")]           // cloud metadata endpoint
-    [InlineData("https://10.0.0.5/services/T1/B1/abc")]      // RFC 1918 private
-    public async Task SendAsync_PrivateOrReservedIp_BlockedWithoutPosting(string webhookUrl)
-    {
-        var handler = HandlerReturning(HttpStatusCode.OK, "ok");
-        var client = CreateClient(handler);
-
-        var result = await client.SendAsync(webhookUrl, new SlackMessage("Hello"), CancellationToken.None);
-
-        result.Success.Should().BeFalse("a webhook URL resolving to a private/reserved IP must be blocked by the SSRF guard");
-        handler.Protected().Verify(
-            "SendAsync", Times.Never(), ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
-    }
+    // #3495 fix 3/N: the private/reserved-IP guarantee moved from a pre-connect DNS check in the
+    // client to the SSRF connect-pin on the DI-wired primary handler (ConfigureSsrfPin). A unit
+    // test with a hand-built mock handler cannot exercise the pin, so that guarantee is proven by
+    // (a) SsrfPinnedConnectTests (the pin fails closed on private/mixed/empty resolutions) and
+    // (b) SlackWebhookClientPinIntegrationTests (the Slack DI registration is actually pinned).
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloaderPinIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloaderPinIntegrationTests.cs
@@ -25,19 +25,25 @@ public sealed class BggCoverDownloaderPinIntegrationTests
     private sealed class StubDnsResolver : IDnsResolver
     {
         private readonly IPAddress _address;
+        public int ResolveCalls { get; private set; }
+
         public StubDnsResolver(string ip) => _address = IPAddress.Parse(ip);
 
         public Task<IReadOnlyList<IPAddress>> ResolveAsync(string host, CancellationToken ct)
-            => Task.FromResult<IReadOnlyList<IPAddress>>(new[] { _address });
+        {
+            ResolveCalls++;
+            return Task.FromResult<IReadOnlyList<IPAddress>>(new[] { _address });
+        }
     }
 
     [Fact]
     public async Task Bgg_CoverHostResolvingToPrivateIp_FailsClosedWithoutUploading()
     {
+        var dns = new StubDnsResolver("169.254.169.254"); // cloud metadata endpoint
         var pipeline = new Mock<IBggCoverUploadPipeline>();
         var services = new ServiceCollection();
         // Registered BEFORE the seam so its TryAddSingleton<IDnsResolver> does not override this stub.
-        services.AddSingleton<IDnsResolver>(new StubDnsResolver("169.254.169.254")); // cloud metadata endpoint
+        services.AddSingleton<IDnsResolver>(dns);
         services.AddSingleton(pipeline.Object);
         SharedGameCatalogServiceExtensions.AddBggCoverDownloaderForTests(services);
         using var provider = services.BuildServiceProvider();
@@ -53,5 +59,10 @@ public sealed class BggCoverDownloaderPinIntegrationTests
         pipeline.Verify(
             p => p.UploadAsync(It.IsAny<int>(), It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);
+        // The stub is consulted ONLY by the pin's ConnectCallback — a non-zero count proves
+        // ConfigureSsrfPin is actually wired. Without the pin the default handler would do its own
+        // DNS (8.8.8.8, public) and never touch this stub, so this assertion fails deterministically
+        // if the pin is ever silently dropped from AddBggCoverDownloader.
+        dns.ResolveCalls.Should().BeGreaterThan(0, "the connect-pin must consult the injected resolver");
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloaderPinIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloaderPinIntegrationTests.cs
@@ -1,0 +1,57 @@
+using System.Net;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.DependencyInjection;
+using Api.SharedKernel.Infrastructure.Http;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Services;
+
+/// <summary>
+/// Proves the BGG cover-download egress is actually wired to the SSRF connect-pin (issue #3495 fix
+/// 3/N): a cover host resolving to a private/reserved address fails closed at connect time (returns
+/// null, never uploads) — WITHOUT the removed pre-connect DNS check. Resolving through the real DI
+/// registration (<see cref="SharedGameCatalogServiceExtensions.AddBggCoverDownloaderForTests"/>)
+/// guards against the pin being silently dropped; the pin's own fail-closed decision is covered by
+/// SsrfPinnedConnectTests.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class BggCoverDownloaderPinIntegrationTests
+{
+    private sealed class StubDnsResolver : IDnsResolver
+    {
+        private readonly IPAddress _address;
+        public StubDnsResolver(string ip) => _address = IPAddress.Parse(ip);
+
+        public Task<IReadOnlyList<IPAddress>> ResolveAsync(string host, CancellationToken ct)
+            => Task.FromResult<IReadOnlyList<IPAddress>>(new[] { _address });
+    }
+
+    [Fact]
+    public async Task Bgg_CoverHostResolvingToPrivateIp_FailsClosedWithoutUploading()
+    {
+        var pipeline = new Mock<IBggCoverUploadPipeline>();
+        var services = new ServiceCollection();
+        // Registered BEFORE the seam so its TryAddSingleton<IDnsResolver> does not override this stub.
+        services.AddSingleton<IDnsResolver>(new StubDnsResolver("169.254.169.254")); // cloud metadata endpoint
+        services.AddSingleton(pipeline.Object);
+        SharedGameCatalogServiceExtensions.AddBggCoverDownloaderForTests(services);
+        using var provider = services.BuildServiceProvider();
+
+        var downloader = provider.GetRequiredService<IBggCoverDownloader>();
+
+        // The host literal (8.8.8.8) is public, but the pinned resolver returns the metadata IP,
+        // so the pin throws at connect and the download aborts before any upload.
+        var result = await downloader.DownloadAndUploadAsync(
+            13, "https://8.8.8.8/cover.jpg", CancellationToken.None);
+
+        result.Should().BeNull("the SSRF connect-pin must block a private-resolving cover host");
+        pipeline.Verify(
+            p => p.UploadAsync(It.IsAny<int>(), It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloaderTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloaderTests.cs
@@ -94,20 +94,11 @@ public sealed class BggCoverDownloaderTests
         VerifyNoHttpCall(handler);
     }
 
-    [Theory]
-    [InlineData("https://127.0.0.1/abc.jpg")]
-    [InlineData("https://169.254.169.254/latest")]
-    [InlineData("https://10.0.0.5/abc.jpg")]
-    public async Task DownloadAndUploadAsync_PrivateOrReservedIp_BlockedWithoutFetching(string url)
-    {
-        var handler = TrackingHandler(HttpStatusCode.OK, new byte[] { 0x01 });
-        var sut = new BggCoverDownloader(new HttpClient(handler.Object), _pipelineMock.Object, _loggerMock.Object);
-
-        var result = await sut.DownloadAndUploadAsync(13, url, CancellationToken.None);
-
-        result.Should().BeNull("a URL resolving to a private/reserved IP must be blocked by the SSRF guard");
-        VerifyNoHttpCall(handler);
-    }
+    // #3495 fix 3/N: the private/reserved-IP guarantee moved from a pre-connect DNS check in the
+    // downloader to the SSRF connect-pin on the DI-wired primary handler (ConfigureSsrfPin). A unit
+    // test with a hand-built mock handler cannot exercise the pin, so that guarantee is proven by
+    // (a) SsrfPinnedConnectTests (the pin fails closed on private/mixed/empty resolutions) and
+    // (b) BggCoverDownloaderPinIntegrationTests (the BGG DI registration is actually pinned).
 
     [Fact]
     public async Task DownloadAndUploadAsync_BodyExceedsSizeCap_ReturnsNullWithoutUploading()

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfPinnedConnectTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfPinnedConnectTests.cs
@@ -1,5 +1,5 @@
 using System.Net;
-using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+using Api.SharedKernel.Infrastructure.Http;
 using Api.Tests.Constants;
 using FluentAssertions;
 using Xunit;

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfPolicyTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfPolicyTests.cs
@@ -1,5 +1,5 @@
 using System.Net;
-using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+using Api.SharedKernel.Infrastructure.Http;
 using Api.Tests.Constants;
 using FluentAssertions;
 using Xunit;


### PR DESCRIPTION
## SSRF hardening — fix 3/N: single connect-pin boundary + Slack egress (issue #3495)

Completes the SSRF hardening by making the connect-pin the **single egress SSRF boundary** and migrating the last live TOCTOU sink (**Slack** webhook).

- **Promote** `SsrfPolicy` + `IDnsResolver` + `SsrfPinnedConnect` → `Api.SharedKernel.Infrastructure.Http` (cross-cutting infra) so any BC uses the pin without a bounded-context boundary violation. Add a DRY `ConfigureSsrfPin()` `IHttpClientBuilder` extension, used by both BGG and Slack.
- **Slack** webhook egress (admin-controlled URL): inline https scheme pre-check, drop the TOCTOU static `ValidateResolvedIpAsync` call, wire `ConfigureSsrfPin` on the Administration DI registration. IP safety now enforced at connect time. Polly retry/CB wraps the pinned handler (a retry just re-invokes the fail-closed pin).
- **BGG** cover download: drop the now-redundant static IP pre-check (the pin covers it); register via the shared helper.
- **Footgun contained**: `SsrfSafeHttpClient.ValidateResolvedIpAsync` is now `private` (only the not-yet-wired PDF-download stub uses it internally).

### Verification
- **103 tests green** (Ssrf/Bgg/Slack). Replaced the two mock-handler private-IP unit tests (which cannot exercise the DI pin) with **DI-integration tests** proving each egress is actually pinned — resolved through the real registration, a private-resolving host fails closed.
- **Adversarial review** ran on the diff. Its one finding — the new integration tests passed *vacuously* (asserting only the swallowed outer failure, which a dropped pin would also produce via a real failed connection to the public `8.8.8.8`) — is fixed: the stub resolver now tracks `ResolveCalls` and the tests assert it was consulted, so they fail deterministically if `ConfigureSsrfPin` is ever silently dropped. All other review points confirmed no regression.

### Deferred (tracked in #3495, no P0 remaining)
Wikimedia pin (fixed-host, low risk), per-hop redirect scheme re-check (in tension with Wikimedia's redirect requirement), per-sink circuit breaker + egress-blocked metric, dial-by-IP test seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
