### PR TITLE
feat(catalog): Card cover resolution for filtered+pending grids (Slice 2b, #3470)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetFilteredSharedGamesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetFilteredSharedGamesQueryHandler.cs
@@ -7,6 +7,7 @@ using Api.Infrastructure.Entities.SharedGameCatalog;
 using Api.Models;
 using Api.Services.Pdf;
 using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Domain.Covers;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 
@@ -88,6 +89,10 @@ internal sealed class GetFilteredSharedGamesQueryHandler : IRequestHandler<GetFi
         // Apply pagination — materialize entities first so we can call the async
         // CoverUrlResolver (EF expression trees cannot invoke async methods).
         var entities = await sortedQuery
+            // Epic #3470 Slice 2b: eager-load CoverAssignments so the per-context (Card)
+            // resolver honors an admin override. Entities are materialized directly (no
+            // Select projection), so the Include is honored — unlike the search handler.
+            .Include(g => g.CoverAssignments)
             .Skip((query.PageNumber - 1) * query.PageSize)
             .Take(query.PageSize)
             .ToListAsync(cancellationToken)
@@ -111,8 +116,9 @@ internal sealed class GetFilteredSharedGamesQueryHandler : IRequestHandler<GetFi
 
         foreach (var g in entities)
         {
+            // Epic #3470 Slice 2b — the filtered/admin catalog list is a Card surface.
             var cover = await CoverUrlResolver
-                .ResolvePublicWithSourceAsync(g, _blobStorage)
+                .ResolveForContextWithSourceAsync(g, CoverContext.Card, _blobStorage)
                 .ConfigureAwait(false);
             var (coverLicense, coverAttribution, coverSourceUrl) = CoverAttribution.ForWinningSource(cover.Kind, g);
 

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetPendingApprovalGamesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetPendingApprovalGamesQueryHandler.cs
@@ -5,6 +5,7 @@ using Api.Infrastructure;
 using Api.Models;
 using Api.Services.Pdf;
 using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Domain.Covers;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 
@@ -46,6 +47,10 @@ internal sealed class GetPendingApprovalGamesQueryHandler : IRequestHandler<GetP
         // Filter by PendingApproval status
         var dbQuery = _context.SharedGames
             .AsNoTracking()
+            // Epic #3470 Slice 2b: eager-load CoverAssignments so the per-context (Card)
+            // resolver honors an admin override. Entities are materialized directly (no
+            // Select projection), so the Include is honored — unlike the search handler.
+            .Include(g => g.CoverAssignments)
             .Where(g => g.Status == (int)GameStatus.PendingApproval)
             .OrderBy(g => g.ModifiedAt ?? g.CreatedAt); // Oldest submissions first
 
@@ -62,8 +67,9 @@ internal sealed class GetPendingApprovalGamesQueryHandler : IRequestHandler<GetP
         var games = new List<SharedGameDto>(entities.Count);
         foreach (var g in entities)
         {
+            // Epic #3470 Slice 2b — the pending-approval queue is a Card surface.
             var cover = await CoverUrlResolver
-                .ResolvePublicWithSourceAsync(g, _blobStorage)
+                .ResolveForContextWithSourceAsync(g, CoverContext.Card, _blobStorage)
                 .ConfigureAwait(false);
             var (coverLicense, coverAttribution, coverSourceUrl) = CoverAttribution.ForWinningSource(cover.Kind, g);
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetFilteredSharedGamesQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetFilteredSharedGamesQueryHandlerTests.cs
@@ -1,0 +1,83 @@
+using Api.BoundedContexts.SharedGameCatalog.Application;
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Services.Pdf;
+using Api.SharedKernel.Domain.Covers;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Queries;
+
+/// <summary>
+/// Epic #3470 Slice 2b — the filtered/admin catalog list is a Card surface, so its
+/// cover resolution must honor an admin per-context (Card) override.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class GetFilteredSharedGamesQueryHandlerTests
+{
+    private readonly Mock<IBlobStorageService> _blob = new();
+    private readonly Mock<ILogger<GetFilteredSharedGamesQueryHandler>> _logger = new();
+    private readonly Mock<IGameTitleResolver> _titleResolver = CreateIdentityResolverMock();
+
+    private static Mock<IGameTitleResolver> CreateIdentityResolverMock()
+    {
+        var mock = new Mock<IGameTitleResolver>();
+        mock.Setup(r => r.EnrichAsync(It.IsAny<IReadOnlyList<SharedGameDto>>(), It.IsAny<CancellationToken>()))
+            .Returns<IReadOnlyList<SharedGameDto>, CancellationToken>((games, _) => Task.FromResult(games));
+        return mock;
+    }
+
+    [Fact]
+    public async Task Handle_ResolvesCardContextCover_HonoringAdminOverride()
+    {
+        // Slice 2b AC-1: the admin/filtered catalog list renders Card. An admin Card
+        // override pinning Wikidata must win over the implicit precedence (PDF).
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        db.SharedGames.Add(new SharedGameEntity
+        {
+            Id = Guid.NewGuid(),
+            Title = "Catan",
+            Description = "desc",
+            Status = (int)GameStatus.Published,
+            CreatedBy = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow,
+            ImageUrl = string.Empty,
+            ThumbnailUrl = string.Empty,
+            PdfCoverR2Key = "pdf-key",        // would win the implicit precedence
+            WikidataCoverR2Key = "wiki-key",  // pinned by the Card override
+            CoverAssignments = new List<GameCoverAssignmentEntity>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Context = CoverContext.Card,
+                    Source = CoverAssignmentSource.Wikidata,
+                    CreatedBy = Guid.NewGuid(),
+                },
+            },
+        });
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        db.ChangeTracker.Clear();
+
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("wiki-key.webp", null))
+             .ReturnsAsync("https://r2/wiki-card.webp");
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("pdf-key-preview.webp", null))
+             .ReturnsAsync("https://r2/pdf.webp");
+
+        var handler = new GetFilteredSharedGamesQueryHandler(db, _blob.Object, _logger.Object, _titleResolver.Object);
+
+        var result = await handler.Handle(new GetFilteredSharedGamesQuery(), TestContext.Current.CancellationToken);
+
+        result.Items.Should().ContainSingle();
+        result.Items[0].CoverUrl.Should().Be(
+            "https://r2/wiki-card.webp",
+            "the Card admin override pins Wikidata; the PDF implicit precedence must NOT win");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetPendingApprovalGamesQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetPendingApprovalGamesQueryHandlerTests.cs
@@ -1,0 +1,85 @@
+using Api.BoundedContexts.SharedGameCatalog.Application;
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Services.Pdf;
+using Api.SharedKernel.Domain.Covers;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Queries;
+
+/// <summary>
+/// Epic #3470 Slice 2b — the pending-approval admin queue is a Card surface, so its
+/// cover resolution must honor an admin per-context (Card) override.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class GetPendingApprovalGamesQueryHandlerTests
+{
+    private readonly Mock<IBlobStorageService> _blob = new();
+    private readonly Mock<ILogger<GetPendingApprovalGamesQueryHandler>> _logger = new();
+    private readonly Mock<IGameTitleResolver> _titleResolver = CreateIdentityResolverMock();
+
+    private static Mock<IGameTitleResolver> CreateIdentityResolverMock()
+    {
+        var mock = new Mock<IGameTitleResolver>();
+        mock.Setup(r => r.EnrichAsync(It.IsAny<IReadOnlyList<SharedGameDto>>(), It.IsAny<CancellationToken>()))
+            .Returns<IReadOnlyList<SharedGameDto>, CancellationToken>((games, _) => Task.FromResult(games));
+        return mock;
+    }
+
+    [Fact]
+    public async Task Handle_ResolvesCardContextCover_HonoringAdminOverride()
+    {
+        // Slice 2b AC-1: the pending-approval admin queue renders Card. An admin Card
+        // override pinning Wikidata must win over the implicit precedence (PDF is higher
+        // in the chain) — proving the handler resolves the Card context AND eager-loads
+        // CoverAssignments.
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        db.SharedGames.Add(new SharedGameEntity
+        {
+            Id = Guid.NewGuid(),
+            Title = "Catan",
+            Description = "desc",
+            Status = (int)GameStatus.PendingApproval,
+            CreatedBy = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow,
+            ImageUrl = string.Empty,
+            ThumbnailUrl = string.Empty,
+            PdfCoverR2Key = "pdf-key",        // would win the implicit precedence
+            WikidataCoverR2Key = "wiki-key",  // pinned by the Card override
+            CoverAssignments = new List<GameCoverAssignmentEntity>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Context = CoverContext.Card,
+                    Source = CoverAssignmentSource.Wikidata,
+                    CreatedBy = Guid.NewGuid(),
+                },
+            },
+        });
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        db.ChangeTracker.Clear();
+
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("wiki-key.webp", null))
+             .ReturnsAsync("https://r2/wiki-card.webp");
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("pdf-key-preview.webp", null))
+             .ReturnsAsync("https://r2/pdf.webp");
+
+        var handler = new GetPendingApprovalGamesQueryHandler(db, _blob.Object, _logger.Object, _titleResolver.Object);
+
+        var result = await handler.Handle(new GetPendingApprovalGamesQuery(1, 20), TestContext.Current.CancellationToken);
+
+        result.Items.Should().ContainSingle();
+        result.Items[0].CoverUrl.Should().Be(
+            "https://r2/wiki-card.webp",
+            "the Card admin override pins Wikidata; the PDF implicit precedence must NOT win");
+    }
+}


### PR DESCRIPTION
## Epic #3470 — Slice 2b: Card cover resolution per griglie filtered + pending

Continuazione di **Slice 2a** (già mergiata, #3527: Search=Card + GetById=Hero). Cabla gli altri due render-handler **grid live** rimasti al resolver per-contesto, così gli override cover admin vengono resi anche su quelle superfici.

### Cosa fa (AC-1)
- **`GetFilteredSharedGamesQueryHandler`** (lista admin/filtrata) e **`GetPendingApprovalGamesQueryHandler`** (coda approvazione) ora eager-load `CoverAssignments` e chiamano `ResolveForContextWithSourceAsync(g, Card)`.
- Entrambi materializzano **entità piene dirette** (`ToListAsync` senza `Select`), quindi il **plain `.Include` è onorato** — niente workaround di proiezione esplicita (che serviva solo al Search handler per la sua proiezione anonima).
- **`GetAllSharedGamesQueryHandler`** resta **dormant** (nessun dispatcher) → non cablato.

### Note di correttezza (self-review)
- **Cache**: entrambi gli handler **non usano cache** (0 ref) → nessuna staleness; l'invalidazione tag di Slice 2a è sufficiente (queste liste colpiscono sempre il DB).
- **Include onorato**: verificato dai test — con `AsNoTracking` senza Include (o con contesto sbagliato) la nav resta vuota → vince il PDF implicito → il test fallirebbe. RED→GREEN confermato.

### Test
`GetFilteredSharedGamesQueryHandlerTests` + `GetPendingApprovalGamesQueryHandlerTests` (nuovi, InMemory): un override **Card** che pinna Wikidata vince sulla precedenza implicita **PDF**. 57/57 verdi sull'intera superficie SharedGameCatalog affetta, build Debug+Release puliti.

### Rinviato a slice successive
- **UserLibrary L3** (AC-4): richiede una risoluzione **user-aware context-aware** (user-custom > admin-override > precedenza) — cambiamento di resolver più profondo, slice dedicata.
- **Social/OG** (AC-2), **focal read-shape** (AC-5).
- **Slice 3** (URL manuale): bloccata da SSRF **#3495**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
