### PR TITLE
docs(rag-eval): close the McNemar/Holm follow-up (#3523 + #3525)

### DIFF
--- a/docs/for-developers/evaluation-reports/per-enhancement-2026-08-03.md
+++ b/docs/for-developers/evaluation-reports/per-enhancement-2026-08-03.md
@@ -55,5 +55,5 @@ Mechanism notes:
 
 ## Follow-ups
 - ✅ ~~Investigate the grounded-path structural_validity discrepancy~~ — done: fixed (PR #3517) and verified on staging (0.07 → 1.00). The dead-code twin of the same defect on the `/search` path (`SearchResult.ToCitation()`) was also removed (PR #3520).
-- Emit per-sample results from the eval endpoint to enable the full McNemar/Holm protocol.
+- ✅ ~~Emit per-sample results from the eval endpoint to enable the full McNemar/Holm protocol.~~ — done: the endpoint now emits a top-level `samples` array (PR #3523), and `tests/llm-eval/mcnemar_holm.py` (PR #3525) runs the paired McNemar + Holm-Bonferroni offline over the per-config JSONs (`--selftest` proves the statistics; run the endpoint once per config to generate inputs). This aggregate run (aggregate p + test-retest noise floor) predates the per-sample protocol; re-run per-config with the `samples` emission to apply it.
 - Re-baseline the live grounded path formally (this run supersedes #3477's legacy 0.286 as the live-path reference: ~0.50).


### PR DESCRIPTION
Marks the per-sample-results follow-up done in the per-enhancement eval report and points to `tests/llm-eval/mcnemar_holm.py` (PR #3525), which runs the paired McNemar + Holm-Bonferroni offline over the per-config JSONs emitted by #3523. Notes that this report's aggregate run predates the per-sample protocol (re-run per-config to apply it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)