### PR TITLE
feat(catalog): user-library cover honors admin override below L3 (Slice 2c, #3470)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolver.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolver.cs
@@ -49,9 +49,18 @@ internal static class CoverUrlResolver
     /// </summary>
     internal readonly record struct ResolvedCover(string? Url, CoverKind? Kind);
 
+    /// <summary>
+    /// Per-user resolution with the full layering (epic #3470 Slice 2c / SD3 / AC-4):
+    /// L3 user-custom cover → admin per-<paramref name="context"/> override → implicit
+    /// precedence. The user cover outranks the admin override; on an L3 miss the call
+    /// falls through to <see cref="ResolveForContextAsync"/> (which honors the admin
+    /// override then the implicit chain), NOT the context-blind <see cref="ResolvePublicAsync"/>.
+    /// Owns exactly one <see cref="MeepleAiMetrics.CoverResolution"/> emission per call.
+    /// </summary>
     public static async Task<string?> ResolveForUserAsync(
         SharedGameEntity sharedGame,
         UserLibraryEntryEntity? userEntry,
+        CoverContext context,
         IBlobStorageService blobStorage)
     {
         ArgumentNullException.ThrowIfNull(sharedGame);
@@ -70,15 +79,17 @@ internal static class CoverUrlResolver
             }
             // L3 miss while the key was present (R2 unreachable in dev, blob
             // expired, etc.). Intentionally NO metric emission here — the
-            // recursive call to ResolvePublicAsync below emits exactly one
-            // CoverResolution event for the winning fallback layer (or
-            // "placeholder" if all layers miss), preserving the invariant that
-            // every public-facing resolution call increments the counter
-            // exactly once. The L3 miss itself is observable via the storage
-            // service's own logs / metrics, not duplicated here.
+            // ResolveForContextAsync call below emits exactly one CoverResolution
+            // event for the winning layer (admin override / implicit / "placeholder"),
+            // preserving the invariant that every public-facing resolution call
+            // increments the counter exactly once. The L3 miss itself is observable
+            // via the storage service's own logs / metrics, not duplicated here.
         }
 
-        return await ResolvePublicAsync(sharedGame, blobStorage).ConfigureAwait(false);
+        // L3 absent/unresolvable → the admin per-context override sits BELOW L3 (SD3),
+        // so fall through to the context path (admin override → implicit precedence),
+        // NOT the context-blind ResolvePublicAsync.
+        return await ResolveForContextAsync(sharedGame, context, blobStorage).ConfigureAwait(false);
     }
 
     public static async Task<string?> ResolvePublicAsync(

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Queries/GetUserLibraryQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Queries/GetUserLibraryQueryHandler.cs
@@ -7,6 +7,7 @@ using Api.BoundedContexts.UserLibrary.Domain.Repositories;
 using Api.Infrastructure;
 using Api.Services.Pdf;
 using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Domain.Covers;
 using Microsoft.EntityFrameworkCore;
 
 namespace Api.BoundedContexts.UserLibrary.Application.Queries;
@@ -143,6 +144,10 @@ internal class GetUserLibraryQueryHandler : IQueryHandler<GetUserLibraryQuery, P
         // does not carry EF-only columns, so we query the EF DbSet directly.
         var sharedGameEntityMap = await _dbContext.SharedGames
             .AsNoTracking()
+            // Epic #3470 Slice 2c: eager-load CoverAssignments so the per-context (Card)
+            // resolver can honor an admin override below the L3 user-custom cover.
+            // Values are the full entity (no Select projection), so the Include is honored.
+            .Include(sg => sg.CoverAssignments)
             .Where(sg => gameIds.Contains(sg.Id) && !sg.IsDeleted)
             .ToDictionaryAsync(sg => sg.Id, cancellationToken)
             .ConfigureAwait(false);
@@ -179,8 +184,10 @@ internal class GetUserLibraryQueryHandler : IQueryHandler<GetUserLibraryQuery, P
                 // Requires the EF SharedGameEntity (cover keys) and the EF UserLibraryEntryEntity (custom cover key).
                 sharedGameEntityMap.TryGetValue(entry.GameId, out var sharedGameEntity);
                 entryEntityMap.TryGetValue(entry.Id, out var entryEntity);
+                // Epic #3470 Slice 2c — My Library grid is the Card context; L3 user-custom
+                // cover still outranks the admin per-context override (AC-4).
                 var coverUrl = sharedGameEntity is not null
-                    ? await CoverUrlResolver.ResolveForUserAsync(sharedGameEntity, entryEntity, _blobStorage).ConfigureAwait(false)
+                    ? await CoverUrlResolver.ResolveForUserAsync(sharedGameEntity, entryEntity, CoverContext.Card, _blobStorage).ConfigureAwait(false)
                     : null;
 
                 entryDtos.Add(new UserLibraryEntryDto(

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolverTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolverTests.cs
@@ -68,7 +68,7 @@ public class CoverUrlResolverTests
         _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("custom-key.webp", null))
              .ReturnsAsync("https://r2/custom.webp");
 
-        var url = await CoverUrlResolver.ResolveForUserAsync(sg, entry, _blob.Object);
+        var url = await CoverUrlResolver.ResolveForUserAsync(sg, entry, CoverContext.Card, _blob.Object);
 
         url.Should().Be("https://r2/custom.webp");
         _blob.Verify(b => b.GetPresignedUrlForRawKeyAsync("pdf-key-preview.webp", It.IsAny<int?>()), Times.Never);
@@ -82,7 +82,7 @@ public class CoverUrlResolverTests
         _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("pdf-key-preview.webp", null))
              .ReturnsAsync("https://r2/pdf.webp");
 
-        var url = await CoverUrlResolver.ResolveForUserAsync(sg, entry, _blob.Object);
+        var url = await CoverUrlResolver.ResolveForUserAsync(sg, entry, CoverContext.Card, _blob.Object);
 
         url.Should().Be("https://r2/pdf.webp");
     }
@@ -175,7 +175,7 @@ public class CoverUrlResolverTests
         _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync($"{customKey}.webp", null))
              .ReturnsAsync("https://r2/user-custom-cover.webp");
 
-        var url = await CoverUrlResolver.ResolveForUserAsync(sg, entry, _blob.Object);
+        var url = await CoverUrlResolver.ResolveForUserAsync(sg, entry, CoverContext.Card, _blob.Object);
 
         url.Should().Be("https://r2/user-custom-cover.webp");
     }
@@ -191,7 +191,7 @@ public class CoverUrlResolverTests
         _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("custom-key.webp", null))
              .ReturnsAsync("https://r2/custom.webp");
 
-        await CoverUrlResolver.ResolveForUserAsync(sg, entry, _blob.Object);
+        await CoverUrlResolver.ResolveForUserAsync(sg, entry, CoverContext.Card, _blob.Object);
 
         capture.LongMeasurements.Should().ContainSingle(m =>
             m.Name == "meepleai.cover.resolution.total" &&
@@ -292,7 +292,7 @@ public class CoverUrlResolverTests
         _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("wiki-key.webp", null))
              .ReturnsAsync("https://r2/wiki.webp");
 
-        await CoverUrlResolver.ResolveForUserAsync(sg, entry, _blob.Object);
+        await CoverUrlResolver.ResolveForUserAsync(sg, entry, CoverContext.Card, _blob.Object);
 
         capture.LongMeasurements
             .Where(m => m.Name == "meepleai.cover.resolution.total")
@@ -317,7 +317,7 @@ public class CoverUrlResolverTests
         _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("wiki-key.webp", null))
              .ReturnsAsync("https://r2/wiki.webp");
 
-        await CoverUrlResolver.ResolveForUserAsync(sg, entry, _blob.Object);
+        await CoverUrlResolver.ResolveForUserAsync(sg, entry, CoverContext.Card, _blob.Object);
 
         var emissions = capture.LongMeasurements
             .Where(m => m.Name == "meepleai.cover.resolution.total")
@@ -337,7 +337,7 @@ public class CoverUrlResolverTests
         _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("custom-key.webp", null))
              .ReturnsAsync((string?)null);
 
-        await CoverUrlResolver.ResolveForUserAsync(sg, entry, _blob.Object);
+        await CoverUrlResolver.ResolveForUserAsync(sg, entry, CoverContext.Card, _blob.Object);
 
         var emissions = capture.LongMeasurements
             .Where(m => m.Name == "meepleai.cover.resolution.total")
@@ -787,5 +787,59 @@ public class CoverUrlResolverTests
         capture.LongMeasurements
             .Where(m => m.Name == "meepleai.cover.resolution.total")
             .Should().HaveCount(1);
+    }
+
+    // ----- Epic #3470 Slice 2c (AC-4): user library L3 layering --------------
+
+    [Fact]
+    public async Task ResolveForUserAsync_L3CustomCover_WinsOverAdminContextOverride()
+    {
+        // SD3 layering: the user's L3 custom cover must outrank an admin per-context
+        // (Card) override — the override sits BELOW L3.
+        var sg = new SharedGameEntity
+        {
+            PdfCoverR2Key = "pdf-key",
+            WikidataCoverR2Key = "wiki-key",
+            CoverAssignments = new List<GameCoverAssignmentEntity>
+            {
+                Assignment(CoverContext.Card, CoverAssignmentSource.Wikidata),
+            },
+        };
+        var entry = new UserLibraryEntryEntity { CustomCoverR2Key = "custom-key" };
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("custom-key.webp", null))
+             .ReturnsAsync("https://r2/custom.webp");
+
+        var url = await CoverUrlResolver.ResolveForUserAsync(sg, entry, CoverContext.Card, _blob.Object);
+
+        url.Should().Be("https://r2/custom.webp");
+        // Neither the admin override nor the implicit precedence must have been consulted.
+        _blob.Verify(b => b.GetPresignedUrlForRawKeyAsync("wiki-key.webp", It.IsAny<int?>()), Times.Never);
+        _blob.Verify(b => b.GetPresignedUrlForRawKeyAsync("pdf-key-preview.webp", It.IsAny<int?>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ResolveForUserAsync_NoL3_UsesAdminContextOverride_OverImplicitPrecedence()
+    {
+        // No user custom cover: the admin per-context (Card) override must win over the
+        // implicit precedence (PDF is higher in the implicit chain). Proves the user path
+        // falls through to ResolveForContextAsync, not the context-blind ResolvePublicAsync.
+        var sg = new SharedGameEntity
+        {
+            PdfCoverR2Key = "pdf-key",
+            WikidataCoverR2Key = "wiki-key",
+            CoverAssignments = new List<GameCoverAssignmentEntity>
+            {
+                Assignment(CoverContext.Card, CoverAssignmentSource.Wikidata),
+            },
+        };
+        var entry = new UserLibraryEntryEntity { CustomCoverR2Key = null };
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("wiki-key.webp", null))
+             .ReturnsAsync("https://r2/wiki.webp");
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("pdf-key-preview.webp", null))
+             .ReturnsAsync("https://r2/pdf.webp");
+
+        var url = await CoverUrlResolver.ResolveForUserAsync(sg, entry, CoverContext.Card, _blob.Object);
+
+        url.Should().Be("https://r2/wiki.webp");
     }
 }


### PR DESCRIPTION
## Epic #3470 — Slice 2c (AC-4): user-library cover honors admin override sotto L3

Continuazione di Slice 2a (#3527) e 2b (#3529). Cabla l'ultima superficie grid **live** — **My Library** — al resolver per-contesto, **preservando la stratificazione SD3**: L3 user-custom > admin per-context override > implicit precedence.

### Problema
`GetUserLibraryQueryHandler` risolveva via `ResolveForUserAsync`, che dal cover L3 user-custom cadeva dritto alla **precedenza implicita context-blind**, ignorando qualsiasi override admin per-contesto.

### Cosa fa (AC-4)
- **`ResolveForUserAsync`** ora prende un `CoverContext` e, su **L3 miss**, delega a **`ResolveForContextAsync`** (admin override → implicit) invece del context-blind `ResolvePublicAsync`. Layering finale: **L3 user-custom > admin per-context override > implicit** (SD3), una sola metrica per chiamata.
- **`GetUserLibraryQueryHandler`** eager-load `CoverAssignments` (load diretto via `ToDictionaryAsync`, quindi l'`Include` è onorato) e passa **Card**.

### Test (TDD)
- `ResolveForUserAsync_L3CustomCover_WinsOverAdminContextOverride`: il cover L3 utente batte l'override admin Card (né override né implicit consultati).
- `ResolveForUserAsync_NoL3_UsesAdminContextOverride_OverImplicitPrecedence`: su L3 miss l'override admin Card (Wikidata) vince sulla precedenza implicita PDF — **red/green verificato** ribaltando temporaneamente il fall-through.
- Le 7 chiamate `ResolveForUserAsync` esistenti migrate alla nuova firma (comportamento invariato: senza assignment il context-path degrada a implicit).
- 66/66 verdi sull'intera superficie (resolver + handler SharedGameCatalog + test GetUserLibrary esistenti), build Debug+Release puliti.

### Note di correttezza (self-review)
- **Cache**: GetUserLibrary **non usa cache** (0 ref) → nessuna staleness.
- **Metric invariant**: L3 win → `r2_user`; L3 miss → `ResolveForContextAsync` emette esattamente una (override tag o implicit/placeholder).

### Rinviato
Social/OG (AC-2), focal read-shape (AC-5); Slice 3 (URL manuale) bloccata da SSRF **#3495**. Con 2c, **tutte le superfici grid live + hero + user-library sono cablate** (AC-1/AC-4 completi); resta solo Social (AC-2) e focal (AC-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
