### PR TITLE
feat(security): egress SSRF observability counters + alert (#3495)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/DependencyInjection/AdministrationServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/DependencyInjection/AdministrationServiceExtensions.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.Administration.Application.Configuration;
+using Api.Observability;
 using Api.BoundedContexts.Administration.Application.Interfaces;
 using Api.BoundedContexts.Administration.Application.Services;
 using Api.BoundedContexts.Administration.Domain.Repositories;
@@ -316,7 +317,7 @@ internal static class AdministrationServiceExtensions
             {
                 client.Timeout = TimeSpan.FromSeconds(10);
             })
-            .ConfigureSsrfPin();
+            .ConfigureSsrfPin(MeepleAiMetrics.EgressSinks.Slack);
 
     /// <summary>
     /// Test seam (issue #3495 fix 3/N): registers ONLY the SSRF-pinned Slack webhook client so a

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
@@ -1,3 +1,4 @@
+using Api.Observability;
 using Api.SharedKernel.Constants;
 using Api.BoundedContexts.SharedGameCatalog.Application.Configuration;
 using Api.BoundedContexts.SharedGameCatalog.Application.Jobs;
@@ -401,7 +402,7 @@ internal static class SharedGameCatalogServiceExtensions
         {
             client.Timeout = TimeSpan.FromSeconds(10);
         })
-        .ConfigureSsrfPin();
+        .ConfigureSsrfPin(MeepleAiMetrics.EgressSinks.BggCover);
 
     /// <summary>
     /// Issue #3495 fix 5/N — registers the hardened arbitrary-URL download client
@@ -414,7 +415,7 @@ internal static class SharedGameCatalogServiceExtensions
         {
             client.Timeout = TimeSpan.FromSeconds(30);
         })
-        .ConfigureSsrfPin(allowAutoRedirect: false);
+        .ConfigureSsrfPin(MeepleAiMetrics.EgressSinks.Manual, allowAutoRedirect: false);
 
     /// <summary>
     /// Test seam (issue #3495 fix 3/N): registers ONLY the SSRF-pinned BGG cover-download client so
@@ -516,7 +517,7 @@ internal static class SharedGameCatalogServiceExtensions
         // #3495 follow-up: SSRF connect-pin — defense-in-depth on a fixed public host (DNS-rebinding).
         // ConfigureSsrfPin uses ConfigurePrimaryHttpMessageHandler (innermost), so the circuit-breaker
         // delegating handler above stays outer (CB → pin), matching the Slack registration.
-        .ConfigureSsrfPin();
+        .ConfigureSsrfPin(MeepleAiMetrics.EgressSinks.Wikidata);
 
         // Issue #1823 M4 (ADR DEC-3b/3c/3e): Wikimedia Commons license fetcher.
         // Consumed by the M8 orchestrator AFTER the Wikidata SPARQL pass resolves
@@ -554,7 +555,7 @@ internal static class SharedGameCatalogServiceExtensions
         // holds — and each redirect hop's host is independently re-resolved and SSRF-validated by the
         // per-connection pin (upload.wikimedia.org is public → allowed). Do NOT add any other
         // ConfigurePrimaryHttpMessageHandler here: it would override the pin.
-        .ConfigureSsrfPin();
+        .ConfigureSsrfPin(MeepleAiMetrics.EgressSinks.Wikimedia);
 
         services.AddHttpClient<BggCatalogProvider>(client =>
         {
@@ -563,7 +564,7 @@ internal static class SharedGameCatalogServiceExtensions
             client.Timeout = TimeSpan.FromSeconds(30);
         })
         // #3495 follow-up: SSRF connect-pin — defense-in-depth on a fixed public host (DNS-rebinding).
-        .ConfigureSsrfPin();
+        .ConfigureSsrfPin(MeepleAiMetrics.EgressSinks.Bgg);
 
         // Keyed registration so CatalogSeedAggregator can resolve "wikidata" (primary)
         // and "bgg" (fallback) explicitly — avoids relying on registration order.

--- a/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.Egress.cs
+++ b/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.Egress.cs
@@ -1,0 +1,68 @@
+// #3495 M2: SSRF egress observability — blocked/allowed counters by sink + reason.
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace Api.Observability;
+
+internal static partial class MeepleAiMetrics
+{
+    #region Egress SSRF Metrics (#3495 M2)
+
+    /// <summary>
+    /// Bounded set of egress SINKS. A compile-time constant per outbound client — NEVER a host/IP
+    /// (that would be unbounded cardinality). Used as the <c>sink</c> tag on the counters below.
+    /// </summary>
+    public static class EgressSinks
+    {
+        public const string BggCover = "bgg_cover";
+        public const string Manual = "manual";
+        public const string Wikidata = "wikidata";
+        public const string Wikimedia = "wikimedia";
+        public const string Bgg = "bgg";
+        public const string Slack = "slack";
+    }
+
+    /// <summary>
+    /// Bounded set of egress BLOCK reasons. Used as the <c>reason</c> tag; never carries host/IP.
+    /// </summary>
+    public static class EgressBlockReasons
+    {
+        public const string PrivateIp = "private_ip";
+        public const string DenylistHit = "denylist_hit";
+        public const string RedirectExhausted = "redirect_exhausted";
+        public const string SizeCap = "size_cap";
+        public const string DecodeFail = "decode_fail";
+        public const string Timeout = "timeout";
+        public const string BreakerOpen = "breaker_open";
+        public const string Scheme = "scheme";
+    }
+
+    /// <summary>
+    /// Egress requests BLOCKED before/at dial, by sink and reason. Incremented immediately BEFORE the
+    /// throw at each guard site. Tags are ONLY the two bounded constants — host/IP is never a tag.
+    /// </summary>
+    public static readonly Counter<long> EgressBlocked = Meter.CreateCounter<long>(
+        name: "meepleai.egress.blocked.total",
+        unit: "blocks",
+        description: "Egress requests blocked by the SSRF guard, by sink and reason (#3495 M2)");
+
+    /// <summary>
+    /// Egress connections VALIDATED/allowed, by sink. The denominator for a block-ratio alert:
+    /// a ratio that collapses to 0 while traffic flows means the guard was silently bypassed.
+    /// </summary>
+    public static readonly Counter<long> EgressAllowed = Meter.CreateCounter<long>(
+        name: "meepleai.egress.allowed.total",
+        unit: "requests",
+        description: "Egress connections validated and allowed, by sink (block-ratio denominator, #3495 M2)");
+
+    /// <summary>Records an egress block. <paramref name="sink"/>/<paramref name="reason"/> MUST be
+    /// <see cref="EgressSinks"/>/<see cref="EgressBlockReasons"/> constants — never a host or IP.</summary>
+    public static void RecordEgressBlocked(string sink, string reason) =>
+        EgressBlocked.Add(1, new TagList { { "sink", sink }, { "reason", reason } });
+
+    /// <summary>Records an allowed egress connection for the block-ratio denominator.</summary>
+    public static void RecordEgressAllowed(string sink) =>
+        EgressAllowed.Add(1, new TagList { { "sink", sink } });
+
+    #endregion
+}

--- a/apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPinnedConnect.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPinnedConnect.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http;
 using System.Net.Sockets;
+using Api.Observability;
 
 namespace Api.SharedKernel.Infrastructure.Http;
 
@@ -23,12 +24,16 @@ internal static class SsrfPinnedConnect
     internal static async Task<IPAddress> ResolveAndValidateAsync(
         IDnsResolver dns,
         string host,
+        string sink,
         CancellationToken ct)
     {
         IReadOnlyList<IPAddress> addresses = await dns.ResolveAsync(host, ct).ConfigureAwait(false);
 
         if (addresses.Count == 0)
         {
+            // Fail-closed (no address) — count as an SSRF block BEFORE throwing (bounded tags only,
+            // the host is never a metric tag; it stays in the exception message).
+            MeepleAiMetrics.RecordEgressBlocked(sink, MeepleAiMetrics.EgressBlockReasons.PrivateIp);
             throw new InvalidOperationException($"SSRF: host '{host}' did not resolve to any address");
         }
 
@@ -37,25 +42,29 @@ internal static class SsrfPinnedConnect
         {
             if (SsrfPolicy.IsBlocked(ip))
             {
+                MeepleAiMetrics.RecordEgressBlocked(sink, MeepleAiMetrics.EgressBlockReasons.PrivateIp);
                 throw new InvalidOperationException($"SSRF: host '{host}' resolves to blocked address {ip}");
             }
 
             pinned ??= ip;
         }
 
+        // Validated a public address → count for the block-ratio denominator.
+        MeepleAiMetrics.RecordEgressAllowed(sink);
         return pinned!;
     }
 
     /// <summary>
     /// Builds a <see cref="SocketsHttpHandler.ConnectCallback"/> that pins to the validated IP.
     /// </summary>
-    public static Func<SocketsHttpConnectionContext, CancellationToken, ValueTask<Stream>> Create(IDnsResolver dns)
+    public static Func<SocketsHttpConnectionContext, CancellationToken, ValueTask<Stream>> Create(
+        IDnsResolver dns, string sink)
     {
         ArgumentNullException.ThrowIfNull(dns);
 
         return async (context, ct) =>
         {
-            IPAddress pinned = await ResolveAndValidateAsync(dns, context.DnsEndPoint.Host, ct)
+            IPAddress pinned = await ResolveAndValidateAsync(dns, context.DnsEndPoint.Host, sink, ct)
                 .ConfigureAwait(false);
 
             var socket = new Socket(SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };

--- a/apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPinnedHttpClientBuilderExtensions.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPinnedHttpClientBuilderExtensions.cs
@@ -27,13 +27,18 @@ internal static class SsrfPinnedHttpClientBuilderExtensions
     /// redirects itself through an HTTPS-only scheme gate the connect-pin cannot express.
     /// </para>
     /// </summary>
-    public static IHttpClientBuilder ConfigureSsrfPin(this IHttpClientBuilder builder, bool allowAutoRedirect = true)
+    /// <param name="builder">The typed-client HTTP builder whose primary handler is being pinned.</param>
+    /// <param name="sink">A bounded <c>MeepleAiMetrics.EgressSinks</c> constant identifying this client
+    /// (a compile-time value, never a host/IP) — the label on the egress blocked/allowed counters (#3495 M2).</param>
+    /// <param name="allowAutoRedirect">See the summary — <see langword="false"/> only for the arbitrary-URL manual sink.</param>
+    public static IHttpClientBuilder ConfigureSsrfPin(
+        this IHttpClientBuilder builder, string sink, bool allowAutoRedirect = true)
     {
         ArgumentNullException.ThrowIfNull(builder);
 
         return builder.ConfigurePrimaryHttpMessageHandler(sp => new SocketsHttpHandler
         {
-            ConnectCallback = SsrfPinnedConnect.Create(sp.GetRequiredService<IDnsResolver>()),
+            ConnectCallback = SsrfPinnedConnect.Create(sp.GetRequiredService<IDnsResolver>(), sink),
             AllowAutoRedirect = allowAutoRedirect,
             MaxAutomaticRedirections = 5,
         });

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfPinnedConnectTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfPinnedConnectTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using Api.Observability;
 using Api.SharedKernel.Infrastructure.Http;
 using Api.Tests.Constants;
 using FluentAssertions;
@@ -36,7 +37,7 @@ public class SsrfPinnedConnectTests
     {
         var dns = new FakeDnsResolver("8.8.8.8");
 
-        var pinned = await SsrfPinnedConnect.ResolveAndValidateAsync(dns, "cdn.example.com", CancellationToken.None);
+        var pinned = await SsrfPinnedConnect.ResolveAndValidateAsync(dns, "cdn.example.com", MeepleAiMetrics.EgressSinks.Manual, CancellationToken.None);
 
         pinned.Should().Be(IPAddress.Parse("8.8.8.8"));
         dns.ResolveCalls.Should().Be(1, "the pin must not re-resolve after validation");
@@ -47,7 +48,7 @@ public class SsrfPinnedConnectTests
     {
         var dns = new FakeDnsResolver("10.0.0.5");
 
-        var act = () => SsrfPinnedConnect.ResolveAndValidateAsync(dns, "evil.example.com", CancellationToken.None);
+        var act = () => SsrfPinnedConnect.ResolveAndValidateAsync(dns, "evil.example.com", MeepleAiMetrics.EgressSinks.Manual, CancellationToken.None);
 
         await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*blocked*");
     }
@@ -57,7 +58,7 @@ public class SsrfPinnedConnectTests
     {
         var dns = new FakeDnsResolver("169.254.169.254");
 
-        var act = () => SsrfPinnedConnect.ResolveAndValidateAsync(dns, "meta.example.com", CancellationToken.None);
+        var act = () => SsrfPinnedConnect.ResolveAndValidateAsync(dns, "meta.example.com", MeepleAiMetrics.EgressSinks.Manual, CancellationToken.None);
 
         await act.Should().ThrowAsync<InvalidOperationException>();
     }
@@ -69,7 +70,7 @@ public class SsrfPinnedConnectTests
         // address must be rejected (never pin the public one and ignore the private).
         var dns = new FakeDnsResolver("8.8.8.8", "169.254.169.254");
 
-        var act = () => SsrfPinnedConnect.ResolveAndValidateAsync(dns, "rebind.example.com", CancellationToken.None);
+        var act = () => SsrfPinnedConnect.ResolveAndValidateAsync(dns, "rebind.example.com", MeepleAiMetrics.EgressSinks.Manual, CancellationToken.None);
 
         await act.Should().ThrowAsync<InvalidOperationException>();
     }
@@ -79,7 +80,7 @@ public class SsrfPinnedConnectTests
     {
         var dns = new FakeDnsResolver();
 
-        var act = () => SsrfPinnedConnect.ResolveAndValidateAsync(dns, "void.example.com", CancellationToken.None);
+        var act = () => SsrfPinnedConnect.ResolveAndValidateAsync(dns, "void.example.com", MeepleAiMetrics.EgressSinks.Manual, CancellationToken.None);
 
         await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*resolve*");
     }

--- a/apps/api/tests/Api.Tests/Observability/EgressMetricsTests.cs
+++ b/apps/api/tests/Api.Tests/Observability/EgressMetricsTests.cs
@@ -1,0 +1,113 @@
+using System.Diagnostics.Metrics;
+using System.Net;
+using Api.Observability;
+using Api.SharedKernel.Infrastructure.Http;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Observability;
+
+/// <summary>
+/// #3495 M2 — the egress SSRF observability counters, driven through the shared connect-pin
+/// chokepoint (<see cref="SsrfPinnedConnect.ResolveAndValidateAsync"/>). Asserts the block counter
+/// increments BEFORE the throw with ONLY bounded {sink,reason} tags (never host/IP), and that the
+/// allow counter is the block-ratio denominator.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "Observability")]
+public sealed class EgressMetricsTests
+{
+    private sealed class FakeDnsResolver : IDnsResolver
+    {
+        private readonly IReadOnlyList<IPAddress> _addresses;
+        public FakeDnsResolver(params string[] ips) => _addresses = ips.Select(IPAddress.Parse).ToList();
+        public Task<IReadOnlyList<IPAddress>> ResolveAsync(string host, CancellationToken ct) =>
+            Task.FromResult(_addresses);
+    }
+
+    private static List<(long Value, IReadOnlyDictionary<string, object?> Tags)> Capture(
+        string instrumentName, Action act)
+    {
+        var captured = new List<(long, IReadOnlyDictionary<string, object?>)>();
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Name == instrumentName)
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            },
+        };
+        listener.SetMeasurementEventCallback<long>((_, value, tags, _) =>
+        {
+            var dict = new Dictionary<string, object?>(StringComparer.Ordinal);
+            foreach (var t in tags)
+            {
+                dict[t.Key] = t.Value;
+            }
+            captured.Add((value, dict));
+        });
+        listener.Start();
+
+        act();
+
+        return captured;
+    }
+
+    [Fact]
+    public void ResolveAndValidate_PrivateIp_IncrementsBlocked_BeforeThrow_BoundedTags_NoHostOrIp()
+    {
+        var dns = new FakeDnsResolver("10.0.0.5");
+
+        var captured = Capture(MeepleAiMetrics.EgressBlocked.Name, () =>
+        {
+            // The guard records the block BEFORE it throws; swallow the expected throw so we can
+            // assert the increment already happened.
+            try
+            {
+                SsrfPinnedConnect.ResolveAndValidateAsync(
+                        dns, "evil.example.com", MeepleAiMetrics.EgressSinks.Manual, CancellationToken.None)
+                    .GetAwaiter().GetResult();
+                throw new Xunit.Sdk.XunitException("expected the SSRF guard to fail closed");
+            }
+            catch (InvalidOperationException)
+            {
+                // expected — the block metric fired first
+            }
+        });
+
+        captured.Should().HaveCount(1);
+        var (value, tags) = captured[0];
+        value.Should().Be(1);
+        // Bounded cardinality: exactly {sink, reason}, both the intended constants.
+        tags.Keys.Should().BeEquivalentTo("sink", "reason");
+        tags["sink"].Should().Be("manual");
+        tags["reason"].Should().Be("private_ip");
+        // The host/IP must NEVER leak into a metric tag (unbounded cardinality + PII/SSRF-target leak).
+        tags.Values.Should().NotContain("evil.example.com").And.NotContain("10.0.0.5");
+    }
+
+    [Fact]
+    public void ResolveAndValidate_PublicIp_IncrementsAllowed_BySink()
+    {
+        var dns = new FakeDnsResolver("8.8.8.8");
+
+        var captured = Capture(MeepleAiMetrics.EgressAllowed.Name, () =>
+            SsrfPinnedConnect.ResolveAndValidateAsync(
+                    dns, "cdn.example.com", MeepleAiMetrics.EgressSinks.Manual, CancellationToken.None)
+                .GetAwaiter().GetResult());
+
+        captured.Should().HaveCount(1);
+        captured[0].Value.Should().Be(1);
+        captured[0].Tags.Keys.Should().BeEquivalentTo("sink");
+        captured[0].Tags["sink"].Should().Be("manual");
+    }
+
+    [Fact]
+    public void Counters_HaveStableBoundedNames()
+    {
+        MeepleAiMetrics.EgressBlocked.Name.Should().Be("meepleai.egress.blocked.total");
+        MeepleAiMetrics.EgressAllowed.Name.Should().Be("meepleai.egress.allowed.total");
+    }
+}

--- a/infra/compose.prod.yml
+++ b/infra/compose.prod.yml
@@ -242,6 +242,7 @@ services:
       - ./prometheus/alerts/wikidata-enrichment.yml:/etc/prometheus/wikidata-enrichment.yml:ro
       # Issue #3082 — BGG ToS-compliance SLO=0 alert.
       - ./prometheus/alerts/bgg-tos-compliance.yml:/etc/prometheus/bgg-tos-compliance.yml:ro
+      - ./prometheus/alerts/egress-guard.yml:/etc/prometheus/egress-guard.yml:ro
       # Issue #3112 — OPS-02 Slack delivery observability alerts.
       - ./prometheus/alerts/slack-delivery.yml:/etc/prometheus/slack-delivery.yml:ro
       - ./prometheus/alerts/audit-outbox.yml:/etc/prometheus/audit-outbox.yml:ro

--- a/infra/compose.staging.yml
+++ b/infra/compose.staging.yml
@@ -357,6 +357,7 @@ services:
       - ./prometheus/alerts/wikidata-enrichment.yml:/etc/prometheus/wikidata-enrichment.yml:ro
       # Issue #3082 — BGG ToS-compliance SLO=0 alert.
       - ./prometheus/alerts/bgg-tos-compliance.yml:/etc/prometheus/bgg-tos-compliance.yml:ro
+      - ./prometheus/alerts/egress-guard.yml:/etc/prometheus/egress-guard.yml:ro
       # Issue #3112 — OPS-02 Slack delivery observability alerts.
       - ./prometheus/alerts/slack-delivery.yml:/etc/prometheus/slack-delivery.yml:ro
       - ./prometheus/alerts/audit-outbox.yml:/etc/prometheus/audit-outbox.yml:ro

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -355,6 +355,7 @@ services:
       - ./prometheus-rules.yml:/etc/prometheus/prometheus-rules.yml:ro
       # Issue #3082 — BGG ToS-compliance SLO=0 alert (referenced from prometheus.yml rule_files).
       - ./prometheus/alerts/bgg-tos-compliance.yml:/etc/prometheus/bgg-tos-compliance.yml:ro
+      - ./prometheus/alerts/egress-guard.yml:/etc/prometheus/egress-guard.yml:ro
       # Issue #3112 — OPS-02 Slack delivery alerts (referenced from prometheus.yml rule_files).
       - ./prometheus/alerts/slack-delivery.yml:/etc/prometheus/slack-delivery.yml:ro
       - ./prometheus/alerts/audit-outbox.yml:/etc/prometheus/audit-outbox.yml:ro

--- a/infra/prometheus.yml
+++ b/infra/prometheus.yml
@@ -32,6 +32,8 @@ rule_files:
   - '/etc/prometheus/wikidata-enrichment.yml'
   # Issue #3082 — BGG ToS-compliance SLO=0 alert (any nonzero render attempt = P1).
   - '/etc/prometheus/bgg-tos-compliance.yml'
+  # #3495 M2 — SSRF egress guard (manual-cover private_ip/denylist_hit SLO=0).
+  - '/etc/prometheus/egress-guard.yml'
   # Issue #3112 — OPS-02 Slack delivery observability alerts.
   - '/etc/prometheus/slack-delivery.yml'
   # Issue #3116 — SP5 Admin Security audit_outbox health alerts.

--- a/infra/prometheus/alerts/egress-guard.test.yml
+++ b/infra/prometheus/alerts/egress-guard.test.yml
@@ -1,0 +1,39 @@
+# promtool test for egress-guard.yml (#3495 M2). NOT run in CI — on-demand only:
+#   docker run --rm -v "$(pwd)/infra/prometheus/alerts:/work" prom/prometheus:v3.7.0 \
+#     promtool test rules /work/egress-guard.test.yml
+rule_files:
+  - egress-guard.yml
+evaluation_interval: 1m
+tests:
+  # 1) FIRES: a manual-sink private_ip block occurred.
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_egress_blocked_total{sink="manual",reason="private_ip"}'
+        values: '0 0 1 1 1 1'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: EgressBlockedManualSensitive
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              subsystem: egress-ssrf
+
+  # 2) DOES NOT FIRE on cold-start: only an unrelated sink series exists; `or vector(0)` keeps it silent.
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_egress_blocked_total{sink="bgg_cover",reason="size_cap"}'
+        values: '0 0 0 0 0 0'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: EgressBlockedManualSensitive
+        exp_alerts: []
+
+  # 3) DOES NOT FIRE for a non-sensitive reason on the manual sink (size_cap is not private_ip/denylist_hit).
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_egress_blocked_total{sink="manual",reason="size_cap"}'
+        values: '1 1 1 1 1 1'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: EgressBlockedManualSensitive
+        exp_alerts: []

--- a/infra/prometheus/alerts/egress-guard.yml
+++ b/infra/prometheus/alerts/egress-guard.yml
@@ -1,0 +1,26 @@
+# #3495 M2 — SSRF egress guard observability.
+#
+# Metric source (apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.Egress.cs):
+#   - meepleai_egress_blocked_total{sink, reason} — egress blocked by the SSRF guard.
+#   - meepleai_egress_allowed_total{sink}         — allowed connections (block-ratio denominator).
+# Labels are bounded constants (sink/reason); a host or IP is NEVER a label.
+#
+# SLO for the manual (arbitrary-URL) sink hitting private_ip / denylist_hit is ZERO: any nonzero
+# rate means an admin-supplied manual-cover URL resolved to an internal/denied target — a live
+# SSRF attempt. severity=critical pages via the alertmanager critical-alerts route.
+#
+# promtool test: infra/prometheus/alerts/egress-guard.test.yml
+groups:
+  - name: meepleai_egress_guard_alerts
+    rules:
+      - alert: EgressBlockedManualSensitive
+        # `or vector(0)` guards cold-start: the series may not exist yet on a fresh deploy.
+        expr: (sum(rate(meepleai_egress_blocked_total{sink="manual",reason=~"private_ip|denylist_hit"}[5m])) or vector(0)) > 0
+        for: 0m
+        labels:
+          severity: critical
+          subsystem: egress-ssrf
+        annotations:
+          summary: "Manual-cover SSRF attempt blocked (sink=manual, private_ip|denylist_hit)"
+          description: "meepleai_egress_blocked_total incremented for sink=manual with reason private_ip or denylist_hit: an admin-supplied manual-cover URL resolved to an internal/denied target. SLO for this metric is ZERO; any nonzero rate is a P1 SSRF incident (#3495)."
+          runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-developers/operations/operations-manual.md"


### PR DESCRIPTION
**Slice C** del sub-epic #3495 — chiude il P0 **M2 (observability)**. Il guard SSRF bloccava in silenzio (bare throw): impossibile rilevare un bypass o un tentativo SSRF via URL manuale in corso.

## Fix
- **Counter** `meepleai_egress_blocked_total{sink,reason}` + `meepleai_egress_allowed_total{sink}` (`System.Diagnostics.Metrics`), **label a costante bounded** — host/IP **mai** un tag (no cardinalità/leak).
- **Chokepoint instrumentato** (`SsrfPinnedConnect`): registra il block (`private_ip`) **PRIMA** di ogni throw fail-closed, e un allowed (denominatore del block-ratio) sul success path. Passato un `sink` **compile-time** attraverso `ConfigureSsrfPin` → tutti e 6 i client egress (bgg_cover, manual, wikidata, wikimedia, bgg, slack).
- **Alert Prometheus** `EgressBlockedManualSensitive`: `sink=manual & reason∈{private_ip,denylist_hit} > 0` (SLO=0), con guardia cold-start `or vector(0)`; test promtool (on-demand) + registrato in `prometheus.yml` + montato nei 3 compose.

## Test
**8 unit test verdi**: block incrementa **prima** del throw con `{sink,reason}` bounded, mai host/IP; allowed-by-sink; nomi counter stabili.

## Follow-up (flagged)
Segnali reason agli altri throw site (`size_cap`/`redirect_exhausted`/`decode_fail`/`breaker_open` in SsrfSafeHttpClient/BggCoverDownloader/WikimediaCircuitBreaker) — stesso counter, più call-site; wiring di `denylist_hit` al ban host manuale di Slice B.

Refs #3495

🤖 Generated with [Claude Code](https://claude.com/claude-code)
