### PR TITLE
feat(covers): source-neutral cover attribution incl. Manual (#3470)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetAllSharedGamesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetAllSharedGamesQueryHandler.cs
@@ -119,9 +119,9 @@ internal sealed class GetAllSharedGamesQueryHandler : IRequestHandler<GetAllShar
                 CoverUrl: cover.Url,
                 // Epic #3470 Slice 1d-a — attribution follows the WINNING source (was
                 // emitted unconditionally); all-null unless the Wikidata cover won.
-                WikidataCoverLicense: coverLicense,
-                WikidataCoverAttribution: coverAttribution,
-                WikidataCoverSourceUrl: coverSourceUrl));
+                CoverLicense: coverLicense,
+                CoverAttribution: coverAttribution,
+                CoverSourceUrl: coverSourceUrl));
         }
 
         // Issue #2339 (Wave 4 Task 13 — DEC-WIRING): enrich SharedGameDto.Translations

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetFilteredSharedGamesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetFilteredSharedGamesQueryHandler.cs
@@ -154,9 +154,9 @@ internal sealed class GetFilteredSharedGamesQueryHandler : IRequestHandler<GetFi
                 false,  // IsNew
                 CoverUrl: cover.Url,
                 // Epic #3470 Slice 1d-a — attribution follows the winning source.
-                WikidataCoverLicense: coverLicense,
-                WikidataCoverAttribution: coverAttribution,
-                WikidataCoverSourceUrl: coverSourceUrl));
+                CoverLicense: coverLicense,
+                CoverAttribution: coverAttribution,
+                CoverSourceUrl: coverSourceUrl));
         }
 
         // Issue #2339 (Wave 4 Task 13 — DEC-WIRING): enrich SharedGameDto.Translations

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetPendingApprovalGamesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetPendingApprovalGamesQueryHandler.cs
@@ -105,9 +105,9 @@ internal sealed class GetPendingApprovalGamesQueryHandler : IRequestHandler<GetP
                 false,  // IsNew
                 CoverUrl: cover.Url,
                 // Epic #3470 Slice 1d-a — attribution follows the winning source.
-                WikidataCoverLicense: coverLicense,
-                WikidataCoverAttribution: coverAttribution,
-                WikidataCoverSourceUrl: coverSourceUrl));
+                CoverLicense: coverLicense,
+                CoverAttribution: coverAttribution,
+                CoverSourceUrl: coverSourceUrl));
         }
 
         // Issue #2339 (Wave 4 Task 13 — DEC-WIRING): enrich SharedGameDto.Translations

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetSharedGameByIdQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetSharedGameByIdQueryHandler.cs
@@ -463,9 +463,9 @@ internal sealed class GetSharedGameByIdQueryHandler : IRequestHandler<GetSharedG
             CoverUrl: coverUrl,
             // Epic #3470 Slice 1d-a — source-aware attribution (read from the entity, gated
             // on the winning cover source; was emitted unconditionally from the aggregate).
-            WikidataCoverLicense: coverLicense,
-            WikidataCoverAttribution: coverAttribution,
-            WikidataCoverSourceUrl: coverSourceUrl,
+            CoverLicense: coverLicense,
+            CoverAttribution: coverAttribution,
+            CoverSourceUrl: coverSourceUrl,
             SocialCoverUrl: socialCoverUrl);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQueryHandler.cs
@@ -462,9 +462,9 @@ internal sealed class SearchSharedGamesQueryHandler : IRequestHandler<SearchShar
                 p.NewThisWeekCount >= IsNewMinThreshold,
                 CoverUrl: cover.Url,
                 // Epic #3470 Slice 1d-a — attribution follows the winning source.
-                WikidataCoverLicense: coverLicense,
-                WikidataCoverAttribution: coverAttribution,
-                WikidataCoverSourceUrl: coverSourceUrl));
+                CoverLicense: coverLicense,
+                CoverAttribution: coverAttribution,
+                CoverSourceUrl: coverSourceUrl));
         }
 
         // Issue #2339 (Wave 4 Task 13 — DEC-WIRING): enrich SharedGameDto.Translations

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CoverAttribution.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CoverAttribution.cs
@@ -5,19 +5,21 @@ using Api.SharedKernel.Domain.Covers;
 namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
 
 /// <summary>
-/// Epic #3470 Slice 1d-a — maps the WINNING cover source to the license / attribution /
-/// source-url triple the shared-game DTOs surface. Only sources that carry a license
-/// emit one: today that is Wikidata (the DTOs expose Wikidata attribution fields only).
-/// When a PDF / BGG / user cover wins — or nothing wins — the triple is all-null, so the
-/// footer never credits Wikidata over a non-Wikidata image (the source-mislabeling bug
-/// this fixes). Manual-cover attribution surfacing is deferred: no DTO fields exist yet.
+/// Epic #3470 Slice 1d-a / 3b — maps the WINNING cover source to the license / attribution /
+/// source-url triple the shared-game DTOs surface (source-neutral <c>Cover*</c> fields). Only
+/// sources that carry an attested license emit one: Wikidata (the enrichment pipeline) and
+/// Manual (the admin arbitrary-URL path, Slice 3b — copyright-critical: a whitelist-admitted
+/// CC-BY/CC-BY-SA image MUST render its credit). When a PDF / BGG / user cover wins — none of
+/// which carry a license — or nothing wins, the triple is all-null, so the footer never credits
+/// a source over a different image (the source-mislabeling bug Slice 1d-a fixed).
 /// </summary>
 internal static class CoverAttribution
 {
     /// <summary>
-    /// Returns the attribution triple for the <paramref name="winningKind"/>, reading
-    /// from <paramref name="entity"/>. HTML in the Wikidata attribution is stripped
-    /// (DEC-G6-1). All-null for any non-Wikidata winner or when no source won.
+    /// Returns the attribution triple for the <paramref name="winningKind"/>, reading from
+    /// <paramref name="entity"/>. HTML in the attribution is stripped (DEC-G6-1) for both the
+    /// Wikidata and the admin-attested Manual credit. All-null for any source without a license
+    /// (PDF / BGG / user) or when no source won.
     /// </summary>
     public static (string? License, string? Attribution, string? SourceUrl) ForWinningSource(
         CoverKind? winningKind,
@@ -25,10 +27,15 @@ internal static class CoverAttribution
     {
         ArgumentNullException.ThrowIfNull(entity);
 
-        return winningKind == CoverKind.Wikidata
-            ? (entity.WikidataCoverLicense,
-               AttributionTextExtractor.Strip(entity.WikidataCoverAttribution),
-               entity.WikidataCoverSourceUrl)
-            : (null, null, null);
+        return winningKind switch
+        {
+            CoverKind.Wikidata => (entity.WikidataCoverLicense,
+                                   AttributionTextExtractor.Strip(entity.WikidataCoverAttribution),
+                                   entity.WikidataCoverSourceUrl),
+            CoverKind.Manual => (entity.ManualCoverLicense,
+                                 AttributionTextExtractor.Strip(entity.ManualCoverAttribution),
+                                 entity.ManualCoverSourceUrl),
+            _ => (null, null, null),
+        };
     }
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/SharedGameDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/SharedGameDto.cs
@@ -62,13 +62,15 @@ public sealed record SharedGameDto(
     // Enriched by GameTitleResolver in list query handlers; raw list handlers may emit null when
     // the resolver is not on the pipeline (e.g. admin endpoints that don't surface translations).
     IReadOnlyList<SharedGameTranslationDto>? Translations = null,
-    // Issue #2055 Phase G AC-G6: Wikidata cover license + attribution (plain text,
-    // HTML-stripped upstream by AttributionTextExtractor per DEC-G6-1). Null when
-    // the game lacks a Wikidata cover or the attempt is pending. FE renders only
-    // when WikidataCoverLicense is non-null.
-    string? WikidataCoverLicense = null,
-    string? WikidataCoverAttribution = null,
-    string? WikidataCoverSourceUrl = null);
+    // Issue #2055 Phase G AC-G6 / epic #3470 Slice 3b: license + attribution + source URL of the
+    // WINNING cover source (Wikidata or admin-attested Manual), plain text (HTML-stripped by
+    // AttributionTextExtractor per DEC-G6-1). Source-neutral by design — the value follows
+    // whichever source won (CoverAttribution.ForWinningSource), never a fixed source. Null when
+    // the winner carries no license (PDF/BGG/user) or none won. FE renders the credit only when
+    // CoverLicense is non-null.
+    string? CoverLicense = null,
+    string? CoverAttribution = null,
+    string? CoverSourceUrl = null);
 
 /// <summary>
 /// Data transfer object for game rules.
@@ -239,13 +241,15 @@ public sealed record SharedGameDetailDto(
     bool IsNew = false,
     // Issue #1852 (Gap A): cover URL resolved via L4 → L2 priority; null when no cover available or storage unavailable.
     string? CoverUrl = null,
-    // Issue #2055 Phase G AC-G6: Wikidata cover license + attribution (plain text,
-    // HTML-stripped upstream by AttributionTextExtractor per DEC-G6-1). Null when
-    // the game lacks a Wikidata cover or the attempt is pending. FE renders only
-    // when WikidataCoverLicense is non-null.
-    string? WikidataCoverLicense = null,
-    string? WikidataCoverAttribution = null,
-    string? WikidataCoverSourceUrl = null,
+    // Issue #2055 Phase G AC-G6 / epic #3470 Slice 3b: license + attribution + source URL of the
+    // WINNING cover source (Wikidata or admin-attested Manual), plain text (HTML-stripped by
+    // AttributionTextExtractor per DEC-G6-1). Source-neutral by design — the value follows
+    // whichever source won (CoverAttribution.ForWinningSource), never a fixed source. Null when
+    // the winner carries no license (PDF/BGG/user) or none won. FE renders the credit only when
+    // CoverLicense is non-null.
+    string? CoverLicense = null,
+    string? CoverAttribution = null,
+    string? CoverSourceUrl = null,
     // Epic #3470 Slice 2d (AC-2): cover resolved for the Social (OpenGraph) context,
     // consumed by the FE OG meta (#3452). Falls through to the implicit precedence when
     // no Social override is pinned, so it is never worse than CoverUrl.

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/CoverAttributionTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/CoverAttributionTests.cs
@@ -74,4 +74,57 @@ public sealed class CoverAttributionTests
         attribution.Should().BeNull();
         sourceUrl.Should().BeNull();
     }
+
+    // ----- Epic #3470 Slice 3b: Manual cover attribution (copyright-critical) -----
+
+    private static SharedGameEntity EntityWithManual() => new()
+    {
+        ManualCoverLicense = "CC-BY-4.0",
+        ManualCoverAttribution = "<b>Jane Artist</b>",
+        ManualCoverSourceUrl = "https://commons.example.org/img",
+    };
+
+    [Fact]
+    public void ForWinningSource_ManualWins_ReturnsStrippedManualTriple()
+    {
+        // A CC-BY/CC-BY-SA manual cover MUST surface its attested license + attribution,
+        // else the whitelist-admitted image renders without the legally-required credit.
+        var (license, attribution, sourceUrl) = CoverAttribution.ForWinningSource(CoverKind.Manual, EntityWithManual());
+
+        license.Should().Be("CC-BY-4.0");
+        attribution.Should().Be("Jane Artist", "the attested attribution is HTML-stripped like Wikidata");
+        sourceUrl.Should().Be("https://commons.example.org/img");
+    }
+
+    [Fact]
+    public void ForWinningSource_ManualWinsButNoColumns_ReturnsNulls()
+    {
+        var (license, attribution, sourceUrl) = CoverAttribution.ForWinningSource(CoverKind.Manual, new SharedGameEntity());
+
+        license.Should().BeNull();
+        attribution.Should().BeNull();
+        sourceUrl.Should().BeNull();
+    }
+
+    [Fact]
+    public void ForWinningSource_ManualWins_DoesNotLeakWikidata()
+    {
+        // Entity carries BOTH Wikidata and Manual columns; Manual is the winner → only the
+        // Manual triple surfaces (never a Wikidata credit over a Manual image).
+        var entity = new SharedGameEntity
+        {
+            WikidataCoverLicense = "CC BY-SA 4.0",
+            WikidataCoverAttribution = "Wiki Author",
+            WikidataCoverSourceUrl = "https://www.wikidata.org/wiki/Q1",
+            ManualCoverLicense = "CC0",
+            ManualCoverAttribution = "Manual Author",
+            ManualCoverSourceUrl = "https://commons.example.org/m",
+        };
+
+        var (license, attribution, sourceUrl) = CoverAttribution.ForWinningSource(CoverKind.Manual, entity);
+
+        license.Should().Be("CC0");
+        attribution.Should().Be("Manual Author");
+        sourceUrl.Should().Be("https://commons.example.org/m");
+    }
 }

--- a/apps/web/src/app/(public)/shared-games/page-client.tsx
+++ b/apps/web/src/app/(public)/shared-games/page-client.tsx
@@ -237,9 +237,9 @@ export function SharedGamesPageClient({
       kbsCount: g.kbsCount,
       newThisWeekCount: g.newThisWeekCount,
       // Issue #2055 Phase 7 — Wikidata cover attribution pass-through.
-      wikidataCoverLicense: g.wikidataCoverLicense ?? null,
-      wikidataCoverAttribution: g.wikidataCoverAttribution ?? null,
-      wikidataCoverSourceUrl: g.wikidataCoverSourceUrl ?? null,
+      coverLicense: g.coverLicense ?? null,
+      coverAttribution: g.coverAttribution ?? null,
+      coverSourceUrl: g.coverSourceUrl ?? null,
     }));
   }, [data]);
 

--- a/apps/web/src/components/ui/data-display/meeple-card/MeepleCard.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/MeepleCard.tsx
@@ -34,9 +34,9 @@ function MeepleCardImpl(props: MeepleCardProps) {
       <Renderer {...props} />
       {showAttributionFooter && (
         <MeepleCardAttributionFooter
-          license={props.wikidataCoverLicense ?? null}
-          attribution={props.wikidataCoverAttribution ?? null}
-          sourceUrl={props.wikidataCoverSourceUrl ?? null}
+          license={props.coverLicense ?? null}
+          attribution={props.coverAttribution ?? null}
+          sourceUrl={props.coverSourceUrl ?? null}
         />
       )}
     </>

--- a/apps/web/src/components/ui/data-display/meeple-card/MeepleCardAttributionFooter.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/MeepleCardAttributionFooter.tsx
@@ -1,21 +1,21 @@
 /**
- * Attribution footer for Wikidata-sourced cover images.
+ * Attribution footer for the WINNING cover source's license + author credit.
  *
- * Issue #2055 Phase G AC-G6.
+ * Issue #2055 Phase G AC-G6 / epic #3470 Slice 3b (source-neutral: serves both
+ * Wikidata and the admin-attested Manual cover — the value follows whichever
+ * source won on the backend, never a fixed source).
  * DEC-G6-1 LOCKED: render as plain text — BE strips HTML upstream via
  * AttributionTextExtractor. Do NOT use dangerouslySetInnerHTML.
  *
- * <para>This footer is the canonical surface for Wikidata cover license
- * + author credit on the SharedGame catalog. It is rendered by
- * MeepleCard when `entity === 'game'` and the `wikidataCoverLicense`
- * prop is non-null. The component returns `null` when the license is
- * missing, so callers can wire it unconditionally without guards.</para>
+ * <para>This footer is the canonical surface for the licensed cover credit on
+ * the SharedGame catalog. It is rendered by MeepleCard when `entity === 'game'`
+ * and the `coverLicense` prop is non-null. The component returns `null` when the
+ * license is missing, so callers can wire it unconditionally without guards.</para>
  *
  * <para>Distinct from the older <c>CoverAttributionChip</c> (Issue #1823
  * Wave 3 M14) which targets the GridCard cover overlay. A future
  * follow-up may unify the two surfaces; for now they co-exist because
- * the M14 chip already serves L2 Wikidata covers in a different layout
- * position.</para>
+ * the M14 chip already serves L2 covers in a different layout position.</para>
  */
 
 import type { JSX } from 'react';

--- a/apps/web/src/components/ui/data-display/meeple-card/types.ts
+++ b/apps/web/src/components/ui/data-display/meeple-card/types.ts
@@ -175,17 +175,18 @@ export interface MeepleCardProps {
    */
   attribution?: CoverAttribution;
   /**
-   * Issue #2055 Phase G AC-G6 — Wikidata cover license + attribution rendered
-   * as a plain-text footer beneath the card. Activated only for
+   * Issue #2055 Phase G AC-G6 / epic #3470 Slice 3b — the WINNING cover source's
+   * license + attribution (Wikidata or admin-attested Manual) rendered as a
+   * plain-text footer beneath the card. Activated only for
    * `entity === 'game'`. All three fields are optional so the footer
-   * gracefully degrades; when `wikidataCoverLicense` is null/undefined the
+   * gracefully degrades; when `coverLicense` is null/undefined the
    * footer renders nothing. BE strips HTML upstream per DEC-G6-1 LOCKED
    * 2026-06-20 — render as plain text only, do NOT use
    * `dangerouslySetInnerHTML`.
    */
-  wikidataCoverLicense?: string | null;
-  wikidataCoverAttribution?: string | null;
-  wikidataCoverSourceUrl?: string | null;
+  coverLicense?: string | null;
+  coverAttribution?: string | null;
+  coverSourceUrl?: string | null;
 }
 
 /**

--- a/apps/web/src/components/ui/shared-games/meeple-card-game.test.tsx
+++ b/apps/web/src/components/ui/shared-games/meeple-card-game.test.tsx
@@ -122,13 +122,13 @@ describe('MeepleCardGame (adapter over MeepleCard, #2858)', () => {
   });
 
   describe('Wikidata attribution footer (rendered by MeepleCard for entity=game)', () => {
-    it('renders <footer> with license text when wikidataCoverLicense is provided', () => {
+    it('renders <footer> with license text when coverLicense is provided', () => {
       const { container } = render(
         <MeepleCardGame
           {...baseProps}
-          wikidataCoverLicense="CC BY-SA 4.0"
-          wikidataCoverAttribution="Doe, John"
-          wikidataCoverSourceUrl="https://commons.wikimedia.org/wiki/File:Catan.jpg"
+          coverLicense="CC BY-SA 4.0"
+          coverAttribution="Doe, John"
+          coverSourceUrl="https://commons.wikimedia.org/wiki/File:Catan.jpg"
         />
       );
       const footer = container.querySelector('footer');
@@ -136,12 +136,12 @@ describe('MeepleCardGame (adapter over MeepleCard, #2858)', () => {
       expect(footer).toHaveTextContent('CC BY-SA 4.0');
     });
 
-    it('renders a source link when wikidataCoverSourceUrl is provided', () => {
+    it('renders a source link when coverSourceUrl is provided', () => {
       const { container } = render(
         <MeepleCardGame
           {...baseProps}
-          wikidataCoverLicense="CC BY-SA 4.0"
-          wikidataCoverSourceUrl="https://commons.wikimedia.org/wiki/File:Catan.jpg"
+          coverLicense="CC BY-SA 4.0"
+          coverSourceUrl="https://commons.wikimedia.org/wiki/File:Catan.jpg"
         />
       );
       const link = container.querySelector('footer a');
@@ -151,7 +151,7 @@ describe('MeepleCardGame (adapter over MeepleCard, #2858)', () => {
       expect(link).toHaveAttribute('target', '_blank');
     });
 
-    it('renders no <footer> when wikidataCoverLicense is omitted', () => {
+    it('renders no <footer> when coverLicense is omitted', () => {
       const { container } = render(<MeepleCardGame {...baseProps} />);
       expect(container.querySelector('footer')).toBeNull();
     });

--- a/apps/web/src/components/ui/shared-games/meeple-card-game.tsx
+++ b/apps/web/src/components/ui/shared-games/meeple-card-game.tsx
@@ -52,9 +52,9 @@ export interface MeepleCardGameProps {
    * Issue #2055 Phase 7 — Wikidata cover attribution fields. Forwarded to
    * MeepleCard, which renders MeepleCardAttributionFooter for entity=game.
    */
-  readonly wikidataCoverLicense?: string | null;
-  readonly wikidataCoverAttribution?: string | null;
-  readonly wikidataCoverSourceUrl?: string | null;
+  readonly coverLicense?: string | null;
+  readonly coverAttribution?: string | null;
+  readonly coverSourceUrl?: string | null;
   /**
    * Issue #3470 Slice 1d-c — optional admin cover-edit affordance forwarded to the
    * canonical MeepleCard cover slot (rendered outside the card anchor). Omitted for
@@ -75,9 +75,9 @@ export function MeepleCardGame({
   newThisWeekCount,
   labels,
   className,
-  wikidataCoverLicense = null,
-  wikidataCoverAttribution = null,
-  wikidataCoverSourceUrl = null,
+  coverLicense = null,
+  coverAttribution = null,
+  coverSourceUrl = null,
   coverEditSlot,
 }: MeepleCardGameProps): JSX.Element {
   const connections: ConnectionChipProps[] = [];
@@ -118,9 +118,9 @@ export function MeepleCardGame({
       connections={connections}
       className={className}
       data-testid="shared-games-card"
-      wikidataCoverLicense={wikidataCoverLicense}
-      wikidataCoverAttribution={wikidataCoverAttribution}
-      wikidataCoverSourceUrl={wikidataCoverSourceUrl}
+      coverLicense={coverLicense}
+      coverAttribution={coverAttribution}
+      coverSourceUrl={coverSourceUrl}
       coverEditSlot={coverEditSlot}
     />
   );

--- a/apps/web/src/lib/api/schemas/shared-games.schemas.ts
+++ b/apps/web/src/lib/api/schemas/shared-games.schemas.ts
@@ -235,10 +235,10 @@ export const SharedGameSchema = z.object({
     .default([])
     .transform(v => v ?? []),
   // Issue #2055 Phase G AC-G6 — Wikidata cover attribution (plain text, HTML-stripped BE-side per DEC-G6-1).
-  // FE component <MeepleCardAttributionFooter> renders only when wikidataCoverLicense is non-null.
-  wikidataCoverLicense: z.string().nullable().default(null),
-  wikidataCoverAttribution: z.string().nullable().default(null),
-  wikidataCoverSourceUrl: z.string().url().nullable().default(null),
+  // FE component <MeepleCardAttributionFooter> renders only when coverLicense is non-null.
+  coverLicense: z.string().nullable().default(null),
+  coverAttribution: z.string().nullable().default(null),
+  coverSourceUrl: z.string().url().nullable().default(null),
 });
 
 export type SharedGame = z.infer<typeof SharedGameSchema>;
@@ -370,10 +370,10 @@ export const SharedGameDetailSchema = z.object({
     .default([])
     .transform(v => v ?? []),
   // Issue #2055 Phase G AC-G6 — Wikidata cover attribution (plain text, HTML-stripped BE-side per DEC-G6-1).
-  // FE component <MeepleCardAttributionFooter> renders only when wikidataCoverLicense is non-null.
-  wikidataCoverLicense: z.string().nullable().default(null),
-  wikidataCoverAttribution: z.string().nullable().default(null),
-  wikidataCoverSourceUrl: z.string().url().nullable().default(null),
+  // FE component <MeepleCardAttributionFooter> renders only when coverLicense is non-null.
+  coverLicense: z.string().nullable().default(null),
+  coverAttribution: z.string().nullable().default(null),
+  coverSourceUrl: z.string().url().nullable().default(null),
 });
 
 export type SharedGameDetail = z.infer<typeof SharedGameDetailSchema>;

--- a/apps/web/src/lib/shared-games/visual-test-fixture.ts
+++ b/apps/web/src/lib/shared-games/visual-test-fixture.ts
@@ -128,9 +128,9 @@ const FIXTURE_DETAIL: SharedGameDetail = {
   isNew: false,
   translations: [],
   // Issue #2055 Phase G AC-G6 — fixture intentionally null (no Wikidata cover for this synthetic game).
-  wikidataCoverLicense: null,
-  wikidataCoverAttribution: null,
-  wikidataCoverSourceUrl: null,
+  coverLicense: null,
+  coverAttribution: null,
+  coverSourceUrl: null,
 };
 
 const FIXTURE_CONTRIBUTORS: readonly TopContributor[] = [


### PR DESCRIPTION
## Slice 3b — source-neutral cover attribution + Manual (epic #3470)

Closes the **copyright-critical** gap where a winning **Manual** (admin arbitrary-URL) cover rendered without its attested license/attribution: the whitelist gate admits CC-BY/CC-BY-SA on the premise the credit is shown, but `ForWinningSource` only emitted for Wikidata and the DTO exposed Wikidata-branded fields.

### What's in
- **`CoverAttribution.ForWinningSource`** — switch now also handles `CoverKind.Manual` (reads `ManualCover{License,Attribution,SourceUrl}`, same `Strip` HTML-safety as Wikidata). PDF/BGG/user (no license) and no-winner stay all-null.
- **DTO rename (source-neutral, Option A per spec-panel)** — `SharedGameDto` + `SharedGameDetailDto`: `WikidataCover{License,Attribution,SourceUrl}` → `Cover{License,Attribution,SourceUrl}`; 5 query handlers updated. Value follows whichever source won.
- **FE renamed atomically** — Zod schemas, MeepleCard `types`/footer/game-card, `page-client`, fixtures, tests. Footer doc made source-neutral.
- **Scope**: entity columns / aggregate / migrations keep `WikidataCover*` (real Wikidata storage); `GetCoverCandidates` keeps reading them as the Wikidata candidate — only the DTO **output** triple is source-neutral.

### Verification
BE build Debug+Release (0 warn) · 8 `CoverAttribution` tests green (Manual-wins stripped triple, no-columns nulls, Manual-does-not-leak-Wikidata; RED→GREEN) · FE `tsc` 0 err · 30 FE tests green (5 files) · repo-wide sweep: 0 stale JSON consumers (api-smoke/k6/e2e/tests).

### Adversarial review
Single focused reviewer: **diff clean** (backend correct, FE rename atomic + consistent, camelCase serialization matches FE Zod, `Strip` XSS-safe, `GetCoverCandidates` correctly untouched, no missed contract consumer).

### 🔴 Known follow-up surfaced by review (pre-existing, NOT a regression)
The `/shared-games/[id]` **detail Hero** (`Hero.tsx`/`[id]/page-client.tsx`) never renders the triple — `HeroProps` has no attribution fields and never mounts `MeepleCardAttributionFooter`. This predates Slice 3b (Wikidata had the same omission) and is outside this diff, but it means the per-game detail surface still shows a winning CC-BY cover **without credit**. **Next slice** wires the footer into the Hero (closes the compliance goal on all surfaces, for both Wikidata and Manual). Catalog grid/list surfaces are correctly wired by this PR.

### Note
#3482 (source-aware footer, Slice 1d-a) is already **MERGED** — this extends its base to Manual, no coordination needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)