### PR TITLE
feat(storage): presign-only public endpoint for MinIO/E2E (#3498 partial)

### DIFF
--- a/apps/api/src/Api/Services/Pdf/BlobStorageServiceFactory.cs
+++ b/apps/api/src/Api/Services/Pdf/BlobStorageServiceFactory.cs
@@ -37,6 +37,9 @@ internal static class BlobStorageServiceFactory
         var options = new S3StorageOptions
         {
             Endpoint = config["S3_ENDPOINT"] ?? throw new InvalidOperationException("S3_ENDPOINT is required when STORAGE_PROVIDER=s3"),
+            // Issue #3498: optional presign-only public endpoint (e.g. localhost:9000 for MinIO in E2E)
+            // so browser-fetched presigned covers are signed against a browser-reachable host.
+            PublicEndpoint = config["S3_PUBLIC_ENDPOINT"],
             AccessKey = config["S3_ACCESS_KEY"] ?? throw new InvalidOperationException("S3_ACCESS_KEY is required when STORAGE_PROVIDER=s3"),
             SecretKey = config["S3_SECRET_KEY"] ?? throw new InvalidOperationException("S3_SECRET_KEY is required when STORAGE_PROVIDER=s3"),
             BucketName = config["S3_BUCKET_NAME"] ?? throw new InvalidOperationException("S3_BUCKET_NAME is required when STORAGE_PROVIDER=s3"),
@@ -73,11 +76,31 @@ internal static class BlobStorageServiceFactory
         // simply stop returning 501.
         s3Client.BeforeRequestEvent += StripUnsupportedR2Headers;
 
-        logger.LogInformation(
-            "Initialized S3 storage: endpoint={Endpoint}, bucket={Bucket}, region={Region}, encryption={Encryption}",
-            options.Endpoint, options.BucketName, options.Region, options.EnableEncryption);
+        // Issue #3498: when a distinct public presign endpoint is configured, build a presign-only
+        // client signed against it (SigV4 signs the host). Presigning is pure computation, so this
+        // client never opens a connection — HEAD/existence checks stay on the main client.
+        AmazonS3Client? presignClient = null;
+        if (!string.IsNullOrWhiteSpace(options.PublicEndpoint) &&
+            !string.Equals(options.PublicEndpoint, options.Endpoint, StringComparison.OrdinalIgnoreCase))
+        {
+            var presignConfig = new AmazonS3Config
+            {
+                ServiceURL = options.PublicEndpoint,
+                ForcePathStyle = options.ForcePathStyle,
+                AuthenticationRegion = options.Region
+            };
+            if (!string.Equals(options.Region, "auto", StringComparison.Ordinal) && RegionEndpoint.GetBySystemName(options.Region) != null)
+            {
+                presignConfig.RegionEndpoint = RegionEndpoint.GetBySystemName(options.Region);
+            }
+            presignClient = new AmazonS3Client(credentials, presignConfig);
+        }
 
-        return new S3BlobStorageService(s3Client, options, logger);
+        logger.LogInformation(
+            "Initialized S3 storage: endpoint={Endpoint}, presignEndpoint={PresignEndpoint}, bucket={Bucket}, region={Region}, encryption={Encryption}",
+            options.Endpoint, options.PublicEndpoint ?? options.Endpoint, options.BucketName, options.Region, options.EnableEncryption);
+
+        return new S3BlobStorageService(s3Client, options, logger, presignClient);
     }
 
     /// <summary>

--- a/apps/api/src/Api/Services/Pdf/S3BlobStorageService.cs
+++ b/apps/api/src/Api/Services/Pdf/S3BlobStorageService.cs
@@ -12,17 +12,23 @@ namespace Api.Services.Pdf;
 internal sealed class S3BlobStorageService : IBlobStorageService
 {
     private readonly IAmazonS3 _s3Client;
+    private readonly IAmazonS3 _presignClient;
     private readonly S3StorageOptions _options;
     private readonly ILogger<S3BlobStorageService> _logger;
 
+    // Issue #3498: `presignClient` (optional) is configured against S3StorageOptions.PublicEndpoint
+    // and used ONLY to sign presigned URLs (SigV4 signs the host). Defaults to `s3Client` when the
+    // store host is already browser-reachable (prod R2/AWS). HEAD/existence checks always use `s3Client`.
     public S3BlobStorageService(
         IAmazonS3 s3Client,
         S3StorageOptions options,
-        ILogger<S3BlobStorageService> logger)
+        ILogger<S3BlobStorageService> logger,
+        IAmazonS3? presignClient = null)
     {
         _s3Client = s3Client ?? throw new ArgumentNullException(nameof(s3Client));
         _options = options ?? throw new ArgumentNullException(nameof(options));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _presignClient = presignClient ?? s3Client;
     }
 
     /// <summary>
@@ -333,7 +339,7 @@ internal sealed class S3BlobStorageService : IBlobStorageService
                 Verb = HttpVerb.GET
             };
 
-            var url = await _s3Client.GetPreSignedURLAsync(request).ConfigureAwait(false);
+            var url = await _presignClient.GetPreSignedURLAsync(request).ConfigureAwait(false);
 
             _logger.LogInformation(
                 "Generated pre-signed URL for {Key} (expires in {Expiry}s)",
@@ -397,7 +403,7 @@ internal sealed class S3BlobStorageService : IBlobStorageService
                 Verb = HttpVerb.GET
             };
 
-            var url = await _s3Client.GetPreSignedURLAsync(request).ConfigureAwait(false);
+            var url = await _presignClient.GetPreSignedURLAsync(request).ConfigureAwait(false);
 
             _logger.LogInformation(
                 "Generated pre-signed URL for raw key {Key} (expires in {Expiry}s)",

--- a/apps/api/src/Api/Services/Pdf/S3StorageOptions.cs
+++ b/apps/api/src/Api/Services/Pdf/S3StorageOptions.cs
@@ -12,6 +12,16 @@ internal sealed class S3StorageOptions
     public required string Endpoint { get; init; }
 
     /// <summary>
+    /// Optional public endpoint used ONLY to generate presigned URLs (issue #3498). SigV4 signs the
+    /// host, so when server-side ops reach the store on a private/container hostname
+    /// (e.g. <c>http://minio:9000</c>) but the browser must fetch presigned covers from a different
+    /// host (e.g. <c>http://localhost:9000</c>), presigns must be signed against THIS endpoint. When
+    /// null/empty (prod: R2/AWS, where the store host is publicly reachable) presigns use
+    /// <see cref="Endpoint"/>. HEAD/existence checks always use <see cref="Endpoint"/>.
+    /// </summary>
+    public string? PublicEndpoint { get; init; }
+
+    /// <summary>
     /// S3 access key ID
     /// </summary>
     public required string AccessKey { get; init; }

--- a/apps/api/tests/Api.Tests/Unit/Services/S3BlobStorageServiceTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/Services/S3BlobStorageServiceTests.cs
@@ -697,6 +697,34 @@ public sealed class S3BlobStorageServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task GetPresignedUrlForRawKeyAsync_SignsWithPresignClient_HeadStaysOnMainClient()
+    {
+        // Issue #3498: when a distinct presign client is supplied it (the public-endpoint client)
+        // must sign the URL, while the HEAD/existence check stays on the main (private/container)
+        // client — SigV4 signs the host, so the browser-reachable host must be the one signed.
+        var rawKey = $"covers/{Guid.NewGuid():D}/cover.webp";
+        var presignUrl = $"http://localhost:9000/test-bucket/{rawKey}?X-Amz-Signature=sig";
+
+        var presignMock = new Mock<IAmazonS3>();
+        presignMock.Setup(x => x.GetPreSignedURLAsync(It.IsAny<GetPreSignedUrlRequest>()))
+            .ReturnsAsync(presignUrl);
+
+        _mockS3Client.Setup(x => x.GetObjectMetadataAsync("test-bucket", rawKey, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetObjectMetadataResponse { HttpStatusCode = HttpStatusCode.OK });
+
+        var sut = new S3BlobStorageService(_mockS3Client.Object, _options, _mockLogger.Object, presignMock.Object);
+
+        var result = await sut.GetPresignedUrlForRawKeyAsync(rawKey);
+
+        result.Should().Be(presignUrl);
+        presignMock.Verify(x => x.GetPreSignedURLAsync(It.IsAny<GetPreSignedUrlRequest>()), Times.Once);
+        // The main client signed nothing — it only performed the HEAD existence check.
+        _mockS3Client.Verify(x => x.GetPreSignedURLAsync(It.IsAny<GetPreSignedUrlRequest>()), Times.Never);
+        _mockS3Client.Verify(
+            x => x.GetObjectMetadataAsync("test-bucket", rawKey, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
     public async Task GetPresignedUrlForRawKeyAsync_ObjectMissing_ReturnsNull()
     {
         // Arrange


### PR DESCRIPTION
## #3498 (parziale) — presign-only public endpoint per MinIO/E2E

Landa la **metà codice** di #3498: il **meccanismo di raggiungibilità** che serve all'assert R2-strict delle cover.

### Il problema risolto
MinIO presigna verso il **proprio** endpoint (`http://minio:9000`), un hostname di container che il browser Playwright **non può raggiungere** → una cover presigned dà 404. E poiché **SigV4 firma l'host**, l'host raggiungibile dal browser dev'essere quello **firmato** (non basta riscrivere l'URL a valle).

### Cosa fa
- `S3StorageOptions` guadagna un **`PublicEndpoint`** opzionale (bind da `S3_PUBLIC_ENDPOINT`, es. `http://localhost:9000`). Se impostato (e ≠ `Endpoint`), la factory costruisce un **client di presign** firmato contro di esso; il presign è pura computazione → non apre mai una connessione.
- `S3BlobStorageService` instrada i due `GetPreSignedURLAsync` su quel client; gli **HEAD/existence check restano sul client principale** (endpoint di container). In prod (R2/AWS, store host già pubblico) `PublicEndpoint` resta null → **comportamento invariato**.
- Unit test: presign firmato dal client di presign, HEAD sul principale, il principale non firma nulla. 25/25 verdi, build Debug+Release puliti.

### Non in questa PR (richiede l'harness real-backend E2E + iterazione CI, non validabile in locale)
Scoperta durante l'investigazione: il test R2-strict `cover-l4.spec.ts` (fixme) vive nel suite **library-E2E mockato** (`next start` + `page.route`), non in un backend reale. Chiuderlo davvero richiede l'harness **real-backend** (`e2e-smoke-real-backend.yml`) con MinIO + dati seminati:
- Wire `STORAGE_PROVIDER=s3` + `S3_PUBLIC_ENDPOINT=localhost:9000` + MinIO (già nel `docker-compose.yml`) nel job real-backend, health-gated.
- Spostare il cover-strict test lì con **assert real-load** (`naturalWidth>0` / intercept 200), rimuovere il `test.fixme`.
- **Lint gate** anti-`.fixme` (coupled all'un-fixme → non può landare prima).

Questa PR landa la metà codice così che il follow-up sia **puro wiring infra** (iterabile sulla CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
