### PR TITLE
docs(covers): accurate 4xx wording on cover-editor validators (#3470)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AssignCoverCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AssignCoverCommandValidator.cs
@@ -3,9 +3,10 @@ using FluentValidation;
 namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands;
 
 /// <summary>
-/// Boundary validation for <see cref="AssignCoverCommand"/> — turns bad input into a
-/// 400 rather than letting the domain factory throw a 500. Mirrors the domain guards
-/// on <c>GameCoverAssignment.Create</c> (focal in [0,1], defined enums).
+/// Boundary validation for <see cref="AssignCoverCommand"/> — turns bad input into a 4xx
+/// client error (422 via the FluentValidation pipeline) rather than letting the domain factory
+/// throw a 500. Mirrors the domain guards on <c>GameCoverAssignment.Create</c> (focal in [0,1],
+/// defined enums).
 /// </summary>
 internal sealed class AssignCoverCommandValidator : AbstractValidator<AssignCoverCommand>
 {

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandValidator.cs
@@ -4,7 +4,8 @@ using FluentValidation;
 namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands;
 
 /// <summary>
-/// Boundary validation for <see cref="SetManualCoverCommand"/> — 400 (not 500) on bad input.
+/// Boundary validation for <see cref="SetManualCoverCommand"/> — a 4xx client error (422 via the
+/// FluentValidation pipeline), not a 500, on bad input.
 /// <para>
 /// The license MUST be on the DEC-3c whitelist (Public Domain / CC0 / CC-BY / CC-BY-SA). This is the
 /// primary copyright gate for the arbitrary-URL manual path (epic #3470 Slice 3a / ADR-059): it


### PR DESCRIPTION
## Item-2 cleanup (partial) — cover-editor validator doc accuracy (#3470)

The FluentValidation pipeline returns **422** (via `ApiExceptionHandlerMiddleware`), not 400. Corrects the `AssignCover` + `SetManualCover` validator docs to say "4xx client error (422)" so all four #3470 cover-editor validators (Assign / SetManual / Revoke / RemoveCoverAssignment) are consistent with the earlier `RevokeManualCover` fix. **Doc-only, no behavior change.**

Deliberately **not** touching `.Produces()`: the 422 OpenAPI omission is uniform across every FluentValidation endpoint in the API — a repo-wide cosmetic sweep, out of scope here (leaving it keeps the API-wide contract uniform).

🤖 Generated with [Claude Code](https://claude.com/claude-code)