### PR TITLE
fix(security): pin the manual-URL fetch client, retire TOCTOU (#3495 fix 5/N)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
@@ -203,6 +203,12 @@ internal static class SharedGameCatalogServiceExtensions
         // request and each of the ≤5 auto-redirect hops).
         AddBggCoverDownloader(services);
 
+        // #3495 fix 5/N: the arbitrary-URL manual/PDF download client (SsrfSafeHttpClient) — the
+        // prerequisite egress client for #3470 Slice 3. Pinned like the cover clients, but with
+        // AllowAutoRedirect=false so the client follows redirects itself through an HTTPS-only
+        // per-hop scheme gate (the pin only re-checks the IP). 30s timeout accommodates larger PDFs.
+        AddSsrfSafeHttpClient(services);
+
         // Issue #1903 M5.2: register HttpClients, keyed catalog providers,
         // aggregator, and Quartz CatalogSeedFetchJob.
         RegisterCatalogSeedProviders(services);
@@ -398,6 +404,19 @@ internal static class SharedGameCatalogServiceExtensions
         .ConfigureSsrfPin();
 
     /// <summary>
+    /// Issue #3495 fix 5/N — registers the hardened arbitrary-URL download client
+    /// (<see cref="SsrfSafeHttpClient"/>, the #3470 Slice 3 prerequisite) with the SSRF connect-pin.
+    /// <c>allowAutoRedirect: false</c> so the client follows redirects manually through an HTTPS-only
+    /// per-hop scheme gate — the connect-pin re-validates the IP of each hop but not the scheme.
+    /// </summary>
+    private static void AddSsrfSafeHttpClient(IServiceCollection services) =>
+        services.AddHttpClient<SsrfSafeHttpClient>(client =>
+        {
+            client.Timeout = TimeSpan.FromSeconds(30);
+        })
+        .ConfigureSsrfPin(allowAutoRedirect: false);
+
+    /// <summary>
     /// Test seam (issue #3495 fix 3/N): registers ONLY the SSRF-pinned BGG cover-download client so
     /// a DI-resolution test can prove a private-resolving cover host fails closed at the connect-pin.
     /// The caller MUST register an <see cref="IBggCoverUploadPipeline"/> + <see cref="IDnsResolver"/>
@@ -408,6 +427,19 @@ internal static class SharedGameCatalogServiceExtensions
         services.AddLogging();
         services.TryAddSingleton<IDnsResolver, SystemDnsResolver>();
         AddBggCoverDownloader(services);
+    }
+
+    /// <summary>
+    /// Test seam (issue #3495 fix 5/N): registers ONLY the SSRF-pinned arbitrary-URL client
+    /// (<see cref="SsrfSafeHttpClient"/>) so a DI-resolution test can prove a private-resolving host
+    /// fails closed at the connect-pin. The caller MUST register an <see cref="IDnsResolver"/> on the
+    /// same collection before resolving to override the <c>TryAddSingleton</c> default.
+    /// </summary>
+    internal static void AddSsrfSafeHttpClientForTests(IServiceCollection services)
+    {
+        services.AddLogging();
+        services.TryAddSingleton<IDnsResolver, SystemDnsResolver>();
+        AddSsrfSafeHttpClient(services);
     }
 
     private static BggCoverUploadPipeline BuildBggCoverUploadPipeline(

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfSafeHttpClient.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfSafeHttpClient.cs
@@ -1,16 +1,30 @@
 using System.Net;
-using Api.SharedKernel.Infrastructure.Http;
 
 namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 
 /// <summary>
-/// HTTP client wrapper that validates URLs against SSRF attacks before downloading.
-/// Blocks private/reserved IP ranges, non-HTTPS schemes, and oversized responses.
+/// Hardened egress client for the manual / arbitrary-URL download path (epic #3470 Slice 3
+/// prerequisite, issue #3495 fix 5/N).
+/// <para>
+/// The IP boundary is the connect-pin (<see cref="Api.SharedKernel.Infrastructure.Http.SsrfPinnedConnect"/>,
+/// applied to this client's <see cref="HttpClient"/> via <c>ConfigureSsrfPin(allowAutoRedirect: false)</c>):
+/// every connection resolves the host once and dials a validated public IP, closing DNS-rebinding
+/// and redirect-to-internal by construction. This class adds the remaining arbitrary-URL guards the
+/// pin cannot express: HTTPS-only scheme re-validated on EVERY hop (blocks a redirect that downgrades
+/// to <c>http/file/gopher</c> or points at a non-HTTP scheme — the pin only re-checks the IP), a
+/// bounded manual redirect follow with loop detection, and a mid-stream byte ceiling.
+/// </para>
+/// <para>
+/// Auto-redirect is DISABLED on the primary handler so 3xx responses surface here and are followed
+/// manually through the scheme gate — with <c>AllowAutoRedirect=true</c> the handler would follow a
+/// downgrade before this code could reject it.
+/// </para>
 /// </summary>
 internal sealed class SsrfSafeHttpClient
 {
     private readonly HttpClient _httpClient;
     private const long MaxPdfSizeBytes = 100 * 1024 * 1024; // 100MB
+    private const int MaxRedirectHops = 5;
 
     public SsrfSafeHttpClient(HttpClient httpClient)
     {
@@ -18,53 +32,104 @@ internal sealed class SsrfSafeHttpClient
     }
 
     /// <summary>
-    /// Downloads a PDF from the given URL after validating it is safe (HTTPS, public IP, valid PDF).
+    /// Downloads a PDF from the given URL through the hardened fetch path (HTTPS-only per hop,
+    /// bounded redirect follow, mid-stream 100MB ceiling, IP-pinned connection), then validates
+    /// the payload is a PDF.
     /// </summary>
-    /// <param name="url">The HTTPS URL to download the PDF from.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>A seekable MemoryStream containing the PDF content.</returns>
-    /// <exception cref="ArgumentException">If the URL is invalid or not HTTPS.</exception>
-    /// <exception cref="InvalidOperationException">If the URL resolves to a private IP, the file is too large, or content is not a valid PDF.</exception>
+    /// <exception cref="ArgumentException">The URL (or a redirect target) is not an absolute HTTPS URL.</exception>
+    /// <exception cref="InvalidOperationException">Redirect loop / too many hops, oversize, or non-PDF content.</exception>
     public async Task<Stream> DownloadPdfAsync(string url, CancellationToken ct)
     {
-        ValidateUrlScheme(url);
-        await ValidateResolvedIpAsync(url, ct).ConfigureAwait(false);
+        var bytes = await FetchWithLimitAsync(url, MaxPdfSizeBytes, ct).ConfigureAwait(false);
 
-        // Dispose the response on every exit path: with ResponseHeadersRead it holds the live
-        // connection open until disposed. Disposing the response also disposes its content and
-        // the stream returned by ReadAsStreamAsync (the content owns that stream), so the source
-        // is fully released once this scope exits. The validated payload is copied into an
-        // independent MemoryStream before this method returns, so scope-exit disposal is safe.
-        using var response = await _httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
-
-        // Validate size from Content-Length header if available
-        if (response.Content.Headers.ContentLength > MaxPdfSizeBytes)
-            throw new InvalidOperationException($"PDF exceeds maximum size of {MaxPdfSizeBytes / (1024 * 1024)}MB");
-
-        // Owned by `response`; disposed together with it at scope exit (see comment above).
-        var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
-
-        // Validate PDF magic bytes (%PDF)
-        var buffer = new byte[4];
-        var bytesRead = await stream.ReadAsync(buffer, ct).ConfigureAwait(false);
-        if (bytesRead < 4 || buffer[0] != 0x25 || buffer[1] != 0x50 || buffer[2] != 0x44 || buffer[3] != 0x46)
+        // Validate PDF magic bytes (%PDF).
+        if (bytes.Length < 4 || bytes[0] != 0x25 || bytes[1] != 0x50 || bytes[2] != 0x44 || bytes[3] != 0x46)
             throw new InvalidOperationException("Downloaded content is not a valid PDF file");
 
-        // Return a new stream that includes the magic bytes we already read
-        var memStream = new MemoryStream();
-        await memStream.WriteAsync(buffer.AsMemory(0, bytesRead), ct).ConfigureAwait(false);
-        await stream.CopyToAsync(memStream, ct).ConfigureAwait(false);
-
-        if (memStream.Length > MaxPdfSizeBytes)
-            throw new InvalidOperationException($"PDF exceeds maximum size of {MaxPdfSizeBytes / (1024 * 1024)}MB");
-
-        memStream.Position = 0;
-        return memStream;
+        return new MemoryStream(bytes, writable: false);
     }
 
     /// <summary>
-    /// Validates that the URL uses the HTTPS scheme.
+    /// Hardened fetch shared by every arbitrary-URL sink on this client: validates the scheme on
+    /// the initial URL and on every redirect hop (HTTPS-only), follows up to
+    /// <see cref="MaxRedirectHops"/> redirects with loop detection, and reads the body under a
+    /// streamed <paramref name="maxBytes"/> ceiling (aborts at limit+1, before buffering the whole
+    /// payload). The connection-level IP validation is provided by the connect-pin. Returns the
+    /// fully-read, within-limit bytes; the response and its content stream are disposed on exit.
+    /// </summary>
+    internal async Task<byte[]> FetchWithLimitAsync(string url, long maxBytes, CancellationToken ct)
+    {
+        var current = ParseHttpsAbsolute(url);
+        var visited = new HashSet<string>(StringComparer.Ordinal);
+
+        // The initial request plus up to MaxRedirectHops redirect follows.
+        for (var hop = 0; hop <= MaxRedirectHops; hop++)
+        {
+            if (!visited.Add(current.AbsoluteUri))
+                throw new InvalidOperationException("Redirect loop detected");
+
+            using var request = new HttpRequestMessage(HttpMethod.Get, current);
+            using var response = await _httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct)
+                .ConfigureAwait(false);
+
+            if (!IsRedirect(response.StatusCode))
+            {
+                response.EnsureSuccessStatusCode();
+
+                // Reject early on an advertised over-cap length; Content-Length is spoofable/absent
+                // (chunked), so the ceiling is ALSO enforced during the streamed read below.
+                if (response.Content.Headers.ContentLength > maxBytes)
+                    throw new InvalidOperationException($"Response exceeds the maximum size of {maxBytes / (1024 * 1024)}MB");
+
+                return await ReadWithCeilingAsync(response, maxBytes, ct).ConfigureAwait(false);
+            }
+
+            var location = response.Headers.Location
+                ?? throw new InvalidOperationException("Redirect response had no Location header");
+
+            // Resolve relative → absolute against the current URL, then RE-VALIDATE the scheme:
+            // an absolute http/file/gopher Location or a relative-to-non-http target is rejected
+            // here (the pin only re-checks the IP, not the scheme).
+            current = ParseHttpsAbsolute(new Uri(current, location).AbsoluteUri);
+        }
+
+        throw new InvalidOperationException($"Exceeded the maximum of {MaxRedirectHops} redirects");
+    }
+
+    private static async Task<byte[]> ReadWithCeilingAsync(HttpResponseMessage response, long maxBytes, CancellationToken ct)
+    {
+        using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+        using var buffer = new MemoryStream();
+
+        var chunk = new byte[81920];
+        long total = 0;
+        int read;
+        while ((read = await stream.ReadAsync(chunk, ct).ConfigureAwait(false)) > 0)
+        {
+            total += read;
+            if (total > maxBytes)
+                throw new InvalidOperationException($"Response exceeds the maximum size of {maxBytes / (1024 * 1024)}MB");
+
+            await buffer.WriteAsync(chunk.AsMemory(0, read), ct).ConfigureAwait(false);
+        }
+
+        return buffer.ToArray();
+    }
+
+    private static bool IsRedirect(HttpStatusCode code) => code is
+        HttpStatusCode.MovedPermanently or HttpStatusCode.Found or HttpStatusCode.SeeOther
+        or HttpStatusCode.TemporaryRedirect or HttpStatusCode.PermanentRedirect;
+
+    private static Uri ParseHttpsAbsolute(string url)
+    {
+        ValidateUrlScheme(url);
+        return new Uri(url, UriKind.Absolute);
+    }
+
+    /// <summary>
+    /// Validates that the URL is absolute and uses the HTTPS scheme. Applied to the initial URL and
+    /// re-applied to every redirect target.
     /// </summary>
     internal static void ValidateUrlScheme(string url)
     {
@@ -74,33 +139,4 @@ internal sealed class SsrfSafeHttpClient
         if (!string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
             throw new ArgumentException("Only HTTPS URLs are allowed", nameof(url));
     }
-
-    /// <summary>
-    /// Validates that the URL does not resolve to a private or reserved IP address.
-    /// <para>
-    /// PRIVATE (issue #3495 fix 3/N): this pre-connect DNS check is inherently TOCTOU
-    /// (DNS-rebinding). It is NOT a security boundary for live egress — the connect-pin
-    /// (<see cref="Api.SharedKernel.Infrastructure.Http.SsrfPinnedConnect"/>, applied via
-    /// <c>ConfigureSsrfPin</c>) is. It survives only as an internal fail-fast pre-check for the
-    /// not-yet-wired <see cref="DownloadPdfAsync"/> path; when that path is integrated into the
-    /// DocumentProcessing BC its HttpClient MUST be registered with the pin.
-    /// </para>
-    /// </summary>
-    private static async Task ValidateResolvedIpAsync(string url, CancellationToken ct)
-    {
-        var uri = new Uri(url);
-        var addresses = await Dns.GetHostAddressesAsync(uri.Host, ct).ConfigureAwait(false);
-
-        foreach (var ip in addresses)
-        {
-            if (IsPrivateOrReserved(ip))
-                throw new InvalidOperationException($"URL resolves to blocked IP range: {ip}");
-        }
-    }
-
-    /// <summary>
-    /// Checks whether an IP address belongs to a private or reserved range. Delegates to the
-    /// IANA-driven <see cref="SsrfPolicy"/> classifier (issue #3495, finding H3).
-    /// </summary>
-    internal static bool IsPrivateOrReserved(IPAddress ip) => SsrfPolicy.IsBlocked(ip);
 }

--- a/apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPinnedHttpClientBuilderExtensions.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPinnedHttpClientBuilderExtensions.cs
@@ -20,15 +20,21 @@ internal static class SsrfPinnedHttpClientBuilderExtensions
     /// Configures the client's primary handler as a <see cref="SocketsHttpHandler"/> whose
     /// <see cref="SocketsHttpHandler.ConnectCallback"/> pins to the validated address. Requires an
     /// <see cref="IDnsResolver"/> to be registered in the same container.
+    /// <para>
+    /// <paramref name="allowAutoRedirect"/> defaults to <see langword="true"/> for fixed-host sinks
+    /// (BGG/Wikidata/Commons/Slack), where every ≤5 auto-redirect hop is re-pinned at connect. The
+    /// arbitrary-URL manual sink (issue #3495 fix 5/N) passes <see langword="false"/> so it can follow
+    /// redirects itself through an HTTPS-only scheme gate the connect-pin cannot express.
+    /// </para>
     /// </summary>
-    public static IHttpClientBuilder ConfigureSsrfPin(this IHttpClientBuilder builder)
+    public static IHttpClientBuilder ConfigureSsrfPin(this IHttpClientBuilder builder, bool allowAutoRedirect = true)
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        return builder.ConfigurePrimaryHttpMessageHandler(static sp => new SocketsHttpHandler
+        return builder.ConfigurePrimaryHttpMessageHandler(sp => new SocketsHttpHandler
         {
             ConnectCallback = SsrfPinnedConnect.Create(sp.GetRequiredService<IDnsResolver>()),
-            AllowAutoRedirect = true,
+            AllowAutoRedirect = allowAutoRedirect,
             MaxAutomaticRedirections = 5,
         });
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfSafeHttpClientPinIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfSafeHttpClientPinIntegrationTests.cs
@@ -1,0 +1,61 @@
+using System.Net;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.DependencyInjection;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+using Api.SharedKernel.Infrastructure.Http;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+
+/// <summary>
+/// Proves the arbitrary-URL download client (<see cref="SsrfSafeHttpClient"/>, the #3470 Slice 3
+/// prerequisite) is actually wired to the SSRF connect-pin (issue #3495 fix 5/N): a host resolving
+/// to a private/reserved address fails closed at connect time — WITHOUT the retired pre-connect DNS
+/// check. Resolving through the real DI registration
+/// (<see cref="SharedGameCatalogServiceExtensions.AddSsrfSafeHttpClientForTests"/>) guards against the
+/// pin being silently dropped; the pin's own fail-closed decision is covered by SsrfPinnedConnectTests.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class SsrfSafeHttpClientPinIntegrationTests
+{
+    private sealed class StubDnsResolver : IDnsResolver
+    {
+        private readonly IPAddress _address;
+        public int ResolveCalls { get; private set; }
+
+        public StubDnsResolver(string ip) => _address = IPAddress.Parse(ip);
+
+        public Task<IReadOnlyList<IPAddress>> ResolveAsync(string host, CancellationToken ct)
+        {
+            ResolveCalls++;
+            return Task.FromResult<IReadOnlyList<IPAddress>>(new[] { _address });
+        }
+    }
+
+    [Fact]
+    public async Task ManualFetch_HostResolvingToPrivateIp_FailsClosedAtConnectPin()
+    {
+        var dns = new StubDnsResolver("169.254.169.254"); // cloud metadata endpoint
+        var services = new ServiceCollection();
+        // Registered BEFORE the seam so its TryAddSingleton<IDnsResolver> does not override this stub.
+        services.AddSingleton<IDnsResolver>(dns);
+        SharedGameCatalogServiceExtensions.AddSsrfSafeHttpClientForTests(services);
+        using var provider = services.BuildServiceProvider();
+
+        var client = provider.GetRequiredService<SsrfSafeHttpClient>();
+
+        // The host literal (8.8.8.8) is public and passes the scheme check, but the pinned resolver
+        // returns the metadata IP, so the pin throws at connect and the download aborts.
+        var act = () => client.DownloadPdfAsync("https://8.8.8.8/rules.pdf", CancellationToken.None);
+
+        await act.Should().ThrowAsync<Exception>("the SSRF connect-pin must block a private-resolving host");
+        // The stub is consulted ONLY by the pin's ConnectCallback — a non-zero count proves
+        // ConfigureSsrfPin is actually wired. Without the pin the default handler would do its own
+        // DNS (8.8.8.8, public) and never touch this stub, so this fails deterministically if the pin
+        // is ever silently dropped from AddSsrfSafeHttpClient.
+        dns.ResolveCalls.Should().BeGreaterThan(0, "the connect-pin must consult the injected resolver");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfSafeHttpClientTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfSafeHttpClientTests.cs
@@ -56,53 +56,119 @@ public class SsrfSafeHttpClientTests
 
     #endregion
 
-    #region IsPrivateOrReserved Tests
+    // IsPrivateOrReserved tests removed with the method (#3495 fix 5/N): the pre-connect DNS
+    // check was TOCTOU and is retired in favor of the connect-pin (SsrfPinnedConnect), whose
+    // IANA IP policy is covered by SsrfPolicyTests. The IP boundary is no longer this class's.
 
-    [Theory]
-    [InlineData("127.0.0.1")]       // Loopback
-    [InlineData("127.0.0.2")]       // Loopback range
-    [InlineData("10.0.0.1")]        // 10.0.0.0/8
-    [InlineData("10.255.255.255")]  // 10.0.0.0/8 end
-    [InlineData("172.16.0.1")]      // 172.16.0.0/12 start
-    [InlineData("172.31.255.255")]  // 172.16.0.0/12 end
-    [InlineData("192.168.0.1")]     // 192.168.0.0/16
-    [InlineData("192.168.255.255")] // 192.168.0.0/16 end
-    [InlineData("169.254.0.1")]     // Link-local / AWS metadata
-    [InlineData("169.254.169.254")] // AWS metadata endpoint
-    [InlineData("0.0.0.0")]         // 0.0.0.0/8
-    public void IsPrivateOrReserved_PrivateIp_ShouldReturnTrue(string ipStr)
+    #region Redirect / scheme / size-cap tests (#3495 fix 5/N)
+
+    private static HttpResponseMessage Redirect(HttpStatusCode code, string location)
     {
-        var ip = IPAddress.Parse(ipStr);
+        var r = new HttpResponseMessage(code);
+        r.Headers.Location = new Uri(location, UriKind.RelativeOrAbsolute);
+        return r;
+    }
 
-        SsrfSafeHttpClient.IsPrivateOrReserved(ip).Should().BeTrue();
+    private static HttpResponseMessage Pdf() => new(HttpStatusCode.OK)
+    {
+        Content = new ByteArrayContent(System.Text.Encoding.ASCII.GetBytes("%PDF-1.4\nok")),
+    };
+
+    [Fact]
+    public async Task DownloadPdfAsync_FollowsHttpsRedirect_ToFinalPayload()
+    {
+        using var handler = new SequenceHttpMessageHandler(
+            _ => Redirect(HttpStatusCode.Found, "https://cdn.example/final.pdf"),
+            _ => Pdf());
+        using var httpClient = new HttpClient(handler);
+        var sut = new SsrfSafeHttpClient(httpClient);
+
+        var result = await sut.DownloadPdfAsync("https://example.com/rules.pdf", CancellationToken.None);
+
+        using var reader = new StreamReader(result);
+        (await reader.ReadToEndAsync()).Should().StartWith("%PDF");
+        handler.RequestedUris.Should().HaveCount(2);
+        handler.RequestedUris[1].Should().Be(new Uri("https://cdn.example/final.pdf"));
     }
 
     [Theory]
-    [InlineData("8.8.8.8")]         // Google DNS
-    [InlineData("1.1.1.1")]         // Cloudflare DNS
-    [InlineData("104.18.32.7")]     // Public IP
-    [InlineData("172.15.255.255")]  // Just outside 172.16.0.0/12
-    [InlineData("172.32.0.0")]      // Just outside 172.16.0.0/12
-    [InlineData("192.167.0.1")]     // Not 192.168.x.x
-    public void IsPrivateOrReserved_PublicIp_ShouldReturnFalse(string ipStr)
+    [InlineData("http://cdn.example/final.pdf")]     // https → http downgrade
+    [InlineData("file:///etc/passwd")]                // scheme downgrade to file
+    [InlineData("gopher://internal/x")]               // exotic scheme
+    public async Task DownloadPdfAsync_RejectsSchemeDowngradeOnRedirect(string location)
     {
-        var ip = IPAddress.Parse(ipStr);
+        using var handler = new SequenceHttpMessageHandler(_ => Redirect(HttpStatusCode.Found, location));
+        using var httpClient = new HttpClient(handler);
+        var sut = new SsrfSafeHttpClient(httpClient);
 
-        SsrfSafeHttpClient.IsPrivateOrReserved(ip).Should().BeFalse();
+        var act = () => sut.DownloadPdfAsync("https://example.com/rules.pdf", CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("Only HTTPS URLs are allowed*");
     }
 
     [Fact]
-    public void IsPrivateOrReserved_IPv6Loopback_ShouldReturnTrue()
+    public async Task DownloadPdfAsync_RejectsRedirectLoop()
     {
-        SsrfSafeHttpClient.IsPrivateOrReserved(IPAddress.IPv6Loopback).Should().BeTrue();
+        using var handler = new SequenceHttpMessageHandler(
+            _ => Redirect(HttpStatusCode.Found, "https://example.com/rules.pdf")); // → itself
+        using var httpClient = new HttpClient(handler);
+        var sut = new SsrfSafeHttpClient(httpClient);
+
+        var act = () => sut.DownloadPdfAsync("https://example.com/rules.pdf", CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*loop*");
     }
 
     [Fact]
-    public void IsPrivateOrReserved_IPv6LinkLocal_ShouldReturnTrue()
+    public async Task DownloadPdfAsync_RejectsTooManyRedirects()
     {
-        var ip = IPAddress.Parse("fe80::1");
+        var n = 0;
+        using var handler = new SequenceHttpMessageHandler(
+            _ => Redirect(HttpStatusCode.Found, $"https://example.com/hop{++n}.pdf"));
+        using var httpClient = new HttpClient(handler);
+        var sut = new SsrfSafeHttpClient(httpClient);
 
-        SsrfSafeHttpClient.IsPrivateOrReserved(ip).Should().BeTrue();
+        var act = () => sut.DownloadPdfAsync("https://example.com/rules.pdf", CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*maximum*redirects*");
+    }
+
+    [Fact]
+    public async Task FetchWithLimitAsync_AbortsMidStreamOverCeiling()
+    {
+        // 2 KB body against a 1 KB ceiling → must throw before buffering the whole payload.
+        var body = new byte[2048];
+        using var handler = new SequenceHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(body),
+        });
+        using var httpClient = new HttpClient(handler);
+        var sut = new SsrfSafeHttpClient(httpClient);
+
+        var act = () => sut.FetchWithLimitAsync("https://example.com/blob", 1024, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*exceeds*");
+    }
+
+    private sealed class SequenceHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Queue<Func<HttpRequestMessage, HttpResponseMessage>> _responders;
+        public List<Uri> RequestedUris { get; } = new();
+
+        public SequenceHttpMessageHandler(params Func<HttpRequestMessage, HttpResponseMessage>[] responders)
+            => _responders = new Queue<Func<HttpRequestMessage, HttpResponseMessage>>(responders);
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestedUris.Add(request.RequestUri!);
+            // Reuse the last responder once the queue is down to one (steady-state redirect/payload).
+            var responder = _responders.Count > 1 ? _responders.Dequeue() : _responders.Peek();
+            return Task.FromResult(responder(request));
+        }
     }
 
     #endregion


### PR DESCRIPTION
## #3495 fix 5/N — pin the manual/arbitrary-URL fetch client + retire TOCTOU

Indurisce `SsrfSafeHttpClient`, il **client di download arbitrary-URL** che è l'**unico gate di codice** per la Slice 3 di #3470 (`SetManualCoverCommand`). La spina dorsale del connect-pin (`SsrfPolicy` IANA + `SsrfPinnedConnect` + `ConfigureSsrfPin`) era già a terra (fix 1-3/N); qui il sink manuale viene **cablato ad essa** e riceve i guard che il pin non può esprimere per un URL controllato dall'utente.

### Cosa fa
- **Registra + pinna** `SsrfSafeHttpClient` come typed `HttpClient` con `ConfigureSsrfPin(allowAutoRedirect: false)` → il connect-pin è ora il suo **boundary IP** (DNS-rebinding/redirect-to-internal chiusi by-construction). Aggiunto un param opzionale `allowAutoRedirect` a `ConfigureSsrfPin` (default `true`; i sink a host fisso restano invariati) + un DI seam `AddSsrfSafeHttpClientForTests`.
- **Ritira il TOCTOU**: rimossi `ValidateResolvedIpAsync` (pre-check DNS, intrinsecamente rebindable) e l'ormai inutile `IsPrivateOrReserved`.
- **Re-check schema per-hop (H2)**: follow manuale bounded (≤5 hop, loop-detection) che ri-valida **HTTPS-only** sull'URL iniziale **e su ogni target di redirect**, rigettando i downgrade `http/file/gopher` che il pin lascerebbe passare (ri-controlla solo l'IP). Auto-redirect OFF così i 3xx emergono qui.
- **Cap mid-stream**: sostituito l'unbounded `CopyToAsync` con una lettura a chunk che aborta a limit+1 prima di bufferizzare l'intero payload.

### Test
`SsrfSafeHttpClientTests`: redirect seguito (https) / rigettato (downgrade, loop, >5 hop), cap mid-stream. `SsrfSafeHttpClientPinIntegrationTests`: **pin-integration non-vacuo** — un host che risolve a IP privato fail-closed al connect (`ResolveCalls>0`, prova che il pin è cablato e non silenziosamente droppato). Rimossi i test unit `IsPrivateOrReserved` col metodo (la policy IANA è coperta da `SsrfPolicyTests`). 75/75 verdi sulla superficie SSRF; build Debug+Release puliti.

### Contesto / dipendenze
- Sblocca il **codice** di #3470 Slice 3: `SetManualCoverCommand` consuma questo client pinnato. Vedi gap-analysis su [#3495](https://github.com/meepleAi-app/meepleai-monorepo/issues/3495).
- **#3498** (MinIO/E2E) gate solo gli **acceptance H5** R2-strict di Slice 3, non questa fix.

### Fuori scope (follow-up de-escalati, i vettori P0 live sono chiusi)
Port-anomaly per-hop (H2), decoder hardening (M1), gzip-bomb (C5/L3), circuit-breaker BGG-cover (H8), astrazione `IHardenedEgressClient` + architecture-gate, observability `egress_blocked_total` (M2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
