### PR TITLE
feat(smoldocling): crop-discriminator + /extract-image endpoint (#3435 SP3)

### DIFF
--- a/apps/smoldocling-service/src/api/schemas.py
+++ b/apps/smoldocling-service/src/api/schemas.py
@@ -45,6 +45,31 @@ class PdfExtractionResponse(BaseModel):
     metadata: Dict[str, Any] = Field(description="Extraction metadata")
 
 
+class ExtractImageResponse(BaseModel):
+    """Response for POST /api/v1/extract-image (issue #3435 SP3 crop-discriminator)."""
+
+    is_table: bool = Field(description="True if the crop is an OTSL table to keep")
+    reason: str = Field(
+        description=(
+            "table-otsl | prefilter-colorful | no-otsl | degenerate-earlystop | "
+            "conversion-failed | empty-output | service-unavailable"
+        )
+    )
+    markdown: str = Field(description="Rebuilt table markdown; empty when discarded")
+    bbox: Optional[List[float]] = Field(
+        default=None,
+        description="[x0,y0,x1,y1] in [0,1] top-left; null when discarded/absent",
+    )
+    doctags: str = Field(default="", description="Raw cleaned DocTags (audit/debug)")
+    confidence: float = Field(ge=0.0, le=1.0)
+    prefiltered: bool = Field(
+        description="True when rejected by the colorfulness pre-filter (VLM not run)"
+    )
+    degenerated: bool = Field(description="True when the repetition early-stop fired")
+    colorfulness: float = Field(description="Hasler-Süsstrunk colorfulness of the crop")
+    duration_ms: int = Field(ge=0)
+
+
 # Error Schemas (reuse from Unstructured for consistency)
 class ErrorDetail(BaseModel):
     """Error detail information"""

--- a/apps/smoldocling-service/src/api/schemas.py
+++ b/apps/smoldocling-service/src/api/schemas.py
@@ -3,6 +3,8 @@ from typing import List, Dict, Any, Optional
 from pydantic import BaseModel, Field
 from datetime import datetime
 
+from ..domain.models import CROP_REASONS
+
 
 # Response Schemas
 class PageResultSchema(BaseModel):
@@ -49,12 +51,7 @@ class ExtractImageResponse(BaseModel):
     """Response for POST /api/v1/extract-image (issue #3435 SP3 crop-discriminator)."""
 
     is_table: bool = Field(description="True if the crop is an OTSL table to keep")
-    reason: str = Field(
-        description=(
-            "table-otsl | prefilter-colorful | no-otsl | degenerate-earlystop | "
-            "conversion-failed | empty-output | service-unavailable"
-        )
-    )
+    reason: str = Field(description="One of: " + " | ".join(CROP_REASONS))
     markdown: str = Field(description="Rebuilt table markdown; empty when discarded")
     bbox: Optional[List[float]] = Field(
         default=None,

--- a/apps/smoldocling-service/src/application/__init__.py
+++ b/apps/smoldocling-service/src/application/__init__.py
@@ -1,5 +1,11 @@
 """Application layer"""
 from .pdf_extraction_service import PdfExtractionService
 from .quality_calculator import QualityScoreCalculator
+from .crop_discriminator import CropDiscriminator, colorfulness
 
-__all__ = ["PdfExtractionService", "QualityScoreCalculator"]
+__all__ = [
+    "PdfExtractionService",
+    "QualityScoreCalculator",
+    "CropDiscriminator",
+    "colorfulness",
+]

--- a/apps/smoldocling-service/src/application/crop_discriminator.py
+++ b/apps/smoldocling-service/src/application/crop_discriminator.py
@@ -1,0 +1,82 @@
+"""Crop-table discriminator (issue #3435 SP3 — Option B).
+
+Decides whether an hi_res image-region crop is a *table* worth extracting or a decorative
+*illustration* to discard, and — for tables — returns the rebuilt markdown plus the table
+bbox in [0,1] top-left.
+
+Design (de-risked empirically on GPU; spec §5quinquies / memory "De-risk Opzione B"):
+  1. Colorfulness pre-filter (CPU, ms): reject obviously-colorful illustrations BEFORE the
+     VLM to contain cost. Fail-open — the ``<otsl>`` gate below is authoritative, so the
+     threshold is conservative and a table is never rejected on colour alone.
+  2. VLM plain mode + repetition early-stop (adapter.extract_crop): NO ``no_repeat_ngram_size``
+     (it fabricates spurious tables from illustrations — a proven false positive).
+  3. ``<otsl>`` gate: only an OTSL table in the DocTags is authoritative. Illustrations do not
+     emit ``<otsl>``.
+
+The heavy VLM/docling work lives in ``SmolDoclingAdapter``; this application service owns only
+the cheap pre-filter and the orchestration, so it stays trivially unit-testable with a fake
+adapter (no model).
+"""
+import logging
+from typing import Optional
+
+import numpy as np
+from PIL import Image
+
+from ..config import settings
+from ..domain.models import CropExtractionResult, PageImage
+
+logger = logging.getLogger(__name__)
+
+
+def colorfulness(image: Image.Image) -> float:
+    """Hasler-Süsstrunk (2003) colorfulness metric.
+
+    ~0 for a grayscale / black-and-white image (tables), high for saturated multi-colour
+    images (illustrations). Computed as ``sqrt(std_rg^2 + std_yb^2) + 0.3 * sqrt(mean_rg^2 +
+    mean_yb^2)`` where ``rg = R - G`` and ``yb = 0.5*(R+G) - B``.
+    """
+    rgb = np.asarray(image.convert("RGB"), dtype=np.float32)
+    r, g, b = rgb[..., 0], rgb[..., 1], rgb[..., 2]
+    rg = r - g
+    yb = 0.5 * (r + g) - b
+    std_root = np.sqrt(float(rg.std()) ** 2 + float(yb.std()) ** 2)
+    mean_root = np.sqrt(float(rg.mean()) ** 2 + float(yb.mean()) ** 2)
+    return std_root + 0.3 * mean_root
+
+
+class CropDiscriminator:
+    """Orchestrates pre-filter → VLM (adapter.extract_crop) → ``<otsl>`` gate → markdown+bbox."""
+
+    def __init__(self, adapter, config=settings):
+        self.adapter = adapter
+        self.settings = config
+
+    def discriminate(self, image: Image.Image, prefilter: Optional[bool] = None) -> CropExtractionResult:
+        """Classify a crop and, if it is a table, return its markdown + bbox.
+
+        Args:
+            image: the crop (a PIL image of an hi_res Image/FigureCaption region).
+            prefilter: override the colorfulness pre-filter; ``None`` uses the config default.
+        """
+        use_prefilter = self.settings.crop_prefilter_enabled if prefilter is None else prefilter
+        crop_colorfulness = colorfulness(image)
+
+        # 1. Cheap colorfulness reject (fail-open; the <otsl> gate stays authoritative).
+        if use_prefilter and crop_colorfulness > self.settings.crop_prefilter_colorfulness_threshold:
+            logger.info(
+                "Crop rejected by colorfulness pre-filter (%.1f > %.1f) — VLM skipped",
+                crop_colorfulness,
+                self.settings.crop_prefilter_colorfulness_threshold,
+            )
+            return CropExtractionResult(
+                is_table=False, reason="prefilter-colorful", markdown="", bbox=None,
+                doctags="", confidence=0.0, prefiltered=True, degenerated=False,
+                colorfulness=crop_colorfulness, duration_ms=0,
+            )
+
+        # 2/3. VLM plain mode + early-stop + <otsl> gate + markdown/bbox (all in the adapter).
+        page = PageImage.from_pil_image(1, image.convert("RGB"), dpi=self.settings.image_dpi)
+        result = self.adapter.extract_crop(page)
+        result.colorfulness = crop_colorfulness
+        return result

--- a/apps/smoldocling-service/src/application/crop_discriminator.py
+++ b/apps/smoldocling-service/src/application/crop_discriminator.py
@@ -6,12 +6,15 @@ bbox in [0,1] top-left.
 
 Design (de-risked empirically on GPU; spec §5quinquies / memory "De-risk Opzione B"):
   1. Colorfulness pre-filter (CPU, ms): reject obviously-colorful illustrations BEFORE the
-     VLM to contain cost. Fail-open — the ``<otsl>`` gate below is authoritative, so the
-     threshold is conservative and a table is never rejected on colour alone.
+     VLM to contain cost. This is the ONE place colour alone decides (the VLM never runs for a
+     rejected crop), so the threshold is deliberately conservative to keep false-rejects of
+     real tables rare, and it is overridable per-request (``prefilter=False``). It is a cost
+     optimization, NOT a hard guarantee — a sufficiently colourful real table can be rejected
+     here.
   2. VLM plain mode + repetition early-stop (adapter.extract_crop): NO ``no_repeat_ngram_size``
      (it fabricates spurious tables from illustrations — a proven false positive).
-  3. ``<otsl>`` gate: only an OTSL table in the DocTags is authoritative. Illustrations do not
-     emit ``<otsl>``.
+  3. ``<otsl>`` gate: for every crop that REACHES the VLM, only an OTSL table in the DocTags is
+     authoritative. Illustrations do not emit ``<otsl>``.
 
 The heavy VLM/docling work lives in ``SmolDoclingAdapter``; this application service owns only
 the cheap pre-filter and the orchestration, so it stays trivially unit-testable with a fake
@@ -62,7 +65,9 @@ class CropDiscriminator:
         use_prefilter = self.settings.crop_prefilter_enabled if prefilter is None else prefilter
         crop_colorfulness = colorfulness(image)
 
-        # 1. Cheap colorfulness reject (fail-open; the <otsl> gate stays authoritative).
+        # 1. Cheap colorfulness reject: colour alone decides here (the VLM is skipped). A
+        #    conservative threshold + the per-request override keep false-rejects of real
+        #    tables rare; the <otsl> gate is authoritative only for crops that reach the VLM.
         if use_prefilter and crop_colorfulness > self.settings.crop_prefilter_colorfulness_threshold:
             logger.info(
                 "Crop rejected by colorfulness pre-filter (%.1f > %.1f) — VLM skipped",

--- a/apps/smoldocling-service/src/config/settings.py
+++ b/apps/smoldocling-service/src/config/settings.py
@@ -36,9 +36,11 @@ class Settings(BaseSettings):
     # Crop-table discrimination (issue #3435 SP3 — Option B crop-discriminator)
     # The <otsl> gate is authoritative; these only contain cost / cap the degenerate loop.
     crop_prefilter_enabled: bool = True  # cheap colorfulness reject BEFORE the VLM
-    # Hasler-Süsstrunk colorfulness above which a crop is treated as an illustration and
-    # rejected without the VLM. Fail-open + uncalibrated: a conservative (high) default so a
-    # real table (even one with a tinted header) is never rejected on colour alone. Tunable.
+    # Hasler-Süsstrunk colorfulness above which a crop is rejected as an illustration WITHOUT
+    # running the VLM. Uncalibrated: a conservative (high) default keeps false-rejects of real
+    # tables (even ones with a tinted header) rare — but a sufficiently colourful table WILL be
+    # rejected here (the <otsl> gate only sees crops that reach the VLM). Tunable; the
+    # per-request `prefilter` flag disables it entirely.
     crop_prefilter_colorfulness_threshold: float = 40.0
     crop_max_new_tokens: int = 512  # crops are small (~76-300 tok); cap well below full-page 2048
     crop_rep_stop_window: int = 24  # trailing generated tokens inspected for the repetition early-stop

--- a/apps/smoldocling-service/src/config/settings.py
+++ b/apps/smoldocling-service/src/config/settings.py
@@ -33,6 +33,17 @@ class Settings(BaseSettings):
     quality_threshold: float = 0.70
     min_chars_per_page: int = 300  # VLM may extract less due to layout focus
 
+    # Crop-table discrimination (issue #3435 SP3 — Option B crop-discriminator)
+    # The <otsl> gate is authoritative; these only contain cost / cap the degenerate loop.
+    crop_prefilter_enabled: bool = True  # cheap colorfulness reject BEFORE the VLM
+    # Hasler-Süsstrunk colorfulness above which a crop is treated as an illustration and
+    # rejected without the VLM. Fail-open + uncalibrated: a conservative (high) default so a
+    # real table (even one with a tinted header) is never rejected on colour alone. Tunable.
+    crop_prefilter_colorfulness_threshold: float = 40.0
+    crop_max_new_tokens: int = 512  # crops are small (~76-300 tok); cap well below full-page 2048
+    crop_rep_stop_window: int = 24  # trailing generated tokens inspected for the repetition early-stop
+    crop_rep_stop_max_distinct: int = 2  # <= this many distinct ids in the window => degenerate loop
+
     # Server Configuration
     host: str = "0.0.0.0"
     port: int = 8002

--- a/apps/smoldocling-service/src/domain/__init__.py
+++ b/apps/smoldocling-service/src/domain/__init__.py
@@ -2,6 +2,7 @@
 from .models import (
     PageImage,
     PageExtractionResult,
+    CropExtractionResult,
     QualityScore,
     TextChunk,
     ExtractionResult,
@@ -11,6 +12,7 @@ from .models import (
 __all__ = [
     "PageImage",
     "PageExtractionResult",
+    "CropExtractionResult",
     "QualityScore",
     "TextChunk",
     "ExtractionResult",

--- a/apps/smoldocling-service/src/domain/models.py
+++ b/apps/smoldocling-service/src/domain/models.py
@@ -61,6 +61,22 @@ class PageExtractionResult:
         return len(self.markdown_text.strip()) == 0
 
 
+# Canonical crop-discriminator outcome codes (issue #3435 SP3). Single source of truth for the
+# CropExtractionResult.reason field, referenced by the API schema description so the documented
+# contract cannot desync from the emitted literals (mirrors the STRUCTURE_TAGS consolidation
+# from #3538).
+CROP_REASONS = (
+    "table-otsl",            # kept: OTSL table rebuilt into markdown + bbox
+    "prefilter-colorful",    # discarded: rejected by the colorfulness pre-filter (VLM not run)
+    "no-otsl",               # discarded: VLM ran but emitted no <otsl>
+    "degenerate-earlystop",  # discarded: the repetition early-stop fired
+    "conversion-failed",     # discarded: <otsl> present but docling could not rebuild the table
+    "empty-output",          # discarded: VLM produced nothing usable
+    "service-unavailable",   # degraded: pdf_service absent (e.g. unit-test env without lifespan)
+    "init-failed",           # degraded: model initialisation failed (R5 clean degradation)
+)
+
+
 @dataclass
 class CropExtractionResult:
     """Result of running the crop-discriminator on a single image crop (issue #3435 SP3).
@@ -81,9 +97,7 @@ class CropExtractionResult:
     """
 
     is_table: bool
-    # table-otsl | prefilter-colorful | no-otsl | degenerate-earlystop | conversion-failed
-    # | empty-output | service-unavailable
-    reason: str
+    reason: str  # one of CROP_REASONS
     markdown: str  # rebuilt table markdown; "" when discarded
     bbox: Optional[Tuple[float, float, float, float]]  # [x0,y0,x1,y1] in [0,1] top-left; None when discarded/absent
     doctags: str  # raw cleaned DocTags (audit/debug)

--- a/apps/smoldocling-service/src/domain/models.py
+++ b/apps/smoldocling-service/src/domain/models.py
@@ -1,7 +1,7 @@
 """Domain models for SmolDocling PDF extraction"""
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Tuple
 from PIL import Image
 
 
@@ -59,6 +59,39 @@ class PageExtractionResult:
         has non-empty DocTags but empty markdown and must still count as empty.
         """
         return len(self.markdown_text.strip()) == 0
+
+
+@dataclass
+class CropExtractionResult:
+    """Result of running the crop-discriminator on a single image crop (issue #3435 SP3).
+
+    The crop-discriminator decides whether an hi_res image region (an ``Image``/
+    ``FigureCaption`` crop) is a *table* worth extracting or a decorative *illustration* to
+    discard. Only the presence of an OTSL table (``<otsl>``) in the VLM's plain-mode DocTags
+    output is authoritative (spec §5quinquies): illustrations do not emit ``<otsl>``. A cheap
+    colorfulness pre-filter rejects obvious illustrations *before* the VLM to contain cost,
+    and a repetition early-stop caps the degenerate loop the VLM falls into on illustrations
+    (de-risk "Opzione B" — memory ``project_epic_3435_image_table_grounding``).
+
+    Field ownership: the ``SmolDoclingAdapter`` fills the VLM-side fields (``is_table``,
+    ``reason``, ``markdown``, ``bbox``, ``doctags``, ``confidence``, ``degenerated``,
+    ``duration_ms``) with ``prefiltered=False`` and ``colorfulness=0.0``; the
+    ``CropDiscriminator`` sets ``colorfulness`` (always) and builds the whole result itself on
+    the pre-filter-reject path.
+    """
+
+    is_table: bool
+    # table-otsl | prefilter-colorful | no-otsl | degenerate-earlystop | conversion-failed
+    # | empty-output | service-unavailable
+    reason: str
+    markdown: str  # rebuilt table markdown; "" when discarded
+    bbox: Optional[Tuple[float, float, float, float]]  # [x0,y0,x1,y1] in [0,1] top-left; None when discarded/absent
+    doctags: str  # raw cleaned DocTags (audit/debug)
+    confidence: float  # heuristic VLM confidence (0-1)
+    prefiltered: bool  # True when rejected by the colorfulness pre-filter (VLM NOT run)
+    degenerated: bool  # True when the repetition early-stop fired
+    colorfulness: float  # Hasler-Süsstrunk colorfulness of the crop (0 = grayscale)
+    duration_ms: int
 
 
 @dataclass

--- a/apps/smoldocling-service/src/infrastructure/smoldocling_adapter.py
+++ b/apps/smoldocling-service/src/infrastructure/smoldocling_adapter.py
@@ -1,14 +1,59 @@
 """Adapter for SmolDocling VLM model"""
 import logging
+import time
 import torch
-from typing import List, Optional
-from transformers import AutoProcessor, AutoModelForImageTextToText
+from typing import List, Optional, Tuple
+from transformers import (
+    AutoProcessor,
+    AutoModelForImageTextToText,
+    StoppingCriteria,
+    StoppingCriteriaList,
+)
 from docling_core.types.doc.document import DoclingDocument, DocTagsDocument
 
-from ..domain.models import PageImage, PageExtractionResult, STRUCTURE_TAGS
+from ..domain.models import (
+    PageImage,
+    PageExtractionResult,
+    CropExtractionResult,
+    STRUCTURE_TAGS,
+)
 from ..config import settings
 
 logger = logging.getLogger(__name__)
+
+
+class RepetitionStoppingCriteria(StoppingCriteria):
+    """Stop generation when the VLM degenerates into a repetition loop.
+
+    On a decorative illustration (not a table) SmolDocling collapses into emitting the same
+    token hundreds of times (~19s wasted before the caller discards the crop for lack of
+    ``<otsl>``; issue #3435 de-risk "Opzione B"). We watch the *trailing window* of generated
+    ids and stop once it collapses to ``<= max_distinct`` distinct token ids.
+
+    This is deliberately NOT ``no_repeat_ngram_size``: forcing the model off its repeated
+    token makes it *fabricate a spurious OTSL table* from an illustration — a proven false
+    positive that would corrupt the RAG corpus (issue #3435). Early-stop only caps the wasted
+    compute; the ``<otsl>`` gate stays authoritative. Assumes batch size 1 (one crop).
+    """
+
+    def __init__(self, window: int = 24, max_distinct: int = 2, prompt_len: int = 0):
+        self.window = max(1, window)
+        self.max_distinct = max(1, max_distinct)
+        self.prompt_len = prompt_len  # set by _run_inference so the prompt is excluded
+        self.stopped = False
+
+    def __call__(self, input_ids, scores, **kwargs) -> bool:
+        seq = input_ids[0]
+        # Only inspect GENERATED tokens: the prompt front-loads many identical image
+        # placeholder ids, which would false-trip the "uniform tail" check otherwise.
+        generated_len = int(seq.shape[0]) - self.prompt_len
+        if generated_len < self.window:
+            return False
+        tail = seq[-self.window:].tolist()
+        if len(set(tail)) <= self.max_distinct:
+            self.stopped = True
+            return True
+        return False
 
 
 class SmolDoclingAdapter:
@@ -112,6 +157,78 @@ class SmolDoclingAdapter:
             logger.error(f"Failed to initialize SmolDocling model: {e}", exc_info=True)
             raise RuntimeError(f"Model initialization failed: {e}")
 
+    def _run_inference(
+        self,
+        page_image: PageImage,
+        stopping_criteria: Optional[StoppingCriteriaList] = None,
+        max_new_tokens: Optional[int] = None,
+    ) -> str:
+        """Run one VLM forward pass and return the cleaned DocTags text.
+
+        Shared core of ``process_page`` (full page) and ``generate_crop_doctags`` (crop). It
+        builds the official SmolDocling chat prompt, generates deterministically, trims the
+        prompt, decodes WITH special tokens (so DocTags markup survives), and strips only the
+        chat/control tokens.
+
+        - The Idefics3Processor only emits ``input_ids`` when a text prompt is supplied
+          (``processing_idefics3.py``: ``input_ids`` is added inside ``if text is not None:``);
+          an images-only call yields no ``input_ids`` and breaks the <image>-token alignment
+          and the prompt trim (issue #3435, §5quater).
+        - Decode with ``skip_special_tokens=False``: the DocTags tokens (``<loc_*>``,
+          ``<otsl>``, ``<fcel>``, ...) are flagged *special*, so skipping them would strip the
+          location coordinates and table structure this feature needs (issue #3435, §5ter).
+        - The prompt trim (``generated_ids[:, prompt_len:]``) means a model that generated
+          nothing beyond the prompt decodes to ``""`` (clean degradation, R5) instead of
+          leaking prompt/instruction text into the DocTags.
+        """
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image"},
+                    {"type": "text", "text": self._PROMPT_TEXT},
+                ],
+            }
+        ]
+        prompt = self.processor.apply_chat_template(messages, add_generation_prompt=True)
+
+        # text + image so input_ids and the image tokens are aligned
+        inputs = self.processor(
+            text=prompt, images=[page_image.image], return_tensors="pt"
+        ).to(self.device)
+
+        # Some processor outputs (rows/cols) are unused by the current model and would
+        # surface as "Unused model_kwargs" warnings/errors. Filter them out before generation.
+        filtered_inputs = {
+            key: value for key, value in inputs.items() if key not in {"rows", "cols"}
+        }
+
+        prompt_len = filtered_inputs["input_ids"].shape[1]
+
+        # Tell any repetition early-stop where the prompt ends so it inspects only generated
+        # tokens (the prompt front-loads many identical image placeholder ids).
+        if stopping_criteria is not None:
+            for criterion in stopping_criteria:
+                if isinstance(criterion, RepetitionStoppingCriteria):
+                    criterion.prompt_len = prompt_len
+
+        generate_kwargs = {
+            "max_new_tokens": max_new_tokens or self.settings.max_new_tokens,
+            "do_sample": False,  # Deterministic output
+        }
+        if stopping_criteria is not None:
+            generate_kwargs["stopping_criteria"] = stopping_criteria
+
+        with torch.no_grad():
+            generated_ids = self.model.generate(**filtered_inputs, **generate_kwargs)
+
+        generated_ids = generated_ids[:, prompt_len:]
+
+        raw_doctags = self.processor.batch_decode(
+            generated_ids, skip_special_tokens=False
+        )[0]
+        return self._clean_doctags(raw_doctags)
+
     def process_page(self, page_image: PageImage) -> PageExtractionResult:
         """
         Process a single page image with SmolDocling VLM
@@ -133,63 +250,7 @@ class SmolDoclingAdapter:
         logger.debug(f"Processing page {page_image.page_number} with SmolDocling VLM")
 
         try:
-            # Build the chat prompt (official SmolDocling recipe). The Idefics3Processor
-            # only emits input_ids when a text prompt is supplied (processing_idefics3.py:
-            # input_ids is added inside `if text is not None:`); calling it images-only
-            # yields no input_ids, so generation cannot align the <image> tokens and the
-            # prompt-trim below would KeyError (issue #3435).
-            messages = [
-                {
-                    "role": "user",
-                    "content": [
-                        {"type": "image"},
-                        {"type": "text", "text": self._PROMPT_TEXT},
-                    ],
-                }
-            ]
-            prompt = self.processor.apply_chat_template(
-                messages, add_generation_prompt=True
-            )
-
-            # Prepare inputs (text + image so input_ids and the image tokens are aligned)
-            inputs = self.processor(
-                text=prompt, images=[page_image.image], return_tensors="pt"
-            ).to(self.device)
-
-            # Some processor outputs (rows/cols) are unused by the current model
-            # and would surface as "Unused model_kwargs" warnings/errors.
-            # Filter them out before generation.
-            filtered_inputs = {
-                key: value
-                for key, value in inputs.items()
-                if key not in {"rows", "cols"}
-            }
-
-            # Generate DocTags with VLM
-            with torch.no_grad():
-                generated_ids = self.model.generate(
-                    **filtered_inputs,
-                    max_new_tokens=self.settings.max_new_tokens,
-                    do_sample=False,  # Deterministic output
-                )
-
-            # Trim the prompt (image/instruction placeholder tokens) so only the newly
-            # generated DocTags are decoded — matches the official SmolDocling recipe
-            # (generated_ids[:, prompt_length:]). If the model generated nothing beyond
-            # the prompt, the slice is empty and decode yields "" (clean degradation, R5)
-            # rather than leaking prompt/instruction text into doctags_text.
-            prompt_len = filtered_inputs["input_ids"].shape[1]
-            generated_ids = generated_ids[:, prompt_len:]
-
-            # Decode WITH special tokens: DocTags markup (<loc_*>, <otsl>, <fcel>, ...)
-            # is flagged `special` in the tokenizer, so skip_special_tokens=True would
-            # strip the location coordinates and table structure this feature needs
-            # (issue #3435, spec §5ter). We decode everything, then remove only the true
-            # chat/control tokens in _clean_doctags().
-            raw_doctags = self.processor.batch_decode(
-                generated_ids, skip_special_tokens=False
-            )[0]
-            doctags_text = self._clean_doctags(raw_doctags)
+            doctags_text = self._run_inference(page_image)
 
             # Convert to Markdown using Docling
             markdown_text = self._convert_to_markdown(doctags_text)
@@ -266,31 +327,196 @@ class SmolDoclingAdapter:
         """
         return "<otsl>" in doctags_text.lower()
 
-    def _convert_to_markdown(self, doctags_text: str) -> str:
-        """
-        Convert DocTags markup to Markdown
+    def _build_docling_doc(self, doctags_text: str) -> Optional[DoclingDocument]:
+        """Parse cleaned DocTags into a DoclingDocument (no image) or return None on failure.
 
-        Args:
-            doctags_text: Raw DocTags output from SmolDocling
-
-        Returns:
-            Markdown-formatted text, or "" if conversion fails (never raw DocTags markup).
+        Uses ``images=None``: the DocTags ``<loc_*>`` grid alone yields ``prov[].bbox`` already
+        normalized to [0,1] top-left (issue #3435 §5ter), so no page raster is needed.
         """
         try:
             doctags_doc = DocTagsDocument.from_doctags_and_image_pairs(
-                doctags=[doctags_text],
-                images=None,
+                doctags=[doctags_text], images=None
             )
-            docling_doc = DoclingDocument.load_from_doctags(doctags_doc)
-            return docling_doc.export_to_markdown()
-
+            return DoclingDocument.load_from_doctags(doctags_doc)
         except Exception as e:
-            # Do NOT fall back to raw DocTags: doctags_text now carries markup
-            # (<loc_*>, <otsl>, <fcel>, ...) that would pollute the RAG corpus and the
-            # /preprocess extracted_text handed to the LLM (issue #3435). Return "" so the
-            # page is treated as empty (is_empty) instead of ingesting markup as content.
-            logger.warning("Markdown conversion failed, dropping page content: %s", e)
+            logger.warning("DocTags parse failed: %s", e)
+            return None
+
+    def _convert_to_markdown(self, doctags_text: str) -> str:
+        """
+        Convert DocTags markup to Markdown, or "" if conversion fails (never raw DocTags markup).
+
+        Do NOT fall back to raw DocTags: doctags_text carries markup (<loc_*>, <otsl>, <fcel>,
+        ...) that would pollute the RAG corpus and the /preprocess extracted_text handed to the
+        LLM (issue #3435). Returning "" makes the page count as empty (is_empty) instead of
+        ingesting markup as content.
+        """
+        doc = self._build_docling_doc(doctags_text)
+        if doc is None:
+            logger.warning("Markdown conversion failed, dropping page content")
             return ""
+        try:
+            return doc.export_to_markdown()
+        except Exception as e:
+            logger.warning("Markdown export failed, dropping page content: %s", e)
+            return ""
+
+    # -- Crop-table discrimination (issue #3435 SP3, Option B) -----------------------------
+
+    def generate_crop_doctags(self, page_image: PageImage) -> Tuple[str, bool]:
+        """Run plain-mode VLM inference on a single crop with a repetition early-stop.
+
+        Returns ``(cleaned_doctags, degenerated)``. On any *inference* failure returns
+        ``("", False)`` so the caller treats the crop as a non-table (clean degradation, R5) —
+        it does not propagate transient generation errors. It DOES raise ``RuntimeError`` for
+        the uninitialized-model precondition, matching ``process_page`` (a programmer error, not
+        an inference failure). Uses the same plain prompt as full pages (NO
+        ``no_repeat_ngram_size`` — it fabricates spurious tables from illustrations, a proven
+        false positive; issue #3435).
+        """
+        if not self._is_initialized:
+            raise RuntimeError(
+                "SmolDocling model not initialized. Call initialize() first."
+            )
+        criterion = RepetitionStoppingCriteria(
+            window=self.settings.crop_rep_stop_window,
+            max_distinct=self.settings.crop_rep_stop_max_distinct,
+        )
+        try:
+            doctags = self._run_inference(
+                page_image,
+                stopping_criteria=StoppingCriteriaList([criterion]),
+                max_new_tokens=self.settings.crop_max_new_tokens,
+            )
+            return doctags, criterion.stopped
+        except Exception as e:
+            logger.error(f"Crop inference failed: {e}", exc_info=True)
+            return "", False
+
+    def extract_crop(self, page_image: PageImage) -> CropExtractionResult:
+        """Discriminate a single crop with the VLM: plain mode + early-stop -> <otsl> gate ->
+        markdown + bbox.
+
+        Returns a CropExtractionResult with ``prefiltered=False`` and ``colorfulness=0.0`` —
+        those belong to the CropDiscriminator, which sets ``colorfulness`` and owns the cheap
+        pre-filter that may reject a crop *before* this method runs.
+        """
+        start = time.time()
+
+        def _elapsed_ms() -> int:
+            return int((time.time() - start) * 1000)
+
+        doctags, degenerated = self.generate_crop_doctags(page_image)
+
+        if not doctags:
+            return CropExtractionResult(
+                is_table=False,
+                reason="degenerate-earlystop" if degenerated else "empty-output",
+                markdown="", bbox=None, doctags="", confidence=0.0,
+                prefiltered=False, degenerated=degenerated, colorfulness=0.0,
+                duration_ms=_elapsed_ms(),
+            )
+
+        if not self._detect_has_tables(doctags):
+            return CropExtractionResult(
+                is_table=False,
+                reason="degenerate-earlystop" if degenerated else "no-otsl",
+                markdown="", bbox=None, doctags=doctags,
+                confidence=self._estimate_confidence(doctags),
+                prefiltered=False, degenerated=degenerated, colorfulness=0.0,
+                duration_ms=_elapsed_ms(),
+            )
+
+        markdown, bbox = self.extract_table_markdown_and_bbox(doctags)
+        if not markdown:
+            # OTSL present but docling could not rebuild it -> discard (never inject markup).
+            return CropExtractionResult(
+                is_table=False, reason="conversion-failed",
+                markdown="", bbox=None, doctags=doctags,
+                confidence=self._estimate_confidence(doctags),
+                prefiltered=False, degenerated=degenerated, colorfulness=0.0,
+                duration_ms=_elapsed_ms(),
+            )
+
+        return CropExtractionResult(
+            is_table=True, reason="table-otsl", markdown=markdown, bbox=bbox,
+            doctags=doctags, confidence=self._estimate_confidence(doctags),
+            prefiltered=False, degenerated=degenerated, colorfulness=0.0,
+            duration_ms=_elapsed_ms(),
+        )
+
+    def extract_table_markdown_and_bbox(
+        self, doctags_text: str
+    ) -> Tuple[str, Optional[Tuple[float, float, float, float]]]:
+        """Rebuild a crop's table markdown and its bbox from one DoclingDocument.
+
+        Returns ``("", None)`` if docling cannot parse/export — the caller then discards the
+        crop rather than inject unstructured markup.
+        """
+        doc = self._build_docling_doc(doctags_text)
+        if doc is None:
+            return "", None
+        try:
+            markdown = doc.export_to_markdown()
+        except Exception as e:
+            logger.warning("Table markdown export failed for crop: %s", e)
+            return "", None
+        bbox = self._extract_table_bbox(doc)
+        return (markdown or ""), bbox
+
+    def _extract_table_bbox(
+        self, docling_doc: DoclingDocument
+    ) -> Optional[Tuple[float, float, float, float]]:
+        """First table's bbox as (x0,y0,x1,y1) in [0,1] top-left, or None.
+
+        ``load_from_doctags(images=None)`` yields ``prov[].bbox`` already normalized to [0,1]
+        with a top-left origin (issue #3435 §5ter). MVP is 1:1 (one table per region, IA-6):
+        with >1 table we take the first and log.
+        """
+        tables = getattr(docling_doc, "tables", None) or []
+        if not tables:
+            return None
+        if len(tables) > 1:
+            logger.info(
+                "Crop yielded %d tables; using the first (MVP 1:1, IA-6)", len(tables)
+            )
+        prov = getattr(tables[0], "prov", None) or []
+        if not prov:
+            return None
+        bbox = getattr(prov[0], "bbox", None)
+        if bbox is None:
+            return None
+        return self._normalize_bbox(bbox)
+
+    @staticmethod
+    def _normalize_bbox(bbox) -> Optional[Tuple[float, float, float, float]]:
+        """Coerce a docling BoundingBox to (x0,y0,x1,y1) in [0,1] top-left.
+
+        Robust to docling-core attribute drift (l/t/r/b vs x0/y0/x1/y1) and to a BOTTOMLEFT
+        coordinate origin (flipped to TOPLEFT).
+        """
+        def _get(obj, *names):
+            for name in names:
+                value = getattr(obj, name, None)
+                if value is not None:
+                    return float(value)
+            return None
+
+        left = _get(bbox, "l", "x0", "left")
+        right = _get(bbox, "r", "x1", "right")
+        top = _get(bbox, "t", "y0", "top")
+        bottom = _get(bbox, "b", "y1", "bottom")
+        if None in (left, right, top, bottom):
+            return None
+
+        origin = getattr(bbox, "coord_origin", None)
+        origin_name = getattr(origin, "name", str(origin)) if origin is not None else ""
+        if origin_name.upper().startswith("BOTTOM"):
+            top, bottom = 1.0 - top, 1.0 - bottom
+
+        x0, x1 = sorted((left, right))
+        y0, y1 = sorted((top, bottom))
+        return (x0, y0, x1, y1)
 
     def _estimate_confidence(self, doctags_text: str) -> float:
         """

--- a/apps/smoldocling-service/src/main.py
+++ b/apps/smoldocling-service/src/main.py
@@ -16,12 +16,13 @@ import cv2
 import numpy as np
 
 from .config import settings
-from .application import PdfExtractionService
-from .domain.models import PageImage
+from .application import PdfExtractionService, CropDiscriminator
+from .domain.models import PageImage, CropExtractionResult
 from .api.schemas import (
     PdfExtractionResponse,
     TextChunkSchema,
     PageResultSchema,
+    ExtractImageResponse,
     ErrorDetail,
     ErrorResponse,
     HealthCheckResponse,
@@ -43,6 +44,13 @@ metrics = {
     "extract_failures_total": 0,
     "extract_duration_ms_sum": 0.0,
     "extract_payload_bytes_sum": 0.0,
+    # Crop-discriminator (issue #3435 SP3) — §8 observability
+    "extract_image_requests_total": 0,
+    "extract_image_failures_total": 0,
+    "extract_image_tables_total": 0,
+    "extract_image_prefiltered_total": 0,
+    "extract_image_degenerated_total": 0,
+    "extract_image_duration_ms_sum": 0.0,
 }
 
 
@@ -503,6 +511,24 @@ async def metrics_endpoint():
             "# HELP extract_payload_bytes_sum Cumulative payload bytes processed",
             "# TYPE extract_payload_bytes_sum counter",
             f"extract_payload_bytes_sum {metrics['extract_payload_bytes_sum']}",
+            "# HELP extract_image_requests_total Total extract-image (crop-discriminator) requests",
+            "# TYPE extract_image_requests_total counter",
+            f"extract_image_requests_total {metrics['extract_image_requests_total']}",
+            "# HELP extract_image_failures_total Total extract-image failures",
+            "# TYPE extract_image_failures_total counter",
+            f"extract_image_failures_total {metrics['extract_image_failures_total']}",
+            "# HELP extract_image_tables_total Crops classified as tables (kept)",
+            "# TYPE extract_image_tables_total counter",
+            f"extract_image_tables_total {metrics['extract_image_tables_total']}",
+            "# HELP extract_image_prefiltered_total Crops rejected by the colorfulness pre-filter",
+            "# TYPE extract_image_prefiltered_total counter",
+            f"extract_image_prefiltered_total {metrics['extract_image_prefiltered_total']}",
+            "# HELP extract_image_degenerated_total Crops where the repetition early-stop fired",
+            "# TYPE extract_image_degenerated_total counter",
+            f"extract_image_degenerated_total {metrics['extract_image_degenerated_total']}",
+            "# HELP extract_image_duration_ms_sum Cumulative crop-discriminator latency in ms",
+            "# TYPE extract_image_duration_ms_sum counter",
+            f"extract_image_duration_ms_sum {metrics['extract_image_duration_ms_sum']}",
         ]
     return PlainTextResponse("\n".join(lines) + "\n")
 
@@ -751,6 +777,122 @@ async def preprocess_photo(
         orientation="portrait",
         is_blank=False,
         warnings=warnings,
+    )
+
+
+# ---------------------------------------------------------------------------
+# /api/v1/extract-image — Crop-table discriminator (issue #3435 SP3, Option B)
+# ---------------------------------------------------------------------------
+# Given a single hi_res image-region crop, decide table-vs-illustration and — for tables —
+# return rebuilt markdown + bbox [0,1] top-left. The <otsl> gate is authoritative; a cheap
+# colorfulness pre-filter and a repetition early-stop only contain the VLM cost on
+# illustrations (de-risk "Opzione B"). Copyright gating of the returned table content — ALL of
+# markdown, bbox AND the raw doctags (which carries the same table cell text) — is the
+# consumer's responsibility (spec §5quinquies open risk), not this service's.
+# ---------------------------------------------------------------------------
+
+
+def _discriminate_crop(img: Image.Image, prefilter: Optional[bool]) -> CropExtractionResult:
+    """Run the crop-discriminator (blocking; called via run_in_threadpool).
+
+    Lazily initialises the VLM, mirroring _extract_text_with_confidence. Returns a non-table
+    ``service-unavailable`` result when pdf_service is absent (unit-test env without lifespan)
+    so the endpoint still answers 200 with is_table=False.
+    """
+    global pdf_service  # noqa: PLW0602
+    if pdf_service is None or pdf_service.vlm_adapter is None:
+        return CropExtractionResult(
+            is_table=False, reason="service-unavailable", markdown="", bbox=None,
+            doctags="", confidence=0.0, prefiltered=False, degenerated=False,
+            colorfulness=0.0, duration_ms=0,
+        )
+    adapter = pdf_service.vlm_adapter
+    if not adapter._is_initialized:
+        adapter.initialize()
+    return CropDiscriminator(adapter).discriminate(img, prefilter=prefilter)
+
+
+@app.post(
+    "/api/v1/extract-image",
+    response_model=ExtractImageResponse,
+    summary="Extract a table from a single image crop (issue #3435)",
+    description=(
+        "Discriminates an hi_res image-region crop as table-vs-illustration. For tables, "
+        "returns the rebuilt markdown and the table bbox in [0,1] top-left; illustrations are "
+        "discarded (is_table=false). A colorfulness pre-filter (overridable via the `prefilter` "
+        "form field) and a repetition early-stop contain the VLM cost."
+    ),
+)
+async def extract_image(
+    image: UploadFile = File(..., description="Image crop (JPEG/PNG)"),
+    prefilter: Optional[bool] = Form(
+        default=None,
+        description="Override the colorfulness pre-filter; omit to use the service default",
+    ),
+) -> ExtractImageResponse:
+    request_id = str(uuid.uuid4())
+    logger.info(
+        "Extract-image request [%s]: file=%s prefilter=%s",
+        request_id, image.filename, prefilter,
+    )
+
+    img_bytes = await image.read()
+    if not img_bytes:
+        with metrics_lock:
+            metrics["extract_image_requests_total"] += 1
+            metrics["extract_image_failures_total"] += 1
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Empty image file")
+
+    try:
+        img = Image.open(io.BytesIO(img_bytes))
+        img.load()
+    except Exception as exc:
+        with metrics_lock:
+            metrics["extract_image_requests_total"] += 1
+            metrics["extract_image_failures_total"] += 1
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Cannot open image: {exc}",
+        ) from exc
+
+    try:
+        result = await run_in_threadpool(_discriminate_crop, img, prefilter)
+    except Exception as exc:
+        logger.error("Extract-image failed [%s]: %s", request_id, exc, exc_info=True)
+        with metrics_lock:
+            metrics["extract_image_requests_total"] += 1
+            metrics["extract_image_failures_total"] += 1
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to extract table from image crop",
+        ) from exc
+
+    with metrics_lock:
+        metrics["extract_image_requests_total"] += 1
+        metrics["extract_image_duration_ms_sum"] += result.duration_ms
+        if result.prefiltered:
+            metrics["extract_image_prefiltered_total"] += 1
+        if result.degenerated:
+            metrics["extract_image_degenerated_total"] += 1
+        if result.is_table:
+            metrics["extract_image_tables_total"] += 1
+
+    logger.info(
+        "Extract-image done [%s]: is_table=%s reason=%s colorfulness=%.1f duration_ms=%d",
+        request_id, result.is_table, result.reason, result.colorfulness, result.duration_ms,
+    )
+
+    return ExtractImageResponse(
+        is_table=result.is_table,
+        reason=result.reason,
+        markdown=result.markdown,
+        bbox=list(result.bbox) if result.bbox is not None else None,
+        doctags=result.doctags,
+        confidence=result.confidence,
+        prefiltered=result.prefiltered,
+        degenerated=result.degenerated,
+        colorfulness=result.colorfulness,
+        duration_ms=result.duration_ms,
     )
 
 

--- a/apps/smoldocling-service/src/main.py
+++ b/apps/smoldocling-service/src/main.py
@@ -795,9 +795,13 @@ async def preprocess_photo(
 def _discriminate_crop(img: Image.Image, prefilter: Optional[bool]) -> CropExtractionResult:
     """Run the crop-discriminator (blocking; called via run_in_threadpool).
 
-    Lazily initialises the VLM, mirroring _extract_text_with_confidence. Returns a non-table
-    ``service-unavailable`` result when pdf_service is absent (unit-test env without lifespan)
-    so the endpoint still answers 200 with is_table=False.
+    Lazily initialises the VLM, mirroring _extract_text_with_confidence: BOTH an absent
+    pdf_service (unit-test env without lifespan) AND a model-initialisation failure (GPU OOM,
+    weight download / Triton-JIT failure — the #3556 class) degrade to a non-table result so
+    the endpoint answers 200 with is_table=False, honouring R5 ("extraction fails -> no error")
+    instead of 500ing. Init failure is logged at ERROR and carries a distinct ``reason`` so it
+    stays observable — a persistent init failure would otherwise silently return "no table" for
+    the whole batch (enable_model_warmup pins _is_initialized False after a failed warmup).
     """
     global pdf_service  # noqa: PLW0602
     if pdf_service is None or pdf_service.vlm_adapter is None:
@@ -808,7 +812,17 @@ def _discriminate_crop(img: Image.Image, prefilter: Optional[bool]) -> CropExtra
         )
     adapter = pdf_service.vlm_adapter
     if not adapter._is_initialized:
-        adapter.initialize()
+        try:
+            adapter.initialize()
+        except Exception as exc:
+            logger.error(
+                "VLM initialisation failed during extract-image: %s", exc, exc_info=True
+            )
+            return CropExtractionResult(
+                is_table=False, reason="init-failed", markdown="", bbox=None,
+                doctags="", confidence=0.0, prefiltered=False, degenerated=False,
+                colorfulness=0.0, duration_ms=0,
+            )
     return CropDiscriminator(adapter).discriminate(img, prefilter=prefilter)
 
 

--- a/apps/smoldocling-service/tests/test_crop_discriminator.py
+++ b/apps/smoldocling-service/tests/test_crop_discriminator.py
@@ -1,0 +1,121 @@
+"""
+Unit tests for the crop-discriminator (issue #3435 SP3, Option B).
+
+No model is loaded — a fake adapter stands in for the VLM so the colorfulness pre-filter and
+the orchestration are tested in isolation. The design contract under test (memory "De-risk
+Opzione B" / spec §5quinquies):
+  - a colorful illustration is rejected by the pre-filter WITHOUT invoking the VLM;
+  - a B/W table-like crop reaches the VLM, whose <otsl> gate (encoded in extract_crop) decides;
+  - the pre-filter is overridable per-request and is fail-open (the gate is authoritative).
+"""
+import numpy as np
+import pytest
+from PIL import Image
+
+from src.application.crop_discriminator import CropDiscriminator, colorfulness
+from src.domain.models import CropExtractionResult
+from src.config import settings
+
+
+class _FakeAdapter:
+    """Records whether extract_crop was called and returns a canned VLM-side result."""
+
+    def __init__(self, result: CropExtractionResult):
+        self._result = result
+        self.calls = 0
+        self._is_initialized = True
+
+    def extract_crop(self, page_image) -> CropExtractionResult:
+        self.calls += 1
+        return self._result
+
+
+def _table_result() -> CropExtractionResult:
+    return CropExtractionResult(
+        is_table=True, reason="table-otsl", markdown="| a | b |\n|---|---|\n| 1 | 2 |",
+        bbox=(0.1, 0.2, 0.9, 0.6), doctags="<otsl>...", confidence=0.9,
+        prefiltered=False, degenerated=False, colorfulness=0.0, duration_ms=3000,
+    )
+
+
+def _discard_result(reason: str = "no-otsl") -> CropExtractionResult:
+    return CropExtractionResult(
+        is_table=False, reason=reason, markdown="", bbox=None, doctags="<picture>",
+        confidence=0.7, prefiltered=False, degenerated=False, colorfulness=0.0, duration_ms=1000,
+    )
+
+
+def _grayscale(size=(400, 300)) -> Image.Image:
+    """A near-B/W table-like image: very low colorfulness."""
+    arr = np.random.default_rng(0).integers(200, 256, size=(size[1], size[0]), dtype=np.uint8)
+    return Image.fromarray(arr, mode="L").convert("RGB")
+
+
+def _colorful(size=(400, 300)) -> Image.Image:
+    """A fully-saturated hue sweep: high colorfulness (illustration-like)."""
+    w, h = size
+    hue = np.tile(np.linspace(0, 255, w, dtype=np.uint8), (h, 1))
+    sat = np.full((h, w), 255, np.uint8)
+    val = np.full((h, w), 255, np.uint8)
+    hsv = np.dstack([hue, sat, val])
+    return Image.fromarray(hsv, mode="HSV").convert("RGB")
+
+
+# ------------------------------------------------------------------ colorfulness metric
+
+def test_colorfulness_low_for_grayscale():
+    assert colorfulness(_grayscale()) < 15.0
+
+
+def test_colorfulness_high_for_saturated_image():
+    assert colorfulness(_colorful()) > settings.crop_prefilter_colorfulness_threshold
+
+
+# ------------------------------------------------------------------ pre-filter gating
+
+def test_prefilter_rejects_colorful_without_invoking_vlm():
+    adapter = _FakeAdapter(_table_result())
+    result = CropDiscriminator(adapter).discriminate(_colorful())
+    assert result.is_table is False
+    assert result.reason == "prefilter-colorful"
+    assert result.prefiltered is True
+    assert result.markdown == ""
+    assert result.bbox is None
+    assert adapter.calls == 0  # the whole point: no VLM on obvious illustrations
+    assert result.colorfulness > settings.crop_prefilter_colorfulness_threshold
+
+
+def test_prefilter_can_be_disabled_per_request():
+    adapter = _FakeAdapter(_table_result())
+    result = CropDiscriminator(adapter).discriminate(_colorful(), prefilter=False)
+    assert adapter.calls == 1  # VLM ran despite the colour
+    assert result.is_table is True
+
+
+def test_table_like_crop_passes_prefilter_and_returns_markdown_and_bbox():
+    adapter = _FakeAdapter(_table_result())
+    result = CropDiscriminator(adapter).discriminate(_grayscale())
+    assert adapter.calls == 1
+    assert result.is_table is True
+    assert result.reason == "table-otsl"
+    assert result.markdown != ""
+    assert result.bbox == (0.1, 0.2, 0.9, 0.6)
+    assert result.colorfulness < 15.0  # set by the discriminator, not the fake adapter
+
+
+def test_illustration_reaching_vlm_is_discarded_by_gate():
+    # Low-colour crop passes the pre-filter but the VLM emits no <otsl> -> discarded.
+    adapter = _FakeAdapter(_discard_result("no-otsl"))
+    result = CropDiscriminator(adapter).discriminate(_grayscale())
+    assert adapter.calls == 1
+    assert result.is_table is False
+    assert result.reason == "no-otsl"
+    assert result.colorfulness < 15.0
+
+
+def test_prefilter_disabled_via_config(monkeypatch):
+    monkeypatch.setattr(settings, "crop_prefilter_enabled", False)
+    adapter = _FakeAdapter(_table_result())
+    result = CropDiscriminator(adapter).discriminate(_colorful())
+    assert adapter.calls == 1  # config default off -> VLM runs even on colourful crops
+    assert result.is_table is True

--- a/apps/smoldocling-service/tests/test_extract_image_endpoint.py
+++ b/apps/smoldocling-service/tests/test_extract_image_endpoint.py
@@ -129,3 +129,25 @@ def test_extract_image_service_unavailable_answers_200_non_table(monkeypatch):
     payload = r.json()
     assert payload["is_table"] is False
     assert payload["reason"] == "service-unavailable"
+
+
+def test_extract_image_init_failure_degrades_to_non_table(monkeypatch):
+    # A model-initialisation failure (GPU OOM / JIT — the #3556 class) must degrade to a 200
+    # non-table result (R5), NOT 500 through the endpoint's generic handler.
+    class _BoomAdapter:
+        _is_initialized = False
+
+        def initialize(self):
+            raise RuntimeError("cuda out of memory")
+
+    svc = PdfExtractionService()
+    svc.vlm_adapter = _BoomAdapter()
+    monkeypatch.setattr(main, "pdf_service", svc)
+
+    r = client.post("/api/v1/extract-image", files={"image": ("t.jpg", _jpeg(), "image/jpeg")})
+    assert r.status_code == 200, r.text
+    payload = r.json()
+    assert payload["is_table"] is False
+    assert payload["reason"] == "init-failed"
+    assert main.metrics["extract_image_requests_total"] == 1
+    assert main.metrics["extract_image_failures_total"] == 0  # a degraded 200, not a failure

--- a/apps/smoldocling-service/tests/test_extract_image_endpoint.py
+++ b/apps/smoldocling-service/tests/test_extract_image_endpoint.py
@@ -1,0 +1,131 @@
+"""
+Tests for the POST /api/v1/extract-image endpoint (issue #3435 SP3, Option B).
+
+The crop-discriminator itself is unit-tested in test_crop_discriminator.py; here we assert the
+HTTP contract only, so _discriminate_crop is monkeypatched to canned results (mirroring the
+pdf_service.extract monkeypatch pattern in test_metrics.py). No model / GPU is involved.
+"""
+import io
+
+import pytest
+from fastapi.testclient import TestClient
+from PIL import Image
+
+import src.main as main
+from src.application import PdfExtractionService
+from src.domain.models import CropExtractionResult
+
+client = TestClient(main.app)
+
+
+@pytest.fixture(autouse=True)
+def reset(monkeypatch):
+    for key in list(main.metrics):
+        main.metrics[key] = type(main.metrics[key])(0)
+    # pdf_service exists but its adapter is uninitialised (no GPU) — most tests monkeypatch
+    # _discriminate_crop anyway, so the model is never touched.
+    monkeypatch.setattr(main, "pdf_service", PdfExtractionService())
+    yield
+
+
+def _jpeg(color: str = "white", size=(300, 200)) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", size, color).save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+def _table_result() -> CropExtractionResult:
+    return CropExtractionResult(
+        is_table=True, reason="table-otsl", markdown="| a |\n|---|\n| 1 |",
+        bbox=(0.1, 0.2, 0.9, 0.6), doctags="<otsl>...", confidence=0.9,
+        prefiltered=False, degenerated=False, colorfulness=5.0, duration_ms=3000,
+    )
+
+
+# ------------------------------------------------------------------ input validation
+
+def test_extract_image_empty_file_returns_400():
+    r = client.post("/api/v1/extract-image", files={"image": ("x.jpg", b"", "image/jpeg")})
+    assert r.status_code == 400
+    assert main.metrics["extract_image_failures_total"] == 1
+
+
+def test_extract_image_invalid_bytes_returns_400():
+    r = client.post(
+        "/api/v1/extract-image",
+        files={"image": ("x.jpg", b"not-an-image", "image/jpeg")},
+    )
+    assert r.status_code == 400
+    assert main.metrics["extract_image_failures_total"] == 1
+
+
+# ------------------------------------------------------------------ response contract
+
+def test_extract_image_table_response_shape(monkeypatch):
+    monkeypatch.setattr(main, "_discriminate_crop", lambda img, prefilter: _table_result())
+
+    r = client.post("/api/v1/extract-image", files={"image": ("t.jpg", _jpeg(), "image/jpeg")})
+    assert r.status_code == 200, r.text
+    payload = r.json()
+    for field in (
+        "is_table", "reason", "markdown", "bbox", "doctags", "confidence",
+        "prefiltered", "degenerated", "colorfulness", "duration_ms",
+    ):
+        assert field in payload, f"Missing field: {field}"
+    assert payload["is_table"] is True
+    assert payload["bbox"] == [0.1, 0.2, 0.9, 0.6]
+    assert payload["markdown"] != ""
+    assert main.metrics["extract_image_requests_total"] == 1
+    assert main.metrics["extract_image_tables_total"] == 1
+    assert main.metrics["extract_image_prefiltered_total"] == 0
+    assert main.metrics["extract_image_duration_ms_sum"] == 3000
+    assert main.metrics["extract_image_degenerated_total"] == 0
+
+
+def test_extract_image_prefiltered_illustration_discarded(monkeypatch):
+    discard = CropExtractionResult(
+        is_table=False, reason="prefilter-colorful", markdown="", bbox=None, doctags="",
+        confidence=0.0, prefiltered=True, degenerated=False, colorfulness=88.0, duration_ms=1,
+    )
+    monkeypatch.setattr(main, "_discriminate_crop", lambda img, prefilter: discard)
+
+    r = client.post("/api/v1/extract-image", files={"image": ("i.jpg", _jpeg("red"), "image/jpeg")})
+    assert r.status_code == 200
+    payload = r.json()
+    assert payload["is_table"] is False
+    assert payload["bbox"] is None
+    assert payload["markdown"] == ""
+    assert payload["prefiltered"] is True
+    assert main.metrics["extract_image_prefiltered_total"] == 1
+    assert main.metrics["extract_image_tables_total"] == 0
+
+
+def test_extract_image_forwards_prefilter_form_field(monkeypatch):
+    seen = {}
+
+    def fake(img, prefilter):
+        seen["prefilter"] = prefilter
+        return CropExtractionResult(
+            is_table=False, reason="no-otsl", markdown="", bbox=None, doctags="",
+            confidence=0.0, prefiltered=False, degenerated=False, colorfulness=1.0, duration_ms=1,
+        )
+
+    monkeypatch.setattr(main, "_discriminate_crop", fake)
+    r = client.post(
+        "/api/v1/extract-image",
+        files={"image": ("i.jpg", _jpeg(), "image/jpeg")},
+        data={"prefilter": "false"},
+    )
+    assert r.status_code == 200
+    assert seen["prefilter"] is False
+
+
+def test_extract_image_service_unavailable_answers_200_non_table(monkeypatch):
+    # No monkeypatch of _discriminate_crop: with pdf_service present but adapter uninitialised,
+    # a real call would try to init the model. Simulate the "no service" branch instead.
+    monkeypatch.setattr(main, "pdf_service", None)
+    r = client.post("/api/v1/extract-image", files={"image": ("t.jpg", _jpeg(), "image/jpeg")})
+    assert r.status_code == 200
+    payload = r.json()
+    assert payload["is_table"] is False
+    assert payload["reason"] == "service-unavailable"

--- a/apps/smoldocling-service/tests/test_smoldocling_adapter.py
+++ b/apps/smoldocling-service/tests/test_smoldocling_adapter.py
@@ -16,11 +16,16 @@ the mock pattern in test_metrics.py. The fakes intentionally reproduce two real 
   (a) the processor yields input_ids ONLY when text is not None (Idefics3Processor);
   (b) batch_decode is a function of the ids it receives (so trim/leak is observable).
 """
+import types
+
 import torch
 import pytest
 from PIL import Image
 
-from src.infrastructure.smoldocling_adapter import SmolDoclingAdapter
+from src.infrastructure.smoldocling_adapter import (
+    SmolDoclingAdapter,
+    RepetitionStoppingCriteria,
+)
 from src.domain.models import PageImage, PageExtractionResult
 
 
@@ -266,3 +271,208 @@ def test_is_empty_false_for_real_content():
         confidence_score=0.8,
     )
     assert r.is_empty is False
+
+
+# =====================================================================================
+# Crop-table discriminator (issue #3435 SP3, Option B) — extract_crop + early-stop + bbox
+# =====================================================================================
+
+# ------------------------------------------------- RepetitionStoppingCriteria (early-stop)
+
+def test_repetition_stopping_criteria_fires_on_uniform_generated_tail():
+    # A degenerate illustration loop: the trailing window collapses to one token id.
+    crit = RepetitionStoppingCriteria(window=8, max_distinct=2, prompt_len=0)
+    ids = torch.tensor([[1, 2, 3] + [9] * 8])
+    assert crit(ids, None) is True
+    assert crit.stopped is True
+
+
+def test_repetition_stopping_criteria_ignores_diverse_tail():
+    crit = RepetitionStoppingCriteria(window=8, max_distinct=2, prompt_len=0)
+    ids = torch.arange(1, 20).unsqueeze(0)  # all-distinct trailing window
+    assert crit(ids, None) is False
+    assert crit.stopped is False
+
+
+def test_repetition_stopping_criteria_excludes_prompt_tokens():
+    # prompt_len=100 with only 4 generated tokens: below the window, so the uniform PROMPT
+    # tail (image placeholder ids) must NOT trip the early-stop.
+    crit = RepetitionStoppingCriteria(window=8, max_distinct=2, prompt_len=100)
+    ids = torch.tensor([[7] * 104])
+    assert crit(ids, None) is False
+
+
+# ------------------------------------------------- extract_crop: <otsl> gate + markdown + bbox
+
+def test_extract_crop_keeps_table_and_returns_bbox_in_unit_range():
+    # RAW_DOCTAGS carries an <otsl> table with <loc_*> coords; extract_crop must keep it and
+    # derive the bbox from the REAL docling-core (no model) — the [0,1] top-left anchor (§5ter).
+    adapter = _make_adapter(_SpyProcessor(output=RAW_DOCTAGS), _FakeModel())
+    result = adapter.extract_crop(_page())
+    assert result.is_table is True
+    assert result.reason == "table-otsl"
+    assert "Campo arato" in result.markdown
+    assert result.bbox is not None
+    # Pin the [0,1] TOP-LEFT contract (§5ter): RAW_DOCTAGS' <otsl> carries loc 50/100/450/300
+    # on the 0..500 grid -> docling normalizes to (0.1, 0.2, 0.9, 0.6). y0~=0.2 proves the TOP
+    # anchor — a bottom-left flip (y0~=0.4) or an x/y swap would still pass a mere range/order
+    # check, so assert the exact value.
+    assert result.bbox == pytest.approx((0.1, 0.2, 0.9, 0.6), abs=0.02)
+    assert result.prefiltered is False
+    assert result.degenerated is False
+
+
+def test_extract_crop_discards_text_only_crop_no_otsl():
+    adapter = _make_adapter(_SpyProcessor(output=TEXT_ONLY_DOCTAGS), _FakeModel())
+    result = adapter.extract_crop(_page())
+    assert result.is_table is False
+    assert result.reason == "no-otsl"
+    assert result.markdown == ""
+    assert result.bbox is None
+
+
+def test_extract_crop_empty_output_when_generation_trimmed_to_empty():
+    # gen_len=0: generation yields only the prompt; the trim empties it -> non-table.
+    adapter = _make_adapter(_SpyProcessor(prompt_len=5), _FakeModel(prompt_len=5, gen_len=0))
+    result = adapter.extract_crop(_page())
+    assert result.is_table is False
+    assert result.reason == "empty-output"
+    assert result.markdown == ""
+    assert result.bbox is None
+
+
+def test_extract_crop_passes_early_stop_and_crop_token_cap_to_generate():
+    proc = _SpyProcessor(output=RAW_DOCTAGS)
+    model = _FakeModel()
+    captured = {}
+    orig_generate = model.generate
+
+    def spy_generate(**kwargs):
+        captured.update(kwargs)
+        return orig_generate(**kwargs)
+
+    model.generate = spy_generate
+    adapter = _make_adapter(proc, model)
+    adapter.extract_crop(_page())
+
+    assert captured["max_new_tokens"] == adapter.settings.crop_max_new_tokens
+    assert "stopping_criteria" in captured
+    assert any(
+        isinstance(c, RepetitionStoppingCriteria) for c in captured["stopping_criteria"]
+    )
+
+
+def test_process_page_still_uses_full_page_token_budget():
+    # The DRY refactor must NOT leak the crop token cap into the full-page path.
+    proc = _SpyProcessor(output=RAW_DOCTAGS)
+    model = _FakeModel()
+    captured = {}
+    orig_generate = model.generate
+
+    def spy_generate(**kwargs):
+        captured.update(kwargs)
+        return orig_generate(**kwargs)
+
+    model.generate = spy_generate
+    adapter = _make_adapter(proc, model)
+    adapter.process_page(_page())
+
+    assert captured["max_new_tokens"] == adapter.settings.max_new_tokens
+    assert "stopping_criteria" not in captured  # full page uses no early-stop
+
+
+class _DegenerateModel:
+    """Fake model whose generate() invokes the passed RepetitionStoppingCriteria with a uniform
+    trailing window (as a real degenerate HF generation loop would), so the early-stop fires and
+    ``degenerated`` propagates through generate_crop_doctags -> extract_crop."""
+
+    def __init__(self, prompt_len: int = 3, tail_len: int = 40, tail_token: int = 7):
+        self.prompt_len = prompt_len
+        self.tail_len = tail_len
+        self.tail_token = tail_token
+
+    def generate(self, **kwargs):
+        seq = torch.tensor(
+            [list(range(1, self.prompt_len + 1)) + [self.tail_token] * self.tail_len]
+        )
+        criteria = kwargs.get("stopping_criteria")
+        if criteria is not None:
+            criteria(seq, None)  # HF calls the criteria with the running sequence
+        return seq
+
+
+def test_extract_crop_reason_degenerate_earlystop_when_early_stop_fires():
+    # No <otsl> output AND the repetition early-stop fired -> reason must attribute the discard
+    # to degeneration, not a plain no-otsl (the observable signal that the early-stop engaged).
+    proc = _SpyProcessor(prompt_len=3, output=TEXT_ONLY_DOCTAGS)
+    adapter = _make_adapter(proc, _DegenerateModel(prompt_len=3))
+    result = adapter.extract_crop(_page())
+    assert result.degenerated is True
+    assert result.is_table is False
+    assert result.reason == "degenerate-earlystop"
+
+
+def test_generate_crop_doctags_never_raises_on_inference_error(monkeypatch):
+    # R5 clean-degradation: a transient inference error must NOT escape to the endpoint (500);
+    # it degrades to ("", False) -> a non-table empty-output result.
+    adapter = _make_adapter(_SpyProcessor(), _FakeModel())
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("inference boom")
+
+    monkeypatch.setattr(adapter, "_run_inference", boom)
+
+    doctags, degenerated = adapter.generate_crop_doctags(_page())
+    assert doctags == ""
+    assert degenerated is False
+
+    result = adapter.extract_crop(_page())
+    assert result.is_table is False
+    assert result.reason == "empty-output"
+    assert result.markdown == ""
+
+
+def test_extract_crop_conversion_failed_when_docling_cannot_rebuild(monkeypatch):
+    # <otsl> present but docling cannot rebuild the table -> discard as conversion-failed rather
+    # than inject DocTags markup into the RAG corpus (corpus-safety guard).
+    adapter = _make_adapter(_SpyProcessor(output=RAW_DOCTAGS), _FakeModel())
+    monkeypatch.setattr(adapter, "_build_docling_doc", lambda doctags: None)
+
+    result = adapter.extract_crop(_page())
+    assert result.is_table is False
+    assert result.reason == "conversion-failed"
+    assert result.markdown == ""
+    assert result.bbox is None
+    assert "<otsl>" in result.doctags  # OTSL was detected, just not rebuildable
+
+
+def test_extract_table_bbox_uses_first_of_multiple_tables():
+    # MVP 1:1 (IA-6): with >1 table, take the FIRST table's bbox (a tables[-1] regression would
+    # be invisible with a single-table doc).
+    adapter = SmolDoclingAdapter()
+    first = types.SimpleNamespace(l=0.1, t=0.2, r=0.3, b=0.4, coord_origin=None)
+    second = types.SimpleNamespace(l=0.5, t=0.6, r=0.7, b=0.8, coord_origin=None)
+    doc = types.SimpleNamespace(
+        tables=[
+            types.SimpleNamespace(prov=[types.SimpleNamespace(bbox=first)]),
+            types.SimpleNamespace(prov=[types.SimpleNamespace(bbox=second)]),
+        ]
+    )
+    assert adapter._extract_table_bbox(doc) == pytest.approx((0.1, 0.2, 0.3, 0.4))
+
+
+def test_normalize_bbox_flips_bottomleft_origin():
+    # The real docling roundtrip is TOPLEFT, so this directly exercises the BOTTOMLEFT flip that
+    # the roundtrip cannot reach: t=0.8/b=0.2 bottom-anchored -> 0.2/0.8 top-anchored.
+    adapter = SmolDoclingAdapter()
+    origin = types.SimpleNamespace(name="BOTTOMLEFT")
+    bbox = types.SimpleNamespace(l=0.1, t=0.8, r=0.9, b=0.2, coord_origin=origin)
+    assert adapter._normalize_bbox(bbox) == pytest.approx((0.1, 0.2, 0.9, 0.8))
+
+
+def test_extract_table_bbox_none_when_no_prov():
+    adapter = SmolDoclingAdapter()
+    doc = types.SimpleNamespace(tables=[types.SimpleNamespace(prov=[])])
+    assert adapter._extract_table_bbox(doc) is None
+    doc_no_tables = types.SimpleNamespace(tables=[])
+    assert adapter._extract_table_bbox(doc_no_tables) is None


### PR DESCRIPTION
## Cosa (SP3 core — Opzione B, epic #3435)

Discriminazione **tabella-vs-illustrazione** sui crop delle image-region hi_res, nel `smoldocling-service`. Dato un crop, decide se è una **tabella** (da tenere) o un'**illustrazione** (da scartare) e, per le tabelle, restituisce **markdown ricostruito + bbox `[0,1]` top-left**.

### Design (de-riskato empiricamente su GPU — spec §5quinquies / memoria "De-risk Opzione B")
- **Gate `<otsl>` autoritativo**: solo una tabella OTSL nell'output VLM è tenuta; le illustrazioni non emettono `<otsl>`.
- **Pre-filtro colorfulness (Hasler–Süsstrunk)**: scarta le illustrazioni ovvie *prima* del VLM (contenimento costo). **Fail-open** — non rigetta mai una tabella per colore; overridable per-request (`prefilter` form field).
- **Early-stop `RepetitionStoppingCriteria`**: cappa il loop degenerato (~19s) sulle illustrazioni. **NON** `no_repeat_ngram_size` (fabbrica tabelle spurie — falso positivo dimostrato).
- **bbox** via `load_from_doctags(images=None)` → `prov[].bbox` `[0,1]` top-left (nessun parsing manuale).

### Deliverable
- `SmolDoclingAdapter`: core `_run_inference` condiviso (DRY con `process_page`), `generate_crop_doctags`, `extract_crop`, `extract_table_markdown_and_bbox`, `_extract_table_bbox`/`_normalize_bbox`.
- `CropDiscriminator` (application layer) + `POST /api/v1/extract-image` (thin endpoint) + contatori Prometheus (`extract_image_{requests,failures,tables,prefiltered,degenerated}_total`, `extract_image_duration_ms_sum`).
- `CropExtractionResult` (domain) + `ExtractImageResponse` (schema) + settings `crop_*`.

### Verifica
- **Suite pytest completa: 59 passed, 1 skipped** nel container `meepleai-smoldocling-service:latest` (deps + docling-core reali). Nessuna regressione sui test preesistenti; il refactor DRY di `process_page` è guardato dai 32 test esistenti.
- **Roundtrip bbox su docling-core REALE** (no model) che pinna il contratto `[0,1]` top-left (`(0.1, 0.2, 0.9, 0.6)`), più test dedicato al flip BOTTOMLEFT.
- Inference GPU già validata in SP3-groundwork (#3556); questo slice non richiede GPU in CI.
- **Review adversariale multi-agente** (5 lenti → verify che tenta di confutare): 0 bug di correttezza/edge-case; 7 finding coverage/qualità recepiti (assert bbox rafforzata, branch `degenerate-earlystop`/`conversion-failed`/never-raises coperti, counter latenza/degenerazione, annotazione `Optional`).

### Fuori scope (follow-up, non bloccanti per questo slice)
- **Copyright-gate `Full`-tier** sulle image-region (markdown/bbox/doctags) = responsabilità del **consumer C#** (spec §5quinquies open risk), da chiudere prima del rollout contenuto.
- **SP4** = job asincrono che consuma `GetTableRegionCandidatesQuery` (SP2, #3553) e chiama questo endpoint.

Refs #3435

🤖 Generated with [Claude Code](https://claude.com/claude-code)
