### PR TITLE
feat(covers): render cover attribution on detail Hero (#3470)

### DIFF
--- a/apps/web/src/app/(public)/shared-games/[id]/page-client.tsx
+++ b/apps/web/src/app/(public)/shared-games/[id]/page-client.tsx
@@ -23,6 +23,7 @@ import { useSearchParams } from 'next/navigation';
 
 import { AdminCoverEditAffordance } from '@/components/features/cover-editor';
 import { ContributorsSection } from '@/components/shared-games/ContributorsSection';
+import { MeepleCardAttributionFooter } from '@/components/ui/data-display/meeple-card/MeepleCardAttributionFooter';
 import {
   AgentListItem,
   ContributorsStrip,
@@ -356,6 +357,16 @@ export function SharedGameDetailPageClient({
           // Self-gated via useAdminRole (renders null for non-admins), so the public
           // audience contract is untouched (#2118).
           coverOverlay={<AdminCoverEditAffordance gameId={game.id} title={resolvedTitle} />}
+          // #3470 Slice 3c — winning-source attribution credit under the hero cover. Renders
+          // null when the winning cover has no license (CoverAttribution.ForWinningSource);
+          // closes the copyright gap where a Manual/Wikidata CC-BY cover showed no credit.
+          coverFooter={
+            <MeepleCardAttributionFooter
+              license={game.coverLicense ?? null}
+              attribution={game.coverAttribution ?? null}
+              sourceUrl={game.coverSourceUrl ?? null}
+            />
+          }
         />
 
         <Tabs

--- a/apps/web/src/components/ui/detail-layout/hero.test.tsx
+++ b/apps/web/src/components/ui/detail-layout/hero.test.tsx
@@ -246,6 +246,26 @@ describe('Hero (Wave A.4)', () => {
     expect(cover?.contains(btn)).toBe(true);
   });
 
+  it('renders the coverFooter slot below the cover region when provided', () => {
+    // Epic #3470 Slice 3c — the winning-source attribution credit is a footer UNDER
+    // the cover (not overlaid on the image), so a licensed cover surfaces its credit
+    // on the detail Hero the same way the catalog cards do.
+    const { container } = render(
+      <Hero
+        title="Catan"
+        toolkitsCount={0}
+        agentsCount={0}
+        kbsCount={0}
+        labels={labels}
+        coverFooter={<span>manual-credit</span>}
+      />
+    );
+    const credit = screen.getByText('manual-credit');
+    const cover = container.querySelector('[data-slot="hero-cover"]');
+    expect(cover).not.toBeNull();
+    expect(cover?.contains(credit)).toBe(false);
+  });
+
   it('renders no overlay content when coverOverlay is omitted', () => {
     render(<Hero title="Catan" toolkitsCount={0} agentsCount={0} kbsCount={0} labels={labels} />);
     expect(screen.queryByRole('button', { name: 'edit-cover' })).toBeNull();

--- a/apps/web/src/components/ui/detail-layout/hero.tsx
+++ b/apps/web/src/components/ui/detail-layout/hero.tsx
@@ -67,6 +67,13 @@ export interface HeroProps {
    * a `group` so a hover-revealed affordance can react to cover hover.
    */
   readonly coverOverlay?: ReactNode;
+  /**
+   * Optional footer rendered directly BELOW the cover region (not overlaid on the image) —
+   * used for the winning cover source's attribution credit (#3470 Slice 3c). Kept generic so
+   * Hero stays domain-agnostic; the shared-games detail wires <MeepleCardAttributionFooter>
+   * into it. Renders nothing when absent, so other Hero consumers are unaffected.
+   */
+  readonly coverFooter?: ReactNode;
 }
 
 function Stars({
@@ -163,6 +170,7 @@ export function Hero({
   compact = false,
   className,
   coverOverlay,
+  coverFooter,
 }: HeroProps): JSX.Element {
   const coverH = compact ? 'h-[160px]' : 'h-[220px]';
   const titleSize = compact ? 'text-[22px]' : 'text-[30px]';
@@ -216,6 +224,9 @@ export function Hero({
         />
         {coverOverlay}
       </div>
+
+      {/* Attribution credit for the winning cover source (#3470 Slice 3c) — below the cover. */}
+      {coverFooter}
 
       {/* Body */}
       <div className="flex flex-col gap-3 p-4 md:p-5">


### PR DESCRIPTION
## Slice 3c — cover attribution on the detail Hero (epic #3470)

Closes the compliance gap the **Slice 3b review** surfaced: the `/shared-games/[id]` detail **Hero** never rendered the winning cover source's license/attribution, so a Manual (or Wikidata) **CC-BY/CC-BY-SA** cover showed on the primary per-game surface **with no credit**. The backend already computed the triple (`GetSharedGameByIdQueryHandler`, Hero context) and the DTO carried it — only the Hero render dropped it (pre-existing, affected Wikidata too).

### What's in
- **`Hero`** — new optional, domain-agnostic `coverFooter?: ReactNode` slot rendered directly **below** the cover region (not overlaid). Renders nothing when absent → the shared `players`/`toolkits` Hero consumers are byte-identical.
- **`shared-games/[id]/page-client`** — wires `<MeepleCardAttributionFooter>` with the source-neutral `coverLicense/coverAttribution/coverSourceUrl`. The footer returns `null` when the winning cover has no license, so games without a licensed cover are unaffected.

Catalog grid/list already rendered the credit (Slice 3b); this brings the detail surface to parity, **completing the copyright goal on all surfaces** for both Wikidata and Manual.

### Verification
Hero `coverFooter` slot test (RED→GREEN, asserts the footer is below the cover, not inside it) · 26 detail-layout/footer tests · 14 `page-client` tests · FE `tsc` clean. Footer is self-contained (`<footer class="mt-1 px-2 text-xs text-muted-foreground">`, semantic tokens, `rel="nofollow noopener noreferrer"` source link) — no card-specific positioning, renders cleanly under the Hero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)