### PR TITLE
feat(catalog): SharedGame.SetManualCover domain foundation (#3470 Slice 3a)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/SharedGame.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/SharedGame.cs
@@ -61,6 +61,14 @@ public sealed class SharedGame : AggregateRoot<Guid>
     private string? _wikidataCoverAttribution;
     private string? _wikidataCoverSourceUrl;
     private DateTime? _wikidataQidLastVerifiedAt;
+    // Epic #3470 Slice 3a — admin manual cover (URL path): the pinned source's R2 key plus the
+    // attested license/attribution/source URL and who attested it, when.
+    private string? _manualCoverR2Key;
+    private string? _manualCoverLicense;
+    private string? _manualCoverAttribution;
+    private string? _manualCoverSourceUrl;
+    private Guid? _manualCoverAttestedBy;
+    private DateTime? _manualCoverAttestedAt;
     private bool _isDeleted;
     private Guid _createdBy;
     private Guid? _modifiedBy;
@@ -211,6 +219,24 @@ public sealed class SharedGame : AggregateRoot<Guid>
     /// (e.g. <c>https://www.wikidata.org/wiki/Q98056728</c>). Issue #1823.
     /// </summary>
     public string? WikidataCoverSourceUrl => _wikidataCoverSourceUrl;
+
+    /// <summary>Epic #3470 Slice 3a — suffix-free R2 key of the admin manual cover, or null.</summary>
+    public string? ManualCoverR2Key => _manualCoverR2Key;
+
+    /// <summary>Epic #3470 Slice 3a — attested license of the manual cover (whitelisted at set time).</summary>
+    public string? ManualCoverLicense => _manualCoverLicense;
+
+    /// <summary>Epic #3470 Slice 3a — attribution of the manual cover, or null.</summary>
+    public string? ManualCoverAttribution => _manualCoverAttribution;
+
+    /// <summary>Epic #3470 Slice 3a — source URL the manual cover was fetched from.</summary>
+    public string? ManualCoverSourceUrl => _manualCoverSourceUrl;
+
+    /// <summary>Epic #3470 Slice 3a — admin who attested the manual cover's license.</summary>
+    public Guid? ManualCoverAttestedBy => _manualCoverAttestedBy;
+
+    /// <summary>Epic #3470 Slice 3a — UTC instant the manual cover was attested.</summary>
+    public DateTime? ManualCoverAttestedAt => _manualCoverAttestedAt;
 
     /// <summary>
     /// Gets the timestamp of the last successful enrichment / re-verification of
@@ -379,7 +405,13 @@ public sealed class SharedGame : AggregateRoot<Guid>
         string? wikidataCoverLicense = null,
         string? wikidataCoverAttribution = null,
         string? wikidataCoverSourceUrl = null,
-        DateTime? wikidataQidLastVerifiedAt = null) : base(id)
+        DateTime? wikidataQidLastVerifiedAt = null,
+        string? manualCoverR2Key = null,
+        string? manualCoverLicense = null,
+        string? manualCoverAttribution = null,
+        string? manualCoverSourceUrl = null,
+        Guid? manualCoverAttestedBy = null,
+        DateTime? manualCoverAttestedAt = null) : base(id)
     {
         _id = id;
         _title = title;
@@ -404,6 +436,12 @@ public sealed class SharedGame : AggregateRoot<Guid>
         _wikidataCoverAttribution = wikidataCoverAttribution;
         _wikidataCoverSourceUrl = wikidataCoverSourceUrl;
         _wikidataQidLastVerifiedAt = wikidataQidLastVerifiedAt;
+        _manualCoverR2Key = manualCoverR2Key;
+        _manualCoverLicense = manualCoverLicense;
+        _manualCoverAttribution = manualCoverAttribution;
+        _manualCoverSourceUrl = manualCoverSourceUrl;
+        _manualCoverAttestedBy = manualCoverAttestedBy;
+        _manualCoverAttestedAt = manualCoverAttestedAt;
         _isDeleted = isDeleted;
         _createdBy = createdBy;
         _modifiedBy = modifiedBy;
@@ -805,6 +843,41 @@ public sealed class SharedGame : AggregateRoot<Guid>
         _wikidataCoverAttribution = string.IsNullOrWhiteSpace(attribution) ? null : attribution;
         _wikidataCoverSourceUrl = sourceUrl;
         _wikidataQidLastVerifiedAt = verifiedAt;
+    }
+
+    /// <summary>
+    /// Epic #3470 Slice 3a — pins an admin-supplied manual cover (fetched from a URL, re-encoded to
+    /// WebP, uploaded to R2). Captures the attested license/attribution/source URL and the attester
+    /// so the manual path carries its own copyright evidence (the caller MUST have validated the
+    /// license against the whitelist and persisted the R2 object before calling this).
+    /// </summary>
+    /// <exception cref="ArgumentException">Any required field is empty, or attestedBy is empty.</exception>
+    public void SetManualCover(
+        string r2Key,
+        string license,
+        string? attribution,
+        string sourceUrl,
+        Guid attestedBy,
+        DateTime attestedAt)
+    {
+        if (string.IsNullOrWhiteSpace(r2Key))
+            throw new ArgumentException("R2 key cannot be empty.", nameof(r2Key));
+
+        if (string.IsNullOrWhiteSpace(license))
+            throw new ArgumentException("License cannot be empty.", nameof(license));
+
+        if (string.IsNullOrWhiteSpace(sourceUrl))
+            throw new ArgumentException("Source URL cannot be empty.", nameof(sourceUrl));
+
+        if (attestedBy == Guid.Empty)
+            throw new ArgumentException("AttestedBy cannot be empty.", nameof(attestedBy));
+
+        _manualCoverR2Key = r2Key;
+        _manualCoverLicense = license;
+        _manualCoverAttribution = string.IsNullOrWhiteSpace(attribution) ? null : attribution;
+        _manualCoverSourceUrl = sourceUrl;
+        _manualCoverAttestedBy = attestedBy;
+        _manualCoverAttestedAt = attestedAt;
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/SharedGameRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/SharedGameRepository.cs
@@ -385,7 +385,13 @@ internal sealed class SharedGameRepository : RepositoryBase, ISharedGameReposito
             wikidataCoverLicense: entity.WikidataCoverLicense,
             wikidataCoverAttribution: entity.WikidataCoverAttribution,
             wikidataCoverSourceUrl: entity.WikidataCoverSourceUrl,
-            wikidataQidLastVerifiedAt: entity.WikidataQidLastVerifiedAt);
+            wikidataQidLastVerifiedAt: entity.WikidataQidLastVerifiedAt,
+            manualCoverR2Key: entity.ManualCoverR2Key,
+            manualCoverLicense: entity.ManualCoverLicense,
+            manualCoverAttribution: entity.ManualCoverAttribution,
+            manualCoverSourceUrl: entity.ManualCoverSourceUrl,
+            manualCoverAttestedBy: entity.ManualCoverAttestedBy,
+            manualCoverAttestedAt: entity.ManualCoverAttestedAt);
 
         // Issue #2035: Hydrate designers from the M:N join — only when the caller
         // eager-loaded the navigation (GetByIdAsync), otherwise the EF Core
@@ -451,6 +457,13 @@ internal sealed class SharedGameRepository : RepositoryBase, ISharedGameReposito
             WikidataCoverAttribution = game.WikidataCoverAttribution,
             WikidataCoverSourceUrl = game.WikidataCoverSourceUrl,
             WikidataQidLastVerifiedAt = game.WikidataQidLastVerifiedAt,
+            // Epic #3470 Slice 3a — manual cover columns (omitting them here would zero them on update).
+            ManualCoverR2Key = game.ManualCoverR2Key,
+            ManualCoverLicense = game.ManualCoverLicense,
+            ManualCoverAttribution = game.ManualCoverAttribution,
+            ManualCoverSourceUrl = game.ManualCoverSourceUrl,
+            ManualCoverAttestedBy = game.ManualCoverAttestedBy,
+            ManualCoverAttestedAt = game.ManualCoverAttestedAt,
             // SearchVector managed by PostgreSQL trigger
             CreatedBy = game.CreatedBy,
             ModifiedBy = game.ModifiedBy,

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Aggregates/SharedGameTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Aggregates/SharedGameTests.cs
@@ -1384,4 +1384,62 @@ public sealed class SharedGameTests
     }
 
     #endregion
+
+    #region SetManualCover (epic #3470 Slice 3a)
+
+    private static SharedGame NewManualCoverGame() => SharedGame.Create(
+        "Catan", 2010, "desc", 3, 4, 90, 10, 2.5m, 7.8m,
+        "https://example.com/c.jpg", "https://example.com/c-thumb.jpg", null, Guid.NewGuid());
+
+    [Fact]
+    public void SetManualCover_ValidInput_SetsAllFields()
+    {
+        var game = NewManualCoverGame();
+        var admin = Guid.NewGuid();
+        var attestedAt = DateTime.UtcNow;
+
+        game.SetManualCover("covers/manual/x/cover", "CC-BY-4.0", "Jane Artist", "https://example.com/src", admin, attestedAt);
+
+        game.ManualCoverR2Key.Should().Be("covers/manual/x/cover");
+        game.ManualCoverLicense.Should().Be("CC-BY-4.0");
+        game.ManualCoverAttribution.Should().Be("Jane Artist");
+        game.ManualCoverSourceUrl.Should().Be("https://example.com/src");
+        game.ManualCoverAttestedBy.Should().Be(admin);
+        game.ManualCoverAttestedAt.Should().Be(attestedAt);
+    }
+
+    [Fact]
+    public void SetManualCover_BlankAttribution_StoresNull()
+    {
+        var game = NewManualCoverGame();
+
+        game.SetManualCover("k", "CC0", "   ", "https://s", Guid.NewGuid(), DateTime.UtcNow);
+
+        game.ManualCoverAttribution.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("", "CC0", "https://s")]  // empty r2Key
+    [InlineData("k", "", "https://s")]    // empty license
+    [InlineData("k", "CC0", "")]          // empty sourceUrl
+    public void SetManualCover_MissingRequiredField_Throws(string r2Key, string license, string sourceUrl)
+    {
+        var game = NewManualCoverGame();
+
+        var act = () => game.SetManualCover(r2Key, license, null, sourceUrl, Guid.NewGuid(), DateTime.UtcNow);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void SetManualCover_EmptyAttestedBy_Throws()
+    {
+        var game = NewManualCoverGame();
+
+        var act = () => game.SetManualCover("k", "CC0", null, "https://s", Guid.Empty, DateTime.UtcNow);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## #3470 Slice 3a (dominio) — `SharedGame.SetManualCover`

Prima fetta della Slice 3 (cover da URL manuale). Il gate di codice (#3534 pin + #3535 presign) è già mergiato; questa aggiunge la **metà dominio** che il futuro `SetManualCoverCommand` guiderà.

### Cosa fa
- **`SharedGame`**: 6 campi manual-cover + getter + **`SetManualCover(r2Key, license, attribution, sourceUrl, attestedBy, attestedAt)`** — validato come `SetWikidataCover` (required non vuoti, `attestedBy` non vuoto, attribution blank → null).
- **`Reconstitute`**: 6 param manual (defaulted → caller esistenti invariati).
- **`SharedGameRepository.MapToEntity`**: persiste le colonne manual su insert **e** sul path `.Update()` (ometterle azzererebbe le colonne su update — memory NoTracking/detached-graph); la chiamata `Reconstitute` le rilegge → round-trip set→persist→reload.
- **6 test aggregato**; **98/98** test dominio SharedGame verdi (zero regressioni). Build Debug+Release puliti.

### Prossimo (Slice 3a-2, separato)
`SetManualCoverCommand` + validator + handler (fetch via `SsrfSafeHttpClient` pinnato #3534, license-gate `LicenseValidator`, WebP re-encode → R2 raw-key put `CoverKeyBuilder.ForManual`, persist via `SetManualCover`) + endpoint admin. Rinviati: `RevokeManualCover`, host deny-list esplicita, evidence-audit same-transaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
