### PR TITLE
feat(covers): SetManualCover command + admin endpoint (#3470)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommand.cs
@@ -1,0 +1,21 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+
+/// <summary>
+/// Epic #3470 Slice 3a — sets an admin-supplied manual cover from a URL: SSRF-pinned fetch (#3534) →
+/// license-gate (whitelist) → WebP re-encode → R2 raw-key put (<c>CoverKeyBuilder.ForManual</c>) →
+/// persist on the aggregate with the license attestation.
+/// </summary>
+internal record SetManualCoverCommand(
+    Guid GameId,
+    string SourceUrl,
+    string License,
+    string? Attribution,
+    Guid AdminId) : ICommand<ManualCoverResult>;
+
+/// <summary>
+/// The persisted manual cover: the suffix-free DB key stored on the game and a presigned URL for the
+/// freshly-written R2 object (so the picker can preview it immediately).
+/// </summary>
+internal record ManualCoverResult(string DbKey, string PresignedUrl);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandler.cs
@@ -1,0 +1,113 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+using Api.Middleware.Exceptions;
+using Api.Services;
+using Api.Services.Pdf;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Domain.Covers;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+
+/// <summary>
+/// Epic #3470 Slice 3a — persists an admin-supplied manual cover. Flow: load game → SSRF-pinned,
+/// 10MB-capped, HTTPS-only fetch of the admin URL (#3534) → re-encode to WebP (strips the original
+/// container/metadata) → R2 raw-key put at the deterministic manual key → persist the manual cover +
+/// license attestation on the aggregate → evict the read-model caches. The DEC-3c license whitelist
+/// is enforced by <see cref="SetManualCoverCommandValidator"/> (400) before this runs.
+/// </summary>
+internal sealed class SetManualCoverCommandHandler : ICommandHandler<SetManualCoverCommand, ManualCoverResult>
+{
+    // Base cover dimensions (2:3 portrait, BGG thumbnail convention) — mirrors the Wikidata pipeline;
+    // per-context crops are generated from this base on assign.
+    private const int WebpTargetWidth = 200;
+    private const int WebpTargetHeight = 300;
+    private const string WebpContentType = "image/webp";
+
+    private readonly ISharedGameRepository _repository;
+    private readonly SsrfSafeHttpClient _fetcher;
+    private readonly IWebpVariantGenerator _webpGenerator;
+    private readonly IBlobStorageService _blobStorage;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IHybridCacheService _cache;
+    private readonly ICacheInvalidationRetryPolicy _cacheRetryPolicy;
+    private readonly ILogger<SetManualCoverCommandHandler> _logger;
+
+    public SetManualCoverCommandHandler(
+        ISharedGameRepository repository,
+        SsrfSafeHttpClient fetcher,
+        IWebpVariantGenerator webpGenerator,
+        IBlobStorageService blobStorage,
+        IUnitOfWork unitOfWork,
+        IHybridCacheService cache,
+        ICacheInvalidationRetryPolicy cacheRetryPolicy,
+        ILogger<SetManualCoverCommandHandler> logger)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _fetcher = fetcher ?? throw new ArgumentNullException(nameof(fetcher));
+        _webpGenerator = webpGenerator ?? throw new ArgumentNullException(nameof(webpGenerator));
+        _blobStorage = blobStorage ?? throw new ArgumentNullException(nameof(blobStorage));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _cacheRetryPolicy = cacheRetryPolicy ?? throw new ArgumentNullException(nameof(cacheRetryPolicy));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<ManualCoverResult> Handle(SetManualCoverCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var game = await _repository.GetByIdAsync(command.GameId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException("SharedGame", command.GameId.ToString());
+
+        // SSRF-pinned, 10MB-capped, HTTPS-only-per-hop fetch of the admin-supplied URL (#3534 fix 5/N).
+        var imageBytes = await _fetcher.DownloadImageAsync(command.SourceUrl, cancellationToken).ConfigureAwait(false);
+
+        // Re-encode to WebP: normalizes the format AND drops the original container/metadata. The
+        // license was whitelisted by the validator, so we persist the attested value below.
+        var webpBytes = await _webpGenerator
+            .GenerateWebpAsync(imageBytes, WebpTargetWidth, WebpTargetHeight, cancellationToken)
+            .ConfigureAwait(false);
+
+        // Write to the deterministic manual physical key via the RAW-KEY path (the categorized
+        // StoreAsync would reject the slash-containing key + mint an unresolvable random key).
+        var coverKey = CoverKeyBuilder.ForManual(game.Id);
+        using var webpStream = new MemoryStream(webpBytes);
+        var stored = await _blobStorage
+            .StoreRawKeyAsync(coverKey.PhysicalKey, webpStream, WebpContentType, cancellationToken)
+            .ConfigureAwait(false);
+        if (!stored)
+        {
+            throw new ExternalServiceException(
+                "Impossibile salvare la cover manuale: storage oggetti non disponibile.");
+        }
+
+        // Persist the suffix-free DB key + the copyright attestation ONLY after the object is written.
+        game.SetManualCover(
+            coverKey.DbKey,
+            LicenseValidator.Normalize(command.License),
+            command.Attribution,
+            command.SourceUrl,
+            command.AdminId,
+            DateTime.UtcNow);
+
+        _repository.Update(game);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        // The cover columns the read-model resolves changed → evict the list + detail caches (AC-6).
+        await CoverCacheInvalidation
+            .EvictReadModelAsync(_cache, _cacheRetryPolicy, game.Id, cancellationToken)
+            .ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Manual cover set for game {GameId} by {AdminId} from {SourceUrl} (license {License})",
+            game.Id, command.AdminId, command.SourceUrl, command.License);
+
+        var presignedUrl = await _blobStorage
+            .GetPresignedUrlForRawKeyAsync(coverKey.PhysicalKey, expirySeconds: 3600)
+            .ConfigureAwait(false) ?? string.Empty;
+
+        return new ManualCoverResult(coverKey.DbKey, presignedUrl);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandValidator.cs
@@ -1,0 +1,35 @@
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+using FluentValidation;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+
+/// <summary>
+/// Boundary validation for <see cref="SetManualCoverCommand"/> — 400 (not 500) on bad input.
+/// <para>
+/// The license MUST be on the DEC-3c whitelist (Public Domain / CC0 / CC-BY / CC-BY-SA). This is the
+/// primary copyright gate for the arbitrary-URL manual path (epic #3470 Slice 3a / ADR-059): it
+/// rejects "All Rights Reserved" / BGG / CC-BY-NC covers BEFORE anything is downloaded or stored, so
+/// the manual path cannot launder around the catalog's redistribution posture.
+/// </para>
+/// </summary>
+internal sealed class SetManualCoverCommandValidator : AbstractValidator<SetManualCoverCommand>
+{
+    public SetManualCoverCommandValidator()
+    {
+        RuleFor(x => x.GameId).NotEqual(Guid.Empty).WithMessage("GameId is required");
+        RuleFor(x => x.AdminId).NotEqual(Guid.Empty).WithMessage("AdminId is required");
+
+        RuleFor(x => x.SourceUrl)
+            .NotEmpty().WithMessage("SourceUrl is required")
+            .Must(BeAbsoluteHttps).WithMessage("SourceUrl must be an absolute HTTPS URL");
+
+        RuleFor(x => x.License)
+            .NotEmpty().WithMessage("License is required")
+            .Must(LicenseValidator.IsWhitelisted)
+            .WithMessage("License must be on the whitelist (Public Domain / CC0 / CC-BY / CC-BY-SA)");
+    }
+
+    private static bool BeAbsoluteHttps(string? url) =>
+        Uri.TryCreate(url, UriKind.Absolute, out var uri) &&
+        string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase);
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfSafeHttpClient.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfSafeHttpClient.cs
@@ -24,6 +24,7 @@ internal sealed class SsrfSafeHttpClient
 {
     private readonly HttpClient _httpClient;
     private const long MaxPdfSizeBytes = 100 * 1024 * 1024; // 100MB
+    private const long MaxImageSizeBytes = 10 * 1024 * 1024; // 10MB (cover images)
     private const int MaxRedirectHops = 5;
 
     public SsrfSafeHttpClient(HttpClient httpClient)
@@ -48,6 +49,16 @@ internal sealed class SsrfSafeHttpClient
 
         return new MemoryStream(bytes, writable: false);
     }
+
+    /// <summary>
+    /// Epic #3470 Slice 3a — downloads an admin-supplied cover image through the hardened fetch path
+    /// (HTTPS-only per hop, bounded redirect follow, IP-pinned connection) under a 10MB streamed
+    /// ceiling. Returns the raw image bytes; the caller validates/re-encodes them.
+    /// </summary>
+    /// <exception cref="ArgumentException">The URL (or a redirect target) is not an absolute HTTPS URL.</exception>
+    /// <exception cref="InvalidOperationException">Redirect loop / too many hops, or oversize.</exception>
+    public Task<byte[]> DownloadImageAsync(string url, CancellationToken ct) =>
+        FetchWithLimitAsync(url, MaxImageSizeBytes, ct);
 
     /// <summary>
     /// Hardened fetch shared by every arbitrary-URL sink on this client: validates the scheme on

--- a/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogAdminEndpoints.cs
+++ b/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogAdminEndpoints.cs
@@ -89,6 +89,17 @@ internal static class SharedGameCatalogAdminEndpoints
             .Produces(StatusCodes.Status204NoContent)
             .Produces(StatusCodes.Status404NotFound);
 
+        // Manual cover from a URL (epic #3470 Slice 3a): admin supplies an HTTPS image URL + attested license.
+        group.MapPost("/admin/shared-games/{id:guid}/manual-cover", HandleSetManualCover)
+            .RequireAuthorization("AdminOrEditorPolicy")
+            .RequireRateLimiting("SharedGamesAdmin")
+            .WithName("SetManualCover")
+            .WithSummary("Set a manual cover from a URL (Admin/Editor)")
+            .WithDescription("Fetches an admin-supplied HTTPS image (SSRF-pinned, 10MB-capped), re-encodes to WebP, stores it in R2, and pins it as the game's manual cover with the attested (whitelisted) license.")
+            .Produces<ManualCoverResult>()
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status404NotFound);
+
         // Submit game for approval (Draft → PendingApproval) - Issue #2514
         group.MapPost("/admin/shared-games/{id:guid}/submit-for-approval", HandleSubmitForApproval)
             .RequireAuthorization("AdminOrEditorPolicy")
@@ -935,6 +946,22 @@ internal static class SharedGameCatalogAdminEndpoints
         await mediator.Send(new RemoveCoverAssignmentCommand(id, context, session!.Principal!.Subject.Id), ct)
             .ConfigureAwait(false);
         return Results.NoContent();
+    }
+
+    private static async Task<IResult> HandleSetManualCover(
+        Guid id,
+        SetManualCoverRequest request,
+        IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken ct)
+    {
+        var (authorized, session, error) = httpContext.RequireAdminOrEditorSession();
+        if (!authorized) return error!;
+
+        var command = new SetManualCoverCommand(
+            id, request.SourceUrl, request.License, request.Attribution, session!.Principal!.Subject.Id);
+        var result = await mediator.Send(command, ct).ConfigureAwait(false);
+        return Results.Ok(result);
     }
 
     private static async Task<IResult> HandleGetApprovalQueue(

--- a/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogRequestDtos.cs
+++ b/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogRequestDtos.cs
@@ -18,6 +18,16 @@ internal record AssignCoverRequest(
     double FocalX = 0.5,
     double FocalY = 0.5);
 
+/// <summary>
+/// Request body for the manual cover set (epic #3470 Slice 3a). The admin supplies an HTTPS image
+/// URL plus the attested license (must be whitelisted) and optional attribution. The acting admin
+/// comes from the session, never the body.
+/// </summary>
+internal record SetManualCoverRequest(
+    string SourceUrl,
+    string License,
+    string? Attribution = null);
+
 // ========================================
 // REQUEST DTOS
 // ========================================

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandlerTests.cs
@@ -1,0 +1,217 @@
+using System.Net;
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+using Api.Middleware.Exceptions;
+using Api.Services;
+using Api.Services.Pdf;
+using Api.SharedKernel.Infrastructure.Persistence;
+using FluentAssertions;
+using ImageMagick;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands;
+
+/// <summary>
+/// Epic #3470 Slice 3a — orchestration tests for the manual (arbitrary-URL) cover set.
+/// Wires the REAL fetch + re-encode pipeline (<see cref="SsrfSafeHttpClient"/> over a stub
+/// <see cref="HttpMessageHandler"/> + the REAL <see cref="WebpVariantGenerator"/>) and mocks only
+/// the storage / repo / cache boundary — per the <c>acceptance_tests_must_exercise_real_pipeline</c>
+/// lesson (fixture-only setup masks handler-level gaps). The license copyright gate lives in
+/// <see cref="SetManualCoverCommandValidator"/> and is covered by its own tests.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class SetManualCoverCommandHandlerTests
+{
+    private const string SourceUrl = "https://commons.example.org/cover.png";
+    private static readonly Guid AdminId = Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd");
+
+    private readonly Mock<ISharedGameRepository> _repository = new();
+    private readonly Mock<IBlobStorageService> _blobStorage = new();
+    private readonly Mock<IUnitOfWork> _unitOfWork = new();
+    private readonly Mock<IHybridCacheService> _cache = new();
+    private readonly Mock<ICacheInvalidationRetryPolicy> _cacheRetryPolicy = new();
+    private readonly StubImageHandler _httpHandler = new();
+
+    public SetManualCoverCommandHandlerTests()
+    {
+        // Passthrough: actually run the wrapped cache op so RemoveByTag* calls are exercised.
+        _cacheRetryPolicy
+            .Setup(p => p.ExecuteAsync(It.IsAny<Func<CancellationToken, ValueTask>>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns((Func<CancellationToken, ValueTask> op, string _, CancellationToken ct) => op(ct).AsTask());
+        _cache
+            .Setup(c => c.RemoveByTagAcrossReplicasAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
+    }
+
+    private SetManualCoverCommandHandler CreateHandler()
+    {
+        var fetcher = new SsrfSafeHttpClient(new HttpClient(_httpHandler));
+        var webp = new WebpVariantGenerator(NullLogger<WebpVariantGenerator>.Instance);
+        return new SetManualCoverCommandHandler(
+            _repository.Object,
+            fetcher,
+            webp,
+            _blobStorage.Object,
+            _unitOfWork.Object,
+            _cache.Object,
+            _cacheRetryPolicy.Object,
+            NullLogger<SetManualCoverCommandHandler>.Instance);
+    }
+
+    private static SharedGame NewGame() => SharedGame.Create(
+        "Catan", 1995, "desc", 3, 4, 90, 10, 2.5m, 7.8m,
+        "https://example.com/c.jpg", "https://example.com/c-thumb.jpg", null, AdminId);
+
+    private static SetManualCoverCommand Command(Guid gameId) =>
+        new(gameId, SourceUrl, "CC BY-SA 4.0", "Jane Doe", AdminId);
+
+    [Fact]
+    public async Task Handle_HappyPath_Downloads_ReEncodes_StoresRawKey_Persists_ReturnsResult()
+    {
+        var game = NewGame();
+        var dbKey = $"covers/manual/{game.Id:D}/cover";
+        var physicalKey = $"{dbKey}.webp";
+
+        _httpHandler.ImageBytes = SolidPng(400, 600);
+        _repository.Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>())).ReturnsAsync(game);
+        _blobStorage
+            .Setup(b => b.StoreRawKeyAsync(physicalKey, It.IsAny<Stream>(), "image/webp", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _blobStorage
+            .Setup(b => b.GetPresignedUrlForRawKeyAsync(physicalKey, 3600))
+            .ReturnsAsync("https://r2.example.com/presigned");
+
+        var result = await CreateHandler().Handle(Command(game.Id), CancellationToken.None);
+
+        // Result carries the suffix-free DB key (the resolver appends .webp) + the preview URL.
+        result.DbKey.Should().Be(dbKey);
+        result.DbKey.Should().NotEndWith(".webp");
+        result.PresignedUrl.Should().Be("https://r2.example.com/presigned");
+
+        // The aggregate got the manual cover + the license attestation (normalized).
+        game.ManualCoverR2Key.Should().Be(dbKey);
+        game.ManualCoverLicense.Should().Be("CC-BY-SA-4.0");
+        game.ManualCoverAttribution.Should().Be("Jane Doe");
+        game.ManualCoverSourceUrl.Should().Be(SourceUrl);
+        game.ManualCoverAttestedBy.Should().Be(AdminId);
+        game.ManualCoverAttestedAt.Should().NotBeNull();
+
+        // The deterministic physical key is written verbatim via the RAW-KEY path (NOT categorized StoreAsync).
+        _blobStorage.Verify(
+            b => b.StoreRawKeyAsync(physicalKey, It.IsAny<Stream>(), "image/webp", It.IsAny<CancellationToken>()),
+            Times.Once);
+        _blobStorage.Verify(
+            b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _repository.Verify(r => r.Update(game), Times.Once);
+        _unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_SuccessfulSet_InvalidatesSearchAndDetailCache()
+    {
+        var game = NewGame();
+        var physicalKey = $"covers/manual/{game.Id:D}/cover.webp";
+
+        _httpHandler.ImageBytes = SolidPng(400, 600);
+        _repository.Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>())).ReturnsAsync(game);
+        _blobStorage
+            .Setup(b => b.StoreRawKeyAsync(physicalKey, It.IsAny<Stream>(), "image/webp", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _blobStorage.Setup(b => b.GetPresignedUrlForRawKeyAsync(physicalKey, 3600)).ReturnsAsync("url");
+
+        await CreateHandler().Handle(Command(game.Id), CancellationToken.None);
+
+        _cache.Verify(c => c.RemoveByTagAcrossReplicasAsync("search-games", It.IsAny<CancellationToken>()), Times.Once);
+        _cache.Verify(c => c.RemoveByTagAcrossReplicasAsync($"shared-game:{game.Id}", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_GameNotFound_ThrowsNotFound_NoDownload_NoSave()
+    {
+        _repository
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SharedGame?)null);
+
+        var act = () => CreateHandler().Handle(Command(Guid.NewGuid()), CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+        _httpHandler.RequestCount.Should().Be(0, "a 404 must short-circuit before any egress");
+        _blobStorage.Verify(
+            b => b.StoreRawKeyAsync(It.IsAny<string>(), It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_RawKeyWriteFails_ThrowsExternal_DoesNotPersistNorInvalidate()
+    {
+        // A failed object write (false — S3 error or local-storage mode) must NOT persist an
+        // unresolvable key: throw and leave the aggregate + DB + cache untouched (#3384 parity).
+        var game = NewGame();
+        var physicalKey = $"covers/manual/{game.Id:D}/cover.webp";
+
+        _httpHandler.ImageBytes = SolidPng(400, 600);
+        _repository.Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>())).ReturnsAsync(game);
+        _blobStorage
+            .Setup(b => b.StoreRawKeyAsync(physicalKey, It.IsAny<Stream>(), "image/webp", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var act = () => CreateHandler().Handle(Command(game.Id), CancellationToken.None);
+
+        await act.Should().ThrowAsync<ExternalServiceException>();
+        game.ManualCoverR2Key.Should().BeNull("no key is persisted when the object write failed");
+        _repository.Verify(r => r.Update(It.IsAny<SharedGame>()), Times.Never);
+        _unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+        _cache.Verify(c => c.RemoveByTagAcrossReplicasAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_NonHttpsSourceUrl_ThrowsBeforeDownload()
+    {
+        // Defence in depth: the validator rejects non-HTTPS at 400, but the SSRF-safe fetch path
+        // ALSO re-validates the scheme, so a handler invoked directly still refuses egress.
+        var game = NewGame();
+        _repository.Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>())).ReturnsAsync(game);
+
+        var act = () => CreateHandler().Handle(
+            Command(game.Id) with { SourceUrl = "http://commons.example.org/cover.png" },
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+        _httpHandler.RequestCount.Should().Be(0);
+        _unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private static byte[] SolidPng(int width, int height)
+    {
+        using var image = new MagickImage(new MagickColor("#4682B4"), (uint)width, (uint)height);
+        image.Format = MagickFormat.Png;
+        using var ms = new MemoryStream();
+        image.Write(ms);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Minimal egress stub: returns the configured image bytes on the first (non-redirect) hop and
+    /// counts requests so tests can assert "no download happened" on the short-circuit paths.
+    /// </summary>
+    private sealed class StubImageHandler : HttpMessageHandler
+    {
+        public byte[] ImageBytes { get; set; } = Array.Empty<byte>();
+        public int RequestCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            var content = new ByteArrayContent(ImageBytes);
+            content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("image/png");
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = content });
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandValidatorTests.cs
@@ -1,0 +1,107 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+using FluentAssertions;
+using FluentValidation.TestHelper;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands;
+
+/// <summary>
+/// Epic #3470 Slice 3a — boundary validation for the manual (arbitrary-URL) cover set.
+/// The license whitelist rule is the PRIMARY copyright gate for this path (ADR-059 / DEC-3c):
+/// it must reject "All Rights Reserved" / BGG / CC-BY-NC BEFORE any download, so the manual
+/// path cannot launder around the catalog's redistribution posture. These tests lock that gate.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class SetManualCoverCommandValidatorTests
+{
+    private static readonly Guid GameId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static readonly Guid AdminId = Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd");
+    private readonly SetManualCoverCommandValidator _validator = new();
+
+    private static SetManualCoverCommand Valid() =>
+        new(GameId, "https://commons.example.org/img.jpg", "CC BY-SA 4.0", "Jane Doe", AdminId);
+
+    [Fact]
+    public void Passes_ForAValidCommand()
+    {
+        _validator.TestValidate(Valid()).ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Passes_WhenAttributionOmitted()
+    {
+        // Attribution is optional (PD / CC0 need none); only the license gate is mandatory.
+        _validator.TestValidate(Valid() with { Attribution = null })
+            .ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Fails_WhenGameIdEmpty()
+    {
+        _validator.TestValidate(Valid() with { GameId = Guid.Empty })
+            .ShouldHaveValidationErrorFor(x => x.GameId);
+    }
+
+    [Fact]
+    public void Fails_WhenAdminIdEmpty()
+    {
+        _validator.TestValidate(Valid() with { AdminId = Guid.Empty })
+            .ShouldHaveValidationErrorFor(x => x.AdminId);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Fails_WhenSourceUrlEmpty(string url)
+    {
+        _validator.TestValidate(Valid() with { SourceUrl = url })
+            .ShouldHaveValidationErrorFor(x => x.SourceUrl);
+    }
+
+    [Theory]
+    [InlineData("http://commons.example.org/img.jpg")]  // http downgrade
+    [InlineData("ftp://host/img.jpg")]                   // non-http scheme
+    [InlineData("/relative/path.jpg")]                   // not absolute
+    [InlineData("not-a-url")]
+    public void Fails_WhenSourceUrlNotAbsoluteHttps(string url)
+    {
+        _validator.TestValidate(Valid() with { SourceUrl = url })
+            .ShouldHaveValidationErrorFor(x => x.SourceUrl);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Fails_WhenLicenseEmpty(string license)
+    {
+        _validator.TestValidate(Valid() with { License = license })
+            .ShouldHaveValidationErrorFor(x => x.License);
+    }
+
+    [Theory]
+    [InlineData("All rights reserved")]
+    [InlineData("CC BY-NC 4.0")]   // NonCommercial — redistribution-encumbered
+    [InlineData("CC BY-ND 4.0")]   // NoDerivatives
+    [InlineData("BGG")]
+    [InlineData("Fair use")]
+    public void Fails_WhenLicenseNotWhitelisted(string license)
+    {
+        // The copyright gate: anything outside PD / CC0 / CC-BY / CC-BY-SA is rejected at 400
+        // BEFORE the handler downloads or stores anything.
+        _validator.TestValidate(Valid() with { License = license })
+            .ShouldHaveValidationErrorFor(x => x.License);
+    }
+
+    [Theory]
+    [InlineData("Public domain")]
+    [InlineData("CC0")]
+    [InlineData("CC BY 2.0")]
+    [InlineData("CC-BY-4.0")]
+    [InlineData("CC BY-SA 3.0")]
+    public void Passes_ForWhitelistedLicenses(string license)
+    {
+        _validator.TestValidate(Valid() with { License = license })
+            .ShouldNotHaveValidationErrorFor(x => x.License);
+    }
+}


### PR DESCRIPTION
## Slice 3a-2 — manual (arbitrary-URL) cover set (epic #3470)

Wires the admin **manual cover** path: an Admin/Editor supplies an HTTPS image URL plus an **attested, whitelisted** license; the server fetches it through the hardened SSRF-pinned client (#3534), re-encodes to WebP, stores it at the deterministic manual R2 key, and pins it on the `SharedGame` aggregate with the license attestation.

### What's in
- **`SetManualCoverCommand` / `ManualCoverResult`** — result carries the suffix-free `DbKey` (resolver appends `.webp`) + a presigned preview URL.
- **Validator** — `GameId`/`AdminId` non-empty, `SourceUrl` absolute HTTPS, and **`License` on the DEC-3c whitelist** (PD / CC0 / CC-BY / CC-BY-SA) → `400`. This is the **primary copyright gate**: it rejects "All Rights Reserved" / BGG / CC-BY-NC **before any download or store**, so the manual path cannot launder around the catalog's redistribution posture (ADR-059).
- **Handler** — `404` short-circuits **before** egress; a failed raw-key write throws `ExternalServiceException` **without persisting** an unresolvable key; read-model caches (`search-games`, `shared-game:{id}`) evicted via the retry policy on success only.
- **Endpoint** — `POST /admin/shared-games/{id:guid}/manual-cover` (`AdminOrEditorPolicy`, `SharedGamesAdmin` rate limit).
- **`SsrfSafeHttpClient.DownloadImageAsync`** — 10 MB streamed ceiling on the shared hardened fetch.

### Security posture
- IP boundary is the connect-pin (#3495 fix 5/N), **not** TOCTOU DNS pre-checks; scheme re-validated HTTPS-only on every redirect hop; the WebP re-encode strips the source container/metadata.
- License whitelist is enforced at the validator (400) **and** the aggregate rejects empty license — defence in depth.

### Tests (33 green)
- Validator: whitelist accept/reject (incl. CC-BY-NC/ND, "All rights reserved", BGG), HTTPS/absolute, empty guards.
- Handler: happy path over the **real fetch + WebP pipeline** (stub egress), `404` no-egress no-save, raw-key-write-fails no-persist no-invalidate, non-HTTPS defence-in-depth.

### Follow-ups (later slices)
`RevokeManualCoverCommand`, explicit host deny-list (ADR-059), same-tx immutable evidence audit (C6/H6), four-eyes queue, observability, FE picker wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)