### PR TITLE
fix(rag): SmolDocling adapter fix + Fase 0 close (SP0 #3435)

### DIFF
--- a/apps/smoldocling-service/src/application/quality_calculator.py
+++ b/apps/smoldocling-service/src/application/quality_calculator.py
@@ -2,7 +2,7 @@
 import logging
 from typing import List
 
-from ..domain.models import QualityScore, PageExtractionResult
+from ..domain.models import QualityScore, PageExtractionResult, STRUCTURE_TAGS
 from ..config import settings
 
 logger = logging.getLogger(__name__)
@@ -95,31 +95,37 @@ class QualityScoreCalculator:
         VLM-specific scoring based on detected elements:
         - Tables detected: +0.4
         - Equations detected: +0.3
-        - Structure (sections, paragraphs): +0.3
+        - Structure (text/section-header/caption/page-header DocTags): +0.3
         """
         if not page_results:
+            return 0.0
+
+        # Only pages that actually contributed content count — mirrors
+        # _calculate_average_confidence / _calculate_page_coverage. Without this, a page
+        # whose markdown conversion failed (is_empty, dropped from the corpus) would still
+        # inflate the layout score via its has_tables/doctags_text (issue #3435).
+        non_empty_pages = [page for page in page_results if not page.is_empty]
+        if not non_empty_pages:
             return 0.0
 
         score = 0.0
 
         # Tables detected
-        pages_with_tables = sum(1 for page in page_results if page.has_tables)
+        pages_with_tables = sum(1 for page in non_empty_pages if page.has_tables)
         if pages_with_tables > 0:
             score += 0.4
 
         # Equations detected
-        pages_with_equations = sum(1 for page in page_results if page.has_equations)
+        pages_with_equations = sum(1 for page in non_empty_pages if page.has_equations)
         if pages_with_equations > 0:
             score += 0.3
 
-        # Structure detected: match the DocTags tags docling actually parses into content
-        # (<text>/<section_header_*>/<caption>/...); the old </section>/</paragraph> checks
-        # never matched real SmolDocling output (issue #3435).
-        structure_tags = ("<text>", "<section_header", "<list_item>", "<caption>", "<page_header>")
+        # Structure detected: real DocTags tags docling parses into content (STRUCTURE_TAGS);
+        # the old </section>/</paragraph> checks never matched SmolDocling output (issue #3435).
         pages_with_structure = sum(
             1
-            for page in page_results
-            if any(tag in page.doctags_text for tag in structure_tags)
+            for page in non_empty_pages
+            if any(tag in page.doctags_text for tag in STRUCTURE_TAGS)
         )
         if pages_with_structure > 0:
             score += 0.3

--- a/apps/smoldocling-service/src/application/quality_calculator.py
+++ b/apps/smoldocling-service/src/application/quality_calculator.py
@@ -112,11 +112,14 @@ class QualityScoreCalculator:
         if pages_with_equations > 0:
             score += 0.3
 
-        # Structure detected (check for DocTags markup)
+        # Structure detected: match the DocTags tags docling actually parses into content
+        # (<text>/<section_header_*>/<caption>/...); the old </section>/</paragraph> checks
+        # never matched real SmolDocling output (issue #3435).
+        structure_tags = ("<text>", "<section_header", "<list_item>", "<caption>", "<page_header>")
         pages_with_structure = sum(
             1
             for page in page_results
-            if "</section>" in page.doctags_text or "</paragraph>" in page.doctags_text
+            if any(tag in page.doctags_text for tag in structure_tags)
         )
         if pages_with_structure > 0:
             score += 0.3

--- a/apps/smoldocling-service/src/domain/models.py
+++ b/apps/smoldocling-service/src/domain/models.py
@@ -5,6 +5,15 @@ from typing import List, Dict, Any, Optional
 from PIL import Image
 
 
+# DocTags structure tags used as a "page has structured layout" signal, matched as
+# substrings on the raw doctags_text (tokenization is irrelevant). Only tags that
+# docling-core actually parses into content are listed (verified: <text> and
+# <section_header_*> export to markdown; the vocab's <paragraph>/<list_item> do NOT).
+# Single source of truth, shared by SmolDoclingAdapter._estimate_confidence and
+# QualityScoreCalculator._calculate_layout_detection (was duplicated + drift-prone).
+STRUCTURE_TAGS = ("<text>", "<section_header", "<caption>", "<page_header>")
+
+
 @dataclass
 class PageImage:
     """Represents a single page converted to image"""

--- a/apps/smoldocling-service/src/domain/models.py
+++ b/apps/smoldocling-service/src/domain/models.py
@@ -41,8 +41,15 @@ class PageExtractionResult:
 
     @property
     def is_empty(self) -> bool:
-        """Check if page extraction is empty"""
-        return len(self.doctags_text.strip()) == 0
+        """Check if the page yields no usable text content.
+
+        Keyed on ``markdown_text`` (the rendered content that becomes RAG chunks), NOT
+        on ``doctags_text``: after issue #3435 the raw DocTags markup (``<doctag>``,
+        ``<loc_*>``, ``<otsl>``, ...) is retained in ``doctags_text``, so a
+        structural-wrapper-only page (e.g. a blank page emitting ``<doctag></doctag>``)
+        has non-empty DocTags but empty markdown and must still count as empty.
+        """
+        return len(self.markdown_text.strip()) == 0
 
 
 @dataclass

--- a/apps/smoldocling-service/src/infrastructure/smoldocling_adapter.py
+++ b/apps/smoldocling-service/src/infrastructure/smoldocling_adapter.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 from transformers import AutoProcessor, AutoModelForImageTextToText
 from docling_core.types.doc.document import DoclingDocument, DocTagsDocument
 
-from ..domain.models import PageImage, PageExtractionResult
+from ..domain.models import PageImage, PageExtractionResult, STRUCTURE_TAGS
 from ..config import settings
 
 logger = logging.getLogger(__name__)
@@ -29,17 +29,8 @@ class SmolDoclingAdapter:
     # Instruction handed to the VLM via the chat template (official SmolDocling recipe).
     _PROMPT_TEXT = "Convert this page to docling."
 
-    # Real DocTags structure tags — the ones docling-core actually parses into content
-    # (verified: <text>/<section_header_*> export to markdown; the vocab's <paragraph>/
-    # <list_item> do NOT). Matched as substrings, so tokenization is irrelevant. Used as a
-    # "page has structured layout" signal.
-    _STRUCTURE_TAGS = (
-        "<text>",
-        "<section_header",
-        "<list_item>",
-        "<caption>",
-        "<page_header>",
-    )
+    # "Page has structured layout" signal — single source of truth in domain.models.
+    _STRUCTURE_TAGS = STRUCTURE_TAGS
 
     def __init__(self):
         self.settings = settings
@@ -266,7 +257,7 @@ class SmolDoclingAdapter:
             doctags_text: Raw DocTags output from SmolDocling
 
         Returns:
-            Markdown-formatted text
+            Markdown-formatted text, or "" if conversion fails (never raw DocTags markup).
         """
         try:
             doctags_doc = DocTagsDocument.from_doctags_and_image_pairs(

--- a/apps/smoldocling-service/src/infrastructure/smoldocling_adapter.py
+++ b/apps/smoldocling-service/src/infrastructure/smoldocling_adapter.py
@@ -14,6 +14,33 @@ logger = logging.getLogger(__name__)
 class SmolDoclingAdapter:
     """Adapter for SmolDocling VLM model (256M parameters)"""
 
+    # True chat/control special tokens to strip from the decoded output. These are
+    # NOT DocTags markup — the DocTags tokens (<loc_*>, <otsl>, <fcel>, <doctag>, ...)
+    # must be preserved for region-grounding + table structure (issue #3435, spec §5ter).
+    _CONTROL_TOKENS = (
+        "<|im_start|>",
+        "<|im_end|>",
+        "<|endoftext|>",
+        "<end_of_utterance>",
+        "<fake_token_around_image>",
+        "<image>",
+    )
+
+    # Instruction handed to the VLM via the chat template (official SmolDocling recipe).
+    _PROMPT_TEXT = "Convert this page to docling."
+
+    # Real DocTags structure tags — the ones docling-core actually parses into content
+    # (verified: <text>/<section_header_*> export to markdown; the vocab's <paragraph>/
+    # <list_item> do NOT). Matched as substrings, so tokenization is irrelevant. Used as a
+    # "page has structured layout" signal.
+    _STRUCTURE_TAGS = (
+        "<text>",
+        "<section_header",
+        "<list_item>",
+        "<caption>",
+        "<page_header>",
+    )
+
     def __init__(self):
         self.settings = settings
         self.device = self._get_device()
@@ -98,9 +125,27 @@ class SmolDoclingAdapter:
         logger.debug(f"Processing page {page_image.page_number} with SmolDocling VLM")
 
         try:
-            # Prepare inputs
+            # Build the chat prompt (official SmolDocling recipe). The Idefics3Processor
+            # only emits input_ids when a text prompt is supplied (processing_idefics3.py:
+            # input_ids is added inside `if text is not None:`); calling it images-only
+            # yields no input_ids, so generation cannot align the <image> tokens and the
+            # prompt-trim below would KeyError (issue #3435).
+            messages = [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image"},
+                        {"type": "text", "text": self._PROMPT_TEXT},
+                    ],
+                }
+            ]
+            prompt = self.processor.apply_chat_template(
+                messages, add_generation_prompt=True
+            )
+
+            # Prepare inputs (text + image so input_ids and the image tokens are aligned)
             inputs = self.processor(
-                images=page_image.image, return_tensors="pt"
+                text=prompt, images=[page_image.image], return_tensors="pt"
             ).to(self.device)
 
             # Some processor outputs (rows/cols) are unused by the current model
@@ -120,17 +165,32 @@ class SmolDoclingAdapter:
                     do_sample=False,  # Deterministic output
                 )
 
-            # Decode output
-            doctags_text = self.processor.batch_decode(
-                generated_ids, skip_special_tokens=True
+            # Trim the prompt (image/instruction placeholder tokens) so only the newly
+            # generated DocTags are decoded — matches the official SmolDocling recipe
+            # (generated_ids[:, prompt_length:]). If the model generated nothing beyond
+            # the prompt, the slice is empty and decode yields "" (clean degradation, R5)
+            # rather than leaking prompt/instruction text into doctags_text.
+            prompt_len = filtered_inputs["input_ids"].shape[1]
+            generated_ids = generated_ids[:, prompt_len:]
+
+            # Decode WITH special tokens: DocTags markup (<loc_*>, <otsl>, <fcel>, ...)
+            # is flagged `special` in the tokenizer, so skip_special_tokens=True would
+            # strip the location coordinates and table structure this feature needs
+            # (issue #3435, spec §5ter). We decode everything, then remove only the true
+            # chat/control tokens in _clean_doctags().
+            raw_doctags = self.processor.batch_decode(
+                generated_ids, skip_special_tokens=False
             )[0]
+            doctags_text = self._clean_doctags(raw_doctags)
 
             # Convert to Markdown using Docling
             markdown_text = self._convert_to_markdown(doctags_text)
 
-            # Extract metadata
-            has_tables = "<table>" in doctags_text.lower()
-            has_equations = "<equation>" in doctags_text.lower() or "$" in doctags_text
+            # Extract metadata. SmolDocling emits tables in OTSL (<otsl>) and formulas as
+            # <formula> — never <table>/<equation>. The old `"$" in doctags_text` heuristic
+            # false-positived on any rulebook price ("pay $5"), so it is dropped (#3435).
+            has_tables = self._detect_has_tables(doctags_text)
+            has_equations = "<formula>" in doctags_text.lower()
 
             # Calculate confidence (placeholder - SmolDocling doesn't return confidence scores)
             # In production, could use token probability if needed
@@ -168,6 +228,36 @@ class SmolDoclingAdapter:
                 confidence_score=0.0,
             )
 
+    def _clean_doctags(self, raw: str) -> str:
+        """
+        Remove chat/control special tokens from a DocTags decode while PRESERVING
+        the DocTags markup (location + structure tokens).
+
+        The output is decoded with ``skip_special_tokens=False`` so that DocTags tokens
+        survive; this strips only the true control tokens (``<|im_end|>``,
+        ``<end_of_utterance>``, image placeholders, ...) — see ``_CONTROL_TOKENS``.
+
+        Args:
+            raw: Raw decoded text (special tokens NOT skipped)
+
+        Returns:
+            DocTags text with control tokens removed, whitespace-trimmed
+        """
+        text = raw
+        for control in self._CONTROL_TOKENS:
+            text = text.replace(control, "")
+        return text.strip()
+
+    @staticmethod
+    def _detect_has_tables(doctags_text: str) -> bool:
+        """
+        Detect whether the DocTags output contains a table.
+
+        SmolDocling renders tables in OTSL (``<otsl>``/``<fcel>``), NOT as ``<table>``;
+        looking for ``<table>`` (the previous behaviour) never matched (issue #3435).
+        """
+        return "<otsl>" in doctags_text.lower()
+
     def _convert_to_markdown(self, doctags_text: str) -> str:
         """
         Convert DocTags markup to Markdown
@@ -187,8 +277,12 @@ class SmolDoclingAdapter:
             return docling_doc.export_to_markdown()
 
         except Exception as e:
-            logger.warning("Markdown conversion failed, returning raw DocTags text: %s", e)
-            return doctags_text
+            # Do NOT fall back to raw DocTags: doctags_text now carries markup
+            # (<loc_*>, <otsl>, <fcel>, ...) that would pollute the RAG corpus and the
+            # /preprocess extracted_text handed to the LLM (issue #3435). Return "" so the
+            # page is treated as empty (is_empty) instead of ingesting markup as content.
+            logger.warning("Markdown conversion failed, dropping page content: %s", e)
+            return ""
 
     def _estimate_confidence(self, doctags_text: str) -> float:
         """
@@ -208,12 +302,15 @@ class SmolDoclingAdapter:
 
         score = 0.7  # Base score for non-empty output
 
-        # Heuristics (rough estimates)
+        # Heuristics (rough estimates). Tags aligned with SmolDocling's real DocTags
+        # vocabulary: OTSL tables (<otsl>) and formulas (<formula>), and structure tags
+        # verified in the tokenizer vocab — the old <table>/<equation>/</section> checks
+        # never matched real output (issue #3435).
         if len(doctags_text) > 500:
             score += 0.1  # Substantial text extracted
-        if "<table>" in doctags_text or "<equation>" in doctags_text:
+        if self._detect_has_tables(doctags_text) or "<formula>" in doctags_text.lower():
             score += 0.1  # Structured elements detected
-        if "</section>" in doctags_text or "</paragraph>" in doctags_text:
+        if any(tag in doctags_text for tag in self._STRUCTURE_TAGS):
             score += 0.1  # Proper structure
 
         return min(score, 1.0)

--- a/apps/smoldocling-service/tests/test_quality_calculator.py
+++ b/apps/smoldocling-service/tests/test_quality_calculator.py
@@ -1,0 +1,49 @@
+"""
+Tests for QualityScoreCalculator — layout detection must ignore empty pages (issue #3435).
+
+Regression guard for the code-review finding: _calculate_layout_detection counted
+has_tables/has_equations/structure over ALL pages, unlike _calculate_average_confidence
+and _calculate_page_coverage which filter is_empty. After the DocTags decode fix
+(is_empty keyed on markdown_text + _convert_to_markdown returning "" on failure), a page
+whose conversion failed is dropped from the corpus but its has_tables/doctags_text would
+still inflate the layout score. Layout detection now filters is_empty too.
+"""
+from src.application.quality_calculator import QualityScoreCalculator
+from src.domain.models import PageExtractionResult, STRUCTURE_TAGS
+
+
+def _page(markdown, doctags, has_tables=False, has_equations=False):
+    return PageExtractionResult(
+        page_number=1,
+        doctags_text=doctags,
+        markdown_text=markdown,
+        char_count=len(markdown),
+        has_tables=has_tables,
+        has_equations=has_equations,
+        confidence_score=0.8,
+    )
+
+
+def test_layout_detection_ignores_empty_pages():
+    calc = QualityScoreCalculator()
+    # markdown conversion failed → markdown_text "" → is_empty True, but has_tables=True
+    # from doctags_text (metadata computed before conversion). Must NOT inflate the score.
+    dropped = _page(markdown="", doctags="<doctag><otsl><fcel>x<nl></otsl></doctag>", has_tables=True)
+    assert dropped.is_empty is True
+    assert calc._calculate_layout_detection([dropped]) == 0.0
+
+
+def test_layout_detection_counts_non_empty_table_page():
+    calc = QualityScoreCalculator()
+    real = _page(markdown="| a | b |", doctags="<doctag><otsl><fcel>a<nl></otsl></doctag>", has_tables=True)
+    assert real.is_empty is False
+    assert calc._calculate_layout_detection([real]) >= 0.4  # table bonus applies
+
+
+def test_layout_detection_structure_bonus_uses_shared_tags():
+    calc = QualityScoreCalculator()
+    # a non-empty page with a real structure tag gets the structure bonus
+    page = _page(markdown="Regole", doctags="<doctag><text>Regole</text></doctag>")
+    assert "<text>" in STRUCTURE_TAGS
+    assert "<list_item>" not in STRUCTURE_TAGS  # dropped: docling does not parse it (#3435)
+    assert calc._calculate_layout_detection([page]) >= 0.3

--- a/apps/smoldocling-service/tests/test_smoldocling_adapter.py
+++ b/apps/smoldocling-service/tests/test_smoldocling_adapter.py
@@ -1,0 +1,268 @@
+"""
+Tests for SmolDoclingAdapter DocTags decoding — fix P1/P2 + review hardening (issue #3435).
+
+Context (spec v1.3 §5ter + adversarial review):
+  - P1: decode with skip_special_tokens=False + trim prompt + strip ONLY chat/control
+        tokens, so DocTags markup (<loc_*>, <otsl>, <fcel>) survives for region grounding.
+  - P2: has_tables checks <otsl> (OTSL), not <table>.
+  - #6: build the chat prompt via apply_chat_template — the real Idefics3Processor only
+        emits input_ids when text= is supplied, so the images-only call produced no
+        input_ids and broke generation + the prompt trim.
+  - #2/#3: content-free / conversion-failed pages must count as empty, never leak markup.
+  - #4/#8/#10: confidence/has_equations aligned to real DocTags tags (<otsl>/<formula>).
+
+The 256M model is never loaded — lightweight fakes stand in for processor/model, mirroring
+the mock pattern in test_metrics.py. The fakes intentionally reproduce two real contracts:
+  (a) the processor yields input_ids ONLY when text is not None (Idefics3Processor);
+  (b) batch_decode is a function of the ids it receives (so trim/leak is observable).
+"""
+import torch
+import pytest
+from PIL import Image
+
+from src.infrastructure.smoldocling_adapter import SmolDoclingAdapter
+from src.domain.models import PageImage, PageExtractionResult
+
+
+# Realistic raw decode (skip_special_tokens=False): DocTags markup + OTSL table wrapped in
+# the chat/control tokens that must be stripped.
+RAW_DOCTAGS = (
+    "<|im_start|>"
+    "<doctag>"
+    "<text><loc_44><loc_43><loc_461><loc_59>Campo arato vale 1 punto</text>"
+    "<otsl><loc_50><loc_100><loc_450><loc_300>"
+    "<fcel>Campo arato<fcel>1<nl><fcel>Pascolo<fcel>1<nl></otsl>"
+    "</doctag>"
+    "<end_of_utterance><|im_end|>"
+)
+
+# Text-only page (no OTSL table): a text element with location tokens.
+TEXT_ONLY_DOCTAGS = (
+    "<|im_start|><doctag>"
+    "<text><loc_10><loc_10><loc_490><loc_60>Alcune regole del gioco.</text>"
+    "</doctag><end_of_utterance><|im_end|>"
+)
+
+FORMULA_DOCTAGS = (
+    "<|im_start|><doctag>"
+    "<formula><loc_10><loc_10><loc_200><loc_60>E = m c^2</formula>"
+    "</doctag><end_of_utterance>"
+)
+
+DOLLAR_NARRATIVE_DOCTAGS = (
+    "<|im_start|><doctag>"
+    "<paragraph><loc_10><loc_10><loc_490><loc_60>Paga $5 alla banca.</paragraph>"
+    "</doctag><end_of_utterance>"
+)
+
+
+class _FakeBatch(dict):
+    """Mimics a transformers BatchFeature: dict-like + a no-op .to(device)."""
+
+    def to(self, device):
+        return self
+
+
+class _SpyProcessor:
+    """Stand-in for the SmolDocling Idefics3Processor.
+
+    Reproduces the real contract: input_ids is returned ONLY when text is not None.
+    Records the chat-template call, the text/images passed, and the ids + skip flag
+    handed to batch_decode. batch_decode is a function of the ids so the prompt trim
+    and any leak are observable.
+    """
+
+    def __init__(self, prompt_len: int = 3, output: str = RAW_DOCTAGS):
+        self.prompt_len = prompt_len
+        self.output = output
+        self.chat_template_called = False
+        self.call_text = None
+        self.call_images = None
+        self.decode_skip_special = None
+        self.decoded_ids = None
+
+    def apply_chat_template(self, messages, add_generation_prompt=False, **kwargs):
+        self.chat_template_called = True
+        return "PROMPT_STRING"
+
+    def __call__(self, text=None, images=None, return_tensors=None, **kwargs):
+        self.call_text = text
+        self.call_images = images
+        batch = _FakeBatch(pixel_values=torch.zeros(1, 3, 8, 8))
+        # Idefics3Processor: input_ids only present when a text prompt is supplied
+        if text is not None:
+            batch["input_ids"] = torch.arange(1, self.prompt_len + 1).unsqueeze(0)
+        return batch
+
+    def batch_decode(self, ids, skip_special_tokens=True, **kwargs):
+        self.decode_skip_special = skip_special_tokens
+        seq = ids[0].tolist() if hasattr(ids, "__getitem__") else list(ids)
+        self.decoded_ids = seq
+        if len(seq) == 0:
+            return [""]  # trimmed-to-empty degenerate case
+        # any prompt id (<= prompt_len) surviving means the prompt leaked into the decode
+        if any(t <= self.prompt_len for t in seq):
+            return ["<PROMPT_LEAK>" + self.output]
+        return [self.output]
+
+
+class _FakeModel:
+    def __init__(self, prompt_len: int = 3, gen_len: int = 12):
+        self.prompt_len = prompt_len
+        self.gen_len = gen_len
+
+    def generate(self, **kwargs):
+        total = self.prompt_len + self.gen_len
+        return torch.arange(1, total + 1).unsqueeze(0)
+
+
+def _make_adapter(processor, model):
+    adapter = SmolDoclingAdapter()
+    adapter.processor = processor
+    adapter.model = model
+    adapter._is_initialized = True
+    adapter.device = "cpu"
+    return adapter
+
+
+def _page():
+    return PageImage.from_pil_image(1, Image.new("RGB", (1000, 1400), "white"), dpi=300)
+
+
+# --------------------------------------------------------------- P1: clean/decode
+
+def test_clean_doctags_strips_control_tokens_but_keeps_doctags():
+    adapter = SmolDoclingAdapter()
+    cleaned = adapter._clean_doctags(RAW_DOCTAGS)
+    for control in ("<|im_start|>", "<|im_end|>", "<end_of_utterance>"):
+        assert control not in cleaned, f"{control} should be stripped"
+    assert "<loc_44>" in cleaned
+    assert "<otsl>" in cleaned
+    assert "<fcel>" in cleaned
+    assert "<doctag>" in cleaned
+
+
+def test_process_page_decodes_without_skipping_special_and_trims_prompt():
+    proc = _SpyProcessor(prompt_len=3)
+    adapter = _make_adapter(proc, _FakeModel(prompt_len=3, gen_len=12))
+
+    result = adapter.process_page(_page())
+
+    assert proc.decode_skip_special is False               # P1a: keep special tokens
+    assert proc.decoded_ids == list(range(4, 16))          # P1b: prompt trimmed off
+    assert "<loc_44>" in result.doctags_text               # P1c: markup preserved
+    assert "<otsl>" in result.doctags_text
+    assert "<|im_end|>" not in result.doctags_text          # control tokens gone
+    assert "<end_of_utterance>" not in result.doctags_text
+
+
+# --------------------------------------------------------------- #6: chat template
+
+def test_process_page_builds_chat_prompt_and_passes_text_to_processor():
+    # The real Idefics3Processor needs text= to emit input_ids; assert the adapter
+    # builds the prompt (apply_chat_template) and passes a non-None text.
+    proc = _SpyProcessor(prompt_len=3)
+    adapter = _make_adapter(proc, _FakeModel())
+    adapter.process_page(_page())
+    assert proc.chat_template_called is True
+    assert proc.call_text is not None
+    assert proc.call_images is not None
+
+
+# --------------------------------------------------------------- #1: degenerate path
+
+def test_process_page_no_prompt_leak_when_generation_empty():
+    # gen_len=0: generate returns only the prompt; trim yields an empty sequence and the
+    # decode must be empty (no prompt/instruction text leaking into doctags_text).
+    proc = _SpyProcessor(prompt_len=5)
+    adapter = _make_adapter(proc, _FakeModel(prompt_len=5, gen_len=0))
+    result = adapter.process_page(_page())
+    assert proc.decoded_ids == []                 # trimmed to empty, not the prompt ids
+    assert result.doctags_text == ""              # no <PROMPT_LEAK>, no prompt text
+    assert result.is_empty is True
+
+
+# --------------------------------------------------------------- P2 + #9: tables/conf
+
+def test_has_tables_detects_otsl_not_html_table():
+    adapter = SmolDoclingAdapter()
+    assert adapter._detect_has_tables("<doctag><otsl><fcel>x<nl></otsl></doctag>") is True
+    assert adapter._detect_has_tables("<doctag><table><tr><td>x</td></tr></table>") is False
+    assert adapter._detect_has_tables("<doctag><paragraph>plain</paragraph></doctag>") is False
+
+
+def test_process_page_sets_has_tables_true_and_confidence_rewards_otsl():
+    adapter = _make_adapter(_SpyProcessor(), _FakeModel())
+    result = adapter.process_page(_page())
+    assert result.has_tables is True
+    # base 0.7 + OTSL table bonus 0.1 — the old <table> check never fired (#9)
+    assert round(result.confidence_score, 2) >= 0.8
+
+
+# --------------------------------------------------------------- #10: equations
+
+def test_has_equations_true_for_formula_tag():
+    adapter = _make_adapter(_SpyProcessor(output=FORMULA_DOCTAGS), _FakeModel())
+    assert adapter.process_page(_page()).has_equations is True
+
+
+def test_has_equations_false_for_dollar_amount_narrative():
+    # "$5" in narrative must NOT be flagged as an equation (old heuristic false-positive)
+    adapter = _make_adapter(_SpyProcessor(output=DOLLAR_NARRATIVE_DOCTAGS), _FakeModel())
+    assert adapter.process_page(_page()).has_equations is False
+
+
+# --------------------------------------------------------------- #5: no markup leak
+
+def test_text_only_page_markdown_has_no_doctags_markup():
+    adapter = _make_adapter(_SpyProcessor(output=TEXT_ONLY_DOCTAGS), _FakeModel())
+    result = adapter.process_page(_page())
+    assert result.has_tables is False
+    for token in ("<loc_", "<otsl>", "<doctag>", "<text>"):
+        assert token not in result.markdown_text, f"{token} leaked into markdown_text"
+    assert "Alcune regole del gioco" in result.markdown_text
+
+
+# --------------------------------------------------------------- #3: fallback safety
+
+def test_convert_to_markdown_fallback_returns_empty_not_raw_doctags(monkeypatch):
+    import src.infrastructure.smoldocling_adapter as mod
+
+    def boom(*a, **k):
+        raise ValueError("docling parse failure")
+
+    monkeypatch.setattr(mod.DocTagsDocument, "from_doctags_and_image_pairs", boom)
+    adapter = SmolDoclingAdapter()
+    out = adapter._convert_to_markdown("<doctag><otsl><fcel>x<nl></otsl></doctag>")
+    assert out == ""                    # never emit raw DocTags as content
+    assert "<otsl>" not in out
+    assert "<loc_" not in out
+
+
+def test_cleaned_doctags_convert_to_markdown_rebuilds_table():
+    # Integration with the REAL docling-core (no model): cleaned DocTags round-trip into
+    # a markdown table, proving the fix yields usable content (spec §5ter).
+    adapter = SmolDoclingAdapter()
+    md = adapter._convert_to_markdown(adapter._clean_doctags(RAW_DOCTAGS))
+    assert "Campo arato" in md
+    assert "|" in md
+
+
+# --------------------------------------------------------------- #2: is_empty semantics
+
+def test_is_empty_true_for_markup_only_page():
+    # A blank page emits only the structural wrapper; markdown is empty → empty page.
+    r = PageExtractionResult(
+        page_number=1, doctags_text="<doctag></doctag>", markdown_text="",
+        char_count=0, has_tables=False, has_equations=False, confidence_score=0.7,
+    )
+    assert r.is_empty is True
+
+
+def test_is_empty_false_for_real_content():
+    r = PageExtractionResult(
+        page_number=1, doctags_text="<doctag><paragraph>hi</paragraph></doctag>",
+        markdown_text="hi", char_count=2, has_tables=False, has_equations=False,
+        confidence_score=0.8,
+    )
+    assert r.is_empty is False

--- a/docs/superpowers/specs/2026-08-01-image-table-region-grounding-design.md
+++ b/docs/superpowers/specs/2026-08-01-image-table-region-grounding-design.md
@@ -4,7 +4,7 @@
 **Tipo**: design — follow-up investigazione #3419
 **Epic**: #3435 — "Image-table extraction & grounding" (il *Livello 2* rinviato dall'epic #3403)
 **Branch previsto**: feature branch per sub-progetto (parent `main-dev`)
-**Stato**: **design v1.2** — v1.1 (spike) + **reframe "Metà C = batch, non servizio" + alternative a costo zero (§5bis)**
+**Stato**: **design v1.3** — v1.2 (batch/costo-zero) + **DC-C risolto via tokenizer-spike (§5ter): SmolDocling `<loc_*>` → `prov[].bbox` usabili, con 2 bug adapter bloccanti scoperti**
 > Panel: Fowler/Nygard/Newman/Wiegers/Adzic/Crispin/Hightower. v1 chiude: retrievability Metà R (§2), Fase-0 spike
 > (§5), IA-6 (§7), job VLM (§8), contratto SmolDocling (DC-G), golden-set (§10), NFR (§4), esempio worked (§12).
 > **v1.1** registra gli esiti spike: **DC-A ✅NO** (fast dà bbox testo ma non le regioni-immagine → serve hi_res async),
@@ -14,6 +14,12 @@
 > **v1.2** riformula: la Metà C è un **batch di arricchimento una-tantum**, non un servizio always-on → **il vincolo
 > infra si applica solo all'ingestion CONTINUA**, non alla validazione né al corpus attuale (che si estraggono con
 > un batch locale/off-box a **costo zero** — §5bis). MVP a costo zero propeso dall'owner = **Opzione E** (region-only via hi_res).
+> **v1.3** (2026-08-03) chiude **DC-C ✅SÌ** senza inference (tokenizer-spike, §5ter): SmolDocling emette DocTags con
+> location `<loc_N>` (griglia 0..500) e `DoclingDocument.load_from_doctags(…, images=None)` le converte in `prov[].bbox`
+> **[0,1] top-left** = formato `bounding_boxes_json` #3403 (DA-1). Tabelle in **OTSL** (`<otsl>/<fcel>`, **non** `<table>`).
+> **⚠️ 2 bug adapter bloccanti** per QUALSIASI opzione VLM (B o C): **P1** `batch_decode(skip_special_tokens=True)`
+> (`smoldocling_adapter.py:124-126`) strippa `<loc_`/`<otsl>`/`<fcel>` (special) → location e struttura tabellare **perse**;
+> **P2** `has_tables="<table>" in doctags_text` (:132) cerca un tag inesistente (è `<otsl>`) → sempre `False`. Vedi §5ter.
 
 > **Origine**: investigazione di attivazione di DC-2 #3419 su staging (2026-08-01). Il wiring hi_res-per-tabelle
 > è corretto e mergiato ma **inerte sul corpus reale**: né `fast` né `hi_res` producono elementi `Table`,
@@ -133,7 +139,7 @@ Non-goal:
 | **DC-A** | `fast` emette bbox `Image`/`FigureCaption` a costo basso, o solo hi_res (>120s)? | ✅ **NO**. `fast` è coordinate-aware (454/454 elementi con bbox su agricola) **ma non emette `Image`/`FigureCaption`** (solo testo) — il layout model è esclusivo di hi_res. La regione precisa richiede hi_res async; niente scorciatoia region-only economica. fast dà solo bbox del testo circostante (grounding debole, già coperto da #3403). |
 | **DC-G** *(nuovo v1)* | SmolDocling accetta **input immagine (crop)** o solo **PDF**? | ✅ **SÌ, con aggiunta minima**. La VLM è image-native (`process_page(PageImage)` → `processor(images=…)`); l'endpoint pubblico è PDF-only per convenzione. Opzione B (crop) = thin endpoint `POST /extract-image` che wrappa il crop in `PageImage` e chiama il `process_page` esistente. Zero nuovo servizio. |
 | **DC-E** *(riformulato v1.1)* | ~~Deploy SmolDocling su staging 8GB~~ → **Su quale infra girano il benchmark e la Metà C?** | ✅ **BLOCCATO su staging**. Misurato: box 8GB con **172 MiB RAM liberi** + **2.6/4.0 GiB swap già usato** (`unstructured` 2.3 GiB, `embedding` 888 MiB/87%). SmolDocling vuole 2-3 GiB → **headroom negativo** → OOM-kill di un container critico (probabile vittima: `unstructured`) o thrashing. `mem_limit` non risolve (non c'è RAM fisica). **DC-E diventa: benchmark OFF-BOX (locale/VM throwaway) + decisione infra (resize a 16 GiB o nodo dedicato) prima di qualsiasi deploy Metà C.** |
-| **DC-C** | SmolDocling DocTags espone **location** (`<loc_*>`) usabili come bbox? | ⏳ Aperto — dipende dal **benchmark off-box** (DC-E): il `process_page` cattura `doctags_text` raw; i DocTags Docling tipicamente hanno `<loc_*>`, ma va confermato su modello running. Decide Opzione B (regione da hi_res) vs C (regione da DocTags). |
+| **DC-C** | SmolDocling DocTags espone **location** (`<loc_*>`) usabili come bbox? | ✅ **SÌ** (2026-08-03, tokenizer-spike §5ter, **senza inference**). `docling-project/SmolDocling-256M-preview` emette DocTags con `<loc_N>` (N∈0..500); `DoclingDocument.load_from_doctags(…, images=None)` → `prov[].bbox` **[0,1] top-left** = formato #3403 (DA-1). **MA** l'adapter attuale ha 2 bug bloccanti (P1 `skip_special_tokens=True` strippa i tag; P2 `has_tables` cerca `<table>` invece di `<otsl>`). DC-C sblocca **sia** Opzione C (regione+contenuto da DocTags) **sia** il crop di Opzione B — dopo il fix adapter. |
 | **DC-F** *(nuovo v1)* | Legame citazione-testo → regione-immagine: prossimità pagina basta? | ⏳ Aperto — valore atteso **debole** dato DC-A (fast dà solo bbox testo → highlight del testo vicino, non della tabella). |
 | **DC-B** | Router "PDF table-heavy": euristica vs flag manuale | ⏳ Aperto (analisi leggera, no deploy) |
 
@@ -168,6 +174,50 @@ SmolDocling su staging" (DC-E) era un over-engineering: il batch può girare **o
 
 ---
 
+## 5ter. Esito spike DC-C (2026-08-03) — location DocTags → bbox, e 2 bug adapter
+
+**Metodo** (costo zero, **nessuna inference** — il VLM su CPU è >95s/pagina, impraticabile): ispezione del
+**tokenizer** di `docling-project/SmolDocling-256M-preview` (solo file tokenizer, ~pochi MB, non i pesi 256M) +
+round-trip encode/decode + parsing di DocTags sintetici con `docling-core` (`DoclingDocument.load_from_doctags`,
+la stessa API dell'adapter `smoldocling_adapter.py:182-186`). Artefatti spike in `scratchpad/dc_c_spike*.py`.
+
+**Evidenze**:
+
+1. **Le location ci sono e sono usabili come bbox.** SmolDocling emette DocTags con `<loc_N>` (N∈0..500, griglia
+   normalizzata). `<loc_` è un token **special** del vocab (id presente), le cifre sono testo. Passando i DocTags
+   **completi** a `DoclingDocument.load_from_doctags(doctags, images=…)`:
+   - `images=None` → `prov[].bbox` in **[0,1] top-left** (es. `<loc_44>` → `0.088`). **= formato `bounding_boxes_json`
+     #3403 (DA-1)** → nessun parsing manuale dei `<loc_*>`, si riusa l'infra grounding esistente.
+   - `images=[PIL(w,h)]` → stesse bbox de-normalizzate in **pixel** (`<loc_44>`→`88.0` su 1000px).
+   - Le tabelle sono in **OTSL** (`<otsl>/<fcel>/<ecel>/<nl>`), **non** `<table>`; `export_to_markdown` le ricostruisce
+     correttamente in tabella markdown.
+
+2. **⚠️ P1 (BLOCCANTE) — `skip_special_tokens=True` distrugge i DocTags.** `smoldocling_adapter.py:124-126` fa
+   `batch_decode(generated_ids, skip_special_tokens=True)`. I tag DocTags (`<loc_`, `<otsl>`, `<fcel>`, `<ecel>`,
+   `<nl>`, `<picture>`, `<caption>`, `<doctag>`) sono `special=True` nel vocab → **vengono strippati**. Round-trip
+   misurato su un DocTags realistico:
+   ```
+   input     : <doctag><text><loc_44><loc_43><loc_461><loc_59>Campo arato vale 1 punto</text><otsl><fcel>Campo<fcel>1<nl></otsl></doctag>
+   skip=True  : <text>44>43>461>59>Campo arato vale 1 punto</text>Campo1     ← location mutilate, tabella collassata
+   skip=False : <doctag><text><loc_44><loc_43><loc_461><loc_59>…</otsl></doctag>  ← integro
+   ```
+   Conseguenza: il `doctags_text` catturato perde location e struttura OTSL; `_convert_to_markdown` riceve input
+   mutilato → nessuna tabella, nessuna bbox. **Fix**: `skip_special_tokens=False` (poi rimuovere a mano solo i veri
+   token di controllo come pad/eos, non i tag DocTags). *Prerequisito per Opzione B **e** C.*
+
+3. **P2 (secondario) — `has_tables` cerca il tag sbagliato.** `smoldocling_adapter.py:132`:
+   `has_tables = "<table>" in doctags_text.lower()`. `<table>` **non esiste** nel vocab SmolDocling (è `<otsl>`) →
+   `has_tables` è sempre `False` (doppiamente, perché su output skip=True anche `<otsl>` è assente). **Fix**:
+   `"<otsl>" in doctags_text` dopo il fix P1.
+
+**Impatto sulla scelta A/B/C (§6)**: DC-C=SÌ rende **Opzione C** tecnicamente praticabile (regione **e** contenuto in
+un colpo dai DocTags). Ma i vincoli di v1.1/v1.2 restano (SmolDocling CPU >95s/pag; box staging saturo; rischio
+"degrada testo narrativo" di C) → **Opzione B** (hi_res per la regione + SmolDocling-crop solo sul contenuto) resta
+operativamente preferibile. **Entrambe** richiedono prima il fix P1 dell'adapter (SP3). Restano aperti solo **DC-B**
+(router) e **DC-F** (linkage), entrambi analisi leggere non bloccanti.
+
+---
+
 ## 6. Opzioni architetturali (scelta POST Fase 0)
 
 Non mutuamente esclusive; la scelta dipende dagli esiti §5.
@@ -198,11 +248,16 @@ location (se DC-C=sì) → contenuto+regione in un colpo.
   testo circostante (già in #3403). Quick-win marginale.
 - **Opzione B** confermata **fattibile** (DC-G=sì, thin endpoint crop) — richiede la Metà C, ma (v1.2) come **batch**
   off-box, **non** un servizio always-on: nessun deploy persistente né spesa infra per il corpus attuale (§5bis).
-- **Opzione C** resta contingente a DC-C (DocTags location), risolvibile col benchmark **locale** (§5bis Opzione A).
-- **Percorso raccomandato v1.2** (a costo zero, vedi §5bis): (1) **MVP = Opzione E** (region-only via hi_res async,
-  nessun VLM) per il grounding visivo immediato; (2) **validare Metà C** con un **batch locale** di SmolDocling
-  (chiude DC-C + numeri); (3) decidere B vs C e l'infra a pagamento **solo dopo** feature-provata, e solo per
-  l'ingestion continua real-time. Il gate non è più "infra o niente" — l'MVP a costo zero è E.
+- **Opzione C** — DC-C **✅ RISOLTO SÌ** (v1.3, §5ter): i DocTags danno location→bbox **e** struttura tabella. C è
+  quindi tecnicamente completa (regione+contenuto in un colpo), **ma** subordinata al fix adapter P1 (§5ter) e ai
+  vincoli CPU/qualità di v1.1/v1.2.
+- **Prerequisito trasversale (nuovo v1.3)**: fix adapter **P1** (`skip_special_tokens=False`) + **P2** (`<otsl>`) in
+  `smoldocling-service` — **bloccante** per Metà C sia in B che in C. È il primo task di SP3.
+- **Percorso raccomandato v1.3** (a costo zero, vedi §5bis): (1) **MVP = Opzione E** (region-only via hi_res async,
+  nessun VLM) per il grounding visivo immediato; (2) **fix adapter P1/P2** (§5ter) — piccolo, sblocca il VLM;
+  (3) **quantificare Metà C** con un **batch locale** di SmolDocling — non più per chiudere DC-C (già chiuso) ma per i
+  **numeri** di qualità-lettura-tabella e latenza reale; (4) decidere B vs C e l'infra a pagamento **solo dopo**
+  feature-provata, e solo per l'ingestion continua real-time. Il gate non è più "infra o niente" — l'MVP a costo zero è E.
 
 ---
 
@@ -250,10 +305,10 @@ location (se DC-C=sì) → contenuto+regione in un colpo.
 
 | SP | Cosa | Metà | Costo | Dipende da |
 |----|------|------|-------|-----------|
-| **SP0 — Fase 0 spike** | ~~DC-A ✅ DC-G ✅ DC-E ✅(blocco infra)~~; resta **benchmark off-box** (chiude DC-C + numeri) + decisione infra | — | S | — |
+| **SP0 — Fase 0 spike** | ~~DC-A ✅ DC-G ✅ DC-E ✅(blocco infra) DC-C ✅(§5ter, tokenizer-spike)~~; resta solo **benchmark off-box** (numeri qualità/latenza, non più DC-C) + decisione infra; restano DC-B/DC-F (analisi leggere) | — | S | — |
 | **SP1 — Image-region capture** | Estendere il capture bbox #3403 a `Image`/`FigureCaption`; linkage per-pagina (DC-F); FE disegna la regione | R | S | #3403 SP-B/SP-D; DC-A/DC-F |
 | **SP2 — Table-region router** | Euristica DC-B per marcare PDF/pagine con tabelle-immagine candidate | R+C | S | SP1 |
-| **SP3 — SmolDocling deploy + extract** | Deploy SmolDocling su **infra adeguata** (NON il box staging 8GB — resize/nodo dedicato, DC-E); thin endpoint `POST /extract-image` per i crop (DC-G ✅) | C | L | SP2, DC-E (infra), DC-G |
+| **SP3 — SmolDocling deploy + extract** | **PRE: fix adapter P1/P2 (§5ter) — `skip_special_tokens=False` + `has_tables` su `<otsl>`, bloccante**; poi deploy SmolDocling su **infra adeguata** (NON il box staging 8GB — resize/nodo dedicato, DC-E); thin endpoint `POST /extract-image` per i crop (DC-G ✅); bbox via `load_from_doctags(images=None)` → [0,1] top-left (§5ter, no parsing manuale) | C | L | SP2, DC-E (infra), DC-G |
 | **SP4 — VLM enrichment job** | Job asincrono §8 (idempotenza/retry/checkpoint/observability/gate qualità) | C | L | SP3 |
 | **SP5 — Table-chunk indexing** | Contenuto-tabella come chunk retrievabile con `bounding_boxes_json`=regione; gating copyright | C | M | SP4 |
 | **SP6 — Answerability + citazione tabella** | Citazione chunk-tabella apre pagina + evidenzia regione; test golden-set (§10) | C | M | SP5 |

--- a/docs/superpowers/specs/2026-08-01-image-table-region-grounding-design.md
+++ b/docs/superpowers/specs/2026-08-01-image-table-region-grounding-design.md
@@ -20,6 +20,11 @@
 > **⚠️ 2 bug adapter bloccanti** per QUALSIASI opzione VLM (B o C): **P1** `batch_decode(skip_special_tokens=True)`
 > (`smoldocling_adapter.py:124-126`) strippa `<loc_`/`<otsl>`/`<fcel>` (special) → location e struttura tabellare **perse**;
 > **P2** `has_tables="<table>" in doctags_text` (:132) cerca un tag inesistente (è `<otsl>`) → sempre `False`. Vedi §5ter.
+> **v1.4** (2026-08-04) chiude la **Fase 0**: (a) **FIX adapter applicato** (commit `62816eeef`) — P1+P2 + hardening da
+> review adversariale (10 finding confermati, incl. **#6 blocker**: mancava `apply_chat_template`; §5quater); (b)
+> **DC-B ✅** (router image-density, riusa il pattern `ExtractionStrategyDecider`) e **DC-F ✅** (page-proximity, già
+> wired; overlap solo refiner) decisi — §5quinquies. **Tutti gli spike DC-* sono chiusi**; resta solo il benchmark
+> off-box per i *numeri* Metà C (qualità/latenza), non più bloccante per l'MVP (Opzione E).
 
 > **Origine**: investigazione di attivazione di DC-2 #3419 su staging (2026-08-01). Il wiring hi_res-per-tabelle
 > è corretto e mergiato ma **inerte sul corpus reale**: né `fast` né `hi_res` producono elementi `Table`,
@@ -139,9 +144,9 @@ Non-goal:
 | **DC-A** | `fast` emette bbox `Image`/`FigureCaption` a costo basso, o solo hi_res (>120s)? | ✅ **NO**. `fast` è coordinate-aware (454/454 elementi con bbox su agricola) **ma non emette `Image`/`FigureCaption`** (solo testo) — il layout model è esclusivo di hi_res. La regione precisa richiede hi_res async; niente scorciatoia region-only economica. fast dà solo bbox del testo circostante (grounding debole, già coperto da #3403). |
 | **DC-G** *(nuovo v1)* | SmolDocling accetta **input immagine (crop)** o solo **PDF**? | ✅ **SÌ, con aggiunta minima**. La VLM è image-native (`process_page(PageImage)` → `processor(images=…)`); l'endpoint pubblico è PDF-only per convenzione. Opzione B (crop) = thin endpoint `POST /extract-image` che wrappa il crop in `PageImage` e chiama il `process_page` esistente. Zero nuovo servizio. |
 | **DC-E** *(riformulato v1.1)* | ~~Deploy SmolDocling su staging 8GB~~ → **Su quale infra girano il benchmark e la Metà C?** | ✅ **BLOCCATO su staging**. Misurato: box 8GB con **172 MiB RAM liberi** + **2.6/4.0 GiB swap già usato** (`unstructured` 2.3 GiB, `embedding` 888 MiB/87%). SmolDocling vuole 2-3 GiB → **headroom negativo** → OOM-kill di un container critico (probabile vittima: `unstructured`) o thrashing. `mem_limit` non risolve (non c'è RAM fisica). **DC-E diventa: benchmark OFF-BOX (locale/VM throwaway) + decisione infra (resize a 16 GiB o nodo dedicato) prima di qualsiasi deploy Metà C.** |
-| **DC-C** | SmolDocling DocTags espone **location** (`<loc_*>`) usabili come bbox? | ✅ **SÌ** (2026-08-03, tokenizer-spike §5ter, **senza inference**). `docling-project/SmolDocling-256M-preview` emette DocTags con `<loc_N>` (N∈0..500); `DoclingDocument.load_from_doctags(…, images=None)` → `prov[].bbox` **[0,1] top-left** = formato #3403 (DA-1). **MA** l'adapter attuale ha 2 bug bloccanti (P1 `skip_special_tokens=True` strippa i tag; P2 `has_tables` cerca `<table>` invece di `<otsl>`). DC-C sblocca **sia** Opzione C (regione+contenuto da DocTags) **sia** il crop di Opzione B — dopo il fix adapter. |
-| **DC-F** *(nuovo v1)* | Legame citazione-testo → regione-immagine: prossimità pagina basta? | ⏳ Aperto — valore atteso **debole** dato DC-A (fast dà solo bbox testo → highlight del testo vicino, non della tabella). |
-| **DC-B** | Router "PDF table-heavy": euristica vs flag manuale | ⏳ Aperto (analisi leggera, no deploy) |
+| **DC-C** | SmolDocling DocTags espone **location** (`<loc_*>`) usabili come bbox? | ✅ **SÌ** (2026-08-03, tokenizer-spike §5ter, **senza inference**). `docling-project/SmolDocling-256M-preview` emette DocTags con `<loc_N>` (N∈0..500); `DoclingDocument.load_from_doctags(…, images=None)` → `prov[].bbox` **[0,1] top-left** = formato #3403 (DA-1). **MA** l'adapter attuale ha 2 bug bloccanti (P1 `skip_special_tokens=True` strippa i tag; P2 `has_tables` cerca `<table>` invece di `<otsl>`). DC-C sblocca **sia** Opzione C (regione+contenuto da DocTags) **sia** il crop di Opzione B — dopo il fix adapter. **FIX APPLICATO** (2026-08-04, commit `62816eeef`): P1+P2 + hardening da review adversariale (10 finding, incl. **#6 blocker**: mancava `apply_chat_template` → nessun `input_ids`); §5quater. |
+| **DC-F** *(nuovo v1)* | Legame citazione-testo → regione-immagine: prossimità pagina basta? | ✅ **SÌ, page-proximity** (2026-08-04, §5quinquies). È l'**unico** segnale primario viabile (DC-A: la bbox del chunk narrativo copre solo il testo circostante → nessun overlap geometrico con la tabella) ed è **già wired** nel viewer (`PdfInlineViewer.tsx`). Overlap solo come *refiner* (regione più vicina verticalmente). Join key `(PdfDocumentId, PageNumber)`, nessun chunk↔region FK. Effort M. |
+| **DC-B** | Router "PDF table-heavy": euristica vs flag manuale | ✅ **Euristica image-density, riusando il pattern `ExtractionStrategyDecider`** (2026-08-04, §5quinquies). NON il predicato `Table` (inerte: 0 `Table` su 52 PDF), NON un `has_tables` VLM-sample (accoppierebbe DC-B al Metà C bloccato), NON un flag per-gioco. Segnale MVP = **region count in `pdf_image_regions`** (già area-filtered #3456). Effort S. |
 
 **Output di Fase 0**: una decisione documentata A/B/C con effort stimato. Solo allora partono gli SP §7.
 
@@ -215,6 +220,71 @@ un colpo dai DocTags). Ma i vincoli di v1.1/v1.2 restano (SmolDocling CPU >95s/p
 "degrada testo narrativo" di C) → **Opzione B** (hi_res per la regione + SmolDocling-crop solo sul contenuto) resta
 operativamente preferibile. **Entrambe** richiedono prima il fix P1 dell'adapter (SP3). Restano aperti solo **DC-B**
 (router) e **DC-F** (linkage), entrambi analisi leggere non bloccanti.
+
+---
+
+## 5quater. Fix adapter SmolDocling (2026-08-04) — P1/P2 + hardening da review adversariale
+
+Il fix DC-C è stato implementato (commit `62816eeef`, branch `feature/issue-3435-sp0-spike`) e passato a una
+**review adversariale multi-lente** (5 lenti × verifica indipendente): **13 finding, 10 confermati (0 uncertain)**.
+Tutti indirizzati. Il più importante NON era P1/P2 ma un **blocker pre-esistente** che il fix ha reso attivo:
+
+- **#6 (BLOCKER)** — `process_page` chiamava il processor **senza** `apply_chat_template`; il vero `Idefics3Processor`
+  (transformers 4.46.3, `processing_idefics3.py:265`) aggiunge `input_ids` **solo** dentro `if text is not None:`.
+  Quindi la chiamata images-only non produceva `input_ids` → il trim del prompt (`filtered_inputs["input_ids"]`)
+  avrebbe dato `KeyError` a runtime e la generazione non poteva allineare i token immagine. **Fix**: costruito il
+  prompt col chat template ufficiale (`text=prompt, images=[img]`).
+- **P1** — decode `skip_special_tokens=False` + trim prompt (`generated_ids[:, prompt_len:]`, recipe ufficiale) +
+  `_clean_doctags` rimuove **solo** i control token (`<|im_end|>`, `<end_of_utterance>`, image placeholder). I DocTags
+  (`<loc_*>`, `<otsl>`, `<fcel>`) sopravvivono.
+- **P2** — `has_tables` su `<otsl>`.
+- **#2 (regression)** — `PageExtractionResult.is_empty` ora chiave su `markdown_text`, non `doctags_text`: il wrapper
+  `<doctag>` conservato non fa più contare le pagine vuote come non-vuote (evita chunk vuoti nel RAG + skew coverage/confidence).
+- **#3 (regression)** — il fallback di `_convert_to_markdown` su eccezione ritorna `""`, non il raw DocTags (niente
+  markup nel corpus RAG / `extracted_text` del `/preprocess`).
+- **#4/#8/#10** — confidence/layout/`has_equations` allineati ai tag DocTags **reali** (verificati: tabelle `<otsl>`,
+  formule `<formula>`, struttura `<text>`/`<section_header_*>` che docling parsa; `<table>`/`<equation>`/`<paragraph>`
+  NON sono emessi/parsati). Rimossa l'euristica `"$" in text` (false-positive su prezzi "$5").
+- **Test (#1/#5/#7/#9)** — suite adapter riscritta (13 casi): i fake rispecchiano il contratto reale
+  (`input_ids` solo con `text`; `batch_decode` funzione degli ids → trim/leak osservabili), + test text-only no-leak,
+  fallback, confidence, `has_equations`. **Suite servizio verde: 29 passed, 1 skip.**
+
+> **⚠️ Limite noto**: l'inference **end-to-end reale** (VLM su GPU) NON è validata — SmolDocling su CPU è >95s/pagina
+> (impraticabile in sviluppo) e lo staging è saturo (DC-E). I test coprono la logica decode/clean/metadata con fake;
+> la validazione E2E resta parte di **SP3** (quando l'infra VLM è disponibile).
+
+---
+
+## 5quinquies. Decisioni DC-B e DC-F (2026-08-04) — chiudono la Fase 0
+
+Analisi (workflow multi-reader sul codice reale). Entrambe **riusano infrastruttura già esistente**; entrambe sono
+**inerti sul corpus reale** finché non atterra l'ingestion automatica delle regioni (deferred, #3435) — oggi solo
+l'endpoint admin `POST /admin/pdfs/{pdfId}/seed-image-regions` scrive in `pdf_image_regions`.
+
+**DC-B — router table-heavy = euristica image-density (effort S)**
+- **Riusa il *pattern*** static-decider + scoped-selector di `ExtractionStrategyDecider`
+  (`…/DocumentProcessing/Domain/Services/ExtractionStrategy.cs:30-56`, wired a `PdfProcessingPipelineService.cs:528`),
+  **non** il suo predicato `Table`: quest'ultimo è **inerte** sul corpus (0 `ElementType="Table"` su 52 PDF, §1).
+- **Segnale MVP** = **region count in `pdf_image_regions`** (già filtrato per area ≥3%, #3456): "PDF con ≥1
+  image-region ⇒ candidato Metà-C". Zero nuova infra euristica.
+- **Gate pre-hi_res** (solo se serve isolare il costo su ingestion continua, NFR1): densità raster via
+  `pdfimages`/poppler — deterministico, zero-model.
+- **Rifiutati**: `has_tables` VLM-sample (accoppia DC-B al Metà C bloccato, **inverte** la dipendenza IA-5/NFR1 —
+  il router deve *gateare* il VLM, non dipenderne); flag manuale per-gioco (toil su 52 giochi, non scala).
+
+**DC-F — linkage citazione→regione = page-proximity (effort M)**
+- **Page-proximity è l'unico segnale primario viabile** ed è **già wired** nel viewer (`PdfInlineViewer.tsx:101,162-176`;
+  `CitationPdfTab` apre a `initialPage` → le regioni della pagina citata già si disegnano). Join key
+  `(PdfDocumentId, PageNumber)` — **non** esiste chunk↔region FK; le citazioni risolvono già `PdfDocumentId` (#3517).
+- **Overlap geometrico NON può essere primario** (DC-A: la bbox del chunk narrativo copre il **testo circostante**, non
+  la tabella → nessun overlap). Utile **solo come refiner** (regione verticalmente più vicina al chunk citato).
+- **Noise**: il filtro area #3456 già rimuove icone/glifi; per illustrazioni decorative grandi serve la
+  discriminazione tabella-vs-illustrazione, che richiede il segnale `has_tables` della Metà C (IA-1, **deferred L**).
+- **Gap di correttezza da chiudere prima del rollout** (open risk): **copyright-gate divergence** — `regions[]` sono
+  `Full`-gated (R4/IA-4/DA-4) ma l'endpoint image-regions è solo owner/shared-scoped e fetchato incondizionatamente →
+  i box immagine **leakano** per citazioni `Protected`-tier. Aggiungere gating `CopyrightTier=Full` al path image-region
+  (slice S-4, deferred). Quando il pipeline grounded consuma le regioni deve passare per **`IMediator`** (ADR-090,
+  confine KB↔DocumentProcessing), mai query diretta a `pdf_image_regions` da KB.
 
 ---
 
@@ -305,7 +375,7 @@ location (se DC-C=sì) → contenuto+regione in un colpo.
 
 | SP | Cosa | Metà | Costo | Dipende da |
 |----|------|------|-------|-----------|
-| **SP0 — Fase 0 spike** | ~~DC-A ✅ DC-G ✅ DC-E ✅(blocco infra) DC-C ✅(§5ter, tokenizer-spike)~~; resta solo **benchmark off-box** (numeri qualità/latenza, non più DC-C) + decisione infra; restano DC-B/DC-F (analisi leggere) | — | S | — |
+| **SP0 — Fase 0 spike** | ✅ **CHIUSA** (2026-08-04): DC-A/DC-G/DC-E/DC-C/DC-B/DC-F tutti risolti (§5/§5ter/§5quinquies) + **fix adapter applicato** (§5quater, commit `62816eeef`). Resta solo il **benchmark off-box** per i *numeri* Metà C (qualità/latenza) + decisione infra — non bloccante per l'MVP (Opzione E) | — | S | — |
 | **SP1 — Image-region capture** | Estendere il capture bbox #3403 a `Image`/`FigureCaption`; linkage per-pagina (DC-F); FE disegna la regione | R | S | #3403 SP-B/SP-D; DC-A/DC-F |
 | **SP2 — Table-region router** | Euristica DC-B per marcare PDF/pagine con tabelle-immagine candidate | R+C | S | SP1 |
 | **SP3 — SmolDocling deploy + extract** | **PRE: fix adapter P1/P2 (§5ter) — `skip_special_tokens=False` + `has_tables` su `<otsl>`, bloccante**; poi deploy SmolDocling su **infra adeguata** (NON il box staging 8GB — resize/nodo dedicato, DC-E); thin endpoint `POST /extract-image` per i crop (DC-G ✅); bbox via `load_from_doctags(images=None)` → [0,1] top-left (§5ter, no parsing manuale) | C | L | SP2, DC-E (infra), DC-G |


### PR DESCRIPTION
## Contesto

Epic **#3435** (Image-table extraction & grounding) — **Fase 0 (SP0)**. Questa PR chiude gli spike bloccanti e corregge l'adapter SmolDocling, sbloccando la Metà C (estrazione contenuto tabella).

> ⚠️ **Questa PR NON chiude l'epic #3435** — è solo lo spike Fase 0/SP0. L'epic resta aperta per SP1–SP7. (Se un bot dovesse chiuderla al merge, va riaperta.)

## Cosa contiene

### 1. Fix adapter SmolDocling (`apps/smoldocling-service`)
Fix DC-C (P1/P2) + hardening da **review adversariale** (13 finding, **10 confermati**, tutti indirizzati):

- **#6 (BLOCKER)** — `process_page` non costruiva il prompt via `apply_chat_template`. Il vero `Idefics3Processor` emette `input_ids` **solo** con `text=` (`processing_idefics3.py:265`) → la chiamata images-only non produceva `input_ids`, rompendo la generazione e il trim del prompt. **Fix**: chat prompt del recipe ufficiale.
- **P1** — decode `skip_special_tokens=False` + trim prompt + `_clean_doctags` (rimuove solo i control token). I DocTags (`<loc_*>`, `<otsl>`, `<fcel>`) sopravvivono → location usabili come bbox.
- **P2** — `has_tables` su `<otsl>` (era `<table>`, mai emesso).
- **#2/#3 (regression)** — `is_empty` su `markdown_text`; fallback `_convert_to_markdown` → `""` (niente markup DocTags nel corpus RAG / `extracted_text`).
- **#4/#8/#10** — confidence/layout/`has_equations` allineati ai tag DocTags **reali** (verificati con docling: `<otsl>`/`<formula>`/`<text>`/`<section_header_*>`); rimossa l'euristica `"$"` (false-positive su prezzi).

### 2. Documentazione (`docs/superpowers/specs/2026-08-01-image-table-region-grounding-design.md`, v1.4)
- **DC-C ✅** risolto senza inference (tokenizer-spike) — §5ter.
- **DC-B ✅** — router = euristica image-density riusando il pattern `ExtractionStrategyDecider` — §5quinquies.
- **DC-F ✅** — linkage = page-proximity (già wired), overlap solo refiner — §5quinquies.
- **Fase 0 chiusa**: tutti gli spike DC-* risolti.

## Test

- Suite `smoldocling-service`: **29 passed, 1 skip** (13 test adapter nuovi/riscritti; i fake rispecchiano il contratto reale `Idefics3Processor`).
- ⚠️ **Limite noto**: l'inference **E2E reale** (VLM GPU) NON è validata — SmolDocling su CPU è >95s/pagina e lo staging è saturo (DC-E). Coperta la logica decode/clean/metadata; l'E2E resta parte di **SP3**.

## Note
- Nessuna modifica al backend .NET o al FE: solo il servizio Python + doc.
- DC-B/DC-F sono **inerti sul corpus reale** finché non atterra l'ingestion automatica delle regioni (deferred, prossimo SP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
