### PR TITLE
feat(covers): revoke cascade-removes Manual pins + attribution guard (#3470)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RevokeManualCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RevokeManualCoverCommandHandler.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.Middleware.Exceptions;
 using Api.Services;
@@ -53,8 +54,13 @@ internal sealed class RevokeManualCoverCommandHandler : ICommandHandler<RevokeMa
         var game = await _repository.GetByIdAsync(command.GameId, cancellationToken).ConfigureAwait(false)
             ?? throw new NotFoundException("SharedGame", command.GameId.ToString());
 
-        // Capture the key BEFORE clearing so we can best-effort delete the object afterwards.
+        // Capture BEFORE clearing: the manual base object key + the rendered crop object keys of
+        // any Manual-pinned assignment, so we can best-effort delete them after the DB revoke.
         var keyToDelete = game.ManualCoverR2Key;
+        var manualCropKeys = game.CoverAssignments
+            .Where(a => a.Source == CoverAssignmentSource.Manual && !string.IsNullOrWhiteSpace(a.GeneratedR2Key))
+            .Select(a => a.GeneratedR2Key!)
+            .ToList();
 
         // Idempotent: nothing was set → no persistence, no R2 delete, no cache churn (204).
         if (!game.RevokeManualCover())
@@ -63,6 +69,10 @@ internal sealed class RevokeManualCoverCommandHandler : ICommandHandler<RevokeMa
         }
 
         _repository.Update(game);
+        // RevokeManualCover also removed any Manual-pinned assignment rows → reconcile the child
+        // collection so those deletes persist (Update maps scalars only). Update + Reconcile
+        // compose (disjoint DbSets); verified on Postgres by the reconcile integration suite.
+        await _repository.ReconcileCoverAssignmentsAsync(game, cancellationToken).ConfigureAwait(false);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
         // Best-effort R2 cleanup AFTER the authoritative DB revoke. The raw-key delete (#3384)
@@ -79,6 +89,21 @@ internal sealed class RevokeManualCoverCommandHandler : ICommandHandler<RevokeMa
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 _logger.LogWarning(ex, "Failed to delete manual cover R2 key {Key}; DB is already revoked", keyToDelete);
+            }
+        }
+
+        // Best-effort delete the rendered crop objects of the removed Manual assignments (each
+        // GeneratedR2Key is a full physical key). None exist today (no crop is rendered for a
+        // Manual assignment), so this is a forward-compatible no-op until crop generation lands.
+        foreach (var cropKey in manualCropKeys)
+        {
+            try
+            {
+                await _blobStorage.DeleteRawKeyAsync(cropKey, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogWarning(ex, "Failed to delete manual cover crop R2 key {Key}; DB is already revoked", cropKey);
             }
         }
 

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/SharedGame.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/SharedGame.cs
@@ -881,27 +881,32 @@ public sealed class SharedGame : AggregateRoot<Guid>
     }
 
     /// <summary>
-    /// Epic #3470 Slice 3a-3 — revokes the admin-set manual cover by clearing the six manual
-    /// cover / attestation fields. Returns <c>true</c> when something was cleared, <c>false</c>
-    /// when there was no manual cover to revoke — an idempotent no-op the caller turns into a
-    /// 204 without persisting or evicting caches.
+    /// Epic #3470 Slice 3a-3 / 3f — revokes the admin-set manual cover: clears the six manual
+    /// cover / attestation fields AND drops any per-context assignment still pinned to the Manual
+    /// source (so no phantom pin survives to auto-resurface a future manual cover). Returns
+    /// <c>true</c> when anything was cleared, <c>false</c> when there was nothing to revoke — an
+    /// idempotent no-op the caller turns into a 204 without persisting or evicting caches.
     /// </summary>
     /// <remarks>
-    /// Follow-up (gated on per-context crop generation): once an <c>AssignCover</c> flow
-    /// populates a rendered <c>GeneratedR2Key</c> on a Manual-sourced assignment, revoke must
-    /// ALSO remove those assignments (and delete their crop objects), else the crop would keep
-    /// serving after revoke. Today no crop is generated for a Manual assignment, so a dangling
-    /// Manual assignment resolves to a null base key and falls through to the implicit
-    /// precedence — the revoked image genuinely stops serving.
+    /// The handler persists the removed assignments via <c>ReconcileCoverAssignmentsAsync</c> and
+    /// best-effort deletes each removed assignment's rendered crop object (<c>GeneratedR2Key</c>).
+    /// Today <c>AssignCover</c> renders no crop for a Manual assignment, so there is nothing to
+    /// delete yet — but removing the assignment row is still correct (a dangling Manual pin would
+    /// otherwise silently re-apply the next manual cover to that context).
     /// </remarks>
     public bool RevokeManualCover()
     {
-        if (_manualCoverR2Key is null
-            && _manualCoverLicense is null
-            && _manualCoverAttribution is null
-            && _manualCoverSourceUrl is null
-            && _manualCoverAttestedBy is null
-            && _manualCoverAttestedAt is null)
+        var hadColumns = _manualCoverR2Key is not null
+            || _manualCoverLicense is not null
+            || _manualCoverAttribution is not null
+            || _manualCoverSourceUrl is not null
+            || _manualCoverAttestedBy is not null
+            || _manualCoverAttestedAt is not null;
+
+        var removedAssignments =
+            _coverAssignments.RemoveAll(a => a.Source == CoverAssignmentSource.Manual) > 0;
+
+        if (!hadColumns && !removedAssignments)
         {
             return false;
         }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/RevokeManualCoverCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/RevokeManualCoverCommandHandlerTests.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.Middleware.Exceptions;
 using Api.Services;
@@ -78,6 +79,29 @@ public sealed class RevokeManualCoverCommandHandlerTests
         _blobStorage.Verify(b => b.DeleteRawKeyAsync(physicalKey, It.IsAny<CancellationToken>()), Times.Once);
         _cache.Verify(c => c.RemoveByTagAcrossReplicasAsync("search-games", It.IsAny<CancellationToken>()), Times.Once);
         _cache.Verify(c => c.RemoveByTagAcrossReplicasAsync($"shared-game:{game.Id}", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WithManualPinnedToContext_DropsManualAssignment_Reconciles_KeepsOthers()
+    {
+        // Slice 3f: revoking the manual source cascades to its per-context pins — the Manual
+        // assignment is removed (and persisted via the child-safe reconcile) while a non-Manual
+        // pin survives, so no phantom Manual pin lingers to auto-resurface a future manual cover.
+        var game = GameWithManualCover();
+        game.AssignCover(CoverContext.Hero, CoverAssignmentSource.Manual, AdminId);
+        game.AssignCover(CoverContext.Card, CoverAssignmentSource.Wikidata, AdminId);
+        var physicalKey = $"covers/manual/{game.Id:D}/cover.webp";
+        _repository.Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>())).ReturnsAsync(game);
+        _blobStorage
+            .Setup(b => b.DeleteRawKeyAsync(physicalKey, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        await CreateHandler().Handle(new RevokeManualCoverCommand(game.Id, AdminId), CancellationToken.None);
+
+        game.CoverAssignments.Should().ContainSingle();
+        game.CoverAssignments.Single().Source.Should().Be(CoverAssignmentSource.Wikidata);
+        _repository.Verify(r => r.ReconcileCoverAssignmentsAsync(game, It.IsAny<CancellationToken>()), Times.Once);
+        _unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/GetSharedGameByIdQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/GetSharedGameByIdQueryHandlerTests.cs
@@ -203,6 +203,63 @@ public class GetSharedGameByIdQueryHandlerTests
     }
 
     [Fact]
+    public async Task Handle_ManualCoverWinsHero_SurfacesLicenseAttributionSourceUrl()
+    {
+        // Epic #3470 Slice 3b/3f (copyright guard): a whitelist-admitted Manual cover that WINS
+        // the Hero context MUST surface its attested license + attribution + source URL on the
+        // detail DTO — a CC-BY/CC-BY-SA image cannot render creditless. End-to-end proof that a
+        // game with only ManualCover* columns + a Manual Hero pin flows the triple through the
+        // resolver -> CoverAttribution.ForWinningSource -> DTO.
+        var game = SharedGame.Create(
+            "Catan", 1995, "Description", 3, 4, 90, 10, 2.5m, 7.8m,
+            "https://example.com/catan.jpg", "https://example.com/thumb.jpg",
+            GameRules.Create("Rules content", "en"), Guid.NewGuid(), 13);
+
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(game);
+
+        _blobStorageMock
+            .Setup(b => b.GetPresignedUrlForRawKeyAsync("manual-key.webp", null))
+            .ReturnsAsync("https://r2/manual-hero.webp");
+
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        db.SharedGames.Add(new SharedGameEntity
+        {
+            Id = game.Id,
+            Title = "Catan",
+            Description = "desc",
+            Status = 1,
+            ManualCoverR2Key = "manual-key",
+            ManualCoverLicense = "CC-BY-4.0",
+            ManualCoverAttribution = "Jane Artist",
+            ManualCoverSourceUrl = "https://commons.example.org/img",
+            CoverAssignments = new List<GameCoverAssignmentEntity>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Context = CoverContext.Hero,
+                    Source = CoverAssignmentSource.Manual,
+                    CreatedBy = Guid.NewGuid(),
+                },
+            },
+        });
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        db.ChangeTracker.Clear();
+
+        var handler = CreateHandler(db);
+
+        var result = await handler.Handle(new GetSharedGameByIdQuery(game.Id), TestContext.Current.CancellationToken);
+
+        result.Should().NotBeNull();
+        result!.CoverUrl.Should().Be("https://r2/manual-hero.webp", "the Manual Hero pin wins");
+        result.CoverLicense.Should().Be("CC-BY-4.0");
+        result.CoverAttribution.Should().Be("Jane Artist");
+        result.CoverSourceUrl.Should().Be("https://commons.example.org/img");
+    }
+
+    [Fact]
     public async Task Handle_ResolvesSocialCover_IndependentlyOfHero()
     {
         // Epic #3470 Slice 2d AC-2: the detail DTO exposes a Social cover (for OG meta)

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Aggregates/SharedGameTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Aggregates/SharedGameTests.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.SharedKernel.Domain.Covers;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Events;
 using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
 using FluentAssertions;
@@ -1483,6 +1484,39 @@ public sealed class SharedGameTests
 
         game.RevokeManualCover().Should().BeTrue();
         game.RevokeManualCover().Should().BeFalse("the manual cover is already cleared");
+    }
+
+    [Fact]
+    public void RevokeManualCover_RemovesManualSourcedAssignments_KeepsOthers()
+    {
+        // Revoking the manual source must also drop any per-context assignment pinned to Manual,
+        // so no phantom pin survives to auto-resurface a future manual cover. Non-Manual pins stay.
+        var game = NewManualCoverGame();
+        var admin = Guid.NewGuid();
+        game.SetManualCover("k", "CC0", null, "https://s", admin, DateTime.UtcNow);
+        game.AssignCover(CoverContext.Hero, CoverAssignmentSource.Manual, admin);
+        game.AssignCover(CoverContext.Card, CoverAssignmentSource.Wikidata, admin);
+
+        var changed = game.RevokeManualCover();
+
+        changed.Should().BeTrue();
+        game.CoverAssignments.Should().ContainSingle();
+        game.CoverAssignments.Single().Source.Should().Be(CoverAssignmentSource.Wikidata);
+        game.ManualCoverR2Key.Should().BeNull();
+    }
+
+    [Fact]
+    public void RevokeManualCover_WithOnlyManualAssignment_RemovesItAndReturnsTrue()
+    {
+        // Even with no manual columns set, a lingering Manual assignment is cleaned up.
+        var game = NewManualCoverGame();
+        var admin = Guid.NewGuid();
+        game.AssignCover(CoverContext.Hero, CoverAssignmentSource.Manual, admin);
+
+        var changed = game.RevokeManualCover();
+
+        changed.Should().BeTrue();
+        game.CoverAssignments.Should().BeEmpty();
     }
 
     #endregion

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/SharedGameCoverAssignmentReconcileIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/SharedGameCoverAssignmentReconcileIntegrationTests.cs
@@ -181,4 +181,43 @@ public sealed class SharedGameCoverAssignmentReconcileIntegrationTests : IAsyncL
         reloaded!.CoverAssignments.Should().HaveCount(2, "two collection includes must not duplicate via a cartesian product");
         reloaded.Designers.Should().HaveCount(2);
     }
+
+    [Fact]
+    public async Task RevokeManualCover_Cascades_NullsColumnsAndRemovesManualAssignment_OnPostgres()
+    {
+        // Slice 3f: revoking a manual cover must persist BOTH the nulled ManualCover* scalar
+        // columns (via Update) AND the removal of the Manual-pinned assignment row (via the
+        // child-safe Reconcile), while a non-Manual pin survives. Proves the Update + Reconcile
+        // composition on real Postgres (InMemory would hide a lost scalar write or child delete).
+        var gameId = await SeedGameAsync();
+
+        // Set a manual cover + pin Manual to Hero and Wikidata to Card.
+        var g1 = await _repository.GetByIdAsync(gameId);
+        g1!.SetManualCover("covers/manual/x/cover", "CC-BY-4.0", "Jane Artist", "https://s", AdminId, DateTime.UtcNow);
+        g1.AssignCover(CoverContext.Hero, CoverAssignmentSource.Manual, AdminId);
+        g1.AssignCover(CoverContext.Card, CoverAssignmentSource.Wikidata, AdminId);
+        _repository.Update(g1);
+        await _repository.ReconcileCoverAssignmentsAsync(g1);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        var afterSet = await _repository.GetByIdAsync(gameId);
+        afterSet!.ManualCoverR2Key.Should().Be("covers/manual/x/cover");
+        afterSet.CoverAssignments.Should().HaveCount(2);
+
+        // Revoke: nulls the manual columns AND drops the Manual assignment (cascade).
+        var g2 = await _repository.GetByIdAsync(gameId);
+        g2!.RevokeManualCover().Should().BeTrue();
+        _repository.Update(g2);
+        await _repository.ReconcileCoverAssignmentsAsync(g2);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        var afterRevoke = await _repository.GetByIdAsync(gameId);
+        afterRevoke!.ManualCoverR2Key.Should().BeNull("the scalar revoke persisted via Update");
+        afterRevoke.ManualCoverLicense.Should().BeNull();
+        afterRevoke.ManualCoverAttribution.Should().BeNull();
+        afterRevoke.CoverAssignments.Should().ContainSingle("the Manual pin was cascade-removed; Wikidata survives");
+        afterRevoke.CoverAssignments.Single().Source.Should().Be(CoverAssignmentSource.Wikidata);
+    }
 }


### PR DESCRIPTION
## Slice 3f — completes the two #3470 follow-ups

### Follow-up 1 — revoke cascade-remove
- **`SharedGame.RevokeManualCover()`** now also drops any per-context `GameCoverAssignment` pinned to the **Manual** source (returns `true` if columns OR assignments changed), so a revoked cover leaves **no phantom pin** that would auto-resurface the next manual cover on that context. Non-Manual pins survive.
- **Handler**: persists the removed rows via `ReconcileCoverAssignmentsAsync` (`Update` maps scalars only) + best-effort deletes each removed assignment's rendered crop object (`GeneratedR2Key`). The crop cleanup is a **forward-compatible no-op today** (no crop is rendered for a Manual assignment yet) — that was the genuinely-gated bit; the **assignment cascade is a real fix and ships now**.
- **Integration test** proves the `Update` + `Reconcile` composition + cascade on **real Postgres** (nulled scalars + removed Manual row + surviving Wikidata row) — the composition InMemory would hide. ✅ ran green locally.

### Follow-up 2 — attribution integration guard
- **`GetSharedGameByIdQueryHandler` test**: a game with only `ManualCover*` columns + a Manual Hero pin surfaces the license/attribution/sourceUrl triple on the detail DTO **end-to-end** (resolver → `CoverAttribution.ForWinningSource` → DTO). Guards the copyright requirement that a winning CC-BY/CC-BY-SA manual cover renders its credit — would have failed before Slice 3b.

### Tests
15 unit green (domain cascade, handler cascade, attribution guard) + the **integration cascade test green on Postgres (ran locally)**. Release build clean.

Completes epic #3470's manual-cover backend + follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)