### PR TITLE
feat(covers): RevokeManualCover command + DELETE endpoint (#3470)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RevokeManualCoverCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RevokeManualCoverCommand.cs
@@ -1,0 +1,13 @@
+using Api.SharedKernel.Application.Interfaces;
+using MediatR;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+
+/// <summary>
+/// Epic #3470 Slice 3a-3 — revokes a game's admin-set manual cover: clears the manual cover
+/// columns + license attestation and best-effort deletes the R2 object. Idempotent: revoking a
+/// game with no manual cover is a no-op (still 204); only a missing game is a 404.
+/// </summary>
+internal record RevokeManualCoverCommand(
+    Guid GameId,
+    Guid AdminId) : ICommand<Unit>;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RevokeManualCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RevokeManualCoverCommandHandler.cs
@@ -1,0 +1,95 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.Services;
+using Api.Services.Pdf;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Domain.Covers;
+using Api.SharedKernel.Infrastructure.Persistence;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+
+/// <summary>
+/// Epic #3470 Slice 3a-3 — revokes a game's admin-set manual cover. Flow: load game (404 if
+/// missing) → clear the manual columns on the aggregate (idempotent 204 no-op if nothing was
+/// set) → persist → best-effort delete the R2 object → evict the read-model caches.
+/// <para>
+/// Persist-first mirrors the write path (<see cref="SetManualCoverCommandHandler"/> writes R2
+/// then persists the key; revoke persists the null then deletes R2): the DB null is the
+/// authoritative revoke, so a failed R2 delete only leaves an unreferenced orphan object rather
+/// than a DB row pointing at a deleted object.
+/// </para>
+/// </summary>
+internal sealed class RevokeManualCoverCommandHandler : ICommandHandler<RevokeManualCoverCommand, Unit>
+{
+    private readonly ISharedGameRepository _repository;
+    private readonly IBlobStorageService _blobStorage;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IHybridCacheService _cache;
+    private readonly ICacheInvalidationRetryPolicy _cacheRetryPolicy;
+    private readonly ILogger<RevokeManualCoverCommandHandler> _logger;
+
+    public RevokeManualCoverCommandHandler(
+        ISharedGameRepository repository,
+        IBlobStorageService blobStorage,
+        IUnitOfWork unitOfWork,
+        IHybridCacheService cache,
+        ICacheInvalidationRetryPolicy cacheRetryPolicy,
+        ILogger<RevokeManualCoverCommandHandler> logger)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _blobStorage = blobStorage ?? throw new ArgumentNullException(nameof(blobStorage));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _cacheRetryPolicy = cacheRetryPolicy ?? throw new ArgumentNullException(nameof(cacheRetryPolicy));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<Unit> Handle(RevokeManualCoverCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var game = await _repository.GetByIdAsync(command.GameId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException("SharedGame", command.GameId.ToString());
+
+        // Capture the key BEFORE clearing so we can best-effort delete the object afterwards.
+        var keyToDelete = game.ManualCoverR2Key;
+
+        // Idempotent: nothing was set → no persistence, no R2 delete, no cache churn (204).
+        if (!game.RevokeManualCover())
+        {
+            return Unit.Value;
+        }
+
+        _repository.Update(game);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        // Best-effort R2 cleanup AFTER the authoritative DB revoke. The raw-key delete (#3384)
+        // targets the deterministic manual physical key; a failure leaves only an unreferenced
+        // orphan (the DB no longer points at it), so it must not fail the request.
+        if (!string.IsNullOrWhiteSpace(keyToDelete))
+        {
+            try
+            {
+                await _blobStorage.DeleteRawKeyAsync(
+                    CoverKeyBuilder.PhysicalKeyFor(CoverKind.Manual, keyToDelete),
+                    cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogWarning(ex, "Failed to delete manual cover R2 key {Key}; DB is already revoked", keyToDelete);
+            }
+        }
+
+        // The cover columns the read-model resolves changed → evict the list + detail caches (AC-6).
+        await CoverCacheInvalidation
+            .EvictReadModelAsync(_cache, _cacheRetryPolicy, game.Id, cancellationToken)
+            .ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Manual cover revoked for game {GameId} by {AdminId}", game.Id, command.AdminId);
+
+        return Unit.Value;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RevokeManualCoverCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RevokeManualCoverCommandValidator.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+
+/// <summary>
+/// Boundary validation for <see cref="RevokeManualCoverCommand"/> — 400 (not 500) on bad input.
+/// The GameId comes from the route and the AdminId from the session, so both are just identity
+/// guards; the idempotent "nothing to revoke" case is handled in the handler as a 204, not here.
+/// </summary>
+internal sealed class RevokeManualCoverCommandValidator : AbstractValidator<RevokeManualCoverCommand>
+{
+    public RevokeManualCoverCommandValidator()
+    {
+        RuleFor(x => x.GameId).NotEqual(Guid.Empty).WithMessage("GameId is required");
+        RuleFor(x => x.AdminId).NotEqual(Guid.Empty).WithMessage("AdminId is required");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RevokeManualCoverCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RevokeManualCoverCommandValidator.cs
@@ -3,9 +3,10 @@ using FluentValidation;
 namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands;
 
 /// <summary>
-/// Boundary validation for <see cref="RevokeManualCoverCommand"/> — 400 (not 500) on bad input.
-/// The GameId comes from the route and the AdminId from the session, so both are just identity
-/// guards; the idempotent "nothing to revoke" case is handled in the handler as a 204, not here.
+/// Boundary validation for <see cref="RevokeManualCoverCommand"/> — turns bad input into a 4xx
+/// client error (422 via the FluentValidation pipeline) instead of a 500. The GameId comes from
+/// the route and the AdminId from the session, so both are just identity guards; the idempotent
+/// "nothing to revoke" case is handled in the handler as a 204, not here.
 /// </summary>
 internal sealed class RevokeManualCoverCommandValidator : AbstractValidator<RevokeManualCoverCommand>
 {

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/SharedGame.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/SharedGame.cs
@@ -881,6 +881,41 @@ public sealed class SharedGame : AggregateRoot<Guid>
     }
 
     /// <summary>
+    /// Epic #3470 Slice 3a-3 — revokes the admin-set manual cover by clearing the six manual
+    /// cover / attestation fields. Returns <c>true</c> when something was cleared, <c>false</c>
+    /// when there was no manual cover to revoke — an idempotent no-op the caller turns into a
+    /// 204 without persisting or evicting caches.
+    /// </summary>
+    /// <remarks>
+    /// Follow-up (gated on per-context crop generation): once an <c>AssignCover</c> flow
+    /// populates a rendered <c>GeneratedR2Key</c> on a Manual-sourced assignment, revoke must
+    /// ALSO remove those assignments (and delete their crop objects), else the crop would keep
+    /// serving after revoke. Today no crop is generated for a Manual assignment, so a dangling
+    /// Manual assignment resolves to a null base key and falls through to the implicit
+    /// precedence — the revoked image genuinely stops serving.
+    /// </remarks>
+    public bool RevokeManualCover()
+    {
+        if (_manualCoverR2Key is null
+            && _manualCoverLicense is null
+            && _manualCoverAttribution is null
+            && _manualCoverSourceUrl is null
+            && _manualCoverAttestedBy is null
+            && _manualCoverAttestedAt is null)
+        {
+            return false;
+        }
+
+        _manualCoverR2Key = null;
+        _manualCoverLicense = null;
+        _manualCoverAttribution = null;
+        _manualCoverSourceUrl = null;
+        _manualCoverAttestedBy = null;
+        _manualCoverAttestedAt = null;
+        return true;
+    }
+
+    /// <summary>
     /// Assigns a BGG ID to this game. Only allowed for Skeleton or Failed games.
     /// Enables subsequent BGG enrichment.
     /// </summary>

--- a/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogAdminEndpoints.cs
+++ b/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogAdminEndpoints.cs
@@ -100,6 +100,16 @@ internal static class SharedGameCatalogAdminEndpoints
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status404NotFound);
 
+        // Revoke a manual cover (epic #3470 Slice 3a-3): clears the manual cover + attestation.
+        group.MapDelete("/admin/shared-games/{id:guid}/manual-cover", HandleRevokeManualCover)
+            .RequireAuthorization("AdminOrEditorPolicy")
+            .RequireRateLimiting("SharedGamesAdmin")
+            .WithName("RevokeManualCover")
+            .WithSummary("Revoke a game's manual cover (Admin/Editor)")
+            .WithDescription("Clears the manual cover columns + license attestation and best-effort deletes the R2 object. Idempotent: 204 whether or not a manual cover was set; 404 only if the game is missing.")
+            .Produces(StatusCodes.Status204NoContent)
+            .Produces(StatusCodes.Status404NotFound);
+
         // Submit game for approval (Draft → PendingApproval) - Issue #2514
         group.MapPost("/admin/shared-games/{id:guid}/submit-for-approval", HandleSubmitForApproval)
             .RequireAuthorization("AdminOrEditorPolicy")
@@ -962,6 +972,20 @@ internal static class SharedGameCatalogAdminEndpoints
             id, request.SourceUrl, request.License, request.Attribution, session!.Principal!.Subject.Id);
         var result = await mediator.Send(command, ct).ConfigureAwait(false);
         return Results.Ok(result);
+    }
+
+    private static async Task<IResult> HandleRevokeManualCover(
+        Guid id,
+        IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken ct)
+    {
+        var (authorized, session, error) = httpContext.RequireAdminOrEditorSession();
+        if (!authorized) return error!;
+
+        await mediator.Send(new RevokeManualCoverCommand(id, session!.Principal!.Subject.Id), ct)
+            .ConfigureAwait(false);
+        return Results.NoContent();
     }
 
     private static async Task<IResult> HandleGetApprovalQueue(

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/RevokeManualCoverCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/RevokeManualCoverCommandHandlerTests.cs
@@ -1,0 +1,130 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.Services;
+using Api.Services.Pdf;
+using Api.SharedKernel.Domain.Covers;
+using Api.SharedKernel.Infrastructure.Persistence;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands;
+
+/// <summary>
+/// Epic #3470 Slice 3a-3 — orchestration tests for the manual-cover revoke. Mocked repo /
+/// storage / cache over a REAL <see cref="SharedGame"/> aggregate. Verifies the persist-first
+/// order (DB revoke authoritative, R2 delete best-effort after), the idempotent 204 no-op, and
+/// the 404.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class RevokeManualCoverCommandHandlerTests
+{
+    private static readonly Guid AdminId = Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd");
+
+    private readonly Mock<ISharedGameRepository> _repository = new();
+    private readonly Mock<IBlobStorageService> _blobStorage = new();
+    private readonly Mock<IUnitOfWork> _unitOfWork = new();
+    private readonly Mock<IHybridCacheService> _cache = new();
+    private readonly Mock<ICacheInvalidationRetryPolicy> _cacheRetryPolicy = new();
+
+    public RevokeManualCoverCommandHandlerTests()
+    {
+        _cacheRetryPolicy
+            .Setup(p => p.ExecuteAsync(It.IsAny<Func<CancellationToken, ValueTask>>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns((Func<CancellationToken, ValueTask> op, string _, CancellationToken ct) => op(ct).AsTask());
+        _cache
+            .Setup(c => c.RemoveByTagAcrossReplicasAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
+    }
+
+    private RevokeManualCoverCommandHandler CreateHandler() =>
+        new(_repository.Object, _blobStorage.Object, _unitOfWork.Object, _cache.Object,
+            _cacheRetryPolicy.Object, NullLogger<RevokeManualCoverCommandHandler>.Instance);
+
+    private static SharedGame NewGame() => SharedGame.Create(
+        "Catan", 1995, "desc", 3, 4, 90, 10, 2.5m, 7.8m,
+        "https://example.com/c.jpg", "https://example.com/c-thumb.jpg", null, AdminId);
+
+    private static SharedGame GameWithManualCover()
+    {
+        var game = NewGame();
+        var dbKey = CoverKeyBuilder.ForManual(game.Id).DbKey;
+        game.SetManualCover(dbKey, "CC0", null, "https://example.com/src", AdminId, DateTime.UtcNow);
+        return game;
+    }
+
+    [Fact]
+    public async Task Handle_WithManualCoverSet_ClearsAggregate_Persists_DeletesR2_InvalidatesCache()
+    {
+        var game = GameWithManualCover();
+        var physicalKey = $"covers/manual/{game.Id:D}/cover.webp";
+        _repository.Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>())).ReturnsAsync(game);
+        _blobStorage
+            .Setup(b => b.DeleteRawKeyAsync(physicalKey, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        await CreateHandler().Handle(new RevokeManualCoverCommand(game.Id, AdminId), CancellationToken.None);
+
+        game.ManualCoverR2Key.Should().BeNull();
+        game.ManualCoverLicense.Should().BeNull();
+        game.ManualCoverAttestedBy.Should().BeNull();
+
+        _repository.Verify(r => r.Update(game), Times.Once);
+        _unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _blobStorage.Verify(b => b.DeleteRawKeyAsync(physicalKey, It.IsAny<CancellationToken>()), Times.Once);
+        _cache.Verify(c => c.RemoveByTagAcrossReplicasAsync("search-games", It.IsAny<CancellationToken>()), Times.Once);
+        _cache.Verify(c => c.RemoveByTagAcrossReplicasAsync($"shared-game:{game.Id}", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_NoManualCoverSet_Idempotent_NoPersist_NoDelete_NoInvalidate()
+    {
+        // A game that never had a manual cover → 204 no-op: nothing to persist, delete, or evict.
+        var game = NewGame();
+        _repository.Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>())).ReturnsAsync(game);
+
+        await CreateHandler().Handle(new RevokeManualCoverCommand(game.Id, AdminId), CancellationToken.None);
+
+        _repository.Verify(r => r.Update(It.IsAny<SharedGame>()), Times.Never);
+        _unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+        _blobStorage.Verify(b => b.DeleteRawKeyAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _cache.Verify(c => c.RemoveByTagAcrossReplicasAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_GameNotFound_ThrowsNotFound_NoSideEffects()
+    {
+        _repository
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SharedGame?)null);
+
+        var act = () => CreateHandler().Handle(new RevokeManualCoverCommand(Guid.NewGuid(), AdminId), CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+        _unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+        _blobStorage.Verify(b => b.DeleteRawKeyAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_R2DeleteThrows_StillSucceeds_DbAlreadyRevoked()
+    {
+        // Persist-first: the DB revoke is committed BEFORE the best-effort R2 delete, so a
+        // storage failure must be swallowed and the request must still succeed.
+        var game = GameWithManualCover();
+        var physicalKey = $"covers/manual/{game.Id:D}/cover.webp";
+        _repository.Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>())).ReturnsAsync(game);
+        _blobStorage
+            .Setup(b => b.DeleteRawKeyAsync(physicalKey, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("simulated R2 outage"));
+
+        var act = () => CreateHandler().Handle(new RevokeManualCoverCommand(game.Id, AdminId), CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+        _unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once, "DB revoke commits before the best-effort delete");
+        _cache.Verify(c => c.RemoveByTagAcrossReplicasAsync("search-games", It.IsAny<CancellationToken>()), Times.Once, "cache still evicted after a swallowed R2 failure");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/RevokeManualCoverCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/RevokeManualCoverCommandValidatorTests.cs
@@ -1,0 +1,41 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+using FluentValidation.TestHelper;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands;
+
+/// <summary>
+/// Epic #3470 Slice 3a-3 — identity guards for the manual-cover revoke. GameId (route) and
+/// AdminId (session) must be non-empty; the "nothing to revoke" case is a 204 in the handler,
+/// not a validation error.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class RevokeManualCoverCommandValidatorTests
+{
+    private static readonly Guid GameId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static readonly Guid AdminId = Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd");
+    private readonly RevokeManualCoverCommandValidator _validator = new();
+
+    private static RevokeManualCoverCommand Valid() => new(GameId, AdminId);
+
+    [Fact]
+    public void Passes_ForAValidCommand()
+    {
+        _validator.TestValidate(Valid()).ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Fails_WhenGameIdEmpty()
+    {
+        _validator.TestValidate(Valid() with { GameId = Guid.Empty })
+            .ShouldHaveValidationErrorFor(x => x.GameId);
+    }
+
+    [Fact]
+    public void Fails_WhenAdminIdEmpty()
+    {
+        _validator.TestValidate(Valid() with { AdminId = Guid.Empty })
+            .ShouldHaveValidationErrorFor(x => x.AdminId);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Aggregates/SharedGameTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Aggregates/SharedGameTests.cs
@@ -1442,4 +1442,48 @@ public sealed class SharedGameTests
     }
 
     #endregion
+
+    #region RevokeManualCover (epic #3470 Slice 3a-3)
+
+    [Fact]
+    public void RevokeManualCover_WithManualCoverSet_ClearsAllFields_ReturnsTrue()
+    {
+        var game = NewManualCoverGame();
+        game.SetManualCover("covers/manual/x/cover", "CC-BY-4.0", "Jane Artist", "https://example.com/src", Guid.NewGuid(), DateTime.UtcNow);
+
+        var changed = game.RevokeManualCover();
+
+        changed.Should().BeTrue();
+        game.ManualCoverR2Key.Should().BeNull();
+        game.ManualCoverLicense.Should().BeNull();
+        game.ManualCoverAttribution.Should().BeNull();
+        game.ManualCoverSourceUrl.Should().BeNull();
+        game.ManualCoverAttestedBy.Should().BeNull();
+        game.ManualCoverAttestedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void RevokeManualCover_WhenNothingSet_ReturnsFalse_NoChange()
+    {
+        // Idempotent: revoking a game that never had a manual cover is a no-op the
+        // handler can turn into a 204 without persisting/evicting anything.
+        var game = NewManualCoverGame();
+
+        var changed = game.RevokeManualCover();
+
+        changed.Should().BeFalse();
+        game.ManualCoverR2Key.Should().BeNull();
+    }
+
+    [Fact]
+    public void RevokeManualCover_SecondCall_ReturnsFalse()
+    {
+        var game = NewManualCoverGame();
+        game.SetManualCover("k", "CC0", null, "https://s", Guid.NewGuid(), DateTime.UtcNow);
+
+        game.RevokeManualCover().Should().BeTrue();
+        game.RevokeManualCover().Should().BeFalse("the manual cover is already cleared");
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Slice 3a-3 — manual-cover revoke (epic #3470)

Closes the manual-cover **set/revoke lifecycle** (backend). Symmetric inverse of Slice 3a-2's `SetManualCover`.

### What's in
- **`SharedGame.RevokeManualCover()`** — clears the six manual cover/attestation fields; returns `false` (idempotent no-op) when nothing was set.
- **`RevokeManualCoverCommand`** + validator (GameId/AdminId non-empty) + handler.
- **Handler** (persist-first, mirroring the write path): load → `404` if missing → `RevokeManualCover()` → idempotent **204** no-op if nothing set → `Update` + `SaveChanges` (**authoritative** DB revoke) → **best-effort** `DeleteRawKeyAsync` of the manual R2 object (swallowed on failure → only an unreferenced orphan) → read-model cache eviction via the retry policy.
- **`DELETE /admin/shared-games/{id:guid}/manual-cover`** (`AdminOrEditorPolicy`, `SharedGamesAdmin` rate limit), 204/404.

### Correctness note (verified, not assumed)
A dangling Manual `GameCoverAssignment` after revoke resolves to a **null base key** and falls through to the implicit precedence — because no crop (`GeneratedR2Key`) is generated for a Manual assignment today (`AssignCoverCommandHandler` doesn't populate it). So the revoked image **genuinely stops serving** with the simple column-clear + base-object delete; the proven `Update`-only persistence pattern is used (no unproven `Update`+`Reconcile` combo). **Follow-up gated on per-context crop generation**: once crops render for Manual assignments, revoke must also cascade-remove those assignments + delete crop objects.

### Adversarial review
Ran a 3-dimension review (EF-correctness / security-legal / conventions) + per-finding adversarial verification. 1 low-severity CONFIRMED finding (validator doc said "400" but the FluentValidation pipeline returns **422**) — fixed in the doc-wording commit. The `.Produces(422)` omission is a **repo-wide** pattern (all cover validators/endpoints) left for a uniform follow-up.

### Tests (10 green)
- Domain: clear-all-returns-true, idempotent-returns-false, second-call-returns-false.
- Validator: empty-guard rejects.
- Handler: persist+delete+evict happy path, idempotent 204 no-op (no persist/delete/evict), 404, best-effort R2-delete-failure still succeeds (DB already revoked).

### Deferred (epic #3470 follow-ups)
Source-aware **attribution surfacing** for a winning Manual cover (`CoverAttribution.ForWinningSource` is Wikidata-only; DTO lacks Manual triple — **copyright-critical**, must land with the FE "from URL" picker) · FE cover-picker "from URL" wiring · cascade-remove + crop cleanup (gated on crop gen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)