### PR TITLE
fix(smoldocling): unblock + speed up GPU inference (#3435 SP3)

### DIFF
--- a/apps/smoldocling-service/Dockerfile
+++ b/apps/smoldocling-service/Dockerfile
@@ -29,7 +29,9 @@ RUN python -c "from transformers import AutoProcessor, AutoModelForImageTextToTe
     print('Model download complete')"
 
 # ============================================================
-# Stage 2: Runtime — CUDA base for GPU, no build-essential
+# Stage 2: Runtime — CUDA base for GPU. Keeps build-essential OUT of the runtime
+# image (the #248 size optimization), EXCEPT the minimal gcc + headers that Triton's
+# runtime JIT needs on the GPU path — installed below with a rationale comment (#3435).
 # ============================================================
 FROM nvidia/cuda:12.6.3-cudnn-runtime-ubuntu22.04
 

--- a/apps/smoldocling-service/Dockerfile
+++ b/apps/smoldocling-service/Dockerfile
@@ -70,6 +70,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libsm6 \
     libxext6 \
     libxrender-dev \
+    # Triton JIT toolchain (#3435 SP3): torch>=2.12 JIT-compiles Triton CUDA kernels
+    # (e.g. bmm_outer_product) at RUNTIME inside model.generate(). Triton shells out to
+    # gcc to build a `cuda_utils.c` glue module that #includes <Python.h>, so it needs
+    # BOTH a host C compiler (gcc + libc6-dev) AND the Python dev headers
+    # (python3.11-dev → /usr/include/python3.11/Python.h). Without them every GPU
+    # inference fails per-page and the adapter swallows it → empty extraction (0 chunks).
+    # ptxas is already bundled in triton/backends/nvidia. GPU-only overhead, small; the
+    # CPU path never hits the Triton kernel.
+    gcc \
+    libc6-dev \
+    python3.11-dev \
     # Cleanup
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/apps/smoldocling-service/README.md
+++ b/apps/smoldocling-service/README.md
@@ -10,7 +10,7 @@ FastAPI microservice for VLM-based PDF extraction using SmolDocling (256M parame
 
 - ✅ **Vision-Language Model**: SmolDocling 256M (Apache 2.0)
 - ✅ **Complex Layouts**: Multi-column, tables, equations detection
-- ✅ **GPU Optional**: Works on CPU (3-5s/page) or GPU (0.5s/page)
+- ✅ **GPU Optional**: runs on CPU or GPU (see measured latency under Benchmarks — the original per-page estimates proved ~100× optimistic; #3435)
 - ✅ **Markdown Output**: Structured Markdown with DocTags
 - ✅ **Quality Scoring**: VLM-specific 4-metric assessment
 - ✅ **Italian Support**: Latin script languages (ita, eng, spa, fra, deu)
@@ -147,18 +147,23 @@ Health check with GPU status.
 
 ## Performance
 
-### Benchmarks (Estimated)
+### Benchmarks
 
-| Hardware | Time/Page | Total (20 pages) |
-|----------|-----------|------------------|
-| **CPU (4 cores)** | 3-5s | 60-100s (~1.5 min) |
-| **GPU (RTX 3060)** | 0.5-0.8s | 10-16s |
-| **GPU (A100)** | 0.35s | 7s |
+> ⚠️ The *Estimated* rows are the original upstream figures and were **never validated**. The first
+> real end-to-end run (#3435, 2026-08-04, agricola rulebook) measured them as **~100× optimistic** —
+> trust the *Measured* row for capacity planning.
+
+| Hardware | Time/Page | Total (20 pages) | Source |
+|----------|-----------|------------------|--------|
+| **GPU (RTX 4070, SDPA)** | **~57s** | **~11 min** | **Measured (#3435)** |
+| CPU (4 cores) | >95s | hours | Measured (#3435) |
+| GPU (RTX 3060) | 0.5-0.8s | 10-16s | Estimated (unvalidated) |
+| GPU (A100) | 0.35s | 7s | Estimated (unvalidated) |
 
 ### Resource Requirements
 
-- **CPU**: 2-4 cores (3-5s/page)
-- **GPU**: Optional, 500MB VRAM (0.5s/page)
+- **CPU**: 2-4 cores (measured >95s/page — impractical for batch, #3435)
+- **GPU**: Optional, ~500MB VRAM (measured ~57s/page on an RTX 4070 with SDPA, #3435)
 - **RAM**: 2-3GB
 - **Disk**: 1GB (model cache: 513MB)
 

--- a/apps/smoldocling-service/src/infrastructure/smoldocling_adapter.py
+++ b/apps/smoldocling-service/src/infrastructure/smoldocling_adapter.py
@@ -72,13 +72,30 @@ class SmolDoclingAdapter:
                 self.settings.model_name, cache_dir=str(self.settings.model_cache_dir)
             )
 
-            # Load model with specified dtype
+            # Load model with specified dtype. Prefer SDPA attention: on this VLM it is
+            # ~30% faster than the default eager path at the long sequence lengths a full
+            # rulebook page produces (#3435 SP3 GPU benchmark: 25→33 tok/s on an RTX 4070),
+            # with no output change, and it needs no extra dependency (unlike
+            # flash_attention_2, which is not installed). Fall back to eager if the
+            # installed transformers/model can't wire SDPA.
             torch_dtype = getattr(torch, self.settings.torch_dtype)
-            self.model = AutoModelForImageTextToText.from_pretrained(
-                self.settings.model_name,
-                torch_dtype=torch_dtype,
-                cache_dir=str(self.settings.model_cache_dir),
-            ).to(self.device)
+            load_kwargs = {
+                "torch_dtype": torch_dtype,
+                "cache_dir": str(self.settings.model_cache_dir),
+            }
+            try:
+                self.model = AutoModelForImageTextToText.from_pretrained(
+                    self.settings.model_name,
+                    attn_implementation="sdpa",
+                    **load_kwargs,
+                ).to(self.device)
+            except (ValueError, ImportError) as exc:
+                logger.warning(
+                    "SDPA attention unavailable (%s); falling back to eager attention", exc
+                )
+                self.model = AutoModelForImageTextToText.from_pretrained(
+                    self.settings.model_name, **load_kwargs
+                ).to(self.device)
 
             # Set to eval mode
             self.model.eval()

--- a/docs/superpowers/specs/2026-08-01-image-table-region-grounding-design.md
+++ b/docs/superpowers/specs/2026-08-01-image-table-region-grounding-design.md
@@ -249,9 +249,7 @@ Tutti indirizzati. Il più importante NON era P1/P2 ma un **blocker pre-esistent
   (`input_ids` solo con `text`; `batch_decode` funzione degli ids → trim/leak osservabili), + test text-only no-leak,
   fallback, confidence, `has_equations`. **Suite servizio verde: 29 passed, 1 skip.**
 
-> **⚠️ Limite noto**: l'inference **end-to-end reale** (VLM su GPU) NON è validata — SmolDocling su CPU è >95s/pagina
-> (impraticabile in sviluppo) e lo staging è saturo (DC-E). I test coprono la logica decode/clean/metadata con fake;
-> la validazione E2E resta parte di **SP3** (quando l'infra VLM è disponibile).
+> **✅ Inference GPU E2E VALIDATA (2026-08-04, SP3 groundwork, PR pending)** — su una **RTX 4070 (12GB)** locale, non su staging. La prima validazione reale ha scoperto **2 bug immagine bloccanti** (mai visti perché la spike girava su CPU, path senza Triton): l'immagine runtime non aveva né un **compilatore C** né gli **header dev Python**, quindi il JIT Triton di torch≥2.12 (`bmm_outer_product`) falliva su **ogni** `generate()` GPU → estrazione vuota (0 chunk) con HTTP 200. Fix: `gcc`+`libc6-dev`+`python3.11-dev` nel Dockerfile (`ptxas` è già bundled in triton). **Numeri reali** (agricola, 12 pag, quality 0.76): **~57 s/pagina** a regime dopo l'ottimizzazione `attn_implementation="sdpa"` (+31% vs eager; 25→33 tok/s isolato). Il README (0,5 s/pag) è **~100× ottimistico**; il DPI non aiuta (Idefics3 emette un numero fisso di image-token); `flash_attention_2` non installato. **Conseguenze**: (a) VLM su **pagina intera** (Opzione C) resta **impraticabile** per il corpus (~57 s/pag × ~20 pag × 52 PDF ≈ ore) **e** degrada il testo narrativo (errori OCR "szioni"/"usci", 0 tabelle su agricola); (b) **Opzione B (crop-tabella)** è la strada: un crop genera ~100-300 token (non ~1000) → pochi secondi/tabella, e SmolDocling tocca **solo** le tabelle (Unstructured resta primario sul testo). Overlay GPU opt-in: `infra/compose.smoldocling.gpu.local.yml`.
 
 ---
 

--- a/infra/compose.smoldocling.gpu.local.yml
+++ b/infra/compose.smoldocling.gpu.local.yml
@@ -1,9 +1,11 @@
 # Opt-in GPU overlay for smoldocling-service (#3435 SP3 — Metà-C VLM local validation/benchmark).
 #
 # Mirrors compose.gpu.local.yml (embedding-service): gives smoldocling-service access to the host
-# NVIDIA GPU so SmolDocling VLM inference runs on the GPU (~0.5s/page) instead of CPU (>95s/page,
-# impractical — spec §5bis/§5ter). Also pins DEVICE=cuda so the service fails loudly if the GPU is
-# not actually reachable, rather than silently falling back to CPU under device=auto.
+# NVIDIA GPU so SmolDocling VLM inference runs on the GPU (~57s/page measured on an RTX 4070, #3435)
+# instead of CPU (>95s/page, impractical — spec §5bis/§5ter). Both are far slower than the upstream
+# README's 0.5s/page estimate, which #3435 validated as ~100x optimistic. Also pins DEVICE=cuda so the
+# service fails loudly if the GPU is not actually reachable, rather than silently falling back to CPU
+# under device=auto.
 #
 # STANDALONE opt-in overlay: NOT referenced by the default stack, so `make dev` is unaffected on
 # machines without an NVIDIA GPU. A `driver: nvidia` reservation would make `make dev` FAIL if merged
@@ -12,8 +14,12 @@
 # Apply it explicitly only when you have an NVIDIA GPU + container runtime (from repo root):
 #
 #   docker compose -p meepleai \
-#     -f infra/docker-compose.yml -f infra/compose.smoldocling.gpu.local.yml \
+#     -f infra/docker-compose.yml -f infra/compose.dev.yml -f infra/compose.smoldocling.gpu.local.yml \
 #     up -d --build smoldocling-service
+#
+# compose.dev.yml is included so the host port (127.0.0.1:8002) is published for local validation;
+# drop it if you only `docker exec` into the container. The explicit service name starts it despite
+# its `ai` profile.
 services:
   smoldocling-service:
     environment:

--- a/infra/compose.smoldocling.gpu.local.yml
+++ b/infra/compose.smoldocling.gpu.local.yml
@@ -1,0 +1,27 @@
+# Opt-in GPU overlay for smoldocling-service (#3435 SP3 — Metà-C VLM local validation/benchmark).
+#
+# Mirrors compose.gpu.local.yml (embedding-service): gives smoldocling-service access to the host
+# NVIDIA GPU so SmolDocling VLM inference runs on the GPU (~0.5s/page) instead of CPU (>95s/page,
+# impractical — spec §5bis/§5ter). Also pins DEVICE=cuda so the service fails loudly if the GPU is
+# not actually reachable, rather than silently falling back to CPU under device=auto.
+#
+# STANDALONE opt-in overlay: NOT referenced by the default stack, so `make dev` is unaffected on
+# machines without an NVIDIA GPU. A `driver: nvidia` reservation would make `make dev` FAIL if merged
+# into a shared default compose file — that is why it lives here as a separate overlay you opt into.
+#
+# Apply it explicitly only when you have an NVIDIA GPU + container runtime (from repo root):
+#
+#   docker compose -p meepleai \
+#     -f infra/docker-compose.yml -f infra/compose.smoldocling.gpu.local.yml \
+#     up -d --build smoldocling-service
+services:
+  smoldocling-service:
+    environment:
+      DEVICE: cuda
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]


### PR DESCRIPTION
## SP3 groundwork — SmolDocling GPU inference: unblock + optimize (epic #3435)

> ⚠️ **Do NOT auto-close #3435.** This is **SP3 groundwork** (GPU inference validation + fixes), not the full SP3. Epic stays **open**. `Refs`, not `Closes`.

First-ever **end-to-end validation of SmolDocling GPU inference** (deferred as "not validated" in spec §5quater), run on a local **RTX 4070 (12 GB)**. It surfaced two real, blocking image bugs and one optimization.

### Bugs found (only an E2E run could catch these — unit tests use fakes; the earlier spike ran on CPU)
1. **Empty extraction on GPU (HTTP 200, 0 chunks).** torch ≥2.12 JIT-compiles a Triton CUDA kernel (`bmm_outer_product`) at runtime inside `model.generate()`. The runtime image had **no C compiler and no Python dev headers**, so every GPU page raised `Failed to find C compiler` / `Python.h: No such file` — swallowed per-page by the adapter → empty output. The CPU path never hits the Triton kernel, which is why the CPU spike never saw it.
   - Fix: `gcc` + `libc6-dev` + `python3.11-dev` in the runtime stage (`ptxas` is already bundled in `triton/backends/nvidia`).

### Optimization
2. **`attn_implementation="sdpa"`** (fallback to eager). KV cache was already on; the bottleneck was eager attention at long sequence lengths. Benchmarked **+31%** (`25→33 tok/s` isolated; **~79 → ~57 s/page** E2E) with identical output. DPI does not help (Idefics3 emits a fixed image-token count); `flash_attention_2` is not installed.

### Tooling
3. **`infra/compose.smoldocling.gpu.local.yml`** — opt-in GPU overlay (mirrors `compose.gpu.local.yml`), pins `DEVICE=cuda` + an nvidia device reservation; the shared stack still runs on non-GPU machines.

### Benchmark result → architectural verdict
Validated on agricola (12 pages, quality 0.76, **0 per-page failures**). Steady-state **~57 s/page** (README's 0.5 s/page is ~100× optimistic). Full-page VLM (**Option C**) stays impractical for the corpus *and* degrades narrative text (OCR errors, 0 tables on agricola) → **Option B (crop-only VLM)** is the path: a table crop is ~100–300 tokens (a few seconds), and SmolDocling touches only tables (Unstructured stays primary on text).

Test impact: none — the smoldocling adapter tests set `_is_initialized=True` and inject a mock model, bypassing `initialize()`/`from_pretrained`.

Refs #3435

🤖 Generated with [Claude Code](https://claude.com/claude-code)