### PR TITLE
fix(web): repair FE baseline test regression (#3552)

### DIFF
--- a/apps/web/src/components/diff/__tests__/DiffViewModeToggle.test.tsx
+++ b/apps/web/src/components/diff/__tests__/DiffViewModeToggle.test.tsx
@@ -26,8 +26,8 @@ describe('DiffViewModeToggle', () => {
     it('should have radiogroup role', () => {
       render(<DiffViewModeToggle currentMode="list" onModeChange={mockOnModeChange} />);
 
-      // shadcn ToggleGroup uses "group" role, not "radiogroup"
-      expect(screen.getByRole('group')).toBeInTheDocument();
+      // ToggleGroup type="single" exposes role="radiogroup" (with role="radio" items)
+      expect(screen.getByRole('radiogroup')).toBeInTheDocument();
     });
 
     it('should display correct text and icons', () => {
@@ -126,7 +126,9 @@ describe('DiffViewModeToggle', () => {
     it('should handle rapid mode switching', async () => {
       const user = userEvent.setup();
 
-      const { rerender } = render(<DiffViewModeToggle currentMode="list" onModeChange={mockOnModeChange} />);
+      const { rerender } = render(
+        <DiffViewModeToggle currentMode="list" onModeChange={mockOnModeChange} />
+      );
 
       const sideButton = screen.getByLabelText('Side-by-side view');
 
@@ -190,8 +192,8 @@ describe('DiffViewModeToggle', () => {
     it('should be keyboard navigable', () => {
       render(<DiffViewModeToggle currentMode="list" onModeChange={mockOnModeChange} />);
 
-      // Radix ToggleGroup is keyboard navigable - verify group has tabindex
-      const toggleGroup = screen.getByRole('group');
+      // Radix ToggleGroup is keyboard navigable - verify the radiogroup has tabindex
+      const toggleGroup = screen.getByRole('radiogroup');
       expect(toggleGroup).toHaveAttribute('tabindex');
 
       // Verify buttons are focusable
@@ -243,9 +245,7 @@ describe('DiffViewModeToggle', () => {
     });
 
     it('should have toggle group items', () => {
-      render(
-        <DiffViewModeToggle currentMode="list" onModeChange={mockOnModeChange} />
-      );
+      render(<DiffViewModeToggle currentMode="list" onModeChange={mockOnModeChange} />);
 
       // shadcn ToggleGroup creates buttons, not custom class names
       const listButton = screen.getByLabelText('List view');

--- a/apps/web/src/components/features/game-chat/__tests__/CitationPdfTab.test.tsx
+++ b/apps/web/src/components/features/game-chat/__tests__/CitationPdfTab.test.tsx
@@ -29,6 +29,9 @@ vi.mock('@/lib/api', () => ({
     },
     pdf: {
       getPdfDownloadUrl: (id: string) => `http://test/api/v1/pdfs/${id}/download`,
+      // #3453 added image-region fetch to PdfInlineViewer; mock it so the viewer mounts
+      // (an unmocked call threw "getImageRegions is not a function" and blocked rendering).
+      getImageRegions: vi.fn().mockResolvedValue([]),
     },
   },
 }));

--- a/apps/web/src/lib/api/schemas/__tests__/admin-cover.schemas.test.ts
+++ b/apps/web/src/lib/api/schemas/__tests__/admin-cover.schemas.test.ts
@@ -118,7 +118,7 @@ const validCandidatesDto = {
   gameId: '550e8400-e29b-41d4-a716-446655440000',
   candidates: [validCandidate],
   assignments: {
-    card: 'Wikidata',
+    card: { source: 'Wikidata', focalX: 0.5, focalY: 0.5 },
     hero: null,
     social: null,
   },
@@ -129,7 +129,7 @@ describe('CoverCandidatesSchema', () => {
     const result = CoverCandidatesSchema.safeParse(validCandidatesDto);
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data.assignments.card).toBe('Wikidata');
+      expect(result.data.assignments.card?.source).toBe('Wikidata');
       expect(result.data.assignments.hero).toBeNull();
       expect(result.data.candidates).toHaveLength(1);
     }
@@ -162,7 +162,11 @@ describe('CoverCandidatesSchema', () => {
   it('rejects an invalid enum inside assignments', () => {
     const result = CoverCandidatesSchema.safeParse({
       ...validCandidatesDto,
-      assignments: { card: 'custom', hero: null, social: null },
+      assignments: {
+        card: { source: 'custom', focalX: 0.5, focalY: 0.5 },
+        hero: null,
+        social: null,
+      },
     });
     expect(result.success).toBe(false);
   });


### PR DESCRIPTION
## Problema
**11 test FE** fallivano su `main-dev` (confermato localmente + CI shard 2&3), violando il baseline "clean" del CLAUDE.md. **NON** introdotti da #3498/#3550 — ereditati da merge recenti sotto la policy FE non-blocking. Tutti **stale test**, non bug di prodotto.

## Fix (3 file)
- **`admin-cover.schemas.test.ts` (#3470)** — 2 fail: lo schema read-shape è evoluto a per-context assignment **objects** `{source, focalX, focalY}` (backend `CoverContextAssignmentDto`), ma le fixture Slice-1 passavano stringhe bare. Aggiornate fixture + assertion + caso invalid-enum.
- **`CitationPdfTab.test.tsx` (#3435)** — 7 fail: #3453 ha aggiunto `api.pdf.getImageRegions` a `PdfInlineViewer`, ma il mock `@/lib/api` del test-sibling non lo aveva → `TypeError: getImageRegions is not a function` durante il mount → bloccava tutti i 7 test di render. Aggiunto il mock (pattern di `PdfInlineViewer.test`).
- **`DiffViewModeToggle.test.tsx`** — 2 fail (a11y): il componente ora espone `role="radiogroup"` (ToggleGroup type=single → radiogroup + radio + aria-checked, a11y **migliorata**), ma il test cercava ancora `getByRole('group')`. Aggiornate le 2 assertion a `getByRole('radiogroup')` (coerente col nome del test).

## Verifica
Locale: tutti e 3 i file verdi (admin-cover+CitationPdfTab: 31 passed; DiffViewModeToggle: 22 passed). La CI FE sharded valida il suite completo → **baseline ripristinato a 0**.

Resolves #3552

🤖 Generated with [Claude Code](https://claude.com/claude-code)
