### PR TITLE
feat(catalog): Social-context cover for OpenGraph meta (Slice 2d, #3470)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetSharedGameByIdQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetSharedGameByIdQueryHandler.cs
@@ -405,6 +405,7 @@ internal sealed class GetSharedGameByIdQueryHandler : IRequestHandler<GetSharedG
         // attribution unconditionally, even for a PDF/BGG-sourced cover).
         string? coverUrl = null;
         string? coverLicense = null, coverAttribution = null, coverSourceUrl = null;
+        string? socialCoverUrl = null;
         if (sharedGameEntity is not null)
         {
             var cover = await CoverUrlResolver
@@ -413,6 +414,13 @@ internal sealed class GetSharedGameByIdQueryHandler : IRequestHandler<GetSharedG
             coverUrl = cover.Url;
             (coverLicense, coverAttribution, coverSourceUrl) =
                 CoverAttribution.ForWinningSource(cover.Kind, sharedGameEntity);
+
+            // Epic #3470 Slice 2d (AC-2) — the Social-context cover feeds the FE OpenGraph
+            // meta (#3452). Independent of the Hero cover; falls through to the implicit
+            // precedence when no Social override is pinned.
+            socialCoverUrl = await CoverUrlResolver
+                .ResolveForContextAsync(sharedGameEntity, CoverContext.Social, _blobStorage)
+                .ConfigureAwait(false);
         }
 
         return new SharedGameDetailDto(
@@ -457,6 +465,7 @@ internal sealed class GetSharedGameByIdQueryHandler : IRequestHandler<GetSharedG
             // on the winning cover source; was emitted unconditionally from the aggregate).
             WikidataCoverLicense: coverLicense,
             WikidataCoverAttribution: coverAttribution,
-            WikidataCoverSourceUrl: coverSourceUrl);
+            WikidataCoverSourceUrl: coverSourceUrl,
+            SocialCoverUrl: socialCoverUrl);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/SharedGameDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/SharedGameDto.cs
@@ -245,7 +245,11 @@ public sealed record SharedGameDetailDto(
     // when WikidataCoverLicense is non-null.
     string? WikidataCoverLicense = null,
     string? WikidataCoverAttribution = null,
-    string? WikidataCoverSourceUrl = null);
+    string? WikidataCoverSourceUrl = null,
+    // Epic #3470 Slice 2d (AC-2): cover resolved for the Social (OpenGraph) context,
+    // consumed by the FE OG meta (#3452). Falls through to the implicit precedence when
+    // no Social override is pinned, so it is never worse than CoverUrl.
+    string? SocialCoverUrl = null);
 
 /// <summary>
 /// Data transfer object for approval queue items.

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/GetSharedGameByIdQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/GetSharedGameByIdQueryHandlerTests.cs
@@ -203,6 +203,65 @@ public class GetSharedGameByIdQueryHandlerTests
     }
 
     [Fact]
+    public async Task Handle_ResolvesSocialCover_IndependentlyOfHero()
+    {
+        // Epic #3470 Slice 2d AC-2: the detail DTO exposes a Social cover (for OG meta)
+        // resolved for the Social context. A Social override must surface on SocialCoverUrl
+        // WITHOUT affecting the Hero cover (CoverUrl), which here has no override and so
+        // falls through to the implicit PDF precedence.
+        var game = SharedGame.Create(
+            "Catan", 1995, "Description", 3, 4, 90, 10, 2.5m, 7.8m,
+            "https://example.com/catan.jpg", "https://example.com/thumb.jpg",
+            GameRules.Create("Rules content", "en"), Guid.NewGuid(), 13);
+
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(game);
+
+        _blobStorageMock
+            .Setup(b => b.GetPresignedUrlForRawKeyAsync("wiki-key.webp", null))
+            .ReturnsAsync("https://r2/wiki-social.webp");
+        _blobStorageMock
+            .Setup(b => b.GetPresignedUrlForRawKeyAsync("pdf-key-preview.webp", null))
+            .ReturnsAsync("https://r2/pdf.webp");
+
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        db.SharedGames.Add(new SharedGameEntity
+        {
+            Id = game.Id,
+            Title = "Catan",
+            Description = "desc",
+            Status = 1,
+            PdfCoverR2Key = "pdf-key",        // implicit precedence winner (Hero, no override)
+            WikidataCoverR2Key = "wiki-key",  // pinned by the Social override
+            CoverAssignments = new List<GameCoverAssignmentEntity>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Context = CoverContext.Social,
+                    Source = CoverAssignmentSource.Wikidata,
+                    CreatedBy = Guid.NewGuid(),
+                },
+            },
+        });
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        db.ChangeTracker.Clear();
+
+        var handler = CreateHandler(db);
+
+        var result = await handler.Handle(new GetSharedGameByIdQuery(game.Id), TestContext.Current.CancellationToken);
+
+        result.Should().NotBeNull();
+        result!.SocialCoverUrl.Should().Be(
+            "https://r2/wiki-social.webp",
+            "the Social override pins Wikidata for the OG image");
+        result.CoverUrl.Should().Be(
+            "https://r2/pdf.webp",
+            "the Hero cover has no override and must fall through to the implicit PDF precedence, unaffected by the Social override");
+    }
+
+    [Fact]
     public async Task Handle_WithGameWithoutRules_ReturnsNullRules()
     {
         // Arrange

--- a/apps/web/src/app/(public)/shared-games/[id]/__tests__/page.test.tsx
+++ b/apps/web/src/app/(public)/shared-games/[id]/__tests__/page.test.tsx
@@ -264,6 +264,18 @@ describe('SharedGameDetailPage (Wave A.4 — Issue #616)', () => {
       expect(meta.openGraph?.images).toEqual([{ url: coverUrl }]);
     });
 
+    it('prefers the Social-context cover over coverUrl for the OG image (#3470 Slice 2d)', async () => {
+      const socialCoverUrl = 'https://r2.example.test/covers/33333333/social.webp';
+      const coverUrl = 'https://r2.example.test/covers/33333333/cover.webp';
+      mockGetDetail.mockResolvedValue({ ...SAMPLE_DETAIL, socialCoverUrl, coverUrl, imageUrl: '' });
+
+      const meta = await generateMetadata({
+        params: Promise.resolve({ id: SAMPLE_ID }),
+      });
+
+      expect(meta.openGraph?.images).toEqual([{ url: socialCoverUrl }]);
+    });
+
     it('truncates description to 200 chars', async () => {
       const longDescription = 'x'.repeat(300);
       mockGetDetail.mockResolvedValue({ ...SAMPLE_DETAIL, description: longDescription });

--- a/apps/web/src/app/(public)/shared-games/[id]/page.tsx
+++ b/apps/web/src/app/(public)/shared-games/[id]/page.tsx
@@ -129,10 +129,13 @@ export async function generateMetadata({ params }: SharedGameDetailPageProps): P
       ? detail.description.slice(0, 200)
       : SSR_METADATA.descriptionFallback;
 
-  // #3452 — prefer the R2-resolved coverUrl; imageUrl is a #2123 tombstone
-  // (always empty in prod) and is kept only as a defensive fallback.
+  // #3452 / #3470 Slice 2d (AC-2) — prefer the Social-context cover (dedicated OG image),
+  // then the R2-resolved coverUrl; imageUrl is a #2123 tombstone (always empty in prod)
+  // and is kept only as a defensive fallback.
   const ogImage =
-    detail?.coverUrl ?? (detail?.imageUrl && detail.imageUrl.length > 0 ? detail.imageUrl : null);
+    detail?.socialCoverUrl ??
+    detail?.coverUrl ??
+    (detail?.imageUrl && detail.imageUrl.length > 0 ? detail.imageUrl : null);
 
   return {
     title: fullTitle,

--- a/apps/web/src/lib/api/schemas/shared-games.schemas.ts
+++ b/apps/web/src/lib/api/schemas/shared-games.schemas.ts
@@ -323,6 +323,10 @@ export const SharedGameDetailSchema = z.object({
   // has been generated yet — consumers MUST fall back to the deterministic placeholder
   // via `lib/games/cover-utils.ts`.
   coverUrl: z.string().url().nullable().optional(),
+  // Epic #3470 Slice 2d (AC-2) — cover resolved for the Social (OpenGraph) context,
+  // consumed by the OG meta in `[id]/page.tsx`. Falls through to the implicit cover
+  // when no Social override is pinned, so it is never worse than `coverUrl`.
+  socialCoverUrl: z.string().url().nullable().optional(),
   rules: GameRulesSchema.nullable(),
   status: GameStatusSchema, // Now string enum with JsonStringEnumConverter
   createdBy: z.string().uuid(),


### PR DESCRIPTION
## Epic #3470 — Slice 2d (AC-2): Social-context cover per l'OpenGraph meta

Continuazione di Slice 2a/2b/2c. Espone una cover **Social** dedicata (per la condivisione social) sulla pagina di dettaglio, così un admin può pinnare una cover ottimizzata per l'OG distinta da hero/card. Chiude **AC-2**.

### Backend
- **`SharedGameDetailDto`** guadagna `SocialCoverUrl` (trailing optional → binary/positional-compat).
- **`GetSharedGameByIdQueryHandler`** risolve il contesto **Social** accanto al cover Hero (stessa entità già eager-loaded, `ResolveForContextAsync(Social)`); fall-through alla precedenza implicita quando non c'è override Social → mai peggio di `CoverUrl`.
- Test: un override Social emerge su `SocialCoverUrl` **senza** toccare l'Hero `CoverUrl`.

### Frontend
- **`SharedGameDetailSchema`** guadagna `socialCoverUrl` (nullable/optional).
- L'OG image in **`[id]/page.tsx`** ora preferisce `socialCoverUrl → coverUrl → imageUrl` (tombstone #2123/#3452).
- Test: `socialCoverUrl` vince l'OG image su `coverUrl` (14/14 verdi in `page.test.tsx`).

### Note (self-review)
- **Additivo**: campo DTO/schema opzionale → nessun breaking per i consumer esistenti; build BE Debug+Release puliti, FE typecheck pulito.
- **Costo**: +1 risoluzione blob per detail-load (contesto Social); inerente alla risoluzione per-contesto. La presigned URL nell'OG era già il pattern pre-esistente (coverUrl) → nessun nuovo rischio di scadenza.

### Rinviato
Focal read-shape (**AC-5**); Slice 3 (URL manuale) bloccata da SSRF **#3495**. Con 2d, **AC-1/AC-2/AC-4 completi** — resta solo AC-5 della Slice 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
