### PR TITLE
feat(catalog): per-context cover resolution Card+Hero + cache (Slice 2a, #3470)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AssignCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AssignCoverCommandHandler.cs
@@ -24,17 +24,20 @@ internal sealed class AssignCoverCommandHandler : ICommandHandler<AssignCoverCom
     private readonly ISharedGameRepository _repository;
     private readonly IUnitOfWork _unitOfWork;
     private readonly IHybridCacheService _cache;
+    private readonly ICacheInvalidationRetryPolicy _cacheRetryPolicy;
     private readonly ILogger<AssignCoverCommandHandler> _logger;
 
     public AssignCoverCommandHandler(
         ISharedGameRepository repository,
         IUnitOfWork unitOfWork,
         IHybridCacheService cache,
+        ICacheInvalidationRetryPolicy cacheRetryPolicy,
         ILogger<AssignCoverCommandHandler> logger)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _cacheRetryPolicy = cacheRetryPolicy ?? throw new ArgumentNullException(nameof(cacheRetryPolicy));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -54,7 +57,7 @@ internal sealed class AssignCoverCommandHandler : ICommandHandler<AssignCoverCom
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
         await CoverCacheInvalidation
-            .EvictReadModelAsync(_cache, command.GameId, cancellationToken)
+            .EvictReadModelAsync(_cache, _cacheRetryPolicy, command.GameId, cancellationToken)
             .ConfigureAwait(false);
 
         _logger.LogInformation(

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AssignCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AssignCoverCommandHandler.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.Middleware.Exceptions;
+using Api.Services;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Microsoft.Extensions.Logging;
@@ -11,20 +12,29 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands;
 /// (<see cref="Domain.Aggregates.SharedGame.AssignCover"/>) and the child-safe
 /// <see cref="ISharedGameRepository.ReconcileCoverAssignmentsAsync"/>. Returns the
 /// persisted assignment so the picker can reflect the new state.
+///
+/// Slice 2 (AC-6): the cover columns the read-model resolves changed, so this handler
+/// evicts the SharedGameCatalog read caches (list <c>search-games</c> + detail
+/// <c>shared-game:{id}</c>) across replicas — otherwise the assignment stays invisible
+/// until the 15min–2h HybridCache TTL and the picker looks broken. Mirrors
+/// <see cref="EnrichCatalogCover.EnrichCatalogCoverCommandHandler"/>.
 /// </summary>
 internal sealed class AssignCoverCommandHandler : ICommandHandler<AssignCoverCommand, CoverAssignmentDto>
 {
     private readonly ISharedGameRepository _repository;
     private readonly IUnitOfWork _unitOfWork;
+    private readonly IHybridCacheService _cache;
     private readonly ILogger<AssignCoverCommandHandler> _logger;
 
     public AssignCoverCommandHandler(
         ISharedGameRepository repository,
         IUnitOfWork unitOfWork,
+        IHybridCacheService cache,
         ILogger<AssignCoverCommandHandler> logger)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -42,6 +52,10 @@ internal sealed class AssignCoverCommandHandler : ICommandHandler<AssignCoverCom
 
         await _repository.ReconcileCoverAssignmentsAsync(game, cancellationToken).ConfigureAwait(false);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        await CoverCacheInvalidation
+            .EvictReadModelAsync(_cache, command.GameId, cancellationToken)
+            .ConfigureAwait(false);
 
         _logger.LogInformation(
             "Assigned {Source} cover to {Context} for game {GameId} by {AdminId}",

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/CoverCacheInvalidation.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/CoverCacheInvalidation.cs
@@ -10,7 +10,9 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands;
 /// instead of waiting for the 15min–2h HybridCache TTL.
 ///
 /// The literal tags mirror <c>SearchSharedGamesQueryHandler</c> (list) and
-/// <c>GetSharedGameByIdQueryHandler</c> (detail), and the invalidation pattern mirrors
+/// <c>GetSharedGameByIdQueryHandler</c> (detail). Each eviction runs through
+/// <see cref="ICacheInvalidationRetryPolicy"/> (issue #613) so a transient Redis blip
+/// is retried rather than silently leaving the L2 copy stale — mirroring
 /// <c>EnrichCatalogCoverCommandHandler</c>, the other cover-mutating command in this BC.
 /// </summary>
 internal static class CoverCacheInvalidation
@@ -19,15 +21,21 @@ internal static class CoverCacheInvalidation
 
     public static async Task EvictReadModelAsync(
         IHybridCacheService cache,
+        ICacheInvalidationRetryPolicy retryPolicy,
         Guid gameId,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(cache);
+        ArgumentNullException.ThrowIfNull(retryPolicy);
 
-        // Cross-replica L1+L2 eviction via Redis Pub/Sub; falls back to local
-        // eviction when Redis is unreachable (see IHybridCacheService docs), so a
-        // transient Redis outage degrades to a per-node TTL wait rather than throwing.
-        await cache.RemoveByTagAcrossReplicasAsync(SearchGamesTag, cancellationToken).ConfigureAwait(false);
-        await cache.RemoveByTagAcrossReplicasAsync($"shared-game:{gameId}", cancellationToken).ConfigureAwait(false);
+        await retryPolicy.ExecuteAsync(
+            token => new ValueTask(cache.RemoveByTagAcrossReplicasAsync(SearchGamesTag, token)),
+            "shared-games.list",
+            cancellationToken).ConfigureAwait(false);
+
+        await retryPolicy.ExecuteAsync(
+            token => new ValueTask(cache.RemoveByTagAcrossReplicasAsync($"shared-game:{gameId}", token)),
+            "shared-games.detail",
+            cancellationToken).ConfigureAwait(false);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/CoverCacheInvalidation.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/CoverCacheInvalidation.cs
@@ -1,0 +1,33 @@
+using Api.Services;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+
+/// <summary>
+/// Epic #3470 Slice 2 (AC-6): evicts the SharedGameCatalog read-model caches whose
+/// resolved cover changes when an admin assigns or removes a per-context cover. Busts
+/// the list tag (<c>search-games</c>) and the per-game detail tag
+/// (<c>shared-game:{id}</c>) across replicas so the new cover renders immediately
+/// instead of waiting for the 15min–2h HybridCache TTL.
+///
+/// The literal tags mirror <c>SearchSharedGamesQueryHandler</c> (list) and
+/// <c>GetSharedGameByIdQueryHandler</c> (detail), and the invalidation pattern mirrors
+/// <c>EnrichCatalogCoverCommandHandler</c>, the other cover-mutating command in this BC.
+/// </summary>
+internal static class CoverCacheInvalidation
+{
+    private const string SearchGamesTag = "search-games";
+
+    public static async Task EvictReadModelAsync(
+        IHybridCacheService cache,
+        Guid gameId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(cache);
+
+        // Cross-replica L1+L2 eviction via Redis Pub/Sub; falls back to local
+        // eviction when Redis is unreachable (see IHybridCacheService docs), so a
+        // transient Redis outage degrades to a per-node TTL wait rather than throwing.
+        await cache.RemoveByTagAcrossReplicasAsync(SearchGamesTag, cancellationToken).ConfigureAwait(false);
+        await cache.RemoveByTagAcrossReplicasAsync($"shared-game:{gameId}", cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RemoveCoverAssignmentCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RemoveCoverAssignmentCommandHandler.cs
@@ -21,17 +21,20 @@ internal sealed class RemoveCoverAssignmentCommandHandler : ICommandHandler<Remo
     private readonly ISharedGameRepository _repository;
     private readonly IUnitOfWork _unitOfWork;
     private readonly IHybridCacheService _cache;
+    private readonly ICacheInvalidationRetryPolicy _cacheRetryPolicy;
     private readonly ILogger<RemoveCoverAssignmentCommandHandler> _logger;
 
     public RemoveCoverAssignmentCommandHandler(
         ISharedGameRepository repository,
         IUnitOfWork unitOfWork,
         IHybridCacheService cache,
+        ICacheInvalidationRetryPolicy cacheRetryPolicy,
         ILogger<RemoveCoverAssignmentCommandHandler> logger)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _cacheRetryPolicy = cacheRetryPolicy ?? throw new ArgumentNullException(nameof(cacheRetryPolicy));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -51,7 +54,7 @@ internal sealed class RemoveCoverAssignmentCommandHandler : ICommandHandler<Remo
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
         await CoverCacheInvalidation
-            .EvictReadModelAsync(_cache, command.GameId, cancellationToken)
+            .EvictReadModelAsync(_cache, _cacheRetryPolicy, command.GameId, cancellationToken)
             .ConfigureAwait(false);
 
         _logger.LogInformation(

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RemoveCoverAssignmentCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RemoveCoverAssignmentCommandHandler.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.Middleware.Exceptions;
+using Api.Services;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
@@ -11,20 +12,26 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands;
 /// Epic #3470 — removes a context's cover assignment (resetting it to the resolver's
 /// implicit precedence) through the aggregate + reconcile path. Removing an absent
 /// assignment is an idempotent no-op; only a missing game is a 404.
+///
+/// Slice 2 (AC-6): evicts the read-model caches (list + detail) across replicas after
+/// the change so the reverted cover renders immediately instead of waiting for the TTL.
 /// </summary>
 internal sealed class RemoveCoverAssignmentCommandHandler : ICommandHandler<RemoveCoverAssignmentCommand, Unit>
 {
     private readonly ISharedGameRepository _repository;
     private readonly IUnitOfWork _unitOfWork;
+    private readonly IHybridCacheService _cache;
     private readonly ILogger<RemoveCoverAssignmentCommandHandler> _logger;
 
     public RemoveCoverAssignmentCommandHandler(
         ISharedGameRepository repository,
         IUnitOfWork unitOfWork,
+        IHybridCacheService cache,
         ILogger<RemoveCoverAssignmentCommandHandler> logger)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -42,6 +49,10 @@ internal sealed class RemoveCoverAssignmentCommandHandler : ICommandHandler<Remo
 
         await _repository.ReconcileCoverAssignmentsAsync(game, cancellationToken).ConfigureAwait(false);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        await CoverCacheInvalidation
+            .EvictReadModelAsync(_cache, command.GameId, cancellationToken)
+            .ConfigureAwait(false);
 
         _logger.LogInformation(
             "Removed cover assignment for {Context} on game {GameId} by {AdminId}",

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetSharedGameByIdQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetSharedGameByIdQueryHandler.cs
@@ -7,6 +7,7 @@ using Api.Infrastructure;
 using Api.Observability;
 using Api.Services;
 using Api.Services.Pdf;
+using Api.SharedKernel.Domain.Covers;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Hybrid;
@@ -387,21 +388,27 @@ internal sealed class GetSharedGameByIdQueryHandler : IRequestHandler<GetSharedG
         // PdfCoverR2Key, so we load the entity here from the already-open DbContext.
         // _context.SharedGames is already queried above (aggregates query), so EF's
         // identity map will typically satisfy this from its first-level cache.
+        // Epic #3470 Slice 2: eager-load CoverAssignments so the per-context (Hero)
+        // resolver can honor an admin override; without the Include it silently falls
+        // through to the implicit precedence (the assignment appears ignored).
         var sharedGameEntity = await _context.SharedGames
             .AsNoTracking()
+            .Include(g => g.CoverAssignments)
             .Where(g => g.Id == gameId)
             .FirstOrDefaultAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        // Epic #3470 Slice 1d-a — resolve the cover AND its winning source so the
-        // attribution footer follows the actual image (previously emitted Wikidata
-        // license/attribution unconditionally, even for a PDF/BGG-sourced cover).
+        // Epic #3470 Slice 2 — the detail page is the sole Hero surface, so resolve the
+        // cover for the Hero context (admin per-context override → implicit precedence
+        // fall-through) AND its winning source. Source-aware so the attribution footer
+        // follows the actual image (Slice 1d-a: previously emitted Wikidata license/
+        // attribution unconditionally, even for a PDF/BGG-sourced cover).
         string? coverUrl = null;
         string? coverLicense = null, coverAttribution = null, coverSourceUrl = null;
         if (sharedGameEntity is not null)
         {
             var cover = await CoverUrlResolver
-                .ResolvePublicWithSourceAsync(sharedGameEntity, _blobStorage)
+                .ResolveForContextWithSourceAsync(sharedGameEntity, CoverContext.Hero, _blobStorage)
                 .ConfigureAwait(false);
             coverUrl = cover.Url;
             (coverLicense, coverAttribution, coverSourceUrl) =

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQueryHandler.cs
@@ -4,10 +4,12 @@ using Api.BoundedContexts.SharedGameCatalog.Application.Services;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 using Api.Infrastructure;
+using Api.Infrastructure.Entities.SharedGameCatalog;
 using Api.Models;
 using Api.Services;
 using Api.Services.Pdf;
 using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Domain.Covers;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Hybrid;
@@ -117,7 +119,13 @@ internal sealed class SearchSharedGamesQueryHandler : IRequestHandler<SearchShar
 
     private async Task<PagedResult<SharedGameDto>> ExecuteSearchAsync(SearchSharedGamesQuery query, CancellationToken cancellationToken)
     {
-        var dbQuery = _context.SharedGames.AsNoTracking();
+        // Epic #3470 Slice 2: eager-load CoverAssignments so the per-context (Card)
+        // resolver can honor an admin override on each grid card; without the Include
+        // the assignment silently falls through to the implicit precedence. The
+        // projection below keeps `Game = g` (the full entity), so the Include is honored.
+        // Typed IQueryable (not the IIncludableQueryable that Include returns) so the
+        // subsequent `dbQuery = dbQuery.Where(...)` filter reassignments still compile.
+        IQueryable<SharedGameEntity> dbQuery = _context.SharedGames.AsNoTracking().Include(g => g.CoverAssignments);
 
         // Default filter: Published games only (unless specific Status is requested)
         if (query.Status is null)
@@ -412,8 +420,11 @@ internal sealed class SearchSharedGamesQueryHandler : IRequestHandler<SearchShar
         var games = new List<SharedGameDto>(projected2.Count);
         foreach (var p in projected2)
         {
+            // Epic #3470 Slice 2 — catalog grid cards are the Card context: honor an
+            // admin per-context override, else fall through to implicit precedence.
+            // Source-aware so the card attribution follows the winning source.
             var cover = await CoverUrlResolver
-                .ResolvePublicWithSourceAsync(p.Game, _blobStorage)
+                .ResolveForContextWithSourceAsync(p.Game, CoverContext.Card, _blobStorage)
                 .ConfigureAwait(false);
             var (coverLicense, coverAttribution, coverSourceUrl) = CoverAttribution.ForWinningSource(cover.Kind, p.Game);
 

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQueryHandler.cs
@@ -4,7 +4,6 @@ using Api.BoundedContexts.SharedGameCatalog.Application.Services;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 using Api.Infrastructure;
-using Api.Infrastructure.Entities.SharedGameCatalog;
 using Api.Models;
 using Api.Services;
 using Api.Services.Pdf;
@@ -119,13 +118,7 @@ internal sealed class SearchSharedGamesQueryHandler : IRequestHandler<SearchShar
 
     private async Task<PagedResult<SharedGameDto>> ExecuteSearchAsync(SearchSharedGamesQuery query, CancellationToken cancellationToken)
     {
-        // Epic #3470 Slice 2: eager-load CoverAssignments so the per-context (Card)
-        // resolver can honor an admin override on each grid card; without the Include
-        // the assignment silently falls through to the implicit precedence. The
-        // projection below keeps `Game = g` (the full entity), so the Include is honored.
-        // Typed IQueryable (not the IIncludableQueryable that Include returns) so the
-        // subsequent `dbQuery = dbQuery.Where(...)` filter reassignments still compile.
-        IQueryable<SharedGameEntity> dbQuery = _context.SharedGames.AsNoTracking().Include(g => g.CoverAssignments);
+        var dbQuery = _context.SharedGames.AsNoTracking();
 
         // Default filter: Published games only (unless specific Status is requested)
         if (query.Status is null)
@@ -331,6 +324,12 @@ internal sealed class SearchSharedGamesQueryHandler : IRequestHandler<SearchShar
         var projected = dbQuery.Select(g => new
         {
             Game = g,
+            // Epic #3470 Slice 2: project the per-context cover assignments explicitly.
+            // A bare `.Include(g => g.CoverAssignments)` is IGNORED once the query has a
+            // Select projection (EF Core "ignored includes"), so the Card resolver would
+            // never see the admin override. Projecting the collection here loads it; the
+            // materialization loop assigns it back onto `Game` before resolving.
+            Assignments = g.CoverAssignments.ToList(),
             // ToolkitsCount: per-user custom toolkits (excludes the read-only default
             // BR-02 from Issue #5144) for any approved Game linked to this SharedGame.
             ToolkitsCount = ctxToolkits.Count(t =>
@@ -420,6 +419,10 @@ internal sealed class SearchSharedGamesQueryHandler : IRequestHandler<SearchShar
         var games = new List<SharedGameDto>(projected2.Count);
         foreach (var p in projected2)
         {
+            // Attach the separately-projected assignments (AsNoTracking does no fixup)
+            // so the context resolver can read them off the entity.
+            p.Game.CoverAssignments = p.Assignments;
+
             // Epic #3470 Slice 2 — catalog grid cards are the Card context: honor an
             // admin per-context override, else fall through to implicit precedence.
             // Source-aware so the card attribution follows the winning source.

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolver.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolver.cs
@@ -167,8 +167,27 @@ internal static class CoverUrlResolver
     /// Metric invariant (Issue #2123): exactly one <see cref="MeepleAiMetrics.CoverResolution"/>
     /// event per call — the override emits its pinned-source tag on a win; on a
     /// fall-through the single event comes from <see cref="ResolvePublicAsync"/>.
+    ///
+    /// Epic #3470 (Slice 2): delegates to <see cref="ResolveForContextWithSourceAsync"/>
+    /// so per-context render surfaces that also need the winning source (attribution)
+    /// share one code path and one metric emission.
     /// </summary>
     public static async Task<string?> ResolveForContextAsync(
+        SharedGameEntity sharedGame,
+        CoverContext context,
+        IBlobStorageService blobStorage) =>
+        (await ResolveForContextWithSourceAsync(sharedGame, context, blobStorage).ConfigureAwait(false)).Url;
+
+    /// <summary>
+    /// Source-aware variant of <see cref="ResolveForContextAsync"/> (epic #3470 Slice 2):
+    /// returns both the URL and the winning <see cref="CoverKind"/> so per-context render
+    /// surfaces (e.g. the detail Hero, the catalog Card) can credit the correct source in
+    /// their attribution footer instead of the implicit-precedence winner. On an override
+    /// win the Kind is the pinned source's kind; on a fall-through it is the implicit
+    /// precedence winner from <see cref="ResolvePublicWithSourceAsync"/>. Owns exactly one
+    /// <see cref="MeepleAiMetrics.CoverResolution"/> emission per call.
+    /// </summary>
+    public static async Task<ResolvedCover> ResolveForContextWithSourceAsync(
         SharedGameEntity sharedGame,
         CoverContext context,
         IBlobStorageService blobStorage)
@@ -186,16 +205,16 @@ internal static class CoverUrlResolver
             if (overrideUrl is not null)
             {
                 EmitResolution(SourceTagFor(assignment.Source));
-                return overrideUrl;
+                return new ResolvedCover(overrideUrl, assignment.Source.ToCoverKind());
             }
             // Override present but unresolvable (crop stale AND base key
             // absent/unreachable). Intentionally NO metric emission here — the
-            // ResolvePublicAsync call below emits exactly one CoverResolution event
-            // for the winning implicit layer (or "placeholder"), preserving the
+            // ResolvePublicWithSourceAsync call below emits exactly one CoverResolution
+            // event for the winning implicit layer (or "placeholder"), preserving the
             // one-event-per-call invariant.
         }
 
-        return await ResolvePublicAsync(sharedGame, blobStorage).ConfigureAwait(false);
+        return await ResolvePublicWithSourceAsync(sharedGame, blobStorage).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/AssignCoverCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/AssignCoverCommandHandlerTests.cs
@@ -3,6 +3,7 @@ using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.Middleware.Exceptions;
+using Api.Services;
 using Api.SharedKernel.Domain.Covers;
 using Api.SharedKernel.Infrastructure.Persistence;
 using FluentAssertions;
@@ -27,12 +28,13 @@ public sealed class AssignCoverCommandHandlerTests
 
     private readonly Mock<ISharedGameRepository> _repository = new();
     private readonly Mock<IUnitOfWork> _unitOfWork = new();
+    private readonly Mock<IHybridCacheService> _cache = new();
 
     private AssignCoverCommandHandler CreateAssignHandler() =>
-        new(_repository.Object, _unitOfWork.Object, NullLogger<AssignCoverCommandHandler>.Instance);
+        new(_repository.Object, _unitOfWork.Object, _cache.Object, NullLogger<AssignCoverCommandHandler>.Instance);
 
     private RemoveCoverAssignmentCommandHandler CreateRemoveHandler() =>
-        new(_repository.Object, _unitOfWork.Object, NullLogger<RemoveCoverAssignmentCommandHandler>.Instance);
+        new(_repository.Object, _unitOfWork.Object, _cache.Object, NullLogger<RemoveCoverAssignmentCommandHandler>.Instance);
 
     private static SharedGame NewGame() => SharedGame.Create(
         "Catan", 1995, "desc", 3, 4, 90, 10, 2.5m, 7.8m,
@@ -103,5 +105,55 @@ public sealed class AssignCoverCommandHandlerTests
             CancellationToken.None);
 
         await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    // ----- Epic #3470 Slice 2 AC-6: cache invalidation on assign/remove ------
+
+    [Fact]
+    public async Task Assign_InvalidatesSearchAndDetailCacheTags()
+    {
+        // Without busting the read-model tags, a per-context assignment stays
+        // invisible until the 15min–2h HybridCache TTL — the picker looks broken.
+        var game = NewGame();
+        _repository.Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>())).ReturnsAsync(game);
+        var handler = CreateAssignHandler();
+
+        await handler.Handle(
+            new AssignCoverCommand(game.Id, CoverContext.Card, CoverAssignmentSource.Wikidata, AdminId),
+            CancellationToken.None);
+
+        _cache.Verify(c => c.RemoveByTagAcrossReplicasAsync("search-games", It.IsAny<CancellationToken>()), Times.Once);
+        _cache.Verify(c => c.RemoveByTagAcrossReplicasAsync($"shared-game:{game.Id}", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Remove_InvalidatesSearchAndDetailCacheTags()
+    {
+        var game = NewGame();
+        game.AssignCover(CoverContext.Card, CoverAssignmentSource.Wikidata, AdminId);
+        _repository.Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>())).ReturnsAsync(game);
+        var handler = CreateRemoveHandler();
+
+        await handler.Handle(new RemoveCoverAssignmentCommand(game.Id, CoverContext.Card, AdminId), CancellationToken.None);
+
+        _cache.Verify(c => c.RemoveByTagAcrossReplicasAsync("search-games", It.IsAny<CancellationToken>()), Times.Once);
+        _cache.Verify(c => c.RemoveByTagAcrossReplicasAsync($"shared-game:{game.Id}", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Assign_GameNotFound_DoesNotInvalidateCache()
+    {
+        // A 404 short-circuits before any persistence, so nothing changed → no
+        // cache eviction (avoids wasted cross-replica pub/sub churn).
+        _repository.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                   .ReturnsAsync((SharedGame?)null);
+        var handler = CreateAssignHandler();
+
+        var act = () => handler.Handle(
+            new AssignCoverCommand(Guid.NewGuid(), CoverContext.Card, CoverAssignmentSource.Wikidata, AdminId),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+        _cache.Verify(c => c.RemoveByTagAcrossReplicasAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/AssignCoverCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/AssignCoverCommandHandlerTests.cs
@@ -29,12 +29,22 @@ public sealed class AssignCoverCommandHandlerTests
     private readonly Mock<ISharedGameRepository> _repository = new();
     private readonly Mock<IUnitOfWork> _unitOfWork = new();
     private readonly Mock<IHybridCacheService> _cache = new();
+    private readonly Mock<ICacheInvalidationRetryPolicy> _cacheRetryPolicy = new();
+
+    public AssignCoverCommandHandlerTests()
+    {
+        // Passthrough: actually run the wrapped cache operation so the RemoveByTag*
+        // calls are exercised (mirrors the real retry policy on the happy path).
+        _cacheRetryPolicy
+            .Setup(p => p.ExecuteAsync(It.IsAny<Func<CancellationToken, ValueTask>>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns((Func<CancellationToken, ValueTask> op, string _, CancellationToken ct) => op(ct).AsTask());
+    }
 
     private AssignCoverCommandHandler CreateAssignHandler() =>
-        new(_repository.Object, _unitOfWork.Object, _cache.Object, NullLogger<AssignCoverCommandHandler>.Instance);
+        new(_repository.Object, _unitOfWork.Object, _cache.Object, _cacheRetryPolicy.Object, NullLogger<AssignCoverCommandHandler>.Instance);
 
     private RemoveCoverAssignmentCommandHandler CreateRemoveHandler() =>
-        new(_repository.Object, _unitOfWork.Object, _cache.Object, NullLogger<RemoveCoverAssignmentCommandHandler>.Instance);
+        new(_repository.Object, _unitOfWork.Object, _cache.Object, _cacheRetryPolicy.Object, NullLogger<RemoveCoverAssignmentCommandHandler>.Instance);
 
     private static SharedGame NewGame() => SharedGame.Create(
         "Catan", 1995, "desc", 3, 4, 90, 10, 2.5m, 7.8m,

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/GetSharedGameByIdQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/GetSharedGameByIdQueryHandlerTests.cs
@@ -8,6 +8,7 @@ using Api.Infrastructure;
 using Api.Infrastructure.Entities.SharedGameCatalog;
 using Api.Services;
 using Api.Services.Pdf;
+using Api.SharedKernel.Domain.Covers;
 using Api.Tests.Constants;
 using Api.Tests.TestHelpers;
 using FluentAssertions;
@@ -142,6 +143,63 @@ public class GetSharedGameByIdQueryHandlerTests
 
         // Assert
         result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_ResolvesHeroContextCover_HonoringAdminOverride()
+    {
+        // Epic #3470 Slice 2 AC-1: the detail page is the sole Hero surface. An admin
+        // Hero override pinning Wikidata must win over the implicit precedence (PDF is
+        // higher in the chain) — proving the handler resolves the HERO context AND
+        // eager-loads CoverAssignments (without the Include the AsNoTracking entity has
+        // no assignments and the override is silently ignored, yielding the PDF cover).
+        var game = SharedGame.Create(
+            "Catan", 1995, "Description", 3, 4, 90, 10, 2.5m, 7.8m,
+            "https://example.com/catan.jpg", "https://example.com/thumb.jpg",
+            GameRules.Create("Rules content", "en"), Guid.NewGuid(), 13);
+
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(game);
+
+        _blobStorageMock
+            .Setup(b => b.GetPresignedUrlForRawKeyAsync("wiki-key.webp", null))
+            .ReturnsAsync("https://r2/wiki-hero.webp");
+        _blobStorageMock
+            .Setup(b => b.GetPresignedUrlForRawKeyAsync("pdf-key-preview.webp", null))
+            .ReturnsAsync("https://r2/pdf.webp");
+
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        db.SharedGames.Add(new SharedGameEntity
+        {
+            Id = game.Id,
+            Title = "Catan",
+            Description = "desc",
+            Status = 1,
+            PdfCoverR2Key = "pdf-key",        // would win the implicit precedence
+            WikidataCoverR2Key = "wiki-key",  // pinned by the Hero override
+            CoverAssignments = new List<GameCoverAssignmentEntity>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Context = CoverContext.Hero,
+                    Source = CoverAssignmentSource.Wikidata,
+                    CreatedBy = Guid.NewGuid(),
+                },
+            },
+        });
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        db.ChangeTracker.Clear();
+
+        var handler = CreateHandler(db);
+
+        var result = await handler.Handle(new GetSharedGameByIdQuery(game.Id), TestContext.Current.CancellationToken);
+
+        result.Should().NotBeNull();
+        result!.CoverUrl.Should().Be(
+            "https://r2/wiki-hero.webp",
+            "the Hero admin override pins Wikidata; the PDF implicit precedence must NOT win");
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolverTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolverTests.cs
@@ -658,4 +658,134 @@ public class CoverUrlResolverTests
             .Where(m => m.Name == "meepleai.cover.resolution.total")
             .Should().HaveCount(1);
     }
+
+    // ----- Epic #3470 Slice 2: source-aware per-context resolution -----------
+
+    [Fact]
+    public async Task ResolveForContextWithSourceAsync_OverrideWins_ReturnsPinnedSourceKind()
+    {
+        // Admin pinned Wikidata for Hero; PDF would win the implicit chain. The
+        // per-context override must win AND report Wikidata as the winning Kind so
+        // the Hero attribution footer credits the correct source (Slice 2 AC-7).
+        var sg = new SharedGameEntity
+        {
+            PdfCoverR2Key = "pdf-key",
+            WikidataCoverR2Key = "wiki-key",
+            CoverAssignments = new List<GameCoverAssignmentEntity>
+            {
+                Assignment(CoverContext.Hero, CoverAssignmentSource.Wikidata),
+            },
+        };
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("wiki-key.webp", null))
+             .ReturnsAsync("https://r2/wiki.webp");
+
+        var result = await CoverUrlResolver.ResolveForContextWithSourceAsync(sg, CoverContext.Hero, _blob.Object);
+
+        result.Url.Should().Be("https://r2/wiki.webp");
+        result.Kind.Should().Be(CoverKind.Wikidata);
+        _blob.Verify(b => b.GetPresignedUrlForRawKeyAsync("pdf-key-preview.webp", It.IsAny<int?>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ResolveForContextWithSourceAsync_FallThrough_ReturnsImplicitWinningKind()
+    {
+        // Assignment pins Manual but no manual cover exists — resolution falls
+        // through to the implicit PDF layer and must report Pdf as the winning Kind
+        // (NOT the unresolved pinned Manual source), so attribution stays correct.
+        var sg = new SharedGameEntity
+        {
+            PdfCoverR2Key = "pdf-key",
+            CoverAssignments = new List<GameCoverAssignmentEntity>
+            {
+                Assignment(CoverContext.Hero, CoverAssignmentSource.Manual),
+            },
+        };
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("pdf-key-preview.webp", null))
+             .ReturnsAsync("https://r2/pdf.webp");
+
+        var result = await CoverUrlResolver.ResolveForContextWithSourceAsync(sg, CoverContext.Hero, _blob.Object);
+
+        result.Url.Should().Be("https://r2/pdf.webp");
+        result.Kind.Should().Be(CoverKind.Pdf);
+    }
+
+    [Fact]
+    public async Task ResolveForContextWithSourceAsync_NoAssignment_ReturnsImplicitPrecedenceKind()
+    {
+        // No assignment for the resolved context → pure implicit precedence, and the
+        // winning Kind is reported so callers keep source-aware attribution.
+        var sg = new SharedGameEntity { WikidataCoverR2Key = "wiki-key" };
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("wiki-key.webp", null))
+             .ReturnsAsync("https://r2/wiki.webp");
+
+        var result = await CoverUrlResolver.ResolveForContextWithSourceAsync(sg, CoverContext.Card, _blob.Object);
+
+        result.Url.Should().Be("https://r2/wiki.webp");
+        result.Kind.Should().Be(CoverKind.Wikidata);
+    }
+
+    [Fact]
+    public async Task ResolveForContextWithSourceAsync_AllMiss_ReturnsNullUrlAndKind()
+    {
+        var sg = new SharedGameEntity
+        {
+            CoverAssignments = new List<GameCoverAssignmentEntity>
+            {
+                Assignment(CoverContext.Hero, CoverAssignmentSource.Manual),
+            },
+        };
+
+        var result = await CoverUrlResolver.ResolveForContextWithSourceAsync(sg, CoverContext.Hero, _blob.Object);
+
+        result.Url.Should().BeNull();
+        result.Kind.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ResolveForContextWithSourceAsync_OverrideWins_EmitsExactlyOneMetricTaggedPinnedSource()
+    {
+        using var capture = new CoverMetricsCapture();
+        var sg = new SharedGameEntity
+        {
+            ManualCoverR2Key = "manual-key",
+            CoverAssignments = new List<GameCoverAssignmentEntity>
+            {
+                Assignment(CoverContext.Hero, CoverAssignmentSource.Manual),
+            },
+        };
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("manual-key.webp", null))
+             .ReturnsAsync("https://r2/manual.webp");
+
+        await CoverUrlResolver.ResolveForContextWithSourceAsync(sg, CoverContext.Hero, _blob.Object);
+
+        capture.LongMeasurements
+            .Where(m => m.Name == "meepleai.cover.resolution.total")
+            .Should().ContainSingle()
+            .Which.Tags["source"].Should().Be("r2_manual");
+    }
+
+    [Fact]
+    public async Task ResolveForContextAsync_DelegatesToWithSource_ReturnsUrlAndEmitsOnce()
+    {
+        // The string overload must delegate to the source-aware variant, preserving
+        // the exactly-one-metric-per-call invariant (no double emission).
+        using var capture = new CoverMetricsCapture();
+        var sg = new SharedGameEntity
+        {
+            WikidataCoverR2Key = "wiki-key",
+            CoverAssignments = new List<GameCoverAssignmentEntity>
+            {
+                Assignment(CoverContext.Card, CoverAssignmentSource.Wikidata),
+            },
+        };
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("wiki-key.webp", null))
+             .ReturnsAsync("https://r2/wiki.webp");
+
+        var url = await CoverUrlResolver.ResolveForContextAsync(sg, CoverContext.Card, _blob.Object);
+
+        url.Should().Be("https://r2/wiki.webp");
+        capture.LongMeasurements
+            .Where(m => m.Name == "meepleai.cover.resolution.total")
+            .Should().HaveCount(1);
+    }
 }


### PR DESCRIPTION
## Epic #3470 — Slice 2a: per-context cover resolution (Card + Hero) + cache invalidation

Prima slice di implementazione della **Slice 2** dell'epic. Slice 0+1 (contract lock + admin picker) erano già mergiate ma **inerti**: tutti i render-handler risolvevano la cover *context-blind* (`ResolvePublicWithSourceAsync`), quindi le assegnazioni admin venivano persistite ma **mai rese**. Questa slice accende le due superfici a più traffico e chiude il gap di cache.

Spec: `docs/for-developers/specs/2026-08-02-slice-2-cover-context-spec-delta.md`

### Cosa fa (AC coperti)
- **AC-1 (wiring per-contesto)** — `SearchSharedGamesQueryHandler` risolve il grid catalogo come **Card**, `GetSharedGameByIdQueryHandler` risolve la detail hero come **Hero**. Entrambi chiamano ora `ResolveForContextWithSourceAsync` e caricano le `CoverAssignments`.
- **AC-6 (cache)** — `AssignCover`/`RemoveCoverAssignment` invalidano i tag read-model (`search-games` + `shared-game:{id}`) cross-replica via helper condiviso `CoverCacheInvalidation`, così le assegnazioni compaiono senza attendere il TTL (15min–2h). *(Gap confermato: entrambi i command avevano 0 riferimenti a cache.)*
- **AC-7 (attribution)** — nuovo `CoverUrlResolver.ResolveForContextWithSourceAsync` source-aware: ritorna il `CoverKind` vincente (sorgente pinnata su override, vincitore della precedenza implicita su fall-through) così il footer resta corretto. La `ResolveForContextAsync` (string) delega ad esso (una sola metrica per chiamata).
- **Handler #5** (`GetAllSharedGamesQueryHandler`) confermato **dormant** (nessun dispatcher) → volutamente non cablato.

### Note di review (self-review pre-PR)
- **Gotcha EF Core (2° commit)** — un `.Include(g => g.CoverAssignments)` è **ignorato** quando la query ha una `Select` con proiezione (EF Core *"ignored includes"*, [doc](https://learn.microsoft.com/ef/core/querying/related-data/eager#ignored-includes)). Sul path Search (proiezione anonima) la nav non veniva caricata → override ignorato sul grid. Fix: proiezione esplicita di `CoverAssignments` + assegnazione nel loop di materializzazione (AsNoTracking non fa fixup). GetById carica l'entità diretta (no proiezione) → il suo Include resta valido.
- **Resilienza cache (3° commit)** — l'invalidazione passava per una chiamata raw `RemoveByTagAcrossReplicasAsync`, bypassando `ICacheInvalidationRetryPolicy` (issue #613, già usato dal comando gemello `EnrichCatalogCover`). Instradata attraverso la policy (retry con backoff) per resilienza + consistenza.
- Finding minori non risolti (accettati): `RemoveCoverAssignment` su assignment assente busta comunque i tag (churn trascurabile su no-op); il path Card non ha test eseguibili in locale (vedi sotto).

### Test
- `CoverUrlResolverTests` — 6 nuovi test source-aware (override→Kind pinnato, fall-through→Kind implicito, no-assignment, all-miss, metrica singola, delega string). ✅
- `AssignCoverCommandHandlerTests` — 3 nuovi test AC-6 (assign/remove bustano entrambi i tag; 404 non busta). ✅
- `GetSharedGameByIdQueryHandlerTests` — nuovo test AC-1 di isolamento Hero (override Wikidata vince sul PDF implicito), red/green verificato flippando il contesto. ✅
- ⚠️ **Search Card**: i test del `SearchSharedGamesQueryHandler` sono Testcontainers-gated e **skippati localmente** (InMemory non traduce le sub-query cross-BC) → il path Card è validato in **CI**, non localmente.

### Rinviato a slice successive
Social/OG (AC-2, tocca SSR `#3452`), focal read-shape (AC-5), layering L3 user-custom in UserLibrary (AC-4), direct-apply PDF + Wikidata on-demand, gli altri 4 render-handler grid, e URL manuale (**Slice 3**, bloccata da SSRF **#3495**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
