### PR TITLE
feat(rag-eval): emit per-sample results for offline McNemar/Holm

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Evaluation/Services/EvaluationReportFormatter.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Evaluation/Services/EvaluationReportFormatter.cs
@@ -140,7 +140,13 @@ internal static class EvaluationReportFormatter
             ByLanguage = byLanguage.ToDictionary(
                 kvp => kvp.Key,
                 kvp => ToMetricsProjection(kvp.Value),
-                StringComparer.Ordinal)
+                StringComparer.Ordinal),
+            // Per-sample results (#3390 follow-up): the aggregate metrics collapse each sample's
+            // outcome, which loses the paired per-sample data a McNemar test (+ Holm correction
+            // across enhancements) needs. Emit one entry per sample so two runs can be paired by
+            // sample_id offline. CitationMatched (nullable) is the per-sample citation-correct
+            // binary; a null (ungraded) sample serialises as JSON null and is excluded from pairing.
+            Samples = result.SampleResults.Select(ToSampleProjection).ToList()
         };
 
         return JsonSerializer.Serialize(projection, s_jsonOptions);
@@ -169,12 +175,22 @@ internal static class EvaluationReportFormatter
         CitedSampleCount = metrics.CitedSampleCount
     };
 
+    private static SampleProjection ToSampleProjection(EvaluationSampleResult sample) => new()
+    {
+        SampleId = sample.SampleId,
+        CitationMatched = sample.CitationMatched,
+        CitationStructuralValidity = sample.CitationStructuralValidity,
+        AnswerCorrectness = sample.AnswerCorrectness,
+        IsSuccess = sample.IsSuccess
+    };
+
     private sealed class ReportProjection
     {
         public string Dataset { get; init; } = string.Empty;
         public MetricsProjection Metrics { get; init; } = new();
         public CoverageProjection Coverage { get; init; } = new();
         public Dictionary<string, MetricsProjection> ByLanguage { get; init; } = new(StringComparer.Ordinal);
+        public List<SampleProjection> Samples { get; init; } = new();
     }
 
     private sealed class MetricsProjection
@@ -209,5 +225,22 @@ internal static class EvaluationReportFormatter
     {
         public int Labeled { get; init; }
         public int Unlabeled { get; init; }
+    }
+
+    /// <summary>
+    /// Per-sample projection carrying the fields a paired McNemar/Holm analysis needs offline:
+    /// <c>sample_id</c> (pairing key across runs), <c>citation_matched</c> (the per-sample
+    /// citation-correct binary; JSON null when the sample is ungraded and must be excluded),
+    /// plus <c>citation_structural_validity</c>, <c>answer_correctness</c>, and <c>is_success</c>
+    /// as secondary per-sample outcomes / filters. All names are snake_case-clean (no trailing
+    /// digit) so the auto policy needs no <see cref="JsonPropertyNameAttribute"/> overrides.
+    /// </summary>
+    private sealed class SampleProjection
+    {
+        public string SampleId { get; init; } = string.Empty;
+        public bool? CitationMatched { get; init; }
+        public double CitationStructuralValidity { get; init; }
+        public double AnswerCorrectness { get; init; }
+        public bool IsSuccess { get; init; }
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Evaluation/Services/EvaluationReportFormatterTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Evaluation/Services/EvaluationReportFormatterTests.cs
@@ -239,4 +239,50 @@ public class EvaluationReportFormatterTests
         metrics.TryGetProperty("citation_structural_validity", out _).Should().BeTrue();
         metrics.TryGetProperty("cited_sample_count", out _).Should().BeTrue();
     }
+
+    [Fact]
+    public void ToJson_EmitsPerSampleResults_ForPairedMcNemarHolm()
+    {
+        // Arrange — McNemar's paired test consumes a per-sample citation-correct binary
+        // (CitationMatched), keyed by sample_id so two runs can be paired sample-for-sample;
+        // an ungraded sample (no ExpectedCitations) must round-trip as JSON null so the offline
+        // test can exclude it from the pairing (null != false).
+        var sampleResults = new List<EvaluationSampleResult>
+        {
+            CreateSampleResult("s-001") with { CitationMatched = true, CitationStructuralValidity = 1.0 },
+            CreateSampleResult("s-002") with { CitationMatched = false, CitationStructuralValidity = 0.5 },
+            CreateSampleResult("s-003") // no ExpectedCitations -> CitationMatched stays null (ungraded)
+        };
+        var result = CreateResult(sampleResults);
+        var byLanguage = new Dictionary<string, EvaluationMetrics>(StringComparer.Ordinal)
+        {
+            ["en"] = EvaluationMetrics.Compute(sampleResults)
+        };
+
+        // Act
+        var json = EvaluationReportFormatter.ToJson(result, byLanguage);
+
+        // Assert — a top-level `samples` array with one entry per sample.
+        using var document = JsonDocument.Parse(json);
+        var samples = document.RootElement.GetProperty("samples");
+        samples.ValueKind.Should().Be(JsonValueKind.Array);
+        samples.GetArrayLength().Should().Be(3);
+
+        var byId = samples.EnumerateArray().ToDictionary(
+            e => e.GetProperty("sample_id").GetString()!,
+            e => e,
+            StringComparer.Ordinal);
+
+        // graded-true: the per-sample McNemar binary + carried structural validity + success flag.
+        byId["s-001"].GetProperty("citation_matched").GetBoolean().Should().BeTrue();
+        byId["s-001"].GetProperty("citation_structural_validity").GetDouble().Should().Be(1.0);
+        byId["s-001"].GetProperty("is_success").GetBoolean().Should().BeTrue();
+        byId["s-001"].TryGetProperty("answer_correctness", out _).Should().BeTrue();
+
+        // graded-false: distinct binary outcome (a discordant pair vs a true run drives McNemar).
+        byId["s-002"].GetProperty("citation_matched").GetBoolean().Should().BeFalse();
+
+        // ungraded: citation_matched round-trips as JSON null, distinguishable from false.
+        byId["s-003"].GetProperty("citation_matched").ValueKind.Should().Be(JsonValueKind.Null);
+    }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Endpoints/AdminEvalEndpointsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Endpoints/AdminEvalEndpointsIntegrationTests.cs
@@ -172,6 +172,17 @@ public sealed class AdminEvalEndpointsIntegrationTests : IAsyncLifetime
         root.GetProperty("coverage").GetProperty("labeled").GetInt32().Should().Be(1);
         root.GetProperty("coverage").GetProperty("unlabeled").GetInt32().Should().Be(0);
         root.GetProperty("by_language").GetProperty("en").GetProperty("recall_at_10").GetDouble().Should().Be(1.0);
+
+        // Per-sample results (#3390 follow-up): the wire response carries one entry per sample so a
+        // paired McNemar/Holm analysis can be run offline. Assert the array + a graded entry's fields.
+        var samples = root.GetProperty("samples");
+        samples.ValueKind.Should().Be(JsonValueKind.Array);
+        samples.GetArrayLength().Should().Be(1);
+        var sample = samples[0];
+        sample.GetProperty("sample_id").GetString().Should().NotBeNullOrEmpty();
+        sample.GetProperty("is_success").GetBoolean().Should().BeTrue();
+        sample.TryGetProperty("citation_matched", out _).Should().BeTrue(
+            because: "the per-sample McNemar binary must be present (JSON null when the sample is ungraded)");
     }
 
     [Fact]


### PR DESCRIPTION
## What

Adds a top-level `samples` array to the RAG eval report JSON (`POST /api/v1/admin/eval/retrieval`), so the paired **McNemar** test (+ **Holm** correction across the 5 rag enhancements) can be run offline on per-sample citation-correctness. Closes the follow-up from the per-enhancement eval report.

## The gap

The endpoint only emitted aggregate metrics. `DatasetEvaluationService` already computes a per-sample `EvaluationSampleResult` list and `EvaluationResult` carries it all the way to the endpoint — but `EvaluationReportFormatter.ToJson` projected only `dataset/metrics/coverage/by_language`, **dropping `result.SampleResults`**. McNemar needs the per-sample paired outcomes, not the collapsed mean.

## The change

`EvaluationReportFormatter.ToJson` now projects `result.SampleResults` into a `samples` array, one entry per sample:

| field | source | role |
|---|---|---|
| `sample_id` | `EvaluationSampleResult.SampleId` (dataset-derived, stable across runs) | **pairing key** — two runs pair sample-for-sample |
| `citation_matched` | `CitationMatched` (`bool?`) | **the McNemar binary**; JSON `null` when ungraded (no expected citations) → excluded from pairing |
| `citation_structural_validity` | `double` | second per-sample outcome (continuous; binarize offline for a 2nd McNemar) |
| `answer_correctness` | `double` | context |
| `is_success` | computed | filter failed samples (whose `structural_validity` defaults to 1.0) |

`citation_accuracy` is reconstructable bit-for-bit offline: `mean(samples where is_success && citation_matched != null → citation_matched ? 1 : 0)`.

## Safety (adversarially reviewed, 2 lenses, no defect)

- **Purely additive**: endpoint returns raw text via `Results.Text`; no strongly-typed/`.strict()` consumer, no FE (grep of `apps/web` → 0), no exact-key-set assertion. Existing consumers (Makefile `jq`, two tests using `JsonDocument`/`TryGetProperty`) ignore extra keys.
- **snake_case**: no new field has a trailing digit, so no `[JsonPropertyName]` overrides needed (unlike `recall_at_10`). `citation_structural_validity` reuses the already-shipped identifier.
- **null round-trip**: `s_jsonOptions` has no `DefaultIgnoreCondition` → ungraded `citation_matched` serializes as present `null`, distinguishable from `false`.
- No routing/handler change.

## Tests

- **Unit** (`EvaluationReportFormatterTests.ToJson_EmitsPerSampleResults_ForPairedMcNemarHolm`): asserts the array shape + graded-true/graded-false binaries + ungraded-null round-trip. ✅ 7/7 local.
- **Integration** (`AdminEvalEndpointsIntegrationTests`): extends the existing wire-contract test to assert `samples` end-to-end through the endpoint. Runs in **CI** (Testcontainers/Docker unavailable in the local Windows env — compiles clean locally).

## Follow-up (optional, out of scope)

Make `EvaluationResult.Configuration` reflect the enhancement set so each of the 6 sweep JSONs is self-identifying by config (today it defaults to `"baseline"` for all runs; run identity is currently invocation/filename-based). Building the McNemar/Holm computation itself stays offline (a script over these JSONs), as the follow-up scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
