### PR TITLE
fix(security): harden cover image decoder — bomb + non-raster (#3495)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WebpVariantGenerator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WebpVariantGenerator.cs
@@ -107,11 +107,15 @@ internal sealed class WebpVariantGenerator : IWebpVariantGenerator
                 "Source image format is not a supported raster type (PNG/JPEG/WebP/GIF/BMP/TIFF).");
         }
 
+        // Pin the sniffed format for BOTH the header ping and the decode, so neither relies on
+        // ImageMagick's content-based coder auto-detection (the mechanism the allowlist bypasses).
+        var readSettings = new MagickReadSettings { Format = format.Value };
+
         // #3495 M1 — decompression-bomb defense: inspect the header only (no pixel
         // allocation) and reject sources beyond the dimension/megapixel cap before decode.
         try
         {
-            var info = new MagickImageInfo(originalImage);
+            var info = new MagickImageInfo(originalImage, readSettings);
             if (info.Width > MaxSourceDimension ||
                 info.Height > MaxSourceDimension ||
                 (long)info.Width * info.Height > MaxSourcePixels)
@@ -138,7 +142,6 @@ internal sealed class WebpVariantGenerator : IWebpVariantGenerator
             // Decode with the sniffed format pinned (no coder guessing / polyglot confusion)
             // inside Task.Run so callers keep the async contract. The header-only ping cap above
             // has already bounded the source to <= MaxSourcePixels before this allocation.
-            var readSettings = new MagickReadSettings { Format = format.Value };
             image = await Task.Run(() => new MagickImage(originalImage, readSettings), ct).ConfigureAwait(false);
         }
         catch (MagickException ex)

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WebpVariantGenerator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WebpVariantGenerator.cs
@@ -30,7 +30,23 @@ internal sealed class WebpVariantGenerator : IWebpVariantGenerator
     /// </summary>
     private const int WebpQuality = 85;
 
+    /// <summary>
+    /// #3495 M1 — hard caps on the SOURCE image, checked at header-inspection time
+    /// (before any full-raster allocation) to defeat decompression bombs. A source over
+    /// either the per-dimension cap or the total-pixel cap is rejected before decode.
+    /// </summary>
+    private const int MaxSourceDimension = 20_000;
+    private const long MaxSourcePixels = 64_000_000L; // 64 megapixels
+
     private readonly ILogger<WebpVariantGenerator> _logger;
+
+    // #3495 M1 note: Magick.NET ResourceLimits are process-GLOBAL statics. They are deliberately
+    // NOT set here — this class shares the Magick.NET runtime with OCR (VisionOcrAdapter) and user
+    // photos (GamebookPhotoStorageService), which legitimately decode larger images, so imposing
+    // this cover path's tight caps globally (with load-order-dependent timing) would break them.
+    // The decompression-bomb defense is instead enforced per-decode below via the header-only ping
+    // cap, which bounds every WebpVariantGenerator decode to <= MaxSourcePixels before allocation.
+    // A generous, cross-consumer-safe global Memory belt set once at app startup is a follow-up.
 
     public WebpVariantGenerator(ILogger<WebpVariantGenerator> logger)
     {
@@ -78,14 +94,52 @@ internal sealed class WebpVariantGenerator : IWebpVariantGenerator
 
         ct.ThrowIfCancellationRequested();
 
+        // #3495 M1 — raster-only allowlist: reject non-raster / delegate-backed coders
+        // (SVG, MSL, HTTPS, EPHEMERAL, …) by magic bytes BEFORE the source reaches Magick's
+        // decoder, closing the XXE / SSRF / RCE surface those coders expose.
+        var format = DetectRasterFormat(originalImage);
+        if (format is null)
+        {
+            _logger.LogWarning(
+                "Rejected source image with unsupported/non-raster format ({Bytes} bytes).",
+                originalImage.Length);
+            throw new ImageProcessingException(
+                "Source image format is not a supported raster type (PNG/JPEG/WebP/GIF/BMP/TIFF).");
+        }
+
+        // #3495 M1 — decompression-bomb defense: inspect the header only (no pixel
+        // allocation) and reject sources beyond the dimension/megapixel cap before decode.
+        try
+        {
+            var info = new MagickImageInfo(originalImage);
+            if (info.Width > MaxSourceDimension ||
+                info.Height > MaxSourceDimension ||
+                (long)info.Width * info.Height > MaxSourcePixels)
+            {
+                _logger.LogWarning(
+                    "Rejected oversized source image ({Width}x{Height}).",
+                    info.Width, info.Height);
+                throw new ImageProcessingException(
+                    "Source image dimensions exceed the allowed limit.");
+            }
+        }
+        catch (MagickException ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to inspect source image header ({Bytes} bytes).",
+                originalImage.Length);
+            throw new ImageProcessingException(
+                "Source image format is not recognized, unsupported, or corrupted.", ex);
+        }
+
         MagickImage image;
         try
         {
-            // Magick.NET auto-detects PNG/JPEG/WebP/GIF/BMP/TIFF from the
-            // magic-byte header. Wrap the synchronous constructor in Task.Run
-            // so callers preserve the async signature contract.
-            using var sourceStream = new MemoryStream(originalImage, writable: false);
-            image = await Task.Run(() => new MagickImage(sourceStream), ct).ConfigureAwait(false);
+            // Decode with the sniffed format pinned (no coder guessing / polyglot confusion)
+            // inside Task.Run so callers keep the async contract. The header-only ping cap above
+            // has already bounded the source to <= MaxSourcePixels before this allocation.
+            var readSettings = new MagickReadSettings { Format = format.Value };
+            image = await Task.Run(() => new MagickImage(originalImage, readSettings), ct).ConfigureAwait(false);
         }
         catch (MagickException ex)
         {
@@ -159,6 +213,59 @@ internal sealed class WebpVariantGenerator : IWebpVariantGenerator
         var ideal = (int)Math.Round(focal * filledDim, MidpointRounding.AwayFromZero) - (int)(targetDim / 2);
         var max = (int)filledDim - (int)targetDim;
         return Math.Clamp(ideal, 0, Math.Max(0, max));
+    }
+
+    /// <summary>
+    /// #3495 M1 — magic-byte sniff restricting decode to a raster allowlist. Returns the
+    /// detected <see cref="MagickFormat"/> for PNG/JPEG/GIF/BMP/TIFF/WebP, or <c>null</c> for
+    /// anything else (SVG and every delegate-backed coder), which the caller rejects.
+    /// </summary>
+    private static MagickFormat? DetectRasterFormat(byte[] bytes)
+    {
+        if (bytes.Length < 12)
+        {
+            return null;
+        }
+
+        // PNG: 89 50 4E 47
+        if (bytes[0] == 0x89 && bytes[1] == 0x50 && bytes[2] == 0x4E && bytes[3] == 0x47)
+        {
+            return MagickFormat.Png;
+        }
+
+        // JPEG: FF D8 FF
+        if (bytes[0] == 0xFF && bytes[1] == 0xD8 && bytes[2] == 0xFF)
+        {
+            return MagickFormat.Jpeg;
+        }
+
+        // GIF: "GIF8"
+        if (bytes[0] == 0x47 && bytes[1] == 0x49 && bytes[2] == 0x46 && bytes[3] == 0x38)
+        {
+            return MagickFormat.Gif;
+        }
+
+        // BMP: "BM"
+        if (bytes[0] == 0x42 && bytes[1] == 0x4D)
+        {
+            return MagickFormat.Bmp;
+        }
+
+        // TIFF: "II*\0" (little-endian) or "MM\0*" (big-endian)
+        if ((bytes[0] == 0x49 && bytes[1] == 0x49 && bytes[2] == 0x2A && bytes[3] == 0x00) ||
+            (bytes[0] == 0x4D && bytes[1] == 0x4D && bytes[2] == 0x00 && bytes[3] == 0x2A))
+        {
+            return MagickFormat.Tiff;
+        }
+
+        // WebP: "RIFF"????"WEBP"
+        if (bytes[0] == 0x52 && bytes[1] == 0x49 && bytes[2] == 0x46 && bytes[3] == 0x46 &&
+            bytes[8] == 0x57 && bytes[9] == 0x45 && bytes[10] == 0x42 && bytes[11] == 0x50)
+        {
+            return MagickFormat.WebP;
+        }
+
+        return null;
     }
 
     private static void EnsureFocalInRange(double value, string paramName)

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WebpVariantGeneratorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WebpVariantGeneratorTests.cs
@@ -200,6 +200,42 @@ public class WebpVariantGeneratorTests
     }
 
     // ──────────────────────────────────────────────────────────────────────────
+    // Decoder hardening (#3495 M1) — decompression-bomb + non-raster coder defense
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GenerateWebpAsync_SourceExceedingDimensionCap_ThrowsImageProcessingException()
+    {
+        // Decompression-bomb defense: a source whose declared dimensions exceed the guard
+        // cap must be rejected at header-inspection (ping) time, before any full-raster
+        // allocation. A 20001x1 image is trivial to allocate here but trips the dimension cap.
+        var oversized = CreateSolidImagePng(width: 20001, height: 1, color: MagickColors.Red);
+        var sut = CreateSut();
+
+        var act = async () => await sut.GenerateWebpAsync(oversized, TargetWidth, TargetHeight, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ImageProcessingException>(
+            "sources beyond the dimension/megapixel cap must be rejected before decode (decompression-bomb defense)");
+    }
+
+    [Fact]
+    public async Task GenerateWebpAsync_SvgPayload_ThrowsImageProcessingException()
+    {
+        // Non-raster formats (SVG + delegate-backed coders) are an XXE / SSRF / RCE surface
+        // and must never reach Magick's coder — reject via the raster-only magic-byte allowlist
+        // before any decode.
+        var svg = System.Text.Encoding.UTF8.GetBytes(
+            "<?xml version=\"1.0\"?><svg xmlns=\"http://www.w3.org/2000/svg\" width=\"64\" height=\"64\">" +
+            "<rect width=\"64\" height=\"64\" fill=\"red\"/></svg>");
+        var sut = CreateSut();
+
+        var act = async () => await sut.GenerateWebpAsync(svg, TargetWidth, TargetHeight, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ImageProcessingException>(
+            "vector/non-raster formats must be rejected by the raster-only allowlist");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
     // Cancellation
     // ──────────────────────────────────────────────────────────────────────────
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WebpVariantGeneratorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WebpVariantGeneratorTests.cs
@@ -120,6 +120,27 @@ public class WebpVariantGeneratorTests
         decoded.Height.Should().Be((uint)TargetHeight);
     }
 
+    [Theory]
+    [InlineData(MagickFormat.Gif)]
+    [InlineData(MagickFormat.Bmp)]
+    [InlineData(MagickFormat.Tiff)]
+    [InlineData(MagickFormat.WebP)]
+    public async Task GenerateWebpAsync_AllowlistedRasterSource_ProducesWebp(MagickFormat sourceFormat)
+    {
+        // #3495 M1 — the raster-only allowlist gates decode on a 6-branch magic-byte sniff.
+        // Prove each allow-listed source format (beyond PNG/JPEG) is correctly sniffed + decoded,
+        // so a typo'd offset/byte in the GIF/BMP/TIFF/WebP branch would fail CI, not ship silently.
+        var source = CreateSolidImage(width: 400, height: 400, MagickColors.Teal, sourceFormat);
+        var sut = CreateSut();
+
+        var output = await sut.GenerateWebpAsync(source, TargetWidth, TargetHeight, CancellationToken.None);
+
+        output.Should().NotBeNullOrEmpty();
+        System.Text.Encoding.ASCII.GetString(output, 0, 4).Should().Be("RIFF",
+            $"a {sourceFormat} source must be accepted by the allowlist and re-encoded to WebP");
+        System.Text.Encoding.ASCII.GetString(output, 8, 4).Should().Be("WEBP");
+    }
+
     // ──────────────────────────────────────────────────────────────────────────
     // Input validation (ArgumentException)
     // ──────────────────────────────────────────────────────────────────────────
@@ -372,6 +393,15 @@ public class WebpVariantGeneratorTests
         using var image = new MagickImage(color, (uint)width, (uint)height);
         image.Format = MagickFormat.Jpeg;
         image.Quality = 90;
+        using var ms = new MemoryStream();
+        image.Write(ms);
+        return ms.ToArray();
+    }
+
+    private static byte[] CreateSolidImage(int width, int height, MagickColor color, MagickFormat format)
+    {
+        using var image = new MagickImage(color, (uint)width, (uint)height);
+        image.Format = format;
         using var ms = new MemoryStream();
         image.Write(ms);
         return ms.ToArray();


### PR DESCRIPTION
Primo slice del sub-epic **#3495 — SSRF egress hardening**. Il transport plane (connect-pin, IANA deny-list, TOCTOU retirement, size-ceiling, redirect gate, revoke) è già mergiato (#3499/#3501/#3509/#3510/#3534). Questo chiude il **P0 residuo più severo**: **M1 — decoder image hardening**.

## Problema (P0, non mitigato)
`WebpVariantGenerator` decodifica qualsiasi sorgente **senza limiti**: il ceiling da 10MB mergiato limita solo i byte *encoded*, quindi:
- **Decompression bomb**: un file piccolo che dichiara dimensioni gigapixel → OOM al decode.
- **Non-raster coder**: Magick.NET-Q8 14.15 **decodifica l'SVG** (verificato) → superficie XXE/SSRF/delegate.

Esplicitamente rinviato da #3501 e #3534.

## Fix (`WebpVariantGenerator.cs`)
1. **Allowlist raster** — sniff magic-byte (`DetectRasterFormat`: PNG/JPEG/WebP/GIF/BMP/TIFF); l'SVG e ogni coder delegate vengono rigettati **prima** di raggiungere Magick.
2. **Difesa decompression-bomb** — ping header-only (`MagickImageInfo`, nessuna allocazione raster) → rigetta sorgenti oltre **20000px/lato o 64MP** prima del decode.
3. **Decode con formato pinnato** (`MagickReadSettings.Format`) → niente coder-guessing / polyglot confusion.

**Niente `ResourceLimits` globali di Magick**: sono statici e condivisi con i decoder OCR (`VisionOcrAdapter`) e foto-utente (`GamebookPhotoStorageService`), che decodificano immagini più grandi; imporre i cap stretti della cover globalmente (con timing load-order-dipendente) li romperebbe. Il cap per-decode del ping è la difesa targettizzata e load-order-safe. Un belt Memory globale cross-consumer ad app-startup è un follow-up.

## Test (TDD)
Visto il RED (immagine 20001×1 + payload SVG → nessuna eccezione) prima del fix. Dopo: **26/26** `WebpVariantGeneratorTests` verdi (24 esistenti + 2 nuove, zero regressioni).

Refs #3495

🤖 Generated with [Claude Code](https://claude.com/claude-code)
