### PR TITLE
fix(security): manual-cover BGG deny-list + audit evidence (#3495)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SecurityAudit/Application/Services/AuditEventType.cs
+++ b/apps/api/src/Api/BoundedContexts/SecurityAudit/Application/Services/AuditEventType.cs
@@ -126,4 +126,21 @@ public static class AuditEventType
     /// ActorUserId = admin.
     /// </summary>
     public const string CategoryDeleted = "admin.category.deleted";
+
+    // ── Manual cover (arbitrary-URL) copyright evidence (#3495 C6/H6) ────
+
+    /// <summary>
+    /// An admin set a manual cover from an arbitrary URL. Immutable copyright
+    /// evidence written in the SAME transaction as the shared_games write.
+    /// Metadata JSON: <c>{ "sha256": hex, "license": string, "sourceUrl": string, "dbKey": string }</c>
+    /// where <c>sha256</c> is the SHA-256 of the RE-ENCODED WebP bytes stored in R2.
+    /// ActorUserId = attesting admin.
+    /// </summary>
+    public const string ManualCoverSet = "cover.manual.set";
+
+    /// <summary>
+    /// An admin revoked a manual cover (takedown). Metadata JSON:
+    /// <c>{ "reason": string?, "dbKey": string }</c>. ActorUserId = revoking admin.
+    /// </summary>
+    public const string ManualCoverRevoked = "cover.manual.revoked";
 }

--- a/apps/api/src/Api/BoundedContexts/SecurityAudit/Application/Services/ITransactionalAuditWriter.cs
+++ b/apps/api/src/Api/BoundedContexts/SecurityAudit/Application/Services/ITransactionalAuditWriter.cs
@@ -1,0 +1,27 @@
+namespace Api.BoundedContexts.SecurityAudit.Application.Services;
+
+/// <summary>
+/// #3495 H6 — appends an IMMUTABLE audit row to the AMBIENT scoped <c>MeepleAiDbContext</c> WITHOUT
+/// calling SaveChanges, so the caller's <c>IUnitOfWork</c> commits the row ATOMICALLY with the domain
+/// write (evidence-or-nothing).
+/// <para>
+/// This is the deliberate OPPOSITE of <see cref="IAuditLogger"/>, which resolves a fresh DbContext
+/// from a CHILD scope and runs its own SaveChanges precisely so audit rows survive a caller rollback.
+/// That is the wrong guarantee for copyright evidence, which must never be orphaned from — nor leave
+/// orphaned — the row it attests. Use <see cref="IAuditLogger"/> for "audit on every attempt"; use
+/// this for "the evidence and the write commit together or not at all".
+/// </para>
+/// </summary>
+public interface ITransactionalAuditWriter
+{
+    /// <summary>
+    /// Adds an audit row to the ambient scoped DbContext. Does NOT persist — the caller's
+    /// <c>IUnitOfWork.SaveChangesAsync</c> is what commits it, in the same transaction as the write.
+    /// </summary>
+    void Append(
+        string eventType,
+        Guid? actorUserId = null,
+        Guid? targetUserId = null,
+        string? metadata = null,
+        string? correlationId = null);
+}

--- a/apps/api/src/Api/BoundedContexts/SecurityAudit/Infrastructure/Services/TransactionalAuditWriter.cs
+++ b/apps/api/src/Api/BoundedContexts/SecurityAudit/Infrastructure/Services/TransactionalAuditWriter.cs
@@ -1,0 +1,45 @@
+using Api.BoundedContexts.SecurityAudit.Application.Services;
+using Api.BoundedContexts.SecurityAudit.Infrastructure.Entities;
+using Api.Infrastructure;
+
+namespace Api.BoundedContexts.SecurityAudit.Infrastructure.Services;
+
+/// <inheritdoc cref="ITransactionalAuditWriter"/>
+/// <remarks>
+/// Registered SCOPED so it resolves the SAME per-request <see cref="MeepleAiDbContext"/> instance as
+/// the caller's <c>IUnitOfWork</c> — the row added here is tracked by that context and committed by
+/// the caller's SaveChanges. There is intentionally NO SaveChanges and NO try/catch here: a failure
+/// to persist the evidence MUST bubble and roll back the domain write.
+/// </remarks>
+internal sealed class TransactionalAuditWriter : ITransactionalAuditWriter
+{
+    private readonly MeepleAiDbContext _db;
+    private readonly TimeProvider _timeProvider;
+
+    public TransactionalAuditWriter(MeepleAiDbContext db, TimeProvider timeProvider)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+    }
+
+    public void Append(
+        string eventType,
+        Guid? actorUserId = null,
+        Guid? targetUserId = null,
+        string? metadata = null,
+        string? correlationId = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(eventType);
+
+        _db.Set<AuditLogEntity>().Add(new AuditLogEntity
+        {
+            Id = Guid.NewGuid(),
+            EventType = eventType,
+            ActorUserId = actorUserId,
+            TargetUserId = targetUserId,
+            Metadata = metadata,
+            CorrelationId = correlationId,
+            Timestamp = _timeProvider.GetUtcNow().UtcDateTime,
+        });
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RevokeManualCoverCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RevokeManualCoverCommand.cs
@@ -7,7 +7,10 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands;
 /// Epic #3470 Slice 3a-3 — revokes a game's admin-set manual cover: clears the manual cover
 /// columns + license attestation and best-effort deletes the R2 object. Idempotent: revoking a
 /// game with no manual cover is a no-op (still 204); only a missing game is a 404.
+/// <para>#3495 H6 — an optional takedown <paramref name="Reason"/> is captured in the
+/// <c>cover.manual.revoked</c> audit event (committed in the same transaction as the DB null-out).</para>
 /// </summary>
 internal record RevokeManualCoverCommand(
     Guid GameId,
-    Guid AdminId) : ICommand<Unit>;
+    Guid AdminId,
+    string? Reason = null) : ICommand<Unit>;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RevokeManualCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RevokeManualCoverCommandHandler.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+using Api.BoundedContexts.SecurityAudit.Application.Services;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.Middleware.Exceptions;
@@ -29,6 +31,7 @@ internal sealed class RevokeManualCoverCommandHandler : ICommandHandler<RevokeMa
     private readonly IUnitOfWork _unitOfWork;
     private readonly IHybridCacheService _cache;
     private readonly ICacheInvalidationRetryPolicy _cacheRetryPolicy;
+    private readonly ITransactionalAuditWriter _auditWriter;
     private readonly ILogger<RevokeManualCoverCommandHandler> _logger;
 
     public RevokeManualCoverCommandHandler(
@@ -37,6 +40,7 @@ internal sealed class RevokeManualCoverCommandHandler : ICommandHandler<RevokeMa
         IUnitOfWork unitOfWork,
         IHybridCacheService cache,
         ICacheInvalidationRetryPolicy cacheRetryPolicy,
+        ITransactionalAuditWriter auditWriter,
         ILogger<RevokeManualCoverCommandHandler> logger)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
@@ -44,6 +48,7 @@ internal sealed class RevokeManualCoverCommandHandler : ICommandHandler<RevokeMa
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _cache = cache ?? throw new ArgumentNullException(nameof(cache));
         _cacheRetryPolicy = cacheRetryPolicy ?? throw new ArgumentNullException(nameof(cacheRetryPolicy));
+        _auditWriter = auditWriter ?? throw new ArgumentNullException(nameof(auditWriter));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -73,6 +78,14 @@ internal sealed class RevokeManualCoverCommandHandler : ICommandHandler<RevokeMa
         // collection so those deletes persist (Update maps scalars only). Update + Reconcile
         // compose (disjoint DbSets); verified on Postgres by the reconcile integration suite.
         await _repository.ReconcileCoverAssignmentsAsync(game, cancellationToken).ConfigureAwait(false);
+
+        // #3495 H6 — takedown evidence, committed in the SAME transaction as the DB null-out (only
+        // on an actual revoke, never on the idempotent 204 no-op above).
+        _auditWriter.Append(
+            AuditEventType.ManualCoverRevoked,
+            actorUserId: command.AdminId,
+            metadata: JsonSerializer.Serialize(new { reason = command.Reason, dbKey = keyToDelete }));
+
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
         // Best-effort R2 cleanup AFTER the authoritative DB revoke. The raw-key delete (#3384)

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandler.cs
@@ -1,3 +1,6 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+using Api.BoundedContexts.SecurityAudit.Application.Services;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 using Api.Middleware.Exceptions;
@@ -5,6 +8,7 @@ using Api.Services;
 using Api.Services.Pdf;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Domain.Covers;
+using Api.SharedKernel.Infrastructure.Http;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Microsoft.Extensions.Logging;
 
@@ -32,6 +36,7 @@ internal sealed class SetManualCoverCommandHandler : ICommandHandler<SetManualCo
     private readonly IUnitOfWork _unitOfWork;
     private readonly IHybridCacheService _cache;
     private readonly ICacheInvalidationRetryPolicy _cacheRetryPolicy;
+    private readonly ITransactionalAuditWriter _auditWriter;
     private readonly ILogger<SetManualCoverCommandHandler> _logger;
 
     public SetManualCoverCommandHandler(
@@ -42,6 +47,7 @@ internal sealed class SetManualCoverCommandHandler : ICommandHandler<SetManualCo
         IUnitOfWork unitOfWork,
         IHybridCacheService cache,
         ICacheInvalidationRetryPolicy cacheRetryPolicy,
+        ITransactionalAuditWriter auditWriter,
         ILogger<SetManualCoverCommandHandler> logger)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
@@ -51,6 +57,7 @@ internal sealed class SetManualCoverCommandHandler : ICommandHandler<SetManualCo
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _cache = cache ?? throw new ArgumentNullException(nameof(cache));
         _cacheRetryPolicy = cacheRetryPolicy ?? throw new ArgumentNullException(nameof(cacheRetryPolicy));
+        _auditWriter = auditWriter ?? throw new ArgumentNullException(nameof(auditWriter));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -60,6 +67,14 @@ internal sealed class SetManualCoverCommandHandler : ICommandHandler<SetManualCo
 
         var game = await _repository.GetByIdAsync(command.GameId, cancellationToken).ConfigureAwait(false)
             ?? throw new NotFoundException("SharedGame", command.GameId.ToString());
+
+        // #3495 C6 — defense-in-depth mirror of the validator's ADR-059 §5 host ban, guarding against
+        // any path that reaches the handler without the FluentValidation pipeline. Reject BEFORE egress.
+        if (BggHostDenyList.IsBanned(command.SourceUrl))
+        {
+            throw new ArgumentException(
+                "SourceUrl host is banned by ADR-059 §5 (BGG/geekdo assets).", nameof(command));
+        }
 
         // SSRF-pinned, 10MB-capped, HTTPS-only-per-hop fetch of the admin-supplied URL (#3534 fix 5/N).
         var imageBytes = await _fetcher.DownloadImageAsync(command.SourceUrl, cancellationToken).ConfigureAwait(false);
@@ -93,6 +108,23 @@ internal sealed class SetManualCoverCommandHandler : ICommandHandler<SetManualCo
             DateTime.UtcNow);
 
         _repository.Update(game);
+
+        // #3495 H6 — immutable copyright evidence, committed in the SAME transaction as the write
+        // (evidence-or-nothing): SHA-256 of the RE-ENCODED WebP bytes actually stored in R2, plus the
+        // attested license + source URL + AdminId. The writer Adds to the ambient scoped DbContext, so
+        // the SaveChangesAsync below commits the shared_games row AND the security_audit_logs row atomically.
+        var sha256Hex = Convert.ToHexString(SHA256.HashData(webpBytes)).ToLowerInvariant();
+        _auditWriter.Append(
+            AuditEventType.ManualCoverSet,
+            actorUserId: command.AdminId,
+            metadata: JsonSerializer.Serialize(new
+            {
+                sha256 = sha256Hex,
+                license = LicenseValidator.Normalize(command.License),
+                sourceUrl = command.SourceUrl,
+                dbKey = coverKey.DbKey,
+            }));
+
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
         // The cover columns the read-model resolves changed → evict the list + detail caches (AC-6).

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandValidator.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+using Api.SharedKernel.Infrastructure.Http;
 using FluentValidation;
 
 namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands;
@@ -22,7 +23,9 @@ internal sealed class SetManualCoverCommandValidator : AbstractValidator<SetManu
 
         RuleFor(x => x.SourceUrl)
             .NotEmpty().WithMessage("SourceUrl is required")
-            .Must(BeAbsoluteHttps).WithMessage("SourceUrl must be an absolute HTTPS URL");
+            .Must(BeAbsoluteHttps).WithMessage("SourceUrl must be an absolute HTTPS URL")
+            .Must(url => !BggHostDenyList.IsBanned(url))
+            .WithMessage("SourceUrl host is banned by ADR-059 §5 (BGG/geekdo assets)");
 
         RuleFor(x => x.License)
             .NotEmpty().WithMessage("License is required")

--- a/apps/api/src/Api/Extensions/InfrastructureServiceExtensions.cs
+++ b/apps/api/src/Api/Extensions/InfrastructureServiceExtensions.cs
@@ -621,6 +621,14 @@ internal static class InfrastructureServiceExtensions
             BoundedContexts.SecurityAudit.Application.Services.IAuditLogger,
             BoundedContexts.SecurityAudit.Infrastructure.Services.AuditLogger>();
 
+        // #3495 H6: transactional audit writer — the OPPOSITE guarantee to AuditLogger above. Scoped
+        // so it shares the SAME per-request MeepleAiDbContext as IUnitOfWork; it Adds an evidence row
+        // WITHOUT SaveChanges, so the caller's SaveChangesAsync commits evidence + domain write
+        // atomically (evidence-or-nothing). Register both interface + impl (#2565).
+        services.AddScoped<
+            BoundedContexts.SecurityAudit.Application.Services.ITransactionalAuditWriter,
+            BoundedContexts.SecurityAudit.Infrastructure.Services.TransactionalAuditWriter>();
+
         // I5 (auth security fixes): email outbox + drainer. The service is
         // scoped (per-request DbContext); the drainer is hosted (singleton
         // via BackgroundService and uses IServiceScopeFactory to spin up a

--- a/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogAdminEndpoints.cs
+++ b/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogAdminEndpoints.cs
@@ -978,12 +978,15 @@ internal static class SharedGameCatalogAdminEndpoints
         Guid id,
         IMediator mediator,
         HttpContext httpContext,
-        CancellationToken ct)
+        CancellationToken ct,
+        [FromBody] RevokeManualCoverRequest? request = null)
     {
         var (authorized, session, error) = httpContext.RequireAdminOrEditorSession();
         if (!authorized) return error!;
 
-        await mediator.Send(new RevokeManualCoverCommand(id, session!.Principal!.Subject.Id), ct)
+        // #3495 H6 — optional takedown reason (null when the caller sends no body) → audit event.
+        await mediator.Send(
+                new RevokeManualCoverCommand(id, session!.Principal!.Subject.Id, request?.Reason), ct)
             .ConfigureAwait(false);
         return Results.NoContent();
     }

--- a/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogRequestDtos.cs
+++ b/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogRequestDtos.cs
@@ -28,6 +28,14 @@ internal record SetManualCoverRequest(
     string License,
     string? Attribution = null);
 
+/// <summary>
+/// Optional request body for the manual cover revoke (#3495 H6). Carries the takedown reason, which
+/// is recorded in the <c>cover.manual.revoked</c> audit event. The body is optional so the existing
+/// no-body DELETE contract keeps working (reason is then null).
+/// </summary>
+internal record RevokeManualCoverRequest(
+    string? Reason = null);
+
 // ========================================
 // REQUEST DTOS
 // ========================================

--- a/apps/api/src/Api/SharedKernel/Infrastructure/Http/BggHostDenyList.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/Http/BggHostDenyList.cs
@@ -1,0 +1,48 @@
+namespace Api.SharedKernel.Infrastructure.Http;
+
+/// <summary>
+/// #3495 C6 — server-side mirror of the ADR-059 §5 / #2123 BGG asset freeze. The canonical source
+/// is the front-end ESLint rule <c>local/no-bgg-host</c> (regex in
+/// <c>apps/web/eslint-rules/no-bgg-host.js</c>); this is its back-end counterpart so an admin cannot
+/// launder around the ban via the "manual cover from URL" arbitrary-URL path.
+/// <para>
+/// Matched by registrable-domain suffix (exact host or a sub-domain of it), NOT by substring — so a
+/// look-alike attacker host such as <c>evilgeekdo.com</c> or <c>geekdo.com.attacker.example</c> is
+/// NOT banned (it is not a BGG asset), while <c>cf.geekdo-images.com</c>, <c>images.geekdo.com</c>
+/// and <c>www.boardgamegeek.com</c> are.
+/// </para>
+/// </summary>
+internal static class BggHostDenyList
+{
+    private static readonly string[] BannedSuffixes =
+    {
+        "geekdo-images.com",  // cf.geekdo-images.com, geekdo-images.com
+        "geekdo.com",         // images.geekdo.com
+        "boardgamegeek.com",  // *.boardgamegeek.com
+    };
+
+    /// <summary>True when <paramref name="url"/> is an absolute URL whose host is BGG/geekdo.</summary>
+    public static bool IsBanned(string? url) =>
+        Uri.TryCreate(url, UriKind.Absolute, out var uri) && IsBannedHost(uri.Host);
+
+    /// <summary>True when <paramref name="host"/> equals or is a sub-domain of a banned suffix.</summary>
+    public static bool IsBannedHost(string? host)
+    {
+        if (string.IsNullOrWhiteSpace(host))
+        {
+            return false;
+        }
+
+        var normalized = host.Trim().TrimEnd('.').ToLowerInvariant();
+        foreach (var suffix in BannedSuffixes)
+        {
+            if (string.Equals(normalized, suffix, StringComparison.Ordinal) ||
+                normalized.EndsWith("." + suffix, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/RevokeManualCoverCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/RevokeManualCoverCommandHandlerTests.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.SecurityAudit.Application.Services;
 using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
@@ -31,6 +32,7 @@ public sealed class RevokeManualCoverCommandHandlerTests
     private readonly Mock<IUnitOfWork> _unitOfWork = new();
     private readonly Mock<IHybridCacheService> _cache = new();
     private readonly Mock<ICacheInvalidationRetryPolicy> _cacheRetryPolicy = new();
+    private readonly Mock<ITransactionalAuditWriter> _auditWriter = new();
 
     public RevokeManualCoverCommandHandlerTests()
     {
@@ -44,7 +46,7 @@ public sealed class RevokeManualCoverCommandHandlerTests
 
     private RevokeManualCoverCommandHandler CreateHandler() =>
         new(_repository.Object, _blobStorage.Object, _unitOfWork.Object, _cache.Object,
-            _cacheRetryPolicy.Object, NullLogger<RevokeManualCoverCommandHandler>.Instance);
+            _cacheRetryPolicy.Object, _auditWriter.Object, NullLogger<RevokeManualCoverCommandHandler>.Instance);
 
     private static SharedGame NewGame() => SharedGame.Create(
         "Catan", 1995, "desc", 3, 4, 90, 10, 2.5m, 7.8m,

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandlerTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using Api.BoundedContexts.SecurityAudit.Application.Services;
 using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
@@ -35,6 +36,7 @@ public sealed class SetManualCoverCommandHandlerTests
     private readonly Mock<IUnitOfWork> _unitOfWork = new();
     private readonly Mock<IHybridCacheService> _cache = new();
     private readonly Mock<ICacheInvalidationRetryPolicy> _cacheRetryPolicy = new();
+    private readonly Mock<ITransactionalAuditWriter> _auditWriter = new();
     private readonly StubImageHandler _httpHandler = new();
 
     public SetManualCoverCommandHandlerTests()
@@ -60,6 +62,7 @@ public sealed class SetManualCoverCommandHandlerTests
             _unitOfWork.Object,
             _cache.Object,
             _cacheRetryPolicy.Object,
+            _auditWriter.Object,
             NullLogger<SetManualCoverCommandHandler>.Instance);
     }
 
@@ -110,6 +113,31 @@ public sealed class SetManualCoverCommandHandlerTests
             Times.Never);
         _repository.Verify(r => r.Update(game), Times.Once);
         _unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_AppendsImmutableManualCoverSetEvidence_WithSha256AndAdminActor()
+    {
+        var game = NewGame();
+        _httpHandler.ImageBytes = SolidPng(400, 600);
+        _repository.Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>())).ReturnsAsync(game);
+        _blobStorage
+            .Setup(b => b.StoreRawKeyAsync(It.IsAny<string>(), It.IsAny<Stream>(), "image/webp", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        await CreateHandler().Handle(Command(game.Id), CancellationToken.None);
+
+        // #3495 H6 — exactly one immutable evidence event: ManualCoverSet, actor = attesting admin,
+        // metadata carrying a 64-hex-char SHA-256 of the re-encoded WebP + the normalized license + URL.
+        _auditWriter.Verify(w => w.Append(
+            AuditEventType.ManualCoverSet,
+            It.Is<Guid?>(id => id == AdminId),
+            It.IsAny<Guid?>(),
+            It.Is<string>(m => m != null
+                && System.Text.RegularExpressions.Regex.IsMatch(m, "\"sha256\":\"[0-9a-f]{64}\"")
+                && m.Contains("CC-BY-SA-4.0")
+                && m.Contains("commons.example.org")),
+            It.IsAny<string?>()), Times.Once);
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandValidatorTests.cs
@@ -71,6 +71,21 @@ public sealed class SetManualCoverCommandValidatorTests
     }
 
     [Theory]
+    [InlineData("https://cf.geekdo-images.com/x/original/cover.jpg")]
+    [InlineData("https://images.geekdo.com/x/cover.jpg")]
+    [InlineData("https://geekdo-images.com/cover.jpg")]
+    [InlineData("https://api.boardgamegeek.com/xmlapi2/thing?id=13")]
+    [InlineData("https://www.boardgamegeek.com/image/123")]
+    public void Fails_WhenSourceUrlIsBannedBggHost(string url)
+    {
+        // #3495 C6 — ADR-059 §5 / #2123: the manual (arbitrary-URL) path must reject BGG/geekdo
+        // hosts BEFORE download, so it cannot launder around the catalog-wide BGG asset freeze.
+        // Each URL is absolute-HTTPS with a whitelisted license, so ONLY the new host rule can reject it.
+        _validator.TestValidate(Valid() with { SourceUrl = url })
+            .ShouldHaveValidationErrorFor(x => x.SourceUrl);
+    }
+
+    [Theory]
     [InlineData("")]
     [InlineData("   ")]
     public void Fails_WhenLicenseEmpty(string license)

--- a/apps/api/tests/Api.Tests/SharedKernel/Infrastructure/Http/BggHostDenyListTests.cs
+++ b/apps/api/tests/Api.Tests/SharedKernel/Infrastructure/Http/BggHostDenyListTests.cs
@@ -1,0 +1,51 @@
+using Api.SharedKernel.Infrastructure.Http;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.SharedKernel.Infrastructure.Http;
+
+/// <summary>
+/// #3495 C6 — server-side ADR-059 §5 / #2123 BGG asset ban on the manual-cover arbitrary-URL path.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedKernel")]
+public sealed class BggHostDenyListTests
+{
+    [Theory]
+    [InlineData("cf.geekdo-images.com")]
+    [InlineData("geekdo-images.com")]
+    [InlineData("images.geekdo.com")]
+    [InlineData("geekdo.com")]
+    [InlineData("boardgamegeek.com")]
+    [InlineData("www.boardgamegeek.com")]
+    [InlineData("api.boardgamegeek.com")]
+    [InlineData("GEEKDO-IMAGES.COM")]           // case-insensitive
+    [InlineData("cf.geekdo-images.com.")]        // trailing-dot FQDN
+    public void IsBannedHost_BannedHosts_ReturnsTrue(string host)
+    {
+        BggHostDenyList.IsBannedHost(host).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("commons.wikimedia.org")]
+    [InlineData("upload.wikimedia.org")]
+    [InlineData("example.com")]
+    [InlineData("evilgeekdo.com")]               // substring, not a sub-domain boundary
+    [InlineData("evilgeekdo-images.com")]        // the FE substring regex would false-match; we don't
+    [InlineData("geekdo.com.attacker.example")]  // banned label not at the suffix boundary
+    [InlineData("")]
+    [InlineData(null)]
+    public void IsBannedHost_NonBggHosts_ReturnsFalse(string? host)
+    {
+        BggHostDenyList.IsBannedHost(host).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsBanned_ParsesAbsoluteUrl_AndMatchesHost()
+    {
+        BggHostDenyList.IsBanned("https://cf.geekdo-images.com/x/cover.jpg").Should().BeTrue();
+        BggHostDenyList.IsBanned("https://commons.wikimedia.org/x.jpg").Should().BeFalse();
+        BggHostDenyList.IsBanned("not-a-url").Should().BeFalse();
+        BggHostDenyList.IsBanned(null).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
**Slice B** del sub-epic #3495 — chiude i P0 legal/copyright **C6/H6** sul path admin "manual cover from URL".

## Problema
- **C6**: l'URL manuale poteva puntare a host BGG/geekdo, **launderando** attorno al freeze ADR-059/#2123 (il ban esisteva SOLO sul FE — `local/no-bgg-host`).
- **H6**: nessuna evidenza copyright immutabile sul set manuale.

## Fix
- **`BggHostDenyList`** (SharedKernel/Infrastructure/Http) — mirror server-side del ban FE, match per **suffisso di dominio registrabile** (sub-domain sì, substring/lookalike no). Enforced nel **validator (400)** E come **defense-in-depth nell'handler**, prima di qualsiasi egress.
- **`ITransactionalAuditWriter`** — aggiunge la riga audit al **DbContext scoped ambiente SENZA SaveChanges**, così l'`IUnitOfWork` del chiamante la committa **atomicamente** con la write (*evidence-or-nothing*). È l'**opposto** di `IAuditLogger` (scope figlio + SaveChanges proprio), che permetterebbe una cover senza evidenza.
- **SetManualCover** emette `cover.manual.set` con **SHA-256 dei byte WebP ri-encodati** + license + sourceUrl + AdminId, nella stessa tx della write su `shared_games`.
- **Revoke**: takedown reason **opzionale** (non-breaking sul contratto DELETE) + evento `cover.manual.revoked`.

## Test
**56 unit test verdi**: boundary deny-list (sub-domain vs substring/lookalike), regola BGG del validator, `Append` evidence con SHA-256 a 64-hex + actor admin, audit su revoke.

## Follow-up (flagged)
- Test integrazione Testcontainers per l'atomicità same-tx (evidence+write insieme; il meccanismo è già corretto by-construction: ambient scoped DbContext + no-SaveChanges + EF SaveChanges transazionale).
- Guard immutabilità DB-level su `security_audit_logs` (grant/trigger append-only).
- FE revoke che invii `{reason}` + eventuale enforce required.

Refs #3495

🤖 Generated with [Claude Code](https://claude.com/claude-code)
