### PR TITLE
feat(catalog): per-context focal in read-shape, picker pre-fills (Slice 2e, #3470)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/CoverCandidatesDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/CoverCandidatesDto.cs
@@ -27,11 +27,21 @@ public sealed record CoverCandidateDto(
     string? SourceUrl);
 
 /// <summary>
-/// Which cover source is currently pinned for each UI context. A <see langword="null"/>
+/// A single per-context admin assignment: the pinned source plus the persisted focal
+/// point (epic #3470 Slice 2e / AC-5). Exposing the focal lets the picker pre-fill the
+/// saved value instead of always starting at 0.5/0.5.
+/// </summary>
+public sealed record CoverContextAssignmentDto(
+    CoverAssignmentSource Source,
+    double FocalX,
+    double FocalY);
+
+/// <summary>
+/// Which cover assignment is currently pinned for each UI context. A <see langword="null"/>
 /// field means the context has no explicit admin assignment and falls back to the
 /// resolver's implicit precedence.
 /// </summary>
 public sealed record CoverContextAssignmentsDto(
-    CoverAssignmentSource? Card,
-    CoverAssignmentSource? Hero,
-    CoverAssignmentSource? Social);
+    CoverContextAssignmentDto? Card,
+    CoverContextAssignmentDto? Hero,
+    CoverContextAssignmentDto? Social);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetCoverCandidatesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetCoverCandidatesQueryHandler.cs
@@ -61,9 +61,9 @@ internal sealed class GetCoverCandidatesQueryHandler
         var candidates = resolved.Where(c => c is not null).Select(c => c!).ToList();
 
         var assignments = new CoverContextAssignmentsDto(
-            Card: SourceForContext(game, CoverContext.Card),
-            Hero: SourceForContext(game, CoverContext.Hero),
-            Social: SourceForContext(game, CoverContext.Social));
+            Card: AssignmentForContext(game, CoverContext.Card),
+            Hero: AssignmentForContext(game, CoverContext.Hero),
+            Social: AssignmentForContext(game, CoverContext.Social));
 
         return new CoverCandidatesDto(game.Id, candidates, assignments);
     }
@@ -90,6 +90,11 @@ internal sealed class GetCoverCandidatesQueryHandler
         return new CoverCandidateDto(source, previewUrl, license, attribution, sourceUrl);
     }
 
-    private static CoverAssignmentSource? SourceForContext(SharedGameEntity game, CoverContext context) =>
-        game.CoverAssignments.FirstOrDefault(a => a.Context == context)?.Source;
+    private static CoverContextAssignmentDto? AssignmentForContext(SharedGameEntity game, CoverContext context)
+    {
+        var assignment = game.CoverAssignments.FirstOrDefault(a => a.Context == context);
+        return assignment is null
+            ? null
+            : new CoverContextAssignmentDto(assignment.Source, assignment.FocalX, assignment.FocalY);
+    }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetCoverCandidatesQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetCoverCandidatesQueryHandlerTests.cs
@@ -111,7 +111,7 @@ public sealed class GetCoverCandidatesQueryHandlerTests
     }
 
     [Fact]
-    public async Task Handle_ReportsPerContextAssignments()
+    public async Task Handle_ReportsPerContextAssignments_WithSourceAndFocal()
     {
         using var ctx = TestDbContextFactory.CreateInMemoryDbContext();
         var game = SeedGame(ctx, g =>
@@ -119,7 +119,7 @@ public sealed class GetCoverCandidatesQueryHandlerTests
             g.WikidataCoverR2Key = "covers/y/cover";
             g.CoverAssignments = new List<GameCoverAssignmentEntity>
             {
-                new() { Id = Guid.NewGuid(), Context = CoverContext.Card, Source = CoverAssignmentSource.Wikidata, CreatedBy = Guid.NewGuid() },
+                new() { Id = Guid.NewGuid(), Context = CoverContext.Card, Source = CoverAssignmentSource.Wikidata, FocalX = 0.3, FocalY = 0.7, CreatedBy = Guid.NewGuid() },
                 new() { Id = Guid.NewGuid(), Context = CoverContext.Hero, Source = CoverAssignmentSource.Pdf, CreatedBy = Guid.NewGuid() },
             };
         });
@@ -129,8 +129,12 @@ public sealed class GetCoverCandidatesQueryHandlerTests
 
         var result = await handler.Handle(new GetCoverCandidatesQuery(game.Id), CancellationToken.None);
 
-        result!.Assignments.Card.Should().Be(CoverAssignmentSource.Wikidata);
-        result.Assignments.Hero.Should().Be(CoverAssignmentSource.Pdf);
+        // Epic #3470 Slice 2e (AC-5): each context carries source + the persisted focal so
+        // the FE picker can pre-fill the saved focal instead of always starting at 0.5/0.5.
+        result!.Assignments.Card!.Source.Should().Be(CoverAssignmentSource.Wikidata);
+        result.Assignments.Card.FocalX.Should().Be(0.3);
+        result.Assignments.Card.FocalY.Should().Be(0.7);
+        result.Assignments.Hero!.Source.Should().Be(CoverAssignmentSource.Pdf);
         result.Assignments.Social.Should().BeNull("no assignment pins the Social context");
     }
 }

--- a/apps/web/src/components/features/cover-editor/AdminCoverSourceDialog.tsx
+++ b/apps/web/src/components/features/cover-editor/AdminCoverSourceDialog.tsx
@@ -73,49 +73,50 @@ export function AdminCoverSourceDialog({
   const [activeContext, setActiveContext] = useState<CoverContext>('Card');
   const [pendingSource, setPendingSource] = useState<CoverAssignmentSource | null>(null);
   const [focal, setFocal] = useState(DEFAULT_FOCAL);
-  // The read shape carries no persisted focal, so the picker always starts at 0.5/0.5.
-  // Require an explicit change (candidate pick or focal move) before Applica is enabled,
-  // so a zero-interaction click can't silently re-center an already fine-tuned focal.
-  const [focalTouched, setFocalTouched] = useState(false);
 
   const currentAssignment = data?.assignments[ASSIGN_KEY[activeContext]] ?? null;
-  const selectedSource = pendingSource ?? currentAssignment;
+  // Epic #3470 Slice 2e (AC-5): the read shape now carries the persisted focal, so the
+  // picker pre-fills the saved value and "dirty" is a genuine diff against that baseline
+  // — replacing the old focal-touched workaround.
+  const baselineFocal = currentAssignment
+    ? { x: currentAssignment.focalX, y: currentAssignment.focalY }
+    : DEFAULT_FOCAL;
+  const currentSource = currentAssignment?.source ?? null;
+  const selectedSource = pendingSource ?? currentSource;
   const selectedCandidate = data?.candidates.find(c => c.source === selectedSource) ?? null;
-  const dirty = pendingSource !== null || focalTouched;
+  const dirty =
+    selectedSource !== currentSource || focal.x !== baselineFocal.x || focal.y !== baselineFocal.y;
 
-  const resetLocal = () => {
+  // Sync local edit state to the active context's persisted assignment whenever the
+  // context changes or the candidates reload (post-mutation): clear any pending pick and
+  // pre-fill the saved focal, so the picker opens showing the current state. `data` keeps
+  // a stable reference across no-op refetches (react-query structural sharing), so this
+  // does not clobber an in-progress edit.
+  useEffect(() => {
+    const assignment = data?.assignments[ASSIGN_KEY[activeContext]] ?? null;
     setPendingSource(null);
-    setFocal(DEFAULT_FOCAL);
-    setFocalTouched(false);
-  };
+    setFocal(assignment ? { x: assignment.focalX, y: assignment.focalY } : DEFAULT_FOCAL);
+  }, [activeContext, data]);
 
-  // Clear abandoned edit state when the dialog closes so it never resurfaces (and
-  // never becomes accidentally re-appliable) on the next open. The dialog component
-  // stays mounted across open/close, so this reset must be explicit.
+  // Reset to the default context when the dialog closes so it never resurfaces on the
+  // next open; the sync effect above re-derives the focal once data reloads.
   useEffect(() => {
     if (!open) {
       setActiveContext('Card');
       setPendingSource(null);
       setFocal(DEFAULT_FOCAL);
-      setFocalTouched(false);
     }
   }, [open]);
 
-  const handleTabChange = (value: string) => {
-    setActiveContext(value as CoverContext);
-    resetLocal();
-  };
+  const handleTabChange = (value: string) => setActiveContext(value as CoverContext);
 
   const handlePick = (source: CoverAssignmentSource) => {
     setPendingSource(source);
+    // A newly picked source has no saved focal for this context yet → center it.
     setFocal(DEFAULT_FOCAL);
-    setFocalTouched(false);
   };
 
-  const handleFocalChange = (next: { x: number; y: number }) => {
-    setFocal(next);
-    setFocalTouched(true);
-  };
+  const handleFocalChange = (next: { x: number; y: number }) => setFocal(next);
 
   const handleApply = () => {
     if (!selectedSource) return;
@@ -128,7 +129,8 @@ export function AdminCoverSourceDialog({
 
   const handleReset = () => {
     remove.mutate({ gameId, context: activeContext });
-    resetLocal();
+    setPendingSource(null);
+    setFocal(DEFAULT_FOCAL);
   };
 
   return (
@@ -172,7 +174,7 @@ export function AdminCoverSourceDialog({
                   <>
                     <p className="text-sm text-muted-foreground">
                       {currentAssignment
-                        ? `Attualmente: ${SOURCE_LABEL[currentAssignment]}`
+                        ? `Attualmente: ${SOURCE_LABEL[currentAssignment.source]}`
                         : 'Attualmente: automatico (precedenza implicita)'}
                     </p>
 

--- a/apps/web/src/components/features/cover-editor/__tests__/AdminCoverSourceDialog.test.tsx
+++ b/apps/web/src/components/features/cover-editor/__tests__/AdminCoverSourceDialog.test.tsx
@@ -38,7 +38,7 @@ const candidatesData = {
       sourceUrl: 'https://commons.wikimedia.org/wiki/File:x.jpg',
     },
   ],
-  assignments: { card: 'Pdf', hero: null, social: null },
+  assignments: { card: { source: 'Pdf', focalX: 0.25, focalY: 0.75 }, hero: null, social: null },
 };
 
 let assignMutate: ReturnType<typeof vi.fn>;
@@ -73,6 +73,14 @@ describe('AdminCoverSourceDialog', () => {
     renderDialog();
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(screen.getByText(/Catan/)).toBeInTheDocument();
+  });
+
+  it('pre-fills the saved focal for the active context (#3470 Slice 2e)', () => {
+    // The Card context has a saved focal of 0.25 / 0.75; the picker must pre-fill it
+    // (25% / 75%) instead of starting at the 0.5 / 0.5 default.
+    renderDialog();
+    const handle = screen.getByRole('button', { name: /punto focale/i });
+    expect(handle).toHaveStyle({ left: '25%', top: '75%' });
   });
 
   it('renders nothing when closed', () => {

--- a/apps/web/src/components/features/cover-editor/__tests__/cover-editor.axe.test.tsx
+++ b/apps/web/src/components/features/cover-editor/__tests__/cover-editor.axe.test.tsx
@@ -52,7 +52,7 @@ beforeEach(() => {
           sourceUrl: 'https://commons.example/x',
         },
       ],
-      assignments: { card: 'Pdf', hero: null, social: null },
+      assignments: { card: { source: 'Pdf', focalX: 0.5, focalY: 0.5 }, hero: null, social: null },
     },
   });
 });

--- a/apps/web/src/hooks/admin/__tests__/useAssignCover.test.tsx
+++ b/apps/web/src/hooks/admin/__tests__/useAssignCover.test.tsx
@@ -97,7 +97,7 @@ describe('useAssignCover', () => {
 
     await waitFor(() => {
       const cached = queryClient.getQueryData<CoverCandidates>(coverEditorKeys.candidates(GAME_ID));
-      expect(cached?.assignments.hero).toBe('Wikidata');
+      expect(cached?.assignments.hero).toEqual({ source: 'Wikidata', focalX: 0.5, focalY: 0.5 });
     });
 
     resolveAssign({ context: 'Hero', source: 'Wikidata', focalX: 0.5, focalY: 0.5 });

--- a/apps/web/src/hooks/admin/__tests__/useRemoveCoverAssignment.test.tsx
+++ b/apps/web/src/hooks/admin/__tests__/useRemoveCoverAssignment.test.tsx
@@ -37,7 +37,7 @@ function createWrapper() {
 const seededCandidates: CoverCandidates = {
   gameId: GAME_ID,
   candidates: [{ source: 'Wikidata', previewUrl: 'https://r2.example/w.webp' }],
-  assignments: { card: 'Wikidata', hero: null, social: null },
+  assignments: { card: { source: 'Wikidata', focalX: 0.5, focalY: 0.5 }, hero: null, social: null },
 };
 
 describe('useRemoveCoverAssignment', () => {
@@ -105,6 +105,6 @@ describe('useRemoveCoverAssignment', () => {
     await waitFor(() => expect(result.current.isError).toBe(true));
 
     const cached = queryClient.getQueryData<CoverCandidates>(coverEditorKeys.candidates(GAME_ID));
-    expect(cached?.assignments.card).toBe('Wikidata');
+    expect(cached?.assignments.card).toEqual({ source: 'Wikidata', focalX: 0.5, focalY: 0.5 });
   });
 });

--- a/apps/web/src/hooks/admin/useAssignCover.ts
+++ b/apps/web/src/hooks/admin/useAssignCover.ts
@@ -55,7 +55,15 @@ export function useAssignCover(): UseMutationResult<
       if (previous) {
         queryClient.setQueryData<CoverCandidates>(key, {
           ...previous,
-          assignments: { ...previous.assignments, [assignmentKey(context)]: body.source },
+          // Epic #3470 Slice 2e (AC-5): the per-context assignment now carries the focal too.
+          assignments: {
+            ...previous.assignments,
+            [assignmentKey(context)]: {
+              source: body.source,
+              focalX: body.focalX,
+              focalY: body.focalY,
+            },
+          },
         });
       }
       return { previous };

--- a/apps/web/src/lib/api/schemas/admin/admin-cover.schemas.ts
+++ b/apps/web/src/lib/api/schemas/admin/admin-cover.schemas.ts
@@ -32,11 +32,23 @@ export const CoverCandidateSchema = z.object({
 });
 export type CoverCandidate = z.infer<typeof CoverCandidateSchema>;
 
-/** Which source is currently pinned per context; null = implicit precedence (CoverContextAssignmentsDto). */
+/**
+ * A single per-context admin assignment: the pinned source + the persisted focal point
+ * (CoverContextAssignmentDto, epic #3470 Slice 2e / AC-5). Exposing the focal lets the
+ * picker pre-fill the saved value instead of always starting at 0.5/0.5.
+ */
+export const CoverContextAssignmentSchema = z.object({
+  source: CoverAssignmentSourceSchema,
+  focalX: z.number(),
+  focalY: z.number(),
+});
+export type CoverContextAssignment = z.infer<typeof CoverContextAssignmentSchema>;
+
+/** Which assignment is currently pinned per context; null = implicit precedence (CoverContextAssignmentsDto). */
 export const CoverContextAssignmentsSchema = z.object({
-  card: CoverAssignmentSourceSchema.nullable().optional(),
-  hero: CoverAssignmentSourceSchema.nullable().optional(),
-  social: CoverAssignmentSourceSchema.nullable().optional(),
+  card: CoverContextAssignmentSchema.nullable().optional(),
+  hero: CoverContextAssignmentSchema.nullable().optional(),
+  social: CoverContextAssignmentSchema.nullable().optional(),
 });
 export type CoverContextAssignments = z.infer<typeof CoverContextAssignmentsSchema>;
 


### PR DESCRIPTION
## Epic #3470 — Slice 2e (AC-5): focal per-contesto nel read-shape, picker pre-fill

Ultima slice della **Slice 2**. Il read-model del cover-picker ora porta il **focal salvato per contesto**, così il picker admin pre-riempie il focal invece di partire sempre da 0.5/0.5 — rimuovendo il dirty-guard workaround di 1d-c.

### Backend
- `CoverContextAssignmentsDto`: i campi per-contesto passano da `CoverAssignmentSource?` a **`CoverContextAssignmentDto?`** (`Source` + `FocalX` + `FocalY`). `GetCoverCandidatesQueryHandler` proietta source + focal dall'assignment pinnato.
- Test: asserisce source **e** focal per contesto.

### Frontend (shape change coordinata)
- `admin-cover.schemas.ts`: nuovo `CoverContextAssignmentSchema` (source + focal); `assignments.{card,hero,social}` portano ora l'oggetto.
- **`AdminCoverSourceDialog`**: pre-riempie `focal` dall'assignment persistito del contesto attivo via sync-effect; **`dirty` è ora un diff reale contro quel baseline**, rimuovendo il workaround `focalTouched` di 1d-c. Test: l'handle del picker appare a **25%/75%** all'apertura (focal salvato).
- `useAssignCover`: l'optimistic update scrive `{source, focalX, focalY}`. Fixture e asserzioni cache migrate alla nuova shape.

### Test
76/76 verdi su cover-editor + admin hooks (incl. nuovo test pre-fill AC-5); 4/4 sul handler candidati BE; typecheck FE + build BE Debug+Release puliti.

### Nota (self-review)
- **Shape change coordinata BE↔FE**: nessun consumer residuo della vecchia shape (sweep FE + build BE verdi).
- **Sync-effect robusto**: `data` mantiene reference stabile sui refetch no-op (structural sharing react-query) → non clobbera un edit in corso; si ri-sincronizza solo dopo una mutation.

### Stato epic
Con 2e la **Slice 2 è completa** (AC-1/AC-2/AC-4/AC-5/AC-6). Resta solo la **Slice 3** (URL manuale), bloccata da SSRF **#3495**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
