### PR TITLE
feat(covers): manual-cover FE data layer (client+hook+schema) (#3470)

### DIFF
--- a/apps/web/src/hooks/admin/__tests__/useSetManualCover.test.tsx
+++ b/apps/web/src/hooks/admin/__tests__/useSetManualCover.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { type ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/api', () => ({
+  api: { admin: { setManualCover: vi.fn() } },
+}));
+
+import { api } from '@/lib/api';
+
+import { coverEditorKeys } from '../coverEditorKeys';
+import { useSetManualCover } from '../useSetManualCover';
+
+const mockSet = api.admin.setManualCover as ReturnType<typeof vi.fn>;
+const GAME_ID = '550e8400-e29b-41d4-a716-446655440000';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+  return {
+    queryClient,
+    invalidateSpy,
+    wrapper: ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+  };
+}
+
+describe('useSetManualCover', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls api.admin.setManualCover with gameId and body', async () => {
+    mockSet.mockResolvedValue({
+      dbKey: 'covers/manual/x/cover',
+      presignedUrl: 'https://r2/m.webp',
+    });
+    const body = {
+      sourceUrl: 'https://commons.example.org/c.png',
+      license: 'CC0',
+      attribution: null,
+    };
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useSetManualCover(), { wrapper });
+
+    result.current.mutate({ gameId: GAME_ID, body });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockSet).toHaveBeenCalledWith(GAME_ID, body);
+  });
+
+  it('invalidates the candidates query and the shared-game detail on settle', async () => {
+    // A fresh Manual candidate only appears after the candidates query is busted, so the
+    // hook MUST invalidate it (mirrors useAssignCover) — else the picker looks like a no-op.
+    mockSet.mockResolvedValue({ dbKey: 'k', presignedUrl: '' });
+
+    const { wrapper, invalidateSpy } = createWrapper();
+    const { result } = renderHook(() => useSetManualCover(), { wrapper });
+
+    result.current.mutate({
+      gameId: GAME_ID,
+      body: { sourceUrl: 'https://commons.example.org/c.png', license: 'CC0', attribution: null },
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: coverEditorKeys.candidates(GAME_ID) });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['admin', 'shared-games', GAME_ID] });
+  });
+});

--- a/apps/web/src/hooks/admin/useSetManualCover.ts
+++ b/apps/web/src/hooks/admin/useSetManualCover.ts
@@ -1,0 +1,44 @@
+/**
+ * Admin Cover Picker (Epic #3470 — Slice 3d).
+ *
+ * Mutation hook: set a manual (arbitrary-URL) cover for a game. Wraps
+ * `api.admin.setManualCover`. Unlike `useAssignCover` there is NO optimistic update —
+ * the server mints the DB key + presigned URL and materializes a `Manual` candidate — so
+ * the hook simply invalidates the candidates query (+ the shared-game detail) on settle so
+ * the new candidate appears in the picker grid and the public cover reflects the change.
+ *
+ * User-facing feedback is owned by the picker dialog, not this hook (toast-free pattern).
+ */
+
+'use client';
+
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
+
+import { api } from '@/lib/api';
+import type {
+  ManualCoverResult,
+  SetManualCoverRequest,
+} from '@/lib/api/schemas/admin/admin-cover.schemas';
+
+import { coverEditorKeys } from './coverEditorKeys';
+
+export interface UseSetManualCoverVariables {
+  gameId: string;
+  body: SetManualCoverRequest;
+}
+
+export function useSetManualCover(): UseMutationResult<
+  ManualCoverResult,
+  Error,
+  UseSetManualCoverVariables
+> {
+  const queryClient = useQueryClient();
+
+  return useMutation<ManualCoverResult, Error, UseSetManualCoverVariables>({
+    mutationFn: ({ gameId, body }) => api.admin.setManualCover(gameId, body),
+    onSettled: (_data, _error, { gameId }) => {
+      queryClient.invalidateQueries({ queryKey: coverEditorKeys.candidates(gameId) });
+      queryClient.invalidateQueries({ queryKey: ['admin', 'shared-games', gameId] });
+    },
+  });
+}

--- a/apps/web/src/lib/api/clients/admin/__tests__/adminCoverClient.test.ts
+++ b/apps/web/src/lib/api/clients/admin/__tests__/adminCoverClient.test.ts
@@ -3,7 +3,9 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   CoverCandidatesSchema,
   CoverAssignmentSchema,
+  ManualCoverResultSchema,
   type AssignCoverRequest,
+  type SetManualCoverRequest,
 } from '@/lib/api/schemas/admin/admin-cover.schemas';
 
 import { createAdminCoverClient } from '../adminCoverClient';
@@ -75,6 +77,30 @@ describe('adminCoverClient', () => {
       expect(http.delete).toHaveBeenCalledWith(
         `/api/v1/admin/shared-games/${GAME_ID}/cover-assignments/Card`
       );
+    });
+  });
+
+  describe('setManualCover', () => {
+    it('POSTs the manual-cover body to the manual-cover path with the ManualCoverResultSchema', async () => {
+      const http = makeHttp();
+      const body: SetManualCoverRequest = {
+        sourceUrl: 'https://commons.example.org/c.png',
+        license: 'CC0',
+        attribution: null,
+      };
+      const payload = { dbKey: 'covers/manual/x/cover', presignedUrl: 'https://r2.example/m.webp' };
+      http.post.mockResolvedValue(payload);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const client = createAdminCoverClient(http as any);
+      const result = await client.setManualCover(GAME_ID, body);
+
+      expect(http.post).toHaveBeenCalledWith(
+        `/api/v1/admin/shared-games/${GAME_ID}/manual-cover`,
+        body,
+        ManualCoverResultSchema
+      );
+      expect(result).toEqual(payload);
     });
   });
 });

--- a/apps/web/src/lib/api/clients/admin/adminCoverClient.ts
+++ b/apps/web/src/lib/api/clients/admin/adminCoverClient.ts
@@ -9,10 +9,13 @@
 import {
   CoverCandidatesSchema,
   CoverAssignmentSchema,
+  ManualCoverResultSchema,
   type CoverCandidates,
   type CoverAssignment,
   type CoverContext,
   type AssignCoverRequest,
+  type SetManualCoverRequest,
+  type ManualCoverResult,
 } from '../../schemas/admin/admin-cover.schemas';
 
 import type { HttpClient } from '../../core/httpClient';
@@ -50,6 +53,21 @@ export function createAdminCoverClient(http: HttpClient) {
     async removeCoverAssignment(gameId: string, context: CoverContext): Promise<void> {
       return http.delete(
         `/api/v1/admin/shared-games/${encodeURIComponent(gameId)}/cover-assignments/${encodeURIComponent(context)}`
+      );
+    },
+
+    /**
+     * POST: set a manual cover from an admin-supplied HTTPS image URL (epic #3470 Slice 3d).
+     * The server SSRF-fetches + re-encodes + stores it, then materializes a `Manual` candidate
+     * the picker surfaces after a candidates refetch. Returns the persisted DB key + a presigned
+     * R2 preview URL for the freshly-written object. Server 400s on a non-HTTPS URL or a
+     * non-whitelisted license; 404 on a missing game.
+     */
+    async setManualCover(gameId: string, body: SetManualCoverRequest): Promise<ManualCoverResult> {
+      return http.post(
+        `/api/v1/admin/shared-games/${encodeURIComponent(gameId)}/manual-cover`,
+        body,
+        ManualCoverResultSchema
       );
     },
   };

--- a/apps/web/src/lib/api/schemas/admin/admin-cover.schemas.ts
+++ b/apps/web/src/lib/api/schemas/admin/admin-cover.schemas.ts
@@ -76,3 +76,27 @@ export const AssignCoverRequestSchema = z.object({
   focalY: z.number().min(0).max(1),
 });
 export type AssignCoverRequest = z.infer<typeof AssignCoverRequestSchema>;
+
+/**
+ * Request body for the manual (arbitrary-URL) cover set (SetManualCoverRequest, epic #3470
+ * Slice 3d). `sourceUrl` must be an absolute HTTPS URL and `license` must be on the DEC-3c
+ * whitelist (Public Domain / CC0 / CC-BY / CC-BY-SA) — both re-validated server-side (400 on
+ * bad input), so this is the FE-side shape, not the authoritative gate.
+ */
+export const SetManualCoverRequestSchema = z.object({
+  sourceUrl: z.string().url(),
+  license: z.string().min(1),
+  attribution: z.string().nullable().optional(),
+});
+export type SetManualCoverRequest = z.infer<typeof SetManualCoverRequestSchema>;
+
+/**
+ * The persisted manual cover returned by the write command (ManualCoverResult): the suffix-free
+ * DB key + a presigned R2 preview URL (may be empty but is always present). The picker refetches
+ * candidates on success, so the returned value is informational.
+ */
+export const ManualCoverResultSchema = z.object({
+  dbKey: z.string(),
+  presignedUrl: z.string(),
+});
+export type ManualCoverResult = z.infer<typeof ManualCoverResultSchema>;


### PR DESCRIPTION
## Slice 3d-1 — manual-cover FE data layer (epic #3470)

The FE data layer for the "from URL" (Manual) cover source, so the picker dialog (**3d-2**) can wire the form. Backend endpoints (#3539) already exist; this adds the missing client / hook / Zod schemas.

- **`admin-cover.schemas.ts`** — `SetManualCoverRequestSchema` `{ sourceUrl (url), license (min 1), attribution? }` + `ManualCoverResultSchema` `{ dbKey, presignedUrl }`. FE-side shape; the HTTPS + DEC-3c license whitelist is the authoritative **server** gate (400).
- **`adminCoverClient.setManualCover(gameId, body)`** → `POST /api/v1/admin/shared-games/{id}/manual-cover`, validated with `ManualCoverResultSchema`. Auto-exposed on `api.admin` via the existing spread.
- **`useSetManualCover`** — mutation mirroring `useAssignCover`'s `onSettled` invalidation (candidates + shared-game detail) but **without** the optimistic update: the server mints the key/preview and materializes the `Manual` candidate, surfaced on the candidates refetch.

### Tests (6 green)
Client POSTs the body to the manual-cover path with the result schema; hook calls `api.admin.setManualCover` + invalidates both queries on settle. FE `tsc` clean.

Next: **3d-2** wires the "da URL / Manuale" form into `AdminCoverSourceDialog` (URL + whitelisted-license select + attribution), and the materialized `Manual` candidate becomes pinnable via the existing grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)