### PR TITLE
fix(authz): register AdminPolicy + EditorOnlyPolicy (#3472)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
@@ -769,7 +769,17 @@ internal static class SharedGameCatalogServiceExtensions
             .AddPolicy("AdminOrEditorPolicy", policy =>
                 policy.RequireRole("SuperAdmin", "Admin", "Editor"))
             .AddPolicy("AdminOnlyPolicy", policy =>
-                policy.RequireRole("SuperAdmin", "Admin"));
+                policy.RequireRole("SuperAdmin", "Admin"))
+            // Issue #3472: policy names referenced by endpoints via .RequireAuthorization("...")
+            // but previously never registered — an unregistered policy makes the authorization
+            // middleware throw "AuthorizationPolicy named 'X' was not found" → HTTP 500 at request
+            // time. "AdminPolicy" (GameToolkitRoutes review routes + RemoveRag full-cleanup) mirrors
+            // AdminOnlyPolicy; "EditorOnlyPolicy" (bulk approve/reject share-requests) mirrors
+            // AdminOrEditorPolicy (editor tier and above — admins are never below editors).
+            .AddPolicy("AdminPolicy", policy =>
+                policy.RequireRole("SuperAdmin", "Admin"))
+            .AddPolicy("EditorOnlyPolicy", policy =>
+                policy.RequireRole("SuperAdmin", "Admin", "Editor"));
 
         return services;
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/SharedGameCatalogAuthorizationPolicyRegistrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/SharedGameCatalogAuthorizationPolicyRegistrationTests.cs
@@ -1,0 +1,144 @@
+using System.Security.Claims;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.DependencyInjection;
+using Api.Tests.Constants;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using FluentAssertions;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure;
+
+/// <summary>
+/// Issue #3472 — regression guard for authorization policies referenced by endpoints
+/// but never registered.
+///
+/// <para>
+/// <c>GameToolkitRoutes</c> and <c>SharedGameCatalogAdminEndpoints</c> reference
+/// <c>"AdminPolicy"</c>, and <c>SharedGameCatalogAdminShareRequestEndpoints</c> references
+/// <c>"EditorOnlyPolicy"</c>, via <c>.RequireAuthorization("...")</c>. Neither name was
+/// registered by <see cref="SharedGameCatalogServiceExtensions.AddSharedGameCatalogPolicies"/>
+/// (the prod registration wired at <c>Program.cs</c>), so the ASP.NET authorization middleware
+/// threw <c>InvalidOperationException: The AuthorizationPolicy named 'X' was not found</c> at
+/// request time → HTTP 500 on RemoveRag, the GameToolkit review routes and the bulk
+/// approve/reject share-request endpoints.
+/// </para>
+///
+/// These tests invoke the SAME production registration method and assert the two policies are
+/// resolvable and enforce the intended role tiers (aligned with the existing equivalents
+/// <c>AdminOnlyPolicy</c> = SuperAdmin+Admin and <c>AdminOrEditorPolicy</c> = SuperAdmin+Admin+Editor).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("Category", TestCategories.Security)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "3472")]
+public sealed class SharedGameCatalogAuthorizationPolicyRegistrationTests : IDisposable
+{
+    private readonly ServiceProvider _serviceProvider;
+    private readonly IAuthorizationService _authorizationService;
+    private readonly IAuthorizationPolicyProvider _policyProvider;
+
+    public SharedGameCatalogAuthorizationPolicyRegistrationTests()
+    {
+        var services = new ServiceCollection();
+
+        // Invoke the REAL production registration (Program.cs calls this) so the test guards
+        // the actual wiring, not a re-declared copy.
+        services.AddSharedGameCatalogPolicies();
+        services.AddLogging();
+
+        _serviceProvider = services.BuildServiceProvider();
+        _authorizationService = _serviceProvider.GetRequiredService<IAuthorizationService>();
+        _policyProvider = _serviceProvider.GetRequiredService<IAuthorizationPolicyProvider>();
+    }
+
+    [Fact]
+    public async Task AddSharedGameCatalogPolicies_Registers_AdminPolicy()
+    {
+        var policy = await _policyProvider.GetPolicyAsync("AdminPolicy");
+
+        policy.Should().NotBeNull(
+            "endpoints reference \"AdminPolicy\" via RequireAuthorization and an unregistered policy 500s at request time");
+    }
+
+    [Fact]
+    public async Task AddSharedGameCatalogPolicies_Registers_EditorOnlyPolicy()
+    {
+        var policy = await _policyProvider.GetPolicyAsync("EditorOnlyPolicy");
+
+        policy.Should().NotBeNull(
+            "the bulk approve/reject share-request endpoints reference \"EditorOnlyPolicy\" via RequireAuthorization");
+    }
+
+    [Theory]
+    [InlineData("SuperAdmin")]
+    [InlineData("Admin")]
+    public async Task AdminPolicy_Grants_AdminTierRoles(string role)
+    {
+        var result = await _authorizationService.AuthorizeAsync(
+            CreatePrincipalWithRole(role), resource: null, "AdminPolicy");
+
+        result.Succeeded.Should().BeTrue($"'{role}' is an admin-tier role and must satisfy AdminPolicy");
+    }
+
+    [Theory]
+    [InlineData("Editor")]
+    [InlineData("User")]
+    public async Task AdminPolicy_Denies_NonAdminRoles(string role)
+    {
+        var result = await _authorizationService.AuthorizeAsync(
+            CreatePrincipalWithRole(role), resource: null, "AdminPolicy");
+
+        result.Succeeded.Should().BeFalse($"'{role}' is below the admin tier and must NOT satisfy AdminPolicy");
+    }
+
+    [Theory]
+    [InlineData("SuperAdmin")]
+    [InlineData("Admin")]
+    [InlineData("Editor")]
+    public async Task EditorOnlyPolicy_Grants_EditorTierAndAbove(string role)
+    {
+        var result = await _authorizationService.AuthorizeAsync(
+            CreatePrincipalWithRole(role), resource: null, "EditorOnlyPolicy");
+
+        result.Succeeded.Should().BeTrue(
+            $"'{role}' is editor-tier or above and must satisfy EditorOnlyPolicy (admins are never below editors)");
+    }
+
+    [Fact]
+    public async Task EditorOnlyPolicy_Denies_PlainUser()
+    {
+        var result = await _authorizationService.AuthorizeAsync(
+            CreatePrincipalWithRole("User"), resource: null, "EditorOnlyPolicy");
+
+        result.Succeeded.Should().BeFalse("a plain 'User' must NOT satisfy EditorOnlyPolicy");
+    }
+
+    [Theory]
+    [InlineData("AdminOnlyPolicy")]
+    [InlineData("AdminOrEditorPolicy")]
+    public async Task AddSharedGameCatalogPolicies_Keeps_ExistingPolicies(string policyName)
+    {
+        // Non-regression: the pre-existing policies registered by the same method must remain.
+        var policy = await _policyProvider.GetPolicyAsync(policyName);
+
+        policy.Should().NotBeNull($"'{policyName}' was already registered and must not regress");
+    }
+
+    private static ClaimsPrincipal CreatePrincipalWithRole(string role)
+    {
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, Guid.NewGuid().ToString()),
+            new(ClaimTypes.Email, "test@example.com"),
+            new(ClaimTypes.Role, role)
+        };
+
+        var identity = new ClaimsIdentity(claims, "TestScheme");
+        return new ClaimsPrincipal(identity);
+    }
+
+    public void Dispose()
+    {
+        _serviceProvider.Dispose();
+    }
+}


### PR DESCRIPTION
## Problema
Sei endpoint admin referenziano authorization policy **mai registrate**:
- **`AdminPolicy`** — `GameToolkitRoutes` review routes (×3) + RemoveRag full-cleanup (`SharedGameCatalogAdminEndpoints`)
- **`EditorOnlyPolicy`** — bulk approve/reject share-requests (`SharedGameCatalogAdminShareRequestEndpoints` ×2)

Una policy non registrata fa lanciare al middleware di autorizzazione ASP.NET `InvalidOperationException: The AuthorizationPolicy named 'X' was not found` → **HTTP 500 a request-time** su quegli endpoint. Trovato durante il grounding dello Slice 0 di #3470.

## Fix
Registro entrambe in `AddSharedGameCatalogPolicies` (già wired in `Program.cs:439`) con i tier di ruolo allineati alle equivalenti esistenti:
- `AdminPolicy` = `SuperAdmin, Admin` (come `AdminOnlyPolicy` / `RequireAdminOrAbove`)
- `EditorOnlyPolicy` = `SuperAdmin, Admin, Editor` (come `AdminOrEditorPolicy`; gli admin non sono mai sotto gli editor)

Scelta **registrare** invece di swappare le 6 referenze: diff minimale e behavior-preserving sul wiring endpoint; il codebase già tollera policy-alias (`RequireAdminOrAbove` ≡ `AdminOnlyPolicy`).

## Test
Nuovo unit test `SharedGameCatalogAuthorizationPolicyRegistrationTests` (Category=Unit, no Docker) che invoca la registrazione reale e asserisce:
- entrambe le policy risolvono (regression guard sul 500)
- enforcement per-ruolo (AdminPolicy → grant SuperAdmin/Admin, deny Editor/User; EditorOnlyPolicy → grant SuperAdmin/Admin/Editor, deny User)
- non-regressione su `AdminOnlyPolicy`/`AdminOrEditorPolicy` preesistenti

Esito: `Superato! — Passed: 12, Failed: 0`. TDD: visto il RED (policy `null`) prima del fix.

> Nota onestà: il test copre la **root cause** (registrazione policy + semantica ruoli), non una chiamata HTTP end-to-end per endpoint (che sarebbe Testcontainers-gated). Il 500 era un bug di registrazione, interamente catturato da questo livello.

## DoD (#3472)
- [x] Le 6 referenze usano policy registrate
- [x] Test che coprono l'authz (registrazione + tier per-ruolo di quegli endpoint)

Primo slice dell'epic **"Catalog hardening & security"**.

Resolves #3472

🤖 Generated with [Claude Code](https://claude.com/claude-code)
