### PR TITLE
fix(security): SSRF-pin catalog-seed egress clients (#3495 follow-up)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
@@ -480,7 +480,11 @@ internal static class SharedGameCatalogServiceExtensions
         // versa — separate handler instances per typed client.
         .AddHttpMessageHandler(sp => new WikimediaCircuitBreakerHandler(
             sp.GetRequiredService<ILogger<WikimediaCircuitBreakerHandler>>(),
-            clientName: "wikidata-sparql"));
+            clientName: "wikidata-sparql"))
+        // #3495 follow-up: SSRF connect-pin — defense-in-depth on a fixed public host (DNS-rebinding).
+        // ConfigureSsrfPin uses ConfigurePrimaryHttpMessageHandler (innermost), so the circuit-breaker
+        // delegating handler above stays outer (CB → pin), matching the Slack registration.
+        .ConfigureSsrfPin();
 
         // Issue #1823 M4 (ADR DEC-3b/3c/3e): Wikimedia Commons license fetcher.
         // Consumed by the M8 orchestrator AFTER the Wikidata SPARQL pass resolves
@@ -512,14 +516,22 @@ internal static class SharedGameCatalogServiceExtensions
         // breaker independently.
         .AddHttpMessageHandler(sp => new WikimediaCircuitBreakerHandler(
             sp.GetRequiredService<ILogger<WikimediaCircuitBreakerHandler>>(),
-            clientName: "commons-api"));
+            clientName: "commons-api"))
+        // #3495 follow-up: SSRF connect-pin. ConfigureSsrfPin sets AllowAutoRedirect=true, so the
+        // M8 invariant above (Special:FilePath 302 → upload.wikimedia.org MUST be auto-followed) still
+        // holds — and each redirect hop's host is independently re-resolved and SSRF-validated by the
+        // per-connection pin (upload.wikimedia.org is public → allowed). Do NOT add any other
+        // ConfigurePrimaryHttpMessageHandler here: it would override the pin.
+        .ConfigureSsrfPin();
 
         services.AddHttpClient<BggCatalogProvider>(client =>
         {
             client.BaseAddress = new Uri(BggBaseUrl);
             client.DefaultRequestHeaders.UserAgent.ParseAdd(CatalogUserAgent);
             client.Timeout = TimeSpan.FromSeconds(30);
-        });
+        })
+        // #3495 follow-up: SSRF connect-pin — defense-in-depth on a fixed public host (DNS-rebinding).
+        .ConfigureSsrfPin();
 
         // Keyed registration so CatalogSeedAggregator can resolve "wikidata" (primary)
         // and "bgg" (fallback) explicitly — avoids relying on registration order.
@@ -535,6 +547,22 @@ internal static class SharedGameCatalogServiceExtensions
             var logger = sp.GetRequiredService<ILogger<CatalogSeedAggregator>>();
             return new CatalogSeedAggregator(wikidata, bgg, logger);
         });
+    }
+
+    /// <summary>
+    /// Test seam (issue #3495 follow-up): registers the catalog-seed external egress clients via the
+    /// REAL <see cref="RegisterCatalogSeedProviders"/> so a DI-resolution test can prove the SSRF
+    /// connect-pin is actually applied — resolving through the production registration guards against
+    /// the pin being silently dropped. Adds the ambient deps those clients need (logging, the
+    /// <see cref="IDnsResolver"/> seam, the Wikimedia rate limiter). Register a controlling
+    /// <see cref="IDnsResolver"/> BEFORE calling this to steer the pin (the TryAdd below won't override it).
+    /// </summary>
+    internal static void AddCatalogSeedProvidersForTests(IServiceCollection services)
+    {
+        services.AddLogging();
+        services.TryAddSingleton<IDnsResolver, SystemDnsResolver>();
+        services.TryAddSingleton<IWikimediaRateLimiter, InMemoryWikimediaRateLimiter>();
+        RegisterCatalogSeedProviders(services);
     }
 
     /// <summary>

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WikimediaCommonsClientPinIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WikimediaCommonsClientPinIntegrationTests.cs
@@ -1,0 +1,66 @@
+using System.Net;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.DependencyInjection;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+using Api.SharedKernel.Infrastructure.Http;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+
+/// <summary>
+/// Proves the Wikimedia Commons egress is actually wired to the SSRF connect-pin (issue #3495
+/// follow-up): resolved through the REAL catalog-seed registration
+/// (<see cref="SharedGameCatalogServiceExtensions.AddCatalogSeedProvidersForTests"/>), a Commons
+/// host resolving to a private/reserved address fails closed at connect time. The stub resolver is
+/// consulted ONLY by the pin's ConnectCallback, so asserting <c>ResolveCalls &gt; 0</c> guards
+/// against the pin being silently dropped — with no network dependency. This also composes the pin
+/// with the <c>WikimediaCircuitBreakerHandler</c> delegating handler present on the same client, and
+/// exercises the client's NARROW catch (HttpRequestException) — confirming the pin's connect-time
+/// failure surfaces as HttpRequestException rather than escaping as a raw InvalidOperationException.
+/// (Wikidata SPARQL + BGG XMLAPI2 use the identical one-line <c>.ConfigureSsrfPin()</c> in the same
+/// registration; this Commons case — the one with a redirect requirement and a narrow catch — is the
+/// representative proof for the catalog-seed egress slice.)
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class WikimediaCommonsClientPinIntegrationTests
+{
+    private sealed class StubDnsResolver : IDnsResolver
+    {
+        private readonly IPAddress _address;
+        public int ResolveCalls { get; private set; }
+
+        public StubDnsResolver(string ip) => _address = IPAddress.Parse(ip);
+
+        public Task<IReadOnlyList<IPAddress>> ResolveAsync(string host, CancellationToken ct)
+        {
+            ResolveCalls++;
+            return Task.FromResult<IReadOnlyList<IPAddress>>(new[] { _address });
+        }
+    }
+
+    [Fact]
+    public async Task Commons_HostResolvingToPrivateIp_FailsClosedAtConnectPin()
+    {
+        var dns = new StubDnsResolver("169.254.169.254"); // cloud metadata endpoint
+        var services = new ServiceCollection();
+        // Registered BEFORE the seam so its TryAddSingleton<IDnsResolver> does not override this stub.
+        services.AddSingleton<IDnsResolver>(dns);
+        SharedGameCatalogServiceExtensions.AddCatalogSeedProvidersForTests(services);
+        using var provider = services.BuildServiceProvider();
+
+        var client = provider.GetRequiredService<IWikimediaCommonsClient>();
+
+        // commons.wikimedia.org resolves (via the pinned stub) to a blocked address, so the pin
+        // throws at connect; FetchLicenseAsync must swallow that into NotAvailable (not propagate).
+        var result = await client.FetchLicenseAsync("Some_cover.jpg", CancellationToken.None);
+
+        result.Should().Be(
+            CommonsLicenseResult.NotAvailable(),
+            "the SSRF connect-pin must block a private-resolving Commons host and fail closed");
+        dns.ResolveCalls.Should().BeGreaterThan(
+            0, "the connect-pin must consult the injected resolver — proving ConfigureSsrfPin is wired through the real registration");
+    }
+}


### PR DESCRIPTION
## SSRF hardening — catalog-seed egress pins (issue #3495 follow-up)

Defense-in-depth follow-up to the #3495 SSRF work: apply the shared `ConfigureSsrfPin()` to the three remaining **external** catalog-seed `HttpClient`s in `RegisterCatalogSeedProviders`:

- **Wikidata SPARQL** (`query.wikidata.org`)
- **Wikimedia Commons** (`commons.wikimedia.org`)
- **BGG XMLAPI2** (`boardgamegeek.com`)

Fixed public hosts, so SSRF risk is low, but the pin adds DNS-rebinding defense and completes the **single pinned boundary** for the catalog egress surface.

### Correctness (scout + adversarial review verified)
- **Composes with `WikimediaCircuitBreakerHandler`**: `ConfigureSsrfPin` uses `ConfigurePrimaryHttpMessageHandler` (innermost), so the CB delegating handler stays outer — **CB → pin** — like the Slack registration. No collision with other primary-handler configs.
- **Commons redirect preserved**: the pin keeps `AllowAutoRedirect=true`, so the M8 invariant (`Special:FilePath` 302 → `upload.wikimedia.org` must auto-follow) still holds; each redirect hop's host is independently re-resolved/validated (`upload.wikimedia.org` public → allowed).
- **Narrow-catch safe**: the review confirmed against .NET runtime source that a `ConnectCallback` exception is always rethrown as `HttpRequestException`, so Commons' narrow `catch (HttpRequestException)` reliably turns the pin's fail-closed into `NotAvailable` (never a propagated error) — by construction, not coincidence.

### Tests
- New `AddCatalogSeedProvidersForTests` seam routes through the **real** `RegisterCatalogSeedProviders`, and `WikimediaCommonsClientPinIntegrationTests` proves the Commons egress is actually pinned: a private-resolving host fails closed **and** the stub resolver is consulted (`ResolveCalls>0`), guarding against the pin being silently dropped. 162 unit tests green; no existing test breaks (all inject mock/WireMock handlers, bypassing DI).

### Census spinoff → tracked in #3495
The 4-agent scout's egress census surfaced **higher-priority unpinned admin/user-controlled egresses** (not fixed-host): legacy **SlackAlertChannel** webhook (a real gap — its sibling `SlackWebhookClient` IS pinned), **OAuth** provider URLs, **n8n** DB-sourced BaseUrl, **provider-probe** admin baseUrl. These are now tracked in #3495 as the next SSRF priority (above the remaining fixed-host defense-in-depth). Internal-service clients (Ollama, embedding, reranker, …) intentionally NOT pinned — they resolve to private IPs the pin would block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
