### PR TITLE
feat(covers): manual-cover "from URL" form in picker dialog (#3470)

### DIFF
--- a/apps/web/src/components/features/cover-editor/AdminCoverSourceDialog.tsx
+++ b/apps/web/src/components/features/cover-editor/AdminCoverSourceDialog.tsx
@@ -96,26 +96,35 @@ export function AdminCoverSourceDialog({
   const dirty =
     selectedSource !== currentSource || focal.x !== baselineFocal.x || focal.y !== baselineFocal.y;
 
-  // Sync local edit state to the active context's persisted assignment whenever the
-  // context changes or the candidates reload (post-mutation): clear any pending pick and
-  // pre-fill the saved focal, so the picker opens showing the current state. `data` keeps
-  // a stable reference across no-op refetches (react-query structural sharing), so this
-  // does not clobber an in-progress edit.
+  // Clear a staged (un-applied) grid pick ONLY when the admin switches context — deliberately
+  // NOT on a candidates refetch. Adding a Manual source below reloads `data` (new candidate),
+  // which must not discard an in-progress grid selection: the two are independent concerns.
+  useEffect(() => {
+    setPendingSource(null);
+  }, [activeContext]);
+
+  // Pre-fill the focal from the active context's persisted assignment whenever it (re)loads, so
+  // the picker opens on the saved value and "dirty" is a genuine diff against that baseline.
   useEffect(() => {
     const assignment = data?.assignments[ASSIGN_KEY[activeContext]] ?? null;
-    setPendingSource(null);
     setFocal(assignment ? { x: assignment.focalX, y: assignment.focalY } : DEFAULT_FOCAL);
   }, [activeContext, data]);
 
-  // Reset to the default context when the dialog closes so it never resurfaces on the
-  // next open; the sync effect above re-derives the focal once data reloads.
+  // Reset ALL edit state when the dialog closes so nothing resurfaces on the next open — the
+  // grid pick + focal AND the manual-URL form fields + its mutation status (a stale error alert
+  // or a half-typed URL must not reappear). `reset` is a stable react-query callback.
+  const resetManual = setManual.reset;
   useEffect(() => {
     if (!open) {
       setActiveContext('Card');
       setPendingSource(null);
       setFocal(DEFAULT_FOCAL);
+      setManualUrl('');
+      setManualAttribution('');
+      setManualLicense(MANUAL_LICENSES[0]);
+      resetManual();
     }
-  }, [open]);
+  }, [open, resetManual]);
 
   const handleTabChange = (value: string) => setActiveContext(value as CoverContext);
 

--- a/apps/web/src/components/features/cover-editor/AdminCoverSourceDialog.tsx
+++ b/apps/web/src/components/features/cover-editor/AdminCoverSourceDialog.tsx
@@ -24,6 +24,7 @@ import { Button } from '@/components/ui/primitives/button';
 import { useAssignCover } from '@/hooks/admin/useAssignCover';
 import { useCoverCandidates } from '@/hooks/admin/useCoverCandidates';
 import { useRemoveCoverAssignment } from '@/hooks/admin/useRemoveCoverAssignment';
+import { useSetManualCover } from '@/hooks/admin/useSetManualCover';
 import type {
   CoverAssignmentSource,
   CoverContext,
@@ -59,6 +60,10 @@ const ASSIGN_KEY: Record<CoverContext, 'card' | 'hero' | 'social'> = {
 
 const DEFAULT_FOCAL = { x: 0.5, y: 0.5 };
 
+// The DEC-3c whitelist the backend accepts (LicenseValidator). Constraining the select to these
+// keeps the copyright gate from being tripped by a typo; the server still re-validates (400).
+const MANUAL_LICENSES = ['CC0', 'CC-BY-4.0', 'CC-BY-SA-4.0', 'Public domain'] as const;
+
 export function AdminCoverSourceDialog({
   gameId,
   title,
@@ -69,10 +74,14 @@ export function AdminCoverSourceDialog({
   const { data, isLoading, isError } = useCoverCandidates(open ? gameId : '');
   const assign = useAssignCover();
   const remove = useRemoveCoverAssignment();
+  const setManual = useSetManualCover();
 
   const [activeContext, setActiveContext] = useState<CoverContext>('Card');
   const [pendingSource, setPendingSource] = useState<CoverAssignmentSource | null>(null);
   const [focal, setFocal] = useState(DEFAULT_FOCAL);
+  const [manualUrl, setManualUrl] = useState('');
+  const [manualLicense, setManualLicense] = useState<string>(MANUAL_LICENSES[0]);
+  const [manualAttribution, setManualAttribution] = useState('');
 
   const currentAssignment = data?.assignments[ASSIGN_KEY[activeContext]] ?? null;
   // Epic #3470 Slice 2e (AC-5): the read shape now carries the persisted focal, so the
@@ -131,6 +140,29 @@ export function AdminCoverSourceDialog({
     remove.mutate({ gameId, context: activeContext });
     setPendingSource(null);
     setFocal(DEFAULT_FOCAL);
+  };
+
+  const handleAddManual = () => {
+    const url = manualUrl.trim();
+    if (!url) return;
+    setManual.mutate(
+      {
+        gameId,
+        body: {
+          sourceUrl: url,
+          license: manualLicense,
+          attribution: manualAttribution.trim() || null,
+        },
+      },
+      {
+        onSuccess: () => {
+          // The new Manual candidate arrives via the candidates refetch; clear the inputs so
+          // the form is ready for a re-try/replace without a stale URL lingering.
+          setManualUrl('');
+          setManualAttribution('');
+        },
+      }
+    );
   };
 
   return (
@@ -253,6 +285,70 @@ export function AdminCoverSourceDialog({
               </TabsContent>
             ))}
           </Tabs>
+        )}
+
+        {data && (
+          <section
+            aria-labelledby="manual-cover-heading"
+            className="space-y-2 border-t border-border pt-4"
+          >
+            <h3 id="manual-cover-heading" className="text-sm font-medium text-foreground">
+              Aggiungi copertina da URL
+            </h3>
+            <p className="text-xs text-muted-foreground">
+              Immagine con licenza libera (dominio pubblico / CC0 / CC-BY / CC-BY-SA); l&apos;URL
+              deve essere HTTPS. Dopo il caricamento la sorgente &laquo;Manuale&raquo; diventa
+              selezionabile qui sopra.
+            </p>
+            <div className="grid gap-2 sm:grid-cols-2">
+              <label className="flex flex-col gap-1 text-xs text-muted-foreground sm:col-span-2">
+                URL immagine
+                <input
+                  type="url"
+                  value={manualUrl}
+                  onChange={e => setManualUrl(e.target.value)}
+                  placeholder="https://…"
+                  className="rounded border border-border bg-background px-2 py-1.5 text-sm text-foreground"
+                />
+              </label>
+              <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+                Licenza
+                <select
+                  value={manualLicense}
+                  onChange={e => setManualLicense(e.target.value)}
+                  className="rounded border border-border bg-background px-2 py-1.5 text-sm text-foreground"
+                >
+                  {MANUAL_LICENSES.map(l => (
+                    <option key={l} value={l}>
+                      {l}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+                Attribuzione (facoltativa)
+                <input
+                  type="text"
+                  value={manualAttribution}
+                  onChange={e => setManualAttribution(e.target.value)}
+                  className="rounded border border-border bg-background px-2 py-1.5 text-sm text-foreground"
+                />
+              </label>
+            </div>
+            {setManual.isError && (
+              <p role="alert" className="text-xs text-destructive">
+                Impossibile aggiungere la copertina: verifica che l&apos;URL sia HTTPS e che la
+                licenza sia consentita.
+              </p>
+            )}
+            <Button
+              variant="outline"
+              onClick={handleAddManual}
+              disabled={!manualUrl.trim() || setManual.isPending}
+            >
+              {setManual.isPending ? 'Caricamento…' : 'Carica da URL'}
+            </Button>
+          </section>
         )}
       </DialogContent>
     </Dialog>

--- a/apps/web/src/components/features/cover-editor/__tests__/AdminCoverSourceDialog.test.tsx
+++ b/apps/web/src/components/features/cover-editor/__tests__/AdminCoverSourceDialog.test.tsx
@@ -7,10 +7,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('@/hooks/admin/useCoverCandidates', () => ({ useCoverCandidates: vi.fn() }));
 vi.mock('@/hooks/admin/useAssignCover', () => ({ useAssignCover: vi.fn() }));
 vi.mock('@/hooks/admin/useRemoveCoverAssignment', () => ({ useRemoveCoverAssignment: vi.fn() }));
+vi.mock('@/hooks/admin/useSetManualCover', () => ({ useSetManualCover: vi.fn() }));
 
 import { useCoverCandidates } from '@/hooks/admin/useCoverCandidates';
 import { useAssignCover } from '@/hooks/admin/useAssignCover';
 import { useRemoveCoverAssignment } from '@/hooks/admin/useRemoveCoverAssignment';
+import { useSetManualCover } from '@/hooks/admin/useSetManualCover';
 
 import { AdminCoverSourceDialog } from '../AdminCoverSourceDialog';
 
@@ -19,6 +21,7 @@ const GID = '550e8400-e29b-41d4-a716-446655440000';
 const mockUseCandidates = useCoverCandidates as unknown as ReturnType<typeof vi.fn>;
 const mockUseAssign = useAssignCover as unknown as ReturnType<typeof vi.fn>;
 const mockUseRemove = useRemoveCoverAssignment as unknown as ReturnType<typeof vi.fn>;
+const mockUseSetManual = useSetManualCover as unknown as ReturnType<typeof vi.fn>;
 
 const candidatesData = {
   gameId: GID,
@@ -43,6 +46,7 @@ const candidatesData = {
 
 let assignMutate: ReturnType<typeof vi.fn>;
 let removeMutate: ReturnType<typeof vi.fn>;
+let setManualMutate: ReturnType<typeof vi.fn>;
 
 function setCandidates(over: Partial<ReturnType<typeof mockUseCandidates>> = {}) {
   mockUseCandidates.mockReturnValue({
@@ -57,8 +61,15 @@ beforeEach(() => {
   vi.clearAllMocks();
   assignMutate = vi.fn();
   removeMutate = vi.fn();
+  setManualMutate = vi.fn();
   mockUseAssign.mockReturnValue({ mutate: assignMutate, isPending: false });
   mockUseRemove.mockReturnValue({ mutate: removeMutate, isPending: false });
+  mockUseSetManual.mockReturnValue({
+    mutate: setManualMutate,
+    isPending: false,
+    isError: false,
+    isSuccess: false,
+  });
   setCandidates();
 });
 
@@ -69,6 +80,50 @@ function renderDialog(props: Partial<React.ComponentProps<typeof AdminCoverSourc
 }
 
 describe('AdminCoverSourceDialog', () => {
+  // Epic #3470 Slice 3d — the "from URL / Manuale" form: materializes a Manual candidate.
+  it('sets a manual cover from a URL with the whitelisted license and attribution', () => {
+    renderDialog();
+
+    fireEvent.change(screen.getByLabelText(/URL immagine/i), {
+      target: { value: 'https://commons.example.org/img.png' },
+    });
+    fireEvent.change(screen.getByLabelText(/^Licenza$/i), { target: { value: 'CC-BY-4.0' } });
+    fireEvent.change(screen.getByLabelText(/Attribuzione/i), { target: { value: 'Jane Artist' } });
+    fireEvent.click(screen.getByRole('button', { name: /Carica da URL/i }));
+
+    expect(setManualMutate).toHaveBeenCalledTimes(1);
+    expect(setManualMutate.mock.calls[0][0]).toEqual({
+      gameId: GID,
+      body: {
+        sourceUrl: 'https://commons.example.org/img.png',
+        license: 'CC-BY-4.0',
+        attribution: 'Jane Artist',
+      },
+    });
+  });
+
+  it('submits a null attribution when the attribution field is left blank', () => {
+    renderDialog();
+
+    fireEvent.change(screen.getByLabelText(/URL immagine/i), {
+      target: { value: 'https://commons.example.org/pd.png' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Carica da URL/i }));
+
+    expect(setManualMutate.mock.calls[0][0].body.attribution).toBeNull();
+  });
+
+  it('disables the manual-cover submit until a URL is entered', () => {
+    renderDialog();
+    const submit = screen.getByRole('button', { name: /Carica da URL/i });
+    expect(submit).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText(/URL immagine/i), {
+      target: { value: 'https://commons.example.org/img.png' },
+    });
+    expect(submit).toBeEnabled();
+  });
+
   it('renders a titled dialog when open', () => {
     renderDialog();
     expect(screen.getByRole('dialog')).toBeInTheDocument();

--- a/apps/web/src/components/features/cover-editor/__tests__/AdminCoverSourceDialog.test.tsx
+++ b/apps/web/src/components/features/cover-editor/__tests__/AdminCoverSourceDialog.test.tsx
@@ -69,6 +69,7 @@ beforeEach(() => {
     isPending: false,
     isError: false,
     isSuccess: false,
+    reset: vi.fn(),
   });
   setCandidates();
 });
@@ -122,6 +123,56 @@ describe('AdminCoverSourceDialog', () => {
       target: { value: 'https://commons.example.org/img.png' },
     });
     expect(submit).toBeEnabled();
+  });
+
+  it('clears the manual-cover form fields when the dialog is closed and reopened', () => {
+    const { rerender } = renderDialog();
+    fireEvent.change(screen.getByLabelText(/URL immagine/i), {
+      target: { value: 'https://commons.example.org/img.png' },
+    });
+    expect(screen.getByLabelText(/URL immagine/i)).toHaveValue(
+      'https://commons.example.org/img.png'
+    );
+
+    // Close then reopen: a half-typed URL must not resurface (form state is reset on close).
+    rerender(<AdminCoverSourceDialog gameId={GID} title="Catan" open={false} onClose={vi.fn()} />);
+    rerender(<AdminCoverSourceDialog gameId={GID} title="Catan" open onClose={vi.fn()} />);
+
+    expect(screen.getByLabelText(/URL immagine/i)).toHaveValue('');
+  });
+
+  it('preserves a staged grid pick when the candidates reload after adding a manual cover', () => {
+    const { rerender } = renderDialog();
+    // Stage (do NOT apply) the Wikidata candidate.
+    fireEvent.click(screen.getByRole('button', { name: /Copertina Wikidata/i }));
+    expect(screen.getByRole('button', { name: /Copertina Wikidata/i })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+
+    // Simulate the candidates refetch after a Manual source is added (new candidate appended).
+    setCandidates({
+      data: {
+        ...candidatesData,
+        candidates: [
+          ...candidatesData.candidates,
+          {
+            source: 'Manual',
+            previewUrl: 'https://r2.example/manual.webp',
+            license: 'CC0',
+            attribution: null,
+            sourceUrl: null,
+          },
+        ],
+      },
+    });
+    rerender(<AdminCoverSourceDialog gameId={GID} title="Catan" open onClose={vi.fn()} />);
+
+    // The staged, un-applied pick must survive the refetch (not silently reset).
+    expect(screen.getByRole('button', { name: /Copertina Wikidata/i })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
   });
 
   it('renders a titled dialog when open', () => {

--- a/apps/web/src/components/features/cover-editor/__tests__/cover-editor.axe.test.tsx
+++ b/apps/web/src/components/features/cover-editor/__tests__/cover-editor.axe.test.tsx
@@ -38,6 +38,7 @@ beforeEach(() => {
     isPending: false,
     isError: false,
     isSuccess: false,
+    reset: vi.fn(),
   });
   (useCoverCandidates as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
     isLoading: false,

--- a/apps/web/src/components/features/cover-editor/__tests__/cover-editor.axe.test.tsx
+++ b/apps/web/src/components/features/cover-editor/__tests__/cover-editor.axe.test.tsx
@@ -12,10 +12,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('@/hooks/admin/useCoverCandidates', () => ({ useCoverCandidates: vi.fn() }));
 vi.mock('@/hooks/admin/useAssignCover', () => ({ useAssignCover: vi.fn() }));
 vi.mock('@/hooks/admin/useRemoveCoverAssignment', () => ({ useRemoveCoverAssignment: vi.fn() }));
+vi.mock('@/hooks/admin/useSetManualCover', () => ({ useSetManualCover: vi.fn() }));
 
 import { useCoverCandidates } from '@/hooks/admin/useCoverCandidates';
 import { useAssignCover } from '@/hooks/admin/useAssignCover';
 import { useRemoveCoverAssignment } from '@/hooks/admin/useRemoveCoverAssignment';
+import { useSetManualCover } from '@/hooks/admin/useSetManualCover';
 
 import { AdminCoverSourceDialog } from '../AdminCoverSourceDialog';
 import { CoverFocalPointPicker } from '../CoverFocalPointPicker';
@@ -30,6 +32,12 @@ beforeEach(() => {
   (useRemoveCoverAssignment as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
     mutate: vi.fn(),
     isPending: false,
+  });
+  (useSetManualCover as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+    isSuccess: false,
   });
   (useCoverCandidates as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
     isLoading: false,


### PR DESCRIPTION
## Slice 3d-2 — manual-cover "from URL" form (epic #3470)

Makes the manual cover path **user-reachable end to end**. Adds the "Aggiungi copertina da URL" form to `AdminCoverSourceDialog`: an HTTPS image URL + a whitelisted-license `<select>` (CC0 / CC-BY-4.0 / CC-BY-SA-4.0 / Public domain) + optional attribution. On submit it calls `useSetManualCover`; the server SSRF-fetches + re-encodes + stores, and the materialized **"Manuale"** candidate appears in the existing candidate grid via the candidates refetch, where it's pinnable per-context through the existing assign flow.

- Form sits **outside** the per-context Tabs (candidates are context-independent — one global Manual source), shown whenever `data` is loaded (incl. zero existing candidates: the "add your first cover" case).
- License select constrains input to the DEC-3c whitelist so the copyright gate can't be tripped by a typo; the server still re-validates (400). Blank attribution → null.
- a11y: labelled inputs, `aria-labelledby` section heading, `role="alert"` error — the blocking axe suite exercises the open dialog with the form mounted.

### Adversarial review + fixes
A focused reviewer confirmed the core clean (whitelist values all pass the backend regex, end-to-end reachability, role-gating/security, a11y, empty-state) and flagged **2 state-management UX issues**, both fixed in the `fix(covers): reset manual form + preserve staged pick` commit:
1. Adding a manual cover no longer discards an un-applied grid pick (split the sync effect: context-change clears the pick; a candidates refetch only re-derives the focal).
2. The form + mutation error status now reset on dialog close (was persisting across close/reopen since the dialog is mounted unconditionally).

### Tests (19 dialog+axe green)
3 form tests (submit body incl. attribution, blank→null, disabled-until-URL) + 2 regression tests (staged pick survives refetch, form cleared on close/reopen) + the blocking axe suite. FE typecheck + eslint clean.

**Manual cover path is now user-facing** (set via UI → pinnable → attribution rendered on all surfaces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)