### PR TITLE
feat(rag): async VLM table-extraction job (#3435 SP4)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/RunTableExtractionBatchCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/RunTableExtractionBatchCommand.cs
@@ -1,0 +1,22 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Commands;
+
+/// <summary>
+/// #3435 (SP4): runs one batch of the async VLM table-extraction pass. Consumes the SP2 router
+/// (<c>GetTableRegionCandidatesQuery</c>) to pick candidate PDFs, then for each pending image region
+/// renders + crops the page, calls the smoldocling crop-discriminator (<c>/api/v1/extract-image</c>),
+/// and — for tables — persists a retrievable table chunk. Gated by config flag
+/// <c>PdfProcessing:TableExtraction:Enabled</c> (default false). <see cref="BatchSize"/> bounds the
+/// number of REGIONS processed per run.
+/// </summary>
+internal sealed record RunTableExtractionBatchCommand(int? BatchSize = null)
+    : ICommand<RunTableExtractionBatchResult>;
+
+/// <summary>Outcome of one table-extraction batch. <see cref="Enabled"/> is false when the flag is off.</summary>
+internal sealed record RunTableExtractionBatchResult(
+    bool Enabled,
+    int Processed,
+    int Extracted,
+    int NotTable,
+    int Failed);

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/RunTableExtractionBatchCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/RunTableExtractionBatchCommandHandler.cs
@@ -144,6 +144,25 @@ internal sealed class RunTableExtractionBatchCommandHandler
             // unique index, so a plain keyed dictionary is safe.
             var stateByHash = states.ToDictionary(s => s.RegionHash, StringComparer.Ordinal);
 
+            // A document reindex (ReindexDocumentCommandHandler / the pipeline) deletes this PDF's
+            // text_chunks + embeddings WITHOUT clearing this sidecar, so an 'extracted' region is only
+            // truly done if its produced chunk still exists. Load the still-live table-chunk ids so a
+            // wiped chunk is re-indexed (from cached markdown) instead of skipped forever (#3435 SP4 review).
+            var extractedChunkIds = states
+                .Where(s => string.Equals(s.Status, PdfTableExtractionEntity.StatusExtracted, StringComparison.Ordinal)
+                    && s.TextChunkId.HasValue)
+                .Select(s => s.TextChunkId!.Value)
+                .Distinct()
+                .ToList();
+            var liveChunkIds = extractedChunkIds.Count == 0
+                ? new HashSet<Guid>()
+                : (await _dbContext.TextChunks
+                    .AsNoTracking()
+                    .Where(tc => extractedChunkIds.Contains(tc.Id))
+                    .Select(tc => tc.Id)
+                    .ToListAsync(cancellationToken)
+                    .ConfigureAwait(false)).ToHashSet();
+
             byte[]? pdfBytes = null;
             var pdfBytesLoaded = false;
 
@@ -158,8 +177,10 @@ internal sealed class RunTableExtractionBatchCommandHandler
                 var regionHash = TableRegionKey.ComputeRegionHash(
                     pdf.Id, region.PageNumber, region.X, region.Y, region.Width, region.Height);
 
-                // Skip regions already in a terminal state or that exhausted their retry budget.
-                if (stateByHash.TryGetValue(regionHash, out var state) && IsTerminal(state, maxAttempts))
+                // Skip only regions that are terminal AND (for 'extracted') whose produced chunk still
+                // exists — a chunk wiped by a reindex must be re-indexed below, not skipped.
+                stateByHash.TryGetValue(regionHash, out var state);
+                if (state is not null && IsTerminalAndLive(state, maxAttempts, liveChunkIds))
                 {
                     continue;
                 }
@@ -170,52 +191,82 @@ internal sealed class RunTableExtractionBatchCommandHandler
 
                 try
                 {
-                    if (!pdfBytesLoaded)
-                    {
-                        pdfBytes = await LoadPdfBytesAsync(pdf.Id, pdf.FilePath, cancellationToken).ConfigureAwait(false);
-                        pdfBytesLoaded = true;
-                    }
-                    if (pdfBytes is null)
-                    {
-                        _logger.LogWarning(
-                            "RunTableExtractionBatch: PDF {PdfId} binary not found in blob storage; skipping (will retry)",
-                            pdf.Id);
-                        outcome = await RecordFailureAsync(pdf.Id, region, regionHash, "pdf binary not found", maxAttempts, cancellationToken)
-                            .ConfigureAwait(false);
-                        failed++;
-                        break; // a missing blob affects every region of this PDF
-                    }
+                    string markdown;
+                    double? confidence;
+                    string? reason;
 
-                    var cropBytes = _cropper.CropRegion(
-                        pdfBytes, region.PageNumber, region.X, region.Y, region.Width, region.Height, cancellationToken);
-                    if (cropBytes is null)
+                    // Self-heal: an 'extracted' region whose chunk was wiped by a reindex still has the
+                    // cached markdown — re-index it WITHOUT re-running crop/VLM (cheap, correct on bulk
+                    // reindex where re-running the VLM over the whole corpus would be wasteful).
+                    if (state is not null
+                        && string.Equals(state.Status, PdfTableExtractionEntity.StatusExtracted, StringComparison.Ordinal)
+                        && !string.IsNullOrEmpty(state.TableMarkdown))
                     {
-                        outcome = await RecordFailureAsync(pdf.Id, region, regionHash, "region crop failed", maxAttempts, cancellationToken)
-                            .ConfigureAwait(false);
-                        failed++;
-                        continue;
+                        markdown = state.TableMarkdown!;
+                        confidence = state.Confidence;
+                        reason = state.Reason;
                     }
-
-                    var vlm = await _extractor.ExtractTableAsync(cropBytes, prefilter: null, cancellationToken).ConfigureAwait(false);
-
-                    if (!vlm.IsTable)
+                    else
                     {
-                        await MarkTerminalAsync(
-                            pdf.Id, region, regionHash, PdfTableExtractionEntity.StatusNotTable,
-                            markdown: null, confidence: vlm.Confidence, reason: vlm.Reason, textChunkId: null, cancellationToken)
-                            .ConfigureAwait(false);
-                        outcome = MeepleAiMetrics.TableVlmOutcomeNotTable;
-                        notTable++;
-                        continue;
+                        if (!pdfBytesLoaded)
+                        {
+                            pdfBytes = await LoadPdfBytesAsync(pdf.Id, pdf.FilePath, cancellationToken).ConfigureAwait(false);
+                            pdfBytesLoaded = true;
+                        }
+                        if (pdfBytes is null)
+                        {
+                            _logger.LogWarning(
+                                "RunTableExtractionBatch: PDF {PdfId} binary not found in blob storage; skipping (will retry)",
+                                pdf.Id);
+                            outcome = await RecordFailureAsync(pdf.Id, region, regionHash, "pdf binary not found", maxAttempts, cancellationToken)
+                                .ConfigureAwait(false);
+                            failed++;
+                            break; // a missing blob affects every region of this PDF
+                        }
+
+                        var cropBytes = _cropper.CropRegion(
+                            pdfBytes, region.PageNumber, region.X, region.Y, region.Width, region.Height, cancellationToken);
+                        if (cropBytes is null)
+                        {
+                            outcome = await RecordFailureAsync(pdf.Id, region, regionHash, "region crop failed", maxAttempts, cancellationToken)
+                                .ConfigureAwait(false);
+                            failed++;
+                            continue;
+                        }
+
+                        var vlm = await _extractor.ExtractTableAsync(cropBytes, prefilter: null, cancellationToken).ConfigureAwait(false);
+                        if (!vlm.IsTable)
+                        {
+                            await MarkTerminalAsync(
+                                pdf.Id, region, regionHash, PdfTableExtractionEntity.StatusNotTable,
+                                markdown: null, confidence: vlm.Confidence, reason: vlm.Reason, textChunkId: null, cancellationToken)
+                                .ConfigureAwait(false);
+                            outcome = MeepleAiMetrics.TableVlmOutcomeNotTable;
+                            notTable++;
+                            continue;
+                        }
+                        markdown = vlm.Markdown;
+                        confidence = vlm.Confidence;
+                        reason = vlm.Reason;
                     }
 
                     var chunkId = await _indexer.IndexTableAsync(
                         pdf, region.PageNumber, region.X, region.Y, region.Width, region.Height,
-                        vlm.Markdown, regionHash, cancellationToken).ConfigureAwait(false);
+                        markdown, regionHash, cancellationToken).ConfigureAwait(false);
+                    if (chunkId is null)
+                    {
+                        // Confirmed a table but not retrievable yet (no game / vector document) — a transient
+                        // condition, so retry (and eventually dead-letter), NEVER mark terminal 'extracted'.
+                        outcome = await RecordFailureAsync(
+                            pdf.Id, region, regionHash, "table not retrievable (no game/vector document)", maxAttempts, cancellationToken)
+                            .ConfigureAwait(false);
+                        failed++;
+                        continue;
+                    }
 
                     await MarkTerminalAsync(
                         pdf.Id, region, regionHash, PdfTableExtractionEntity.StatusExtracted,
-                        markdown: vlm.Markdown, confidence: vlm.Confidence, reason: vlm.Reason, textChunkId: chunkId, cancellationToken)
+                        markdown: markdown, confidence: confidence, reason: reason, textChunkId: chunkId, cancellationToken)
                         .ConfigureAwait(false);
                     outcome = MeepleAiMetrics.TableVlmOutcomeExtracted;
                     extracted++;
@@ -271,6 +322,22 @@ internal sealed class RunTableExtractionBatchCommandHandler
             or PdfTableExtractionEntity.StatusDeadLetter
         || (string.Equals(state.Status, PdfTableExtractionEntity.StatusFailed, StringComparison.Ordinal)
             && state.Attempts >= maxAttempts);
+
+    // A region is only truly done if it is terminal AND — when it is 'extracted' — its produced chunk
+    // still exists. A document reindex wipes text_chunks/embeddings without clearing this sidecar, so an
+    // 'extracted' row whose chunk is gone must be re-indexed rather than skipped (#3435 SP4 review).
+    private static bool IsTerminalAndLive(PdfTableExtractionEntity state, int maxAttempts, HashSet<Guid> liveChunkIds)
+    {
+        if (!IsTerminal(state, maxAttempts))
+        {
+            return false;
+        }
+        if (string.Equals(state.Status, PdfTableExtractionEntity.StatusExtracted, StringComparison.Ordinal))
+        {
+            return state.TextChunkId is Guid chunkId && liveChunkIds.Contains(chunkId);
+        }
+        return true; // not_table / dead_letter / failed-at-cap remain terminal
+    }
 
     private async Task MarkTerminalAsync(
         Guid pdfId, PdfImageRegionEntity region, string regionHash, string status,

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/RunTableExtractionBatchCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/RunTableExtractionBatchCommandHandler.cs
@@ -128,6 +128,7 @@ internal sealed class RunTableExtractionBatchCommandHandler
             var regions = await _dbContext.PdfImageRegions
                 .AsNoTracking()
                 .Where(r => r.PdfDocumentId == candidate.PdfDocumentId)
+                .OrderBy(r => r.PageNumber).ThenBy(r => r.Y).ThenBy(r => r.X)
                 .ToListAsync(cancellationToken)
                 .ConfigureAwait(false);
             if (regions.Count == 0)
@@ -299,11 +300,16 @@ internal sealed class RunTableExtractionBatchCommandHandler
                     // Isolate each region: detach any entity this item tracked/mutated so a failure
                     // can't be re-flushed by the next item's SaveChanges (#534 pattern).
                     _dbContext.ChangeTracker.Clear();
-                }
 
-                if (processed < regionBudget)
-                {
-                    await Task.Delay(delayMs, cancellationToken).ConfigureAwait(false);
+                    // Pace between regions HERE (in the finally) so it fires on EVERY outcome — the
+                    // not-table and not-retrievable `continue` paths above STILL called the VLM, so the
+                    // throttle must apply to them too, else a corpus of mostly-illustration regions
+                    // hammers the GPU inference service. recordMetric is false only on the cancellation
+                    // rethrow, where pacing must be skipped.
+                    if (recordMetric && processed < regionBudget)
+                    {
+                        await Task.Delay(delayMs, cancellationToken).ConfigureAwait(false);
+                    }
                 }
             }
         }
@@ -351,7 +357,7 @@ internal sealed class RunTableExtractionBatchCommandHandler
         entity.TextChunkId = textChunkId;
         entity.LastError = null;
         entity.UpdatedAt = DateTime.UtcNow;
-        await SaveSidecarAsync(pdfId, ct).ConfigureAwait(false);
+        await SaveMarkerStateAsync(pdfId, ct).ConfigureAwait(false);
     }
 
     private async Task<string> RecordFailureAsync(
@@ -365,7 +371,7 @@ internal sealed class RunTableExtractionBatchCommandHandler
         entity.Status = deadLettered
             ? PdfTableExtractionEntity.StatusDeadLetter
             : PdfTableExtractionEntity.StatusFailed;
-        await SaveSidecarAsync(pdfId, ct).ConfigureAwait(false);
+        await SaveFailureStateAsync(pdfId, ct).ConfigureAwait(false);
         return deadLettered
             ? MeepleAiMetrics.TableVlmOutcomeDeadLetter
             : MeepleAiMetrics.TableVlmOutcomeFailed;
@@ -401,7 +407,27 @@ internal sealed class RunTableExtractionBatchCommandHandler
         return entity;
     }
 
-    private async Task SaveSidecarAsync(Guid pdfId, CancellationToken ct)
+    // Terminal/marker write (extracted / not_table): swallows ONLY a concurrency conflict (benign —
+    // reconciled next run). Any OTHER DbUpdateException is deliberately NOT caught here — it propagates
+    // to the per-item catch -> RecordFailureAsync, so a PERSISTENT marker-save failure counts toward the
+    // retry cap and dead-letters, instead of re-cropping + re-VLM'ing the region forever tagged as if it
+    // succeeded (the asymmetry PR #3547 fixed in the SP1 sibling).
+    private async Task SaveMarkerStateAsync(Guid pdfId, CancellationToken ct)
+    {
+        try
+        {
+            await _dbContext.SaveChangesAsync(ct).ConfigureAwait(false);
+        }
+        catch (DbUpdateConcurrencyException ex)
+        {
+            _logger.LogWarning(ex,
+                "RunTableExtractionBatch: concurrency conflict persisting terminal state for PDF {PdfId}; deferred to next run", pdfId);
+        }
+    }
+
+    // Failure-recording write: per-item isolation — this must NEVER abort the batch, so swallow ANY save
+    // error. The attempt bump is lost and reconstructed on the next run (the region simply reprocesses).
+    private async Task SaveFailureStateAsync(Guid pdfId, CancellationToken ct)
     {
         try
         {
@@ -409,10 +435,8 @@ internal sealed class RunTableExtractionBatchCommandHandler
         }
         catch (DbUpdateException ex)
         {
-            // Per-item isolation: a sidecar write must never abort the batch. The state update is
-            // lost and reconstructed on the next run (the region simply reprocesses).
             _logger.LogWarning(ex,
-                "RunTableExtractionBatch: failed to persist table-extraction state for PDF {PdfId}", pdfId);
+                "RunTableExtractionBatch: failed to persist failure state for PDF {PdfId}", pdfId);
         }
     }
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/RunTableExtractionBatchCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/RunTableExtractionBatchCommandHandler.cs
@@ -1,0 +1,373 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Api.BoundedContexts.DocumentProcessing.Application.Queries;
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Observability;
+using Api.Services.Pdf;
+using Api.SharedKernel.Application.Interfaces;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Commands;
+
+/// <summary>
+/// #3435 (SP4): batch runner for the async VLM table-extraction pass. Consumes SP2's router to pick
+/// candidate PDFs, then for each PENDING image region: renders + crops the page (Docnet/SkiaSharp),
+/// posts the crop to the smoldocling crop-discriminator, and — for OTSL tables — persists a
+/// retrievable table chunk. Per-region state (idempotency + retry-cap/dead-letter) lives in
+/// <c>pdf_table_extractions</c>, keyed by a bbox-stable region hash. Mirrors the batch/isolation
+/// pattern of <see cref="RunImageRegionSeedBatchCommandHandler"/> (per-item try/catch-continue +
+/// <c>ChangeTracker.Clear()</c>). Flag-gated by <c>PdfProcessing:TableExtraction:Enabled</c>.
+/// </summary>
+internal sealed class RunTableExtractionBatchCommandHandler
+    : ICommandHandler<RunTableExtractionBatchCommand, RunTableExtractionBatchResult>
+{
+    internal const int DefaultBatchSize = 10;
+    internal const int DefaultDelayBetweenItemsMs = 200;
+    /// <summary>Failed VLM attempts on one region before it is dead-lettered (excluded from the selector).</summary>
+    internal const int DefaultMaxAttempts = 3;
+    internal const string EnabledConfigKey = "PdfProcessing:TableExtraction:Enabled";
+    internal const string BatchSizeConfigKey = "PdfProcessing:TableExtraction:BatchSize";
+    internal const string DelayMsConfigKey = "PdfProcessing:TableExtraction:DelayMs";
+    internal const string MaxAttemptsConfigKey = "PdfProcessing:TableExtraction:MaxAttempts";
+
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly IMediator _mediator;
+    private readonly IPdfRegionCropper _cropper;
+    private readonly ISmolDoclingTableExtractor _extractor;
+    private readonly ITableChunkIndexer _indexer;
+    private readonly IBlobStorageService _blobStorage;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<RunTableExtractionBatchCommandHandler> _logger;
+
+    public RunTableExtractionBatchCommandHandler(
+        MeepleAiDbContext dbContext,
+        IMediator mediator,
+        IPdfRegionCropper cropper,
+        ISmolDoclingTableExtractor extractor,
+        ITableChunkIndexer indexer,
+        IBlobStorageService blobStorage,
+        IConfiguration configuration,
+        ILogger<RunTableExtractionBatchCommandHandler> logger)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+        _cropper = cropper ?? throw new ArgumentNullException(nameof(cropper));
+        _extractor = extractor ?? throw new ArgumentNullException(nameof(extractor));
+        _indexer = indexer ?? throw new ArgumentNullException(nameof(indexer));
+        _blobStorage = blobStorage ?? throw new ArgumentNullException(nameof(blobStorage));
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<RunTableExtractionBatchResult> Handle(
+        RunTableExtractionBatchCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        if (!_configuration.GetValue<bool>(EnabledConfigKey))
+        {
+            _logger.LogInformation(
+                "RunTableExtractionBatch skipped: feature flag '{Flag}' is disabled", EnabledConfigKey);
+            return new RunTableExtractionBatchResult(Enabled: false, Processed: 0, Extracted: 0, NotTable: 0, Failed: 0);
+        }
+
+        var regionBudget = command.BatchSize
+            ?? _configuration.GetValue<int?>(BatchSizeConfigKey)
+            ?? DefaultBatchSize;
+        if (regionBudget < 1)
+        {
+            regionBudget = DefaultBatchSize;
+        }
+        var delayMs = _configuration.GetValue<int?>(DelayMsConfigKey) ?? DefaultDelayBetweenItemsMs;
+        var maxAttempts = _configuration.GetValue<int?>(MaxAttemptsConfigKey) ?? DefaultMaxAttempts;
+
+        // Consume SP2's router (its own eligibility + threshold config) to pick candidate PDFs.
+        var candidates = await _mediator
+            .Send(new GetTableRegionCandidatesQuery(), cancellationToken)
+            .ConfigureAwait(false);
+        if (candidates.Count == 0)
+        {
+            _logger.LogDebug("RunTableExtractionBatch: no candidate PDFs from the table-region router");
+            return new RunTableExtractionBatchResult(Enabled: true, Processed: 0, Extracted: 0, NotTable: 0, Failed: 0);
+        }
+
+        var processed = 0;
+        var extracted = 0;
+        var notTable = 0;
+        var failed = 0;
+
+        foreach (var candidate in candidates)
+        {
+            if (processed >= regionBudget)
+            {
+                break;
+            }
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Load PDF context (NoTracking — the indexer reads it, nothing mutates it) + its regions
+            // and the already-recorded extraction states for this PDF.
+            var pdf = await _dbContext.PdfDocuments
+                .AsNoTracking()
+                .FirstOrDefaultAsync(p => p.Id == candidate.PdfDocumentId, cancellationToken)
+                .ConfigureAwait(false);
+            if (pdf is null)
+            {
+                continue;
+            }
+
+            var regions = await _dbContext.PdfImageRegions
+                .AsNoTracking()
+                .Where(r => r.PdfDocumentId == candidate.PdfDocumentId)
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+            if (regions.Count == 0)
+            {
+                continue;
+            }
+
+            var states = await _dbContext.PdfTableExtractions
+                .AsNoTracking()
+                .Where(e => e.PdfDocumentId == candidate.PdfDocumentId)
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+            // Region hashes are unique per (pdf, region) via the ux_pdf_table_extractions_pdf_region
+            // unique index, so a plain keyed dictionary is safe.
+            var stateByHash = states.ToDictionary(s => s.RegionHash, StringComparer.Ordinal);
+
+            byte[]? pdfBytes = null;
+            var pdfBytesLoaded = false;
+
+            foreach (var region in regions)
+            {
+                if (processed >= regionBudget)
+                {
+                    break;
+                }
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var regionHash = TableRegionKey.ComputeRegionHash(
+                    pdf.Id, region.PageNumber, region.X, region.Y, region.Width, region.Height);
+
+                // Skip regions already in a terminal state or that exhausted their retry budget.
+                if (stateByHash.TryGetValue(regionHash, out var state) && IsTerminal(state, maxAttempts))
+                {
+                    continue;
+                }
+
+                processed++;
+                var outcome = MeepleAiMetrics.TableVlmOutcomeFailed;
+                var recordMetric = true;
+
+                try
+                {
+                    if (!pdfBytesLoaded)
+                    {
+                        pdfBytes = await LoadPdfBytesAsync(pdf.Id, pdf.FilePath, cancellationToken).ConfigureAwait(false);
+                        pdfBytesLoaded = true;
+                    }
+                    if (pdfBytes is null)
+                    {
+                        _logger.LogWarning(
+                            "RunTableExtractionBatch: PDF {PdfId} binary not found in blob storage; skipping (will retry)",
+                            pdf.Id);
+                        outcome = await RecordFailureAsync(pdf.Id, region, regionHash, "pdf binary not found", maxAttempts, cancellationToken)
+                            .ConfigureAwait(false);
+                        failed++;
+                        break; // a missing blob affects every region of this PDF
+                    }
+
+                    var cropBytes = _cropper.CropRegion(
+                        pdfBytes, region.PageNumber, region.X, region.Y, region.Width, region.Height, cancellationToken);
+                    if (cropBytes is null)
+                    {
+                        outcome = await RecordFailureAsync(pdf.Id, region, regionHash, "region crop failed", maxAttempts, cancellationToken)
+                            .ConfigureAwait(false);
+                        failed++;
+                        continue;
+                    }
+
+                    var vlm = await _extractor.ExtractTableAsync(cropBytes, prefilter: null, cancellationToken).ConfigureAwait(false);
+
+                    if (!vlm.IsTable)
+                    {
+                        await MarkTerminalAsync(
+                            pdf.Id, region, regionHash, PdfTableExtractionEntity.StatusNotTable,
+                            markdown: null, confidence: vlm.Confidence, reason: vlm.Reason, textChunkId: null, cancellationToken)
+                            .ConfigureAwait(false);
+                        outcome = MeepleAiMetrics.TableVlmOutcomeNotTable;
+                        notTable++;
+                        continue;
+                    }
+
+                    var chunkId = await _indexer.IndexTableAsync(
+                        pdf, region.PageNumber, region.X, region.Y, region.Width, region.Height,
+                        vlm.Markdown, regionHash, cancellationToken).ConfigureAwait(false);
+
+                    await MarkTerminalAsync(
+                        pdf.Id, region, regionHash, PdfTableExtractionEntity.StatusExtracted,
+                        markdown: vlm.Markdown, confidence: vlm.Confidence, reason: vlm.Reason, textChunkId: chunkId, cancellationToken)
+                        .ConfigureAwait(false);
+                    outcome = MeepleAiMetrics.TableVlmOutcomeExtracted;
+                    extracted++;
+                    _logger.LogInformation(
+                        "RunTableExtractionBatch: extracted table for PDF {PdfId} page {Page} (chunk {ChunkId})",
+                        pdf.Id, region.PageNumber, chunkId);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    recordMetric = false;
+                    throw;
+                }
+#pragma warning disable CA1031 // Do not catch general exception types
+                catch (Exception ex)
+#pragma warning restore CA1031
+                {
+                    _logger.LogWarning(ex,
+                        "RunTableExtractionBatch: table extraction failed for PDF {PdfId} page {Page}; skipping (will retry)",
+                        pdf.Id, region.PageNumber);
+                    outcome = await RecordFailureAsync(pdf.Id, region, regionHash, ex.Message, maxAttempts, cancellationToken)
+                        .ConfigureAwait(false);
+                    failed++;
+                }
+                finally
+                {
+                    if (recordMetric)
+                    {
+                        MeepleAiMetrics.RecordTableVlm(outcome);
+                    }
+                    // Isolate each region: detach any entity this item tracked/mutated so a failure
+                    // can't be re-flushed by the next item's SaveChanges (#534 pattern).
+                    _dbContext.ChangeTracker.Clear();
+                }
+
+                if (processed < regionBudget)
+                {
+                    await Task.Delay(delayMs, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+
+        _logger.LogInformation(
+            "RunTableExtractionBatch complete: processed={Processed}, extracted={Extracted}, notTable={NotTable}, failed={Failed}",
+            processed, extracted, notTable, failed);
+
+        return new RunTableExtractionBatchResult(
+            Enabled: true, Processed: processed, Extracted: extracted, NotTable: notTable, Failed: failed);
+    }
+
+    private static bool IsTerminal(PdfTableExtractionEntity state, int maxAttempts) =>
+        state.Status is PdfTableExtractionEntity.StatusExtracted
+            or PdfTableExtractionEntity.StatusNotTable
+            or PdfTableExtractionEntity.StatusDeadLetter
+        || (string.Equals(state.Status, PdfTableExtractionEntity.StatusFailed, StringComparison.Ordinal)
+            && state.Attempts >= maxAttempts);
+
+    private async Task MarkTerminalAsync(
+        Guid pdfId, PdfImageRegionEntity region, string regionHash, string status,
+        string? markdown, double? confidence, string? reason, Guid? textChunkId, CancellationToken ct)
+    {
+        var entity = await LoadOrCreateTrackedAsync(pdfId, region, regionHash, ct).ConfigureAwait(false);
+        entity.Status = status;
+        entity.TableMarkdown = markdown;
+        entity.Confidence = confidence;
+        entity.Reason = Truncate(reason, 32);
+        entity.TextChunkId = textChunkId;
+        entity.LastError = null;
+        entity.UpdatedAt = DateTime.UtcNow;
+        await SaveSidecarAsync(pdfId, ct).ConfigureAwait(false);
+    }
+
+    private async Task<string> RecordFailureAsync(
+        Guid pdfId, PdfImageRegionEntity region, string regionHash, string error, int maxAttempts, CancellationToken ct)
+    {
+        var entity = await LoadOrCreateTrackedAsync(pdfId, region, regionHash, ct).ConfigureAwait(false);
+        entity.Attempts += 1;
+        entity.LastError = Truncate(error, 500);
+        entity.UpdatedAt = DateTime.UtcNow;
+        var deadLettered = entity.Attempts >= maxAttempts;
+        entity.Status = deadLettered
+            ? PdfTableExtractionEntity.StatusDeadLetter
+            : PdfTableExtractionEntity.StatusFailed;
+        await SaveSidecarAsync(pdfId, ct).ConfigureAwait(false);
+        return deadLettered
+            ? MeepleAiMetrics.TableVlmOutcomeDeadLetter
+            : MeepleAiMetrics.TableVlmOutcomeFailed;
+    }
+
+    private async Task<PdfTableExtractionEntity> LoadOrCreateTrackedAsync(
+        Guid pdfId, PdfImageRegionEntity region, string regionHash, CancellationToken ct)
+    {
+        // Start from a clean tracker so this write never re-flushes a prior item's pending changes.
+        _dbContext.ChangeTracker.Clear();
+        var entity = await _dbContext.PdfTableExtractions
+            .AsTracking()
+            .FirstOrDefaultAsync(e => e.PdfDocumentId == pdfId && e.RegionHash == regionHash, ct)
+            .ConfigureAwait(false);
+        if (entity is null)
+        {
+            entity = new PdfTableExtractionEntity
+            {
+                Id = Guid.NewGuid(),
+                PdfDocumentId = pdfId,
+                RegionHash = regionHash,
+                PageNumber = region.PageNumber,
+                X = region.X,
+                Y = region.Y,
+                Width = region.Width,
+                Height = region.Height,
+                Status = PdfTableExtractionEntity.StatusPending,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+            };
+            _dbContext.PdfTableExtractions.Add(entity);
+        }
+        return entity;
+    }
+
+    private async Task SaveSidecarAsync(Guid pdfId, CancellationToken ct)
+    {
+        try
+        {
+            await _dbContext.SaveChangesAsync(ct).ConfigureAwait(false);
+        }
+        catch (DbUpdateException ex)
+        {
+            // Per-item isolation: a sidecar write must never abort the batch. The state update is
+            // lost and reconstructed on the next run (the region simply reprocesses).
+            _logger.LogWarning(ex,
+                "RunTableExtractionBatch: failed to persist table-extraction state for PDF {PdfId}", pdfId);
+        }
+    }
+
+    // Mirror of RunImageRegionSeedBatchCommandHandler.LoadPdfBytesAsync (R2/blob-only; #2671).
+    private async Task<byte[]?> LoadPdfBytesAsync(Guid pdfId, string filePath, CancellationToken ct)
+    {
+        var resourceKey = PdfStorageKey.ForPdf(pdfId);
+        var fileId = PdfStorageKey.FileIdFromPath(filePath) ?? resourceKey;
+        var stream = await _blobStorage.RetrieveAsync(fileId, BlobCategory.Pdf, resourceKey, ct).ConfigureAwait(false);
+        if (stream is null)
+        {
+            return null;
+        }
+
+        await using (stream.ConfigureAwait(false))
+        {
+            using var memoryStream = new MemoryStream();
+            await stream.CopyToAsync(memoryStream, ct).ConfigureAwait(false);
+            return memoryStream.ToArray();
+        }
+    }
+
+    private static string? Truncate(string? value, int max) =>
+        value is null || value.Length <= max ? value : value[..max];
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/RunTableExtractionJob.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/RunTableExtractionJob.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Threading.Tasks;
+using Api.BoundedContexts.DocumentProcessing.Application.Commands;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Quartz;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Jobs;
+
+/// <summary>
+/// #3435 (SP4): periodic Quartz trigger for the async VLM table-extraction batch. Thin dispatcher —
+/// resolves <see cref="IMediator"/> in a scope, sends <see cref="RunTableExtractionBatchCommand"/>,
+/// and swallows non-cancellation exceptions so a transient failure doesn't suspend the trigger. A
+/// cheap no-op (one config check) while <c>PdfProcessing:TableExtraction:Enabled</c> is off. Mirrors
+/// <see cref="SeedImageRegionsJob"/>.
+/// </summary>
+[DisallowConcurrentExecution]
+public sealed class RunTableExtractionJob : IJob
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<RunTableExtractionJob> _logger;
+
+    public RunTableExtractionJob(IServiceProvider serviceProvider, ILogger<RunTableExtractionJob> logger)
+    {
+        _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Execute(IJobExecutionContext context)
+    {
+        var ct = context.CancellationToken;
+        try
+        {
+            using var scope = _serviceProvider.CreateScope();
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+            var result = await mediator.Send(new RunTableExtractionBatchCommand(), ct).ConfigureAwait(false);
+            if (result.Enabled && (result.Processed > 0 || result.Failed > 0))
+            {
+                _logger.LogInformation(
+                    "RunTableExtractionJob: processed={Processed}, extracted={Extracted}, notTable={NotTable}, failed={Failed}",
+                    result.Processed, result.Extracted, result.NotTable, result.Failed);
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+#pragma warning disable CA1031 // Do not catch general exception types
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            _logger.LogError(ex, "RunTableExtractionJob failed; will retry on the next trigger");
+        }
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/IPdfRegionCropper.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/IPdfRegionCropper.cs
@@ -1,0 +1,25 @@
+using System.Threading;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Services;
+
+/// <summary>
+/// #3435 (SP4): renders a specific PDF page and crops a normalized [0,1] top-left region to a PNG,
+/// so the VLM crop-discriminator receives just the table graphic. Docnet.Core (PDFium) render +
+/// SkiaSharp crop/encode, mirroring <see cref="PdfCoverExtractor"/>.
+/// </summary>
+public interface IPdfRegionCropper
+{
+    /// <summary>
+    /// Crop the region <c>[x, y, width, height]</c> (normalized [0,1] top-left) from the 1-based
+    /// <paramref name="pageNumber"/> of the PDF. Returns PNG bytes, or <c>null</c> when the page or
+    /// region is out of range, the crop is degenerate, or rendering fails.
+    /// </summary>
+    byte[]? CropRegion(
+        byte[] pdfBytes,
+        int pageNumber,
+        double x,
+        double y,
+        double width,
+        double height,
+        CancellationToken cancellationToken);
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/ISmolDoclingTableExtractor.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/ISmolDoclingTableExtractor.cs
@@ -1,0 +1,31 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Services;
+
+/// <summary>
+/// #3435 (SP4): client for the smoldocling crop-discriminator endpoint
+/// <c>POST /api/v1/extract-image</c>. Sends one pre-cropped image region and reports whether it
+/// is a table plus the rebuilt markdown and diagnostic fields.
+/// </summary>
+public interface ISmolDoclingTableExtractor
+{
+    /// <summary>
+    /// Discriminate a single crop. <paramref name="prefilter"/> overrides the service's colorfulness
+    /// pre-filter (null = service default). The endpoint degrades a non-table / init failure to a
+    /// 200 with <c>is_table=false</c> (R5), so a thrown exception here is a genuine transport/5xx error.
+    /// </summary>
+    Task<CropTableExtractionResult> ExtractTableAsync(
+        byte[] cropImage,
+        bool? prefilter,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>Result of <c>POST /api/v1/extract-image</c> for one crop.</summary>
+public sealed record CropTableExtractionResult(
+    bool IsTable,
+    string Reason,
+    string Markdown,
+    double Confidence,
+    bool Prefiltered,
+    bool Degenerated);

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/ITableChunkIndexer.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/ITableChunkIndexer.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Api.Infrastructure.Entities;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Services;
+
+/// <summary>
+/// #3435 SP4: persists an extracted table as a retrievable, citation-groundable RAG chunk
+/// (a <c>text_chunks</c> row + a <c>pgvector_embeddings</c> row wired via <c>source_chunk_id</c>).
+/// The region bbox is carried on the chunk's <c>bounding_boxes_json</c> so the citation draws the
+/// table region; copyright tier is inherited from the parent PDF (Full-gated at answer time).
+/// </summary>
+public interface ITableChunkIndexer
+{
+    /// <summary>
+    /// Upsert a table chunk for one image region. Idempotent by the deterministic chunk id derived
+    /// from <paramref name="regionHash"/> (re-indexing replaces that chunk + its embedding, never the
+    /// document's narrative chunks). Returns the text-chunk id, or <c>null</c> when the PDF has no
+    /// game / vector document (not retrievable). Throws on a transient failure (embedding / index) so
+    /// the caller can retry.
+    /// </summary>
+    Task<Guid?> IndexTableAsync(
+        PdfDocumentEntity pdf,
+        int pageNumber,
+        double x,
+        double y,
+        double width,
+        double height,
+        string markdown,
+        string regionHash,
+        CancellationToken cancellationToken);
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfRegionCropper.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfRegionCropper.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Docnet.Core;
+using Docnet.Core.Models;
+using Microsoft.Extensions.Logging;
+using SkiaSharp;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Services;
+
+/// <summary>
+/// <see cref="IPdfRegionCropper"/> implementation using Docnet.Core (PDFium wrapper) to rasterise
+/// an arbitrary page and SkiaSharp to crop the region + encode PNG. Same rendering primitives as
+/// <see cref="PdfCoverExtractor"/>; the region bbox is a fraction of the page so any render
+/// resolution yields the correct crop (the bbox is DPI-independent).
+/// </summary>
+internal sealed class PdfRegionCropper : IPdfRegionCropper
+{
+    // Native-size scale factor for rendering. 150/72 ≈ 2.08 gives ~150 DPI — enough detail for the
+    // VLM to read a table crop without oversizing the raster.
+    private const double DefaultRenderScale = 150.0 / 72.0;
+
+    private readonly double _renderScale;
+    private readonly ILogger<PdfRegionCropper> _logger;
+
+    public PdfRegionCropper(ILogger<PdfRegionCropper> logger, double renderScale = DefaultRenderScale)
+    {
+        _logger = logger;
+        _renderScale = renderScale <= 0 ? DefaultRenderScale : renderScale;
+    }
+
+    public byte[]? CropRegion(
+        byte[] pdfBytes,
+        int pageNumber,
+        double x,
+        double y,
+        double width,
+        double height,
+        CancellationToken cancellationToken)
+    {
+        if (pdfBytes is null || pdfBytes.Length == 0)
+        {
+            return null;
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        try
+        {
+            using var docReader = DocLib.Instance.GetDocReader(pdfBytes, new PageDimensions(_renderScale));
+            var pageCount = docReader.GetPageCount();
+            var pageIndex = pageNumber - 1; // region PageNumber is 1-based; Docnet is 0-based
+            if (pageIndex < 0 || pageIndex >= pageCount)
+            {
+                _logger.LogWarning(
+                    "PdfRegionCropper: page {Page} out of range (pageCount={Count})", pageNumber, pageCount);
+                return null;
+            }
+
+            using var pageReader = docReader.GetPageReader(pageIndex);
+            var renderWidth = pageReader.GetPageWidth();
+            var renderHeight = pageReader.GetPageHeight();
+            if (renderWidth <= 0 || renderHeight <= 0)
+            {
+                return null;
+            }
+
+            // Region [0,1] top-left -> pixel rect, clamped to the rendered page (no Y-flip).
+            var left = (int)Math.Round(Math.Clamp(x, 0d, 1d) * renderWidth);
+            var top = (int)Math.Round(Math.Clamp(y, 0d, 1d) * renderHeight);
+            var right = (int)Math.Round(Math.Clamp(x + width, 0d, 1d) * renderWidth);
+            var bottom = (int)Math.Round(Math.Clamp(y + height, 0d, 1d) * renderHeight);
+            var cropWidth = right - left;
+            var cropHeight = bottom - top;
+            if (cropWidth <= 0 || cropHeight <= 0)
+            {
+                _logger.LogWarning(
+                    "PdfRegionCropper: degenerate crop rect ({Width}x{Height}) on page {Page}",
+                    cropWidth, cropHeight, pageNumber);
+                return null;
+            }
+
+            var rawBgra = pageReader.GetImage();
+
+            using var pageBitmap = new SKBitmap(renderWidth, renderHeight, SKColorType.Bgra8888, SKAlphaType.Premul);
+            Marshal.Copy(rawBgra, 0, pageBitmap.GetPixels(), rawBgra.Length);
+
+            using var cropBitmap = new SKBitmap(cropWidth, cropHeight, SKColorType.Bgra8888, SKAlphaType.Premul);
+            if (!pageBitmap.ExtractSubset(cropBitmap, new SKRectI(left, top, right, bottom)))
+            {
+                _logger.LogWarning("PdfRegionCropper: ExtractSubset failed on page {Page}", pageNumber);
+                return null;
+            }
+
+            using var image = SKImage.FromBitmap(cropBitmap);
+            using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+            return data.ToArray();
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "PdfRegionCropper: crop failed on page {Page}", pageNumber);
+            return null;
+        }
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/TableRegionKey.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/TableRegionKey.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Services;
+
+/// <summary>
+/// #3435 SP4 idempotency keys. The image-region row id is regenerated on every replace-by-pdf
+/// re-seed, so per-region state is keyed on a deterministic hash of (pdf, page, quantized bbox)
+/// instead — stable as long as the bbox values are, and independent of the row id. The table
+/// chunk's id is derived from the same hash so re-indexing a region replaces its one chunk.
+/// </summary>
+public static class TableRegionKey
+{
+    /// <summary>Deterministic hex hash over (pdf, page, bbox quantized to 1e-4). 64 chars.</summary>
+    public static string ComputeRegionHash(Guid pdfId, int page, double x, double y, double width, double height)
+    {
+        static long Q(double v) => (long)Math.Round(Math.Clamp(v, 0d, 1d) * 10000d);
+        var raw = $"{pdfId:N}:{page}:{Q(x)}:{Q(y)}:{Q(width)}:{Q(height)}";
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(raw));
+        return Convert.ToHexString(bytes);
+    }
+
+    /// <summary>Deterministic table-chunk Guid derived from the region hash (idempotent upsert key).</summary>
+    public static Guid ChunkIdFromRegionHash(string regionHash)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes("table-chunk:" + regionHash));
+        return new Guid(bytes.AsSpan(0, 16).ToArray());
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/DependencyInjection/DocumentProcessingServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/DependencyInjection/DocumentProcessingServiceExtensions.cs
@@ -166,6 +166,18 @@ internal static class DocumentProcessingServiceExtensions
 
         services.AddScoped<IPhotoPreprocessor, SmoldoclingPhotoPreprocessor>();
 
+        // #3435 (SP4): smoldocling crop-discriminator client for POST /api/v1/extract-image (same
+        // app as the SmolDocling extractor, :8002). No Polly — a single crop is quick and the endpoint
+        // itself degrades init/non-table failures to a 200 (R5).
+        services.AddHttpClient(SmoldoclingTableExtractor.NamedClientKey, client =>
+        {
+            var baseUrl = configuration["PdfProcessing:Extractor:SmolDocling:ApiUrl"] ?? "http://smoldocling-service:8002";
+            client.BaseAddress = new Uri(baseUrl);
+            var timeoutSeconds = configuration.GetValue<int?>("PdfProcessing:TableExtraction:VlmTimeoutSeconds") ?? 120;
+            client.Timeout = TimeSpan.FromSeconds(timeoutSeconds);
+        });
+        services.AddScoped<ISmolDoclingTableExtractor, SmoldoclingTableExtractor>();
+
         // Libro Game AI Assistant MVP Phase 2 — Task 2.3a: KB Indexing Services
         services.AddScoped<IDocumentChunker, PageTextChunker>();
         services.AddScoped<IKnowledgeBaseIndexer, KnowledgeBaseIndexer>();
@@ -183,6 +195,10 @@ internal static class DocumentProcessingServiceExtensions
 
         // Issue #1831 (umbrella #1821 L4) — PDF first-page cover extraction
         services.AddScoped<IPdfCoverExtractor, PdfCoverExtractor>();
+
+        // #3435 (SP4): async VLM table-extraction — arbitrary-page region crop + RAG table-chunk indexing.
+        services.AddScoped<IPdfRegionCropper, PdfRegionCropper>();
+        services.AddScoped<ITableChunkIndexer, TableChunkIndexer>();
 
         // Cover-da-PDF plan Task 3 — MaterializePdfCover R2 upload pipeline.
         // Singleton because the underlying AmazonS3Client is thread-safe and
@@ -225,6 +241,9 @@ internal static class DocumentProcessingServiceExtensions
         // Issue #3435 (SP1 slice 2): Register Quartz job for the automatic image-region hi_res seed.
         RegisterSeedImageRegionsJob(services, configuration);
 
+        // Issue #3435 (SP4): Register Quartz job for the async VLM table-extraction pass.
+        RegisterTableExtractionJob(services, configuration);
+
         return services;
     }
 
@@ -259,6 +278,39 @@ internal static class DocumentProcessingServiceExtensions
                     .WithIntervalInMinutes(intervalMinutes)
                     .RepeatForever())
                 .WithDescription("Runs the automatic image-region hi_res seed batch (#3435, flag-gated)")
+            );
+        });
+    }
+
+    /// <summary>
+    /// #3435 (SP4) — registers <see cref="Api.BoundedContexts.DocumentProcessing.Application.Jobs.RunTableExtractionJob"/>
+    /// with Quartz. Runs every <c>PdfProcessing:TableExtraction:IntervalMinutes</c> (default 30) to drive
+    /// the async VLM table-extraction batch. The command handler is gated by
+    /// <c>PdfProcessing:TableExtraction:Enabled</c> (default false), so the job is a cheap no-op (one
+    /// config check) until the feature is turned on per-environment.
+    /// </summary>
+    private static void RegisterTableExtractionJob(IServiceCollection services, IConfiguration configuration)
+    {
+        var intervalMinutes = configuration.GetValue<int?>("PdfProcessing:TableExtraction:IntervalMinutes") ?? 30;
+        if (intervalMinutes < 1)
+        {
+            intervalMinutes = 30;
+        }
+
+        services.AddQuartz(q =>
+        {
+            var jobKey = new Quartz.JobKey("RunTableExtractionJob", "DocumentProcessing");
+
+            q.AddJob<Api.BoundedContexts.DocumentProcessing.Application.Jobs.RunTableExtractionJob>(opts =>
+                opts.WithIdentity(jobKey));
+
+            q.AddTrigger(opts => opts
+                .ForJob(jobKey)
+                .WithIdentity("RunTableExtractionTrigger", "DocumentProcessing")
+                .WithSimpleSchedule(x => x
+                    .WithIntervalInMinutes(intervalMinutes)
+                    .RepeatForever())
+                .WithDescription("Runs the async VLM table-extraction batch (#3435 SP4, flag-gated)")
             );
         });
     }

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/SmoldoclingTableExtractor.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/SmoldoclingTableExtractor.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.DocumentProcessing.Infrastructure.Services;
+
+/// <summary>
+/// HTTP client adapter for the smoldocling <c>POST /api/v1/extract-image</c> crop-discriminator
+/// (#3435 SP4). Sends one PNG crop as multipart form data and maps the snake_case JSON response to
+/// <see cref="CropTableExtractionResult"/>. Named client <see cref="NamedClientKey"/> (registered in
+/// <c>DocumentProcessingServiceExtensions</c>). Mirrors <see cref="SmoldoclingPhotoPreprocessor"/>.
+/// </summary>
+internal sealed class SmoldoclingTableExtractor : ISmolDoclingTableExtractor
+{
+    public const string NamedClientKey = "smoldocling-table-extractor";
+    private const string ExtractImageEndpoint = "/api/v1/extract-image";
+
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<SmoldoclingTableExtractor> _logger;
+
+    public SmoldoclingTableExtractor(
+        IHttpClientFactory factory,
+        ILogger<SmoldoclingTableExtractor> logger)
+    {
+        _httpClient = factory.CreateClient(NamedClientKey);
+        _logger = logger;
+    }
+
+    public async Task<CropTableExtractionResult> ExtractTableAsync(
+        byte[] cropImage,
+        bool? prefilter,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(cropImage);
+
+        using var content = new MultipartFormDataContent();
+        var imageContent = new ByteArrayContent(cropImage);
+        imageContent.Headers.ContentType = new MediaTypeHeaderValue("image/png");
+        content.Add(imageContent, "image", "crop.png");
+        if (prefilter.HasValue)
+        {
+            content.Add(new StringContent(prefilter.Value ? "true" : "false"), "prefilter");
+        }
+
+        try
+        {
+            var response = await _httpClient
+                .PostAsync(ExtractImageEndpoint, content, cancellationToken)
+                .ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+
+            var dto = await response.Content
+                .ReadFromJsonAsync<ExtractImageDto>(cancellationToken: cancellationToken)
+                .ConfigureAwait(false)
+                ?? throw new InvalidOperationException("Empty response from smoldocling extract-image endpoint.");
+
+            return new CropTableExtractionResult(
+                IsTable: dto.IsTable,
+                Reason: dto.Reason ?? string.Empty,
+                Markdown: dto.Markdown ?? string.Empty,
+                Confidence: dto.Confidence,
+                Prefiltered: dto.Prefiltered,
+                Degenerated: dto.Degenerated);
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "smoldocling extract-image request failed (endpoint: {Endpoint})", ExtractImageEndpoint);
+            throw;
+        }
+    }
+
+    /// <summary>JSON contract for the smoldocling /api/v1/extract-image response (snake_case).</summary>
+    private sealed record ExtractImageDto(
+        [property: JsonPropertyName("is_table")] bool IsTable,
+        [property: JsonPropertyName("reason")] string? Reason,
+        [property: JsonPropertyName("markdown")] string? Markdown,
+        [property: JsonPropertyName("confidence")] double Confidence,
+        [property: JsonPropertyName("prefiltered")] bool Prefiltered,
+        [property: JsonPropertyName("degenerated")] bool Degenerated);
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/TableChunkIndexer.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/TableChunkIndexer.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ChunkingModels = Api.BoundedContexts.KnowledgeBase.Domain.Chunking;
+using KbEntities = Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using KbValueObjects = Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+
+namespace Api.BoundedContexts.DocumentProcessing.Infrastructure.Services;
+
+/// <summary>
+/// <see cref="ITableChunkIndexer"/> implementation. Mirrors the retrievable-chunk contract of
+/// <c>PdfProcessingPipelineService.IndexInVectorStoreAsync</c>: a <c>text_chunks</c> row (with the
+/// region bbox) plus a <c>pgvector_embeddings</c> row whose <c>source_chunk_id</c> points back to it
+/// (the JOIN that carries the bbox into the citation). Appends the table chunk after the PDF's
+/// narrative chunks and scopes idempotency to the single region (never the delete-all-per-pdf path).
+/// </summary>
+internal sealed class TableChunkIndexer : ITableChunkIndexer
+{
+    private const string TableElementType = "Table";
+
+    private readonly MeepleAiDbContext _db;
+    private readonly IEmbeddingService _embeddingService;
+    private readonly IVectorStoreAdapter _vectorStore;
+    private readonly ILogger<TableChunkIndexer> _logger;
+
+    public TableChunkIndexer(
+        MeepleAiDbContext db,
+        IEmbeddingService embeddingService,
+        IVectorStoreAdapter vectorStore,
+        ILogger<TableChunkIndexer> logger)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _embeddingService = embeddingService ?? throw new ArgumentNullException(nameof(embeddingService));
+        _vectorStore = vectorStore ?? throw new ArgumentNullException(nameof(vectorStore));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<Guid?> IndexTableAsync(
+        PdfDocumentEntity pdf,
+        int pageNumber,
+        double x,
+        double y,
+        double width,
+        double height,
+        string markdown,
+        string regionHash,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(pdf);
+
+        // pgvector game scoping: mirror IndexInVectorStoreAsync (PrivateGameId ?? SharedGameId).
+        var gameId = pdf.PrivateGameId ?? pdf.SharedGameId ?? Guid.Empty;
+        if (gameId == Guid.Empty)
+        {
+            _logger.LogWarning(
+                "TableChunkIndexer: PDF {PdfId} has no game; table not retrievable, skipping index", pdf.Id);
+            return null;
+        }
+
+        var vectorDoc = await _db.VectorDocuments
+            .AsNoTracking()
+            .FirstOrDefaultAsync(v => v.PdfDocumentId == pdf.Id, cancellationToken)
+            .ConfigureAwait(false);
+        if (vectorDoc is null)
+        {
+            _logger.LogWarning(
+                "TableChunkIndexer: PDF {PdfId} has no vector document; skipping index", pdf.Id);
+            return null;
+        }
+
+        // Embed FIRST so a transient embedding failure can't leave a half-written chunk.
+        var embedResult = await _embeddingService
+            .GenerateEmbeddingAsync(markdown, cancellationToken)
+            .ConfigureAwait(false);
+        if (!embedResult.Success || embedResult.Embeddings.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"Embedding generation failed for table chunk (pdf {pdf.Id}): {embedResult.ErrorMessage ?? "no vector returned"}");
+        }
+        var vector = embedResult.Embeddings[0];
+
+        var chunkId = TableRegionKey.ChunkIdFromRegionHash(regionHash);
+        var resolvedGameId = await PdfGameIdResolver.ResolveAsync(_db, pdf, cancellationToken).ConfigureAwait(false);
+        var bboxJson = ChunkBoundingBoxJson.Serialize(
+            ChunkingModels.BoundingBox.FromCoordinates((float)x, (float)y, (float)width, (float)height),
+            pageNumber);
+        var now = DateTime.UtcNow;
+
+        // Upsert the text_chunks row (deterministic id -> idempotent replace of this one region).
+        var existing = await _db.TextChunks
+            .FirstOrDefaultAsync(tc => tc.Id == chunkId, cancellationToken)
+            .ConfigureAwait(false);
+        int chunkIndex;
+        if (existing is null)
+        {
+            // Append after the current max so the table chunk never collides with a narrative
+            // chunk on the fusion dedup key {PdfId}:{ChunkIndex}.
+            var maxIndex = await _db.TextChunks
+                .Where(tc => tc.PdfDocumentId == pdf.Id)
+                .Select(tc => (int?)tc.ChunkIndex)
+                .MaxAsync(cancellationToken)
+                .ConfigureAwait(false) ?? -1;
+            chunkIndex = maxIndex + 1;
+
+            _db.TextChunks.Add(new TextChunkEntity
+            {
+                Id = chunkId,
+                GameId = resolvedGameId,
+                SharedGameId = pdf.SharedGameId,
+                PdfDocumentId = pdf.Id,
+                Content = markdown,
+                ChunkIndex = chunkIndex,
+                PageNumber = pageNumber,
+                CharacterCount = markdown.Length,
+                CreatedAt = now,
+                ElementType = TableElementType,
+                BoundingBoxesJson = bboxJson,
+            });
+        }
+        else
+        {
+            chunkIndex = existing.ChunkIndex;
+            existing.Content = markdown;
+            existing.CharacterCount = markdown.Length;
+            existing.PageNumber = pageNumber;
+            existing.ElementType = TableElementType;
+            existing.BoundingBoxesJson = bboxJson;
+            existing.GameId = resolvedGameId;
+            existing.SharedGameId = pdf.SharedGameId;
+        }
+
+        await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        // Replace this chunk's embedding (scoped delete), then index the new one wired to
+        // source_chunk_id so its region bbox reaches the citation.
+        await _vectorStore.EnsureCollectionExistsAsync(gameId, vector.Length, cancellationToken).ConfigureAwait(false);
+        await _vectorStore.DeleteBySourceChunkIdsAsync(new[] { chunkId }, cancellationToken).ConfigureAwait(false);
+
+        var embedding = new KbEntities.Embedding(
+            id: Guid.NewGuid(),
+            vectorDocumentId: vectorDoc.Id,
+            textContent: markdown,
+            vector: new KbValueObjects.Vector(vector),
+            model: _embeddingService.GetModelName(),
+            chunkIndex: chunkIndex,
+            pageNumber: Math.Max(1, pageNumber),
+            language: "en",
+            sourceChunkId: chunkId,
+            isTranslation: false,
+            roleTags: 0);
+
+        await _vectorStore.IndexBatchAsync(new List<KbEntities.Embedding> { embedding }, cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "TableChunkIndexer: indexed table chunk {ChunkId} (idx {ChunkIndex}, page {Page}) for PDF {PdfId}",
+            chunkId, chunkIndex, pageNumber, pdf.Id);
+        return chunkId;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/External/IVectorStoreAdapter.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/External/IVectorStoreAdapter.cs
@@ -49,6 +49,15 @@ internal interface IVectorStoreAdapter
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Deletes embeddings whose <c>source_chunk_id</c> is in <paramref name="sourceChunkIds"/>.
+    /// Scoped delete (a single chunk's embedding), used to replace one chunk's vector without
+    /// wiping the whole document — e.g. the #3435 SP4 per-region table-chunk re-index. No-op on empty.
+    /// </summary>
+    Task DeleteBySourceChunkIdsAsync(
+        IReadOnlyList<Guid> sourceChunkIds,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Performs vector similarity search and returns each result paired with its cosine-similarity
     /// score.  Additive method — does NOT replace <see cref="SearchAsync"/>.
     /// Issue #1653: F3-FU-4 — per-document scored similarity-search.

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/PgVectorStoreAdapter.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/PgVectorStoreAdapter.cs
@@ -450,6 +450,32 @@ internal sealed class PgVectorStoreAdapter : IVectorStoreAdapter
         }
     }
 
+    public async Task DeleteBySourceChunkIdsAsync(
+        IReadOnlyList<Guid> sourceChunkIds,
+        CancellationToken cancellationToken = default)
+    {
+        if (sourceChunkIds is null || sourceChunkIds.Count == 0)
+        {
+            return;
+        }
+
+        var connection = _context.Database.GetDbConnection();
+        await EnsureConnectionOpenAsync(connection, cancellationToken).ConfigureAwait(false);
+
+        var command = (NpgsqlCommand)connection.CreateCommand();
+        await using (command.ConfigureAwait(false))
+        {
+            command.CommandText = $"DELETE FROM {TableName} WHERE source_chunk_id = ANY(@ids)";
+            command.Parameters.AddWithValue("@ids", sourceChunkIds.ToArray());
+
+            var deleted = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+
+            _logger.LogDebug(
+                "Deleted {DeletedCount} embedding(s) for {Count} source chunk id(s) from pgvector",
+                deleted, sourceChunkIds.Count);
+        }
+    }
+
     public async Task<bool> CollectionExistsAsync(
         Guid gameId,
         CancellationToken cancellationToken = default)

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Services/TextChunkSearchService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Services/TextChunkSearchService.cs
@@ -76,21 +76,33 @@ internal sealed class TextChunkSearchService : ITextChunkSearchService
             var minIndex = chunkIndex - radius;
             var maxIndex = chunkIndex + radius;
 
-            var results = await _dbContext.TextChunks
+            // #3435 SP4: table chunks are appended PAST the narrative reading-order range
+            // (ChunkIndex = maxNarrative + 1), so they are NOT linear-adjacency neighbours. A table
+            // SEED has no narrative neighbours (return empty), and a table must never be pulled into a
+            // narrative chunk's window as if it were positionally adjacent (it would inject the last
+            // narrative chunk — often unrelated tail content — into the grounded answer + citations).
+            var window = await _dbContext.TextChunks
                 .AsNoTracking()
                 .Where(tc => tc.PdfDocumentId == pdfDocumentId
                     && tc.ChunkIndex >= minIndex
-                    && tc.ChunkIndex <= maxIndex
-                    && tc.ChunkIndex != chunkIndex) // Exclude the matched chunk itself
-                .OrderBy(tc => tc.ChunkIndex)
-                .Select(tc => new TextChunkMatch(
-                    tc.PdfDocumentId,
-                    tc.Content,
-                    tc.ChunkIndex,
-                    tc.PageNumber,
-                    0f))
+                    && tc.ChunkIndex <= maxIndex)
+                .Select(tc => new { tc.PdfDocumentId, tc.Content, tc.ChunkIndex, tc.PageNumber, tc.ElementType })
                 .ToListAsync(ct)
                 .ConfigureAwait(false);
+
+            var seedIsTable = window.Any(c => c.ChunkIndex == chunkIndex
+                && string.Equals(c.ElementType, "Table", StringComparison.Ordinal));
+            if (seedIsTable)
+            {
+                return [];
+            }
+
+            var results = window
+                .Where(c => c.ChunkIndex != chunkIndex // exclude the matched chunk itself
+                    && !string.Equals(c.ElementType, "Table", StringComparison.Ordinal))
+                .OrderBy(c => c.ChunkIndex)
+                .Select(c => new TextChunkMatch(c.PdfDocumentId, c.Content, c.ChunkIndex, c.PageNumber, 0f))
+                .ToList();
 
             return results;
         }

--- a/apps/api/src/Api/Infrastructure/Entities/DocumentProcessing/PdfTableExtractionEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/DocumentProcessing/PdfTableExtractionEntity.cs
@@ -1,0 +1,60 @@
+using System;
+
+namespace Api.Infrastructure.Entities;
+
+/// <summary>
+/// #3435 (SP4): per-region state for the async VLM table-extraction pass. One row per image
+/// region the VLM job has processed (or attempted), keyed by a deterministic
+/// <see cref="RegionHash"/> so it survives the replace-by-pdf re-seed of <c>pdf_image_regions</c>
+/// (which regenerates <c>PdfImageRegionEntity.Id</c>). Drives idempotency + retry-cap/dead-letter
+/// and records the extracted table markdown + the id of the retrievable table chunk it produced.
+/// </summary>
+public class PdfTableExtractionEntity
+{
+    /// <summary>Region not yet processed.</summary>
+    public const string StatusPending = "pending";
+    /// <summary>VLM confirmed an OTSL table; a retrievable table chunk was persisted.</summary>
+    public const string StatusExtracted = "extracted";
+    /// <summary>VLM ran but the crop is not a table (no &lt;otsl&gt;); nothing persisted.</summary>
+    public const string StatusNotTable = "not_table";
+    /// <summary>Transient failure (crop/VLM/index); retried until the attempt budget is exhausted.</summary>
+    public const string StatusFailed = "failed";
+    /// <summary>Terminal: exceeded the retry budget; excluded from the selector.</summary>
+    public const string StatusDeadLetter = "dead_letter";
+
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid PdfDocumentId { get; set; }
+    public PdfDocumentEntity PdfDocument { get; set; } = null!;
+
+    /// <summary>Deterministic key over (pdf, page, quantized bbox); stable across region re-seed.</summary>
+    public string RegionHash { get; set; } = string.Empty;
+
+    /// <summary>1-based page number of the region (matches <c>pdf_image_regions.page_number</c>).</summary>
+    public int PageNumber { get; set; }
+
+    // Region bbox, copied so the record is self-contained if the region row is re-seeded.
+    // Normalized [0,1] top-left (same convention as pdf_image_regions).
+    public double X { get; set; }
+    public double Y { get; set; }
+    public double Width { get; set; }
+    public double Height { get; set; }
+
+    public string Status { get; set; } = StatusPending;
+    public int Attempts { get; set; }
+
+    /// <summary>Extracted table markdown (null unless <see cref="Status"/> is <see cref="StatusExtracted"/>).</summary>
+    public string? TableMarkdown { get; set; }
+    /// <summary>Heuristic VLM confidence from /extract-image (0-1).</summary>
+    public double? Confidence { get; set; }
+    /// <summary>The /extract-image reason code (table-otsl, no-otsl, prefilter-colorful, ...).</summary>
+    public string? Reason { get; set; }
+
+    /// <summary>Id of the retrievable table text_chunk produced (null unless extracted).</summary>
+    public Guid? TextChunkId { get; set; }
+
+    public string? LastError { get; set; }
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/DocumentProcessing/PdfTableExtractionEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/DocumentProcessing/PdfTableExtractionEntityConfiguration.cs
@@ -1,0 +1,47 @@
+using Api.Infrastructure.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.EntityConfigurations;
+
+/// <summary>EF configuration for <see cref="PdfTableExtractionEntity"/> (#3435 SP4).</summary>
+internal sealed class PdfTableExtractionEntityConfiguration : IEntityTypeConfiguration<PdfTableExtractionEntity>
+{
+    public void Configure(EntityTypeBuilder<PdfTableExtractionEntity> builder)
+    {
+        builder.ToTable("pdf_table_extractions");
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Id).HasColumnName("id");
+        builder.Property(e => e.PdfDocumentId).HasColumnName("pdf_document_id").IsRequired();
+        builder.Property(e => e.RegionHash).HasColumnName("region_hash").HasMaxLength(64).IsRequired();
+        builder.Property(e => e.PageNumber).HasColumnName("page_number");
+        builder.Property(e => e.X).HasColumnName("x");
+        builder.Property(e => e.Y).HasColumnName("y");
+        builder.Property(e => e.Width).HasColumnName("width");
+        builder.Property(e => e.Height).HasColumnName("height");
+        builder.Property(e => e.Status).HasColumnName("status").HasMaxLength(20).IsRequired();
+        builder.Property(e => e.Attempts).HasColumnName("attempts");
+        builder.Property(e => e.TableMarkdown).HasColumnName("table_markdown");
+        builder.Property(e => e.Confidence).HasColumnName("confidence");
+        builder.Property(e => e.Reason).HasColumnName("reason").HasMaxLength(32);
+        builder.Property(e => e.TextChunkId).HasColumnName("text_chunk_id");
+        builder.Property(e => e.LastError).HasColumnName("last_error");
+        builder.Property(e => e.CreatedAt).HasColumnName("created_at");
+        builder.Property(e => e.UpdatedAt).HasColumnName("updated_at");
+
+        builder.HasOne(e => e.PdfDocument)
+            .WithMany()
+            .HasForeignKey(e => e.PdfDocumentId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // Idempotency: one extraction record per (pdf, region). The region hash is deterministic
+        // over the quantized bbox, so it is stable across the replace-by-pdf region re-seed.
+        builder.HasIndex(e => new { e.PdfDocumentId, e.RegionHash })
+            .IsUnique()
+            .HasDatabaseName("ux_pdf_table_extractions_pdf_region");
+
+        // Selector scans by status (+ attempts) to find pending / retry-eligible regions.
+        builder.HasIndex(e => e.Status).HasDatabaseName("ix_pdf_table_extractions_status");
+    }
+}

--- a/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+++ b/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
@@ -121,6 +121,7 @@ public class MeepleAiDbContext : DbContext
     public DbSet<ChatLogEntity> ChatLogs => Set<ChatLogEntity>();
     public DbSet<PdfDocumentEntity> PdfDocuments => Set<PdfDocumentEntity>();
     public DbSet<PdfImageRegionEntity> PdfImageRegions => Set<PdfImageRegionEntity>(); // #3447: image-table regions
+    public DbSet<PdfTableExtractionEntity> PdfTableExtractions => Set<PdfTableExtractionEntity>(); // #3435 SP4: VLM table-extraction state
     public DbSet<ProcessingMetricEntity> ProcessingMetrics => Set<ProcessingMetricEntity>(); // ISSUE-4212: Historical metrics storage
     public DbSet<ProcessingJobEntity> ProcessingJobs => Set<ProcessingJobEntity>(); // ISSUE-4730: Processing queue management
     public DbSet<ProcessingStepEntity> ProcessingSteps => Set<ProcessingStepEntity>(); // ISSUE-4730: Processing queue steps

--- a/apps/api/src/Api/Infrastructure/Migrations/20260804173408_AddPdfTableExtractions.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260804173408_AddPdfTableExtractions.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260804173408_AddPdfTableExtractions")]
+    partial class AddPdfTableExtractions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260804173408_AddPdfTableExtractions.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260804173408_AddPdfTableExtractions.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPdfTableExtractions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "pdf_table_extractions",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    pdf_document_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    region_hash = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    page_number = table.Column<int>(type: "integer", nullable: false),
+                    x = table.Column<double>(type: "double precision", nullable: false),
+                    y = table.Column<double>(type: "double precision", nullable: false),
+                    width = table.Column<double>(type: "double precision", nullable: false),
+                    height = table.Column<double>(type: "double precision", nullable: false),
+                    status = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    attempts = table.Column<int>(type: "integer", nullable: false),
+                    table_markdown = table.Column<string>(type: "text", nullable: true),
+                    confidence = table.Column<double>(type: "double precision", nullable: true),
+                    reason = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: true),
+                    text_chunk_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    last_error = table.Column<string>(type: "text", nullable: true),
+                    created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_pdf_table_extractions", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_pdf_table_extractions_pdf_documents_pdf_document_id",
+                        column: x => x.pdf_document_id,
+                        principalTable: "pdf_documents",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_pdf_table_extractions_status",
+                table: "pdf_table_extractions",
+                column: "status");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_pdf_table_extractions_pdf_region",
+                table: "pdf_table_extractions",
+                columns: new[] { "pdf_document_id", "region_hash" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "pdf_table_extractions");
+        }
+    }
+}

--- a/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.TableVlm.cs
+++ b/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.TableVlm.cs
@@ -1,0 +1,43 @@
+// Issue #3435 (SP4): observability for the async VLM table-extraction pass.
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+
+namespace Api.Observability;
+
+internal static partial class MeepleAiMetrics
+{
+    /// <summary>Wire value for the <c>outcome</c> tag: an OTSL table was extracted and a retrievable
+    /// table chunk persisted.</summary>
+    public const string TableVlmOutcomeExtracted = "extracted";
+
+    /// <summary>Wire value for the <c>outcome</c> tag: the VLM ran but the crop is not a table (no
+    /// <c>&lt;otsl&gt;</c>, or rejected by the colorfulness pre-filter). Terminal, nothing persisted.</summary>
+    public const string TableVlmOutcomeNotTable = "not_table";
+
+    /// <summary>Wire value for the <c>outcome</c> tag: a transient failure (crop render, VLM call, or
+    /// index) that stays retry-eligible (attempts still below the budget).</summary>
+    public const string TableVlmOutcomeFailed = "failed";
+
+    /// <summary>Wire value for the <c>outcome</c> tag: the region hit the attempt budget and was
+    /// dead-lettered (excluded from the selector). Kept distinct from <c>failed</c> so an alert on
+    /// dead-letters tracks only give-ups, not recoverable blips.</summary>
+    public const string TableVlmOutcomeDeadLetter = "dead_letter";
+
+    /// <summary>
+    /// Counter of async VLM table-extraction outcomes, emitted per image region by
+    /// <c>RunTableExtractionBatchCommandHandler</c> (#3435 SP4). Tag <c>outcome</c>:
+    /// <c>extracted</c>|<c>not_table</c>|<c>failed</c>|<c>dead_letter</c>.
+    /// NB (naming, mirrors <c>meepleai_image_region_seed_total</c>): here <c>failed</c> is the
+    /// TRANSIENT/retry-eligible outcome and <c>dead_letter</c> is terminal. Alert on
+    /// <c>dead_letter</c> for give-ups, and on a sustained high <c>failed</c> ratio for a broadly
+    /// failing VLM service (§8 NFR4).
+    /// </summary>
+    public static readonly Counter<long> TableVlm = Meter.CreateCounter<long>(
+        name: "meepleai.table_vlm.total",
+        unit: "regions",
+        description: "Async VLM table-extraction outcomes grouped by outcome (#3435 SP4)");
+
+    /// <summary>Records one table-extraction outcome (one of the <c>TableVlmOutcome*</c> constants).</summary>
+    public static void RecordTableVlm(string outcome) =>
+        TableVlm.Add(1, new KeyValuePair<string, object?>("outcome", outcome));
+}

--- a/apps/api/tests/Api.Tests/Unit/DocumentProcessing/PdfRegionCropperTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/DocumentProcessing/PdfRegionCropperTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Threading;
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Api.Tests.Unit.DocumentProcessing;
+
+/// <summary>
+/// #3435 (SP4): failure-mode tests for the region cropper. The real Docnet render + SkiaSharp crop
+/// path needs a PDF fixture and is covered by integration/E2E (as with <see cref="PdfCoverExtractor"/>).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "3435")]
+public sealed class PdfRegionCropperTests
+{
+    private readonly PdfRegionCropper _sut = new(NullLogger<PdfRegionCropper>.Instance);
+
+    [Fact]
+    public void CropRegion_ReturnsNull_WhenBytesAreNull()
+        => _sut.CropRegion(null!, 1, 0.1, 0.2, 0.5, 0.3, CancellationToken.None).Should().BeNull();
+
+    [Fact]
+    public void CropRegion_ReturnsNull_WhenBytesAreEmpty()
+        => _sut.CropRegion(Array.Empty<byte>(), 1, 0.1, 0.2, 0.5, 0.3, CancellationToken.None).Should().BeNull();
+
+    [Fact]
+    public void CropRegion_ReturnsNull_OnGarbageBytes()
+    {
+        var garbage = new byte[] { 0x42, 0x43, 0x44, 0x45, 0x00, 0xFF, 0x10, 0x20 };
+        _sut.CropRegion(garbage, 1, 0.1, 0.2, 0.5, 0.3, CancellationToken.None).Should().BeNull();
+    }
+
+    [Fact]
+    public void CropRegion_Throws_WhenAlreadyCancelled()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var pdfMagic = new byte[] { 0x25, 0x50, 0x44, 0x46 }; // "%PDF"
+        var act = () => _sut.CropRegion(pdfMagic, 1, 0.1, 0.2, 0.5, 0.3, cts.Token);
+        act.Should().Throw<OperationCanceledException>();
+    }
+}

--- a/apps/api/tests/Api.Tests/Unit/DocumentProcessing/RunTableExtractionBatchCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/DocumentProcessing/RunTableExtractionBatchCommandHandlerTests.cs
@@ -234,11 +234,16 @@ public sealed class RunTableExtractionBatchCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_TerminalRegion_IsSkipped()
+    public async Task Handle_ExtractedRegion_WithLiveChunk_IsSkipped()
     {
         using var db = TestDbContextFactory.CreateInMemoryDbContext($"tvlm_{Guid.NewGuid():N}");
         var pdf = SeedPdf(db);
         SeedRegion(db, pdf, page: 3, x: 0.1, y: 0.2, w: 0.8, h: 0.3);
+        var chunkId = Guid.NewGuid();
+        db.TextChunks.Add(new TextChunkEntity
+        {
+            Id = chunkId, PdfDocumentId = pdf, Content = "| t |", ChunkIndex = 5, ElementType = "Table",
+        });
         db.PdfTableExtractions.Add(new PdfTableExtractionEntity
         {
             Id = Guid.NewGuid(),
@@ -247,6 +252,8 @@ public sealed class RunTableExtractionBatchCommandHandlerTests
             PageNumber = 3,
             X = 0.1, Y = 0.2, Width = 0.8, Height = 0.3,
             Status = PdfTableExtractionEntity.StatusExtracted,
+            TextChunkId = chunkId, // the produced chunk is still live -> truly done
+            TableMarkdown = "| t |",
         });
         await db.SaveChangesAsync();
 
@@ -259,6 +266,71 @@ public sealed class RunTableExtractionBatchCommandHandlerTests
 
         result.Processed.Should().Be(0);
         cropper.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Handle_TableButNotRetrievable_MarksFailed_NotExtracted()
+    {
+        // IndexTableAsync returns null (no game / vector document) -> transient, must NOT be marked
+        // terminal 'extracted' (findings #3/#4): it retries and eventually dead-letters.
+        using var db = TestDbContextFactory.CreateInMemoryDbContext($"tvlm_{Guid.NewGuid():N}");
+        var pdf = SeedPdf(db);
+        SeedRegion(db, pdf);
+        await db.SaveChangesAsync();
+
+        var handler = Create(db, MediatorWithCandidates(pdf).Object, CropperReturning(new byte[] { 9 }).Object,
+            ExtractorReturning(Table()).Object, IndexerReturning(null).Object,
+            BlobReturning(new byte[] { 1 }).Object, Config(enabled: true));
+
+        var result = await handler.Handle(new RunTableExtractionBatchCommand(), CancellationToken.None);
+
+        result.Failed.Should().Be(1);
+        result.Extracted.Should().Be(0);
+        var state = await StateOf(db, pdf);
+        state!.Status.Should().Be(PdfTableExtractionEntity.StatusFailed);
+        state.Attempts.Should().Be(1);
+        state.TextChunkId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_ExtractedButChunkDeleted_ReindexesFromCachedMarkdown_WithoutVlm()
+    {
+        // Self-heal after a document reindex wiped the produced chunk (finding #1): the region is
+        // re-indexed from the cached markdown, without re-running crop/VLM.
+        using var db = TestDbContextFactory.CreateInMemoryDbContext($"tvlm_{Guid.NewGuid():N}");
+        var pdf = SeedPdf(db);
+        SeedRegion(db, pdf, page: 3, x: 0.1, y: 0.2, w: 0.8, h: 0.3);
+        db.PdfTableExtractions.Add(new PdfTableExtractionEntity
+        {
+            Id = Guid.NewGuid(),
+            PdfDocumentId = pdf,
+            RegionHash = TableRegionKey.ComputeRegionHash(pdf, 3, 0.1, 0.2, 0.8, 0.3),
+            PageNumber = 3,
+            X = 0.1, Y = 0.2, Width = 0.8, Height = 0.3,
+            Status = PdfTableExtractionEntity.StatusExtracted,
+            TextChunkId = Guid.NewGuid(), // dangling — no matching text_chunk row
+            TableMarkdown = "| cached |\n|---|\n| 1 |",
+        });
+        await db.SaveChangesAsync();
+
+        var newChunkId = Guid.NewGuid();
+        var cropper = new Mock<IPdfRegionCropper>(MockBehavior.Strict);         // must NOT crop
+        var extractor = new Mock<ISmolDoclingTableExtractor>(MockBehavior.Strict); // must NOT call VLM
+        var indexer = IndexerReturning(newChunkId);
+        var handler = Create(db, MediatorWithCandidates(pdf).Object, cropper.Object,
+            extractor.Object, indexer.Object, BlobReturning(new byte[] { 1 }).Object, Config(enabled: true));
+
+        var result = await handler.Handle(new RunTableExtractionBatchCommand(), CancellationToken.None);
+
+        result.Extracted.Should().Be(1);
+        cropper.VerifyNoOtherCalls();
+        extractor.VerifyNoOtherCalls();
+        indexer.Verify(i => i.IndexTableAsync(
+            It.IsAny<PdfDocumentEntity>(), 3, 0.1, 0.2, 0.8, 0.3,
+            "| cached |\n|---|\n| 1 |", It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+        var state = await StateOf(db, pdf);
+        state!.Status.Should().Be(PdfTableExtractionEntity.StatusExtracted);
+        state.TextChunkId.Should().Be(newChunkId);
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/Unit/DocumentProcessing/RunTableExtractionBatchCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/DocumentProcessing/RunTableExtractionBatchCommandHandlerTests.cs
@@ -1,0 +1,312 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Api.BoundedContexts.DocumentProcessing.Application.Commands;
+using Api.BoundedContexts.DocumentProcessing.Application.Queries;
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Services.Pdf;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Unit.DocumentProcessing;
+
+/// <summary>
+/// #3435 (SP4): orchestration tests for the async VLM table-extraction batch. The cropper, VLM
+/// client and RAG indexer are mocked, so this exercises the control flow (candidate consume, skip
+/// terminal, crop→VLM→index→mark, retry-cap/dead-letter) on an in-memory db. Blind spot (like the
+/// SP1 sibling): the unique index + the DbUpdateException swallow paths are NOT exercised here (EF
+/// InMemory ignores unique indexes and never raises DbUpdateException); those need Postgres.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "3435")]
+public sealed class RunTableExtractionBatchCommandHandlerTests
+{
+    private static IConfiguration Config(bool enabled, int? batchSize = null, int? maxAttempts = null) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [RunTableExtractionBatchCommandHandler.EnabledConfigKey] = enabled ? "true" : "false",
+                [RunTableExtractionBatchCommandHandler.DelayMsConfigKey] = "0",
+                [RunTableExtractionBatchCommandHandler.BatchSizeConfigKey] = batchSize?.ToString(),
+                [RunTableExtractionBatchCommandHandler.MaxAttemptsConfigKey] = maxAttempts?.ToString(),
+            })
+            .Build();
+
+    private static Guid SeedPdf(MeepleAiDbContext db)
+    {
+        var id = Guid.NewGuid();
+        db.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = id,
+            FileName = "t.pdf",
+            FilePath = "pdfs/abc/doc.pdf",
+            FileSizeBytes = 1024,
+            ContentType = "application/pdf",
+            UploadedByUserId = Guid.NewGuid(),
+            ProcessingState = "Ready",
+            IndexerVersion = "v1",
+            UploadedAt = DateTime.UtcNow,
+        });
+        return id;
+    }
+
+    private static void SeedRegion(
+        MeepleAiDbContext db, Guid pdfId, int page = 3,
+        double x = 0.1, double y = 0.2, double w = 0.8, double h = 0.3, string elementType = "Image")
+    {
+        db.PdfImageRegions.Add(new PdfImageRegionEntity
+        {
+            Id = Guid.NewGuid(),
+            PdfDocumentId = pdfId,
+            PageNumber = page,
+            X = x,
+            Y = y,
+            Width = w,
+            Height = h,
+            ElementType = elementType,
+        });
+    }
+
+    private static Mock<IMediator> MediatorWithCandidates(params Guid[] pdfIds)
+    {
+        var mediator = new Mock<IMediator>();
+        IReadOnlyList<TableRegionCandidateDto> dtos =
+            pdfIds.Select(id => new TableRegionCandidateDto(id, 1, 1)).ToList();
+        mediator
+            .Setup(m => m.Send(It.IsAny<GetTableRegionCandidatesQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(dtos);
+        return mediator;
+    }
+
+    private static Mock<IBlobStorageService> BlobReturning(byte[]? bytes)
+    {
+        var blob = new Mock<IBlobStorageService>();
+        blob.Setup(b => b.RetrieveAsync(
+                It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(() => Task.FromResult<Stream?>(bytes is null ? null : new MemoryStream(bytes)));
+        return blob;
+    }
+
+    private static Mock<IPdfRegionCropper> CropperReturning(byte[]? crop)
+    {
+        var cropper = new Mock<IPdfRegionCropper>();
+        cropper.Setup(c => c.CropRegion(
+                It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<double>(), It.IsAny<double>(),
+                It.IsAny<double>(), It.IsAny<double>(), It.IsAny<CancellationToken>()))
+            .Returns(crop);
+        return cropper;
+    }
+
+    private static Mock<ISmolDoclingTableExtractor> ExtractorReturning(CropTableExtractionResult result)
+    {
+        var extractor = new Mock<ISmolDoclingTableExtractor>();
+        extractor.Setup(e => e.ExtractTableAsync(It.IsAny<byte[]>(), It.IsAny<bool?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(result);
+        return extractor;
+    }
+
+    private static Mock<ITableChunkIndexer> IndexerReturning(Guid? chunkId)
+    {
+        var indexer = new Mock<ITableChunkIndexer>();
+        indexer.Setup(i => i.IndexTableAsync(
+                It.IsAny<PdfDocumentEntity>(), It.IsAny<int>(), It.IsAny<double>(), It.IsAny<double>(),
+                It.IsAny<double>(), It.IsAny<double>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(chunkId);
+        return indexer;
+    }
+
+    private static RunTableExtractionBatchCommandHandler Create(
+        MeepleAiDbContext db, IMediator mediator, IPdfRegionCropper cropper,
+        ISmolDoclingTableExtractor extractor, ITableChunkIndexer indexer, IBlobStorageService blob, IConfiguration config)
+        => new(db, mediator, cropper, extractor, indexer, blob, config,
+            NullLogger<RunTableExtractionBatchCommandHandler>.Instance);
+
+    private static CropTableExtractionResult Table(string markdown = "| a |\n|---|\n| 1 |")
+        => new(IsTable: true, Reason: "table-otsl", Markdown: markdown, Confidence: 0.9, Prefiltered: false, Degenerated: false);
+
+    private static CropTableExtractionResult NotTable(string reason = "no-otsl")
+        => new(IsTable: false, Reason: reason, Markdown: "", Confidence: 0.0, Prefiltered: false, Degenerated: false);
+
+    private static async Task<PdfTableExtractionEntity?> StateOf(MeepleAiDbContext db, Guid pdfId)
+        => await db.PdfTableExtractions.AsNoTracking().FirstOrDefaultAsync(e => e.PdfDocumentId == pdfId);
+
+    [Fact]
+    public async Task Handle_FlagDisabled_ReturnsDisabled_AndNeverCrops()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext($"tvlm_{Guid.NewGuid():N}");
+        var pdf = SeedPdf(db);
+        SeedRegion(db, pdf);
+        await db.SaveChangesAsync();
+
+        var cropper = new Mock<IPdfRegionCropper>(MockBehavior.Strict);
+        var handler = Create(db, MediatorWithCandidates(pdf).Object, cropper.Object,
+            ExtractorReturning(Table()).Object, IndexerReturning(Guid.NewGuid()).Object,
+            BlobReturning(new byte[] { 1 }).Object, Config(enabled: false));
+
+        var result = await handler.Handle(new RunTableExtractionBatchCommand(), CancellationToken.None);
+
+        result.Enabled.Should().BeFalse();
+        result.Processed.Should().Be(0);
+        cropper.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Handle_Table_IndexesChunk_AndMarksExtracted()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext($"tvlm_{Guid.NewGuid():N}");
+        var pdf = SeedPdf(db);
+        SeedRegion(db, pdf);
+        await db.SaveChangesAsync();
+
+        var chunkId = Guid.NewGuid();
+        var indexer = IndexerReturning(chunkId);
+        var handler = Create(db, MediatorWithCandidates(pdf).Object, CropperReturning(new byte[] { 9 }).Object,
+            ExtractorReturning(Table()).Object, indexer.Object, BlobReturning(new byte[] { 1 }).Object,
+            Config(enabled: true));
+
+        var result = await handler.Handle(new RunTableExtractionBatchCommand(), CancellationToken.None);
+
+        result.Extracted.Should().Be(1);
+        result.Processed.Should().Be(1);
+        indexer.Verify(i => i.IndexTableAsync(
+            It.IsAny<PdfDocumentEntity>(), 3, 0.1, 0.2, 0.8, 0.3, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        var state = await StateOf(db, pdf);
+        state!.Status.Should().Be(PdfTableExtractionEntity.StatusExtracted);
+        state.TextChunkId.Should().Be(chunkId);
+        state.TableMarkdown.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_NotTable_MarksNotTable_AndNeverIndexes()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext($"tvlm_{Guid.NewGuid():N}");
+        var pdf = SeedPdf(db);
+        SeedRegion(db, pdf);
+        await db.SaveChangesAsync();
+
+        var indexer = new Mock<ITableChunkIndexer>(MockBehavior.Strict);
+        var handler = Create(db, MediatorWithCandidates(pdf).Object, CropperReturning(new byte[] { 9 }).Object,
+            ExtractorReturning(NotTable()).Object, indexer.Object, BlobReturning(new byte[] { 1 }).Object,
+            Config(enabled: true));
+
+        var result = await handler.Handle(new RunTableExtractionBatchCommand(), CancellationToken.None);
+
+        result.NotTable.Should().Be(1);
+        result.Extracted.Should().Be(0);
+        indexer.VerifyNoOtherCalls();
+        (await StateOf(db, pdf))!.Status.Should().Be(PdfTableExtractionEntity.StatusNotTable);
+    }
+
+    [Fact]
+    public async Task Handle_CropFails_MarksFailed_AndCountsAttempt()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext($"tvlm_{Guid.NewGuid():N}");
+        var pdf = SeedPdf(db);
+        SeedRegion(db, pdf);
+        await db.SaveChangesAsync();
+
+        var extractor = new Mock<ISmolDoclingTableExtractor>(MockBehavior.Strict);
+        var handler = Create(db, MediatorWithCandidates(pdf).Object, CropperReturning(null).Object,
+            extractor.Object, IndexerReturning(Guid.NewGuid()).Object, BlobReturning(new byte[] { 1 }).Object,
+            Config(enabled: true));
+
+        var result = await handler.Handle(new RunTableExtractionBatchCommand(), CancellationToken.None);
+
+        result.Failed.Should().Be(1);
+        extractor.VerifyNoOtherCalls(); // crop failed → VLM never called
+        var state = await StateOf(db, pdf);
+        state!.Status.Should().Be(PdfTableExtractionEntity.StatusFailed);
+        state.Attempts.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Handle_TerminalRegion_IsSkipped()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext($"tvlm_{Guid.NewGuid():N}");
+        var pdf = SeedPdf(db);
+        SeedRegion(db, pdf, page: 3, x: 0.1, y: 0.2, w: 0.8, h: 0.3);
+        db.PdfTableExtractions.Add(new PdfTableExtractionEntity
+        {
+            Id = Guid.NewGuid(),
+            PdfDocumentId = pdf,
+            RegionHash = TableRegionKey.ComputeRegionHash(pdf, 3, 0.1, 0.2, 0.8, 0.3),
+            PageNumber = 3,
+            X = 0.1, Y = 0.2, Width = 0.8, Height = 0.3,
+            Status = PdfTableExtractionEntity.StatusExtracted,
+        });
+        await db.SaveChangesAsync();
+
+        var cropper = new Mock<IPdfRegionCropper>(MockBehavior.Strict);
+        var handler = Create(db, MediatorWithCandidates(pdf).Object, cropper.Object,
+            ExtractorReturning(Table()).Object, IndexerReturning(Guid.NewGuid()).Object,
+            BlobReturning(new byte[] { 1 }).Object, Config(enabled: true));
+
+        var result = await handler.Handle(new RunTableExtractionBatchCommand(), CancellationToken.None);
+
+        result.Processed.Should().Be(0);
+        cropper.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Handle_RepeatedFailure_DeadLettersAtMaxAttempts()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext($"tvlm_{Guid.NewGuid():N}");
+        var pdf = SeedPdf(db);
+        SeedRegion(db, pdf, page: 3, x: 0.1, y: 0.2, w: 0.8, h: 0.3);
+        db.PdfTableExtractions.Add(new PdfTableExtractionEntity
+        {
+            Id = Guid.NewGuid(),
+            PdfDocumentId = pdf,
+            RegionHash = TableRegionKey.ComputeRegionHash(pdf, 3, 0.1, 0.2, 0.8, 0.3),
+            PageNumber = 3,
+            X = 0.1, Y = 0.2, Width = 0.8, Height = 0.3,
+            Status = PdfTableExtractionEntity.StatusFailed,
+            Attempts = 2, // one more failure hits MaxAttempts=3
+        });
+        await db.SaveChangesAsync();
+
+        var handler = Create(db, MediatorWithCandidates(pdf).Object, CropperReturning(null).Object,
+            ExtractorReturning(Table()).Object, IndexerReturning(Guid.NewGuid()).Object,
+            BlobReturning(new byte[] { 1 }).Object, Config(enabled: true, maxAttempts: 3));
+
+        var result = await handler.Handle(new RunTableExtractionBatchCommand(), CancellationToken.None);
+
+        result.Failed.Should().Be(1);
+        var state = await StateOf(db, pdf);
+        state!.Status.Should().Be(PdfTableExtractionEntity.StatusDeadLetter);
+        state.Attempts.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task Handle_RespectsRegionBudget()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext($"tvlm_{Guid.NewGuid():N}");
+        var pdf = SeedPdf(db);
+        SeedRegion(db, pdf, page: 1, x: 0.1, y: 0.1, w: 0.3, h: 0.3);
+        SeedRegion(db, pdf, page: 2, x: 0.1, y: 0.1, w: 0.3, h: 0.3);
+        SeedRegion(db, pdf, page: 3, x: 0.1, y: 0.1, w: 0.3, h: 0.3);
+        await db.SaveChangesAsync();
+
+        var handler = Create(db, MediatorWithCandidates(pdf).Object, CropperReturning(new byte[] { 9 }).Object,
+            ExtractorReturning(Table()).Object, IndexerReturning(Guid.NewGuid()).Object,
+            BlobReturning(new byte[] { 1 }).Object, Config(enabled: true, batchSize: 2));
+
+        var result = await handler.Handle(new RunTableExtractionBatchCommand(), CancellationToken.None);
+
+        result.Processed.Should().Be(2);
+    }
+}

--- a/apps/api/tests/Api.Tests/Unit/DocumentProcessing/SmoldoclingTableExtractorTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/DocumentProcessing/SmoldoclingTableExtractorTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Unit.DocumentProcessing;
+
+/// <summary>#3435 (SP4): the smoldocling /extract-image client maps the snake_case JSON contract.</summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "3435")]
+public sealed class SmoldoclingTableExtractorTests
+{
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _status;
+        private readonly string _json;
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        public StubHandler(HttpStatusCode status, string json)
+        {
+            _status = status;
+            _json = json;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            if (request.Content is not null)
+            {
+                // Materialize the multipart body (proves it was built without throwing).
+                await request.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+            }
+            return new HttpResponseMessage(_status)
+            {
+                Content = new StringContent(_json, Encoding.UTF8, "application/json"),
+            };
+        }
+    }
+
+    private static (ISmolDoclingTableExtractor client, StubHandler handler) Create(HttpStatusCode status, string json)
+    {
+        var handler = new StubHandler(status, json);
+        var http = new HttpClient(handler) { BaseAddress = new Uri("http://smoldocling-test") };
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient(SmoldoclingTableExtractor.NamedClientKey)).Returns(http);
+        return (new SmoldoclingTableExtractor(factory.Object, NullLogger<SmoldoclingTableExtractor>.Instance), handler);
+    }
+
+    [Fact]
+    public async Task ExtractTableAsync_MapsTableResponse_AndPostsToExtractImage()
+    {
+        const string json = """
+        {"is_table":true,"reason":"table-otsl","markdown":"| a |","bbox":[0.1,0.2,0.9,0.6],"confidence":0.9,"prefiltered":false,"degenerated":false,"colorfulness":5.0,"duration_ms":3000}
+        """;
+        var (client, handler) = Create(HttpStatusCode.OK, json);
+
+        var result = await client.ExtractTableAsync(new byte[] { 1, 2, 3 }, prefilter: null, CancellationToken.None);
+
+        result.IsTable.Should().BeTrue();
+        result.Reason.Should().Be("table-otsl");
+        result.Markdown.Should().Be("| a |");
+        result.Confidence.Should().Be(0.9);
+        handler.LastRequest!.Method.Should().Be(HttpMethod.Post);
+        handler.LastRequest!.RequestUri!.AbsolutePath.Should().Be("/api/v1/extract-image");
+    }
+
+    [Fact]
+    public async Task ExtractTableAsync_MapsNonTableResponse()
+    {
+        const string json = """
+        {"is_table":false,"reason":"no-otsl","markdown":"","confidence":0.0,"prefiltered":false,"degenerated":false,"colorfulness":80.0,"duration_ms":1000}
+        """;
+        var (client, _) = Create(HttpStatusCode.OK, json);
+
+        var result = await client.ExtractTableAsync(new byte[] { 1 }, prefilter: false, CancellationToken.None);
+
+        result.IsTable.Should().BeFalse();
+        result.Reason.Should().Be("no-otsl");
+        result.Markdown.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExtractTableAsync_ThrowsOnServerError()
+    {
+        var (client, _) = Create(HttpStatusCode.InternalServerError, "boom");
+
+        var act = () => client.ExtractTableAsync(new byte[] { 1 }, null, CancellationToken.None);
+
+        await act.Should().ThrowAsync<HttpRequestException>();
+    }
+}

--- a/apps/api/tests/Api.Tests/Unit/DocumentProcessing/TableChunkIndexerTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/DocumentProcessing/TableChunkIndexerTests.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Services;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Unit.DocumentProcessing;
+
+/// <summary>
+/// #3435 (SP4): unit tests for the RAG table-chunk indexer. Uses an in-memory db + mocked embedding
+/// service and vector store (the vector store is captured via .Callback to assert the wiring), so the
+/// load-bearing branches — source_chunk_id wiring, ChunkIndex allocation, scoped replace, and the
+/// no-game / no-vector-doc / embedding-failure paths — are covered without Postgres.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "3435")]
+public sealed class TableChunkIndexerTests
+{
+    private const string Markdown = "| a | b |\n|---|---|\n| 1 | 2 |";
+
+    private static PdfDocumentEntity NewPdf(Guid? sharedGameId)
+    {
+        return new PdfDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            FileName = "t.pdf",
+            FilePath = "pdfs/abc/doc.pdf",
+            FileSizeBytes = 1024,
+            ContentType = "application/pdf",
+            UploadedByUserId = Guid.NewGuid(),
+            ProcessingState = "Ready",
+            IndexerVersion = "v1",
+            UploadedAt = DateTime.UtcNow,
+            SharedGameId = sharedGameId,
+        };
+    }
+
+    private static Mock<IEmbeddingService> EmbeddingSuccess()
+    {
+        var embed = new Mock<IEmbeddingService>();
+        embed.Setup(e => e.GenerateEmbeddingAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(EmbeddingResult.CreateSuccess(new List<float[]> { new float[768] }));
+        embed.Setup(e => e.GetModelName()).Returns("test-model");
+        return embed;
+    }
+
+    [Fact]
+    public async Task IndexTableAsync_PersistsTableChunk_WithSourceChunkIdWiredAndMaxPlusOneIndex()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext($"tci_{Guid.NewGuid():N}");
+        var pdf = NewPdf(sharedGameId: Guid.NewGuid());
+        db.PdfDocuments.Add(pdf);
+        var vectorDocId = Guid.NewGuid();
+        db.VectorDocuments.Add(new VectorDocumentEntity { Id = vectorDocId, PdfDocumentId = pdf.Id, SharedGameId = pdf.SharedGameId });
+        // two narrative chunks (indexes 0,1) -> the table chunk must land at index 2.
+        db.TextChunks.Add(new TextChunkEntity { Id = Guid.NewGuid(), PdfDocumentId = pdf.Id, Content = "n0", ChunkIndex = 0 });
+        db.TextChunks.Add(new TextChunkEntity { Id = Guid.NewGuid(), PdfDocumentId = pdf.Id, Content = "n1", ChunkIndex = 1 });
+        await db.SaveChangesAsync();
+
+        List<Embedding>? captured = null;
+        List<Guid>? deleted = null;
+        var vectorStore = new Mock<IVectorStoreAdapter>();
+        vectorStore.Setup(v => v.EnsureCollectionExistsAsync(It.IsAny<Guid>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        vectorStore.Setup(v => v.DeleteBySourceChunkIdsAsync(It.IsAny<IReadOnlyList<Guid>>(), It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyList<Guid>, CancellationToken>((ids, _) => deleted = ids.ToList())
+            .Returns(Task.CompletedTask);
+        vectorStore.Setup(v => v.IndexBatchAsync(It.IsAny<List<Embedding>>(), It.IsAny<CancellationToken>()))
+            .Callback<List<Embedding>, CancellationToken>((list, _) => captured = list)
+            .Returns(Task.CompletedTask);
+
+        var indexer = new TableChunkIndexer(db, EmbeddingSuccess().Object, vectorStore.Object, NullLogger<TableChunkIndexer>.Instance);
+        var regionHash = TableRegionKey.ComputeRegionHash(pdf.Id, 3, 0.1, 0.2, 0.8, 0.3);
+        var expectedChunkId = TableRegionKey.ChunkIdFromRegionHash(regionHash);
+
+        var result = await indexer.IndexTableAsync(pdf, 3, 0.1, 0.2, 0.8, 0.3, Markdown, regionHash, CancellationToken.None);
+
+        result.Should().Be(expectedChunkId);
+
+        var chunk = await db.TextChunks.AsNoTracking().FirstAsync(tc => tc.Id == expectedChunkId);
+        chunk.ElementType.Should().Be("Table");
+        chunk.Content.Should().Be(Markdown);
+        chunk.PageNumber.Should().Be(3);
+        chunk.ChunkIndex.Should().Be(2); // max(0,1) + 1
+        chunk.BoundingBoxesJson.Should().NotBeNullOrEmpty();
+
+        deleted.Should().Equal(expectedChunkId); // scoped replace, not delete-all-per-pdf
+        captured.Should().ContainSingle();
+        captured![0].SourceChunkId.Should().Be(expectedChunkId); // the JOIN key that carries the region bbox
+        captured[0].VectorDocumentId.Should().Be(vectorDocId);
+        captured[0].ChunkIndex.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task IndexTableAsync_ReturnsNull_WhenPdfHasNoGame_AndNeverEmbeds()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext($"tci_{Guid.NewGuid():N}");
+        var embed = EmbeddingSuccess();
+        var indexer = new TableChunkIndexer(db, embed.Object, Mock.Of<IVectorStoreAdapter>(), NullLogger<TableChunkIndexer>.Instance);
+        var pdf = NewPdf(sharedGameId: null); // no game -> not retrievable
+
+        var result = await indexer.IndexTableAsync(pdf, 1, 0.1, 0.1, 0.5, 0.5, Markdown,
+            TableRegionKey.ComputeRegionHash(pdf.Id, 1, 0.1, 0.1, 0.5, 0.5), CancellationToken.None);
+
+        result.Should().BeNull();
+        embed.Verify(e => e.GenerateEmbeddingAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task IndexTableAsync_ReturnsNull_WhenNoVectorDocument()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext($"tci_{Guid.NewGuid():N}");
+        var pdf = NewPdf(sharedGameId: Guid.NewGuid());
+        db.PdfDocuments.Add(pdf); // has a game but NO vector document row
+        await db.SaveChangesAsync();
+        var embed = EmbeddingSuccess();
+
+        var indexer = new TableChunkIndexer(db, embed.Object, Mock.Of<IVectorStoreAdapter>(), NullLogger<TableChunkIndexer>.Instance);
+        var result = await indexer.IndexTableAsync(pdf, 1, 0.1, 0.1, 0.5, 0.5, Markdown,
+            TableRegionKey.ComputeRegionHash(pdf.Id, 1, 0.1, 0.1, 0.5, 0.5), CancellationToken.None);
+
+        result.Should().BeNull();
+        embed.Verify(e => e.GenerateEmbeddingAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task IndexTableAsync_Throws_OnEmbeddingFailure_AndWritesNoChunk()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext($"tci_{Guid.NewGuid():N}");
+        var pdf = NewPdf(sharedGameId: Guid.NewGuid());
+        db.PdfDocuments.Add(pdf);
+        db.VectorDocuments.Add(new VectorDocumentEntity { Id = Guid.NewGuid(), PdfDocumentId = pdf.Id, SharedGameId = pdf.SharedGameId });
+        await db.SaveChangesAsync();
+
+        var embed = new Mock<IEmbeddingService>();
+        embed.Setup(e => e.GenerateEmbeddingAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(EmbeddingResult.CreateFailure("embedding service down"));
+        embed.Setup(e => e.GetModelName()).Returns("test-model");
+        var vectorStore = new Mock<IVectorStoreAdapter>();
+
+        var indexer = new TableChunkIndexer(db, embed.Object, vectorStore.Object, NullLogger<TableChunkIndexer>.Instance);
+        var regionHash = TableRegionKey.ComputeRegionHash(pdf.Id, 1, 0.1, 0.1, 0.5, 0.5);
+        var expectedChunkId = TableRegionKey.ChunkIdFromRegionHash(regionHash);
+
+        var act = () => indexer.IndexTableAsync(pdf, 1, 0.1, 0.1, 0.5, 0.5, Markdown, regionHash, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        (await db.TextChunks.CountAsync(tc => tc.Id == expectedChunkId)).Should().Be(0); // no half-written chunk
+        vectorStore.Verify(v => v.IndexBatchAsync(It.IsAny<List<Embedding>>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/apps/api/tests/Api.Tests/Unit/DocumentProcessing/TableRegionKeyTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/DocumentProcessing/TableRegionKeyTests.cs
@@ -1,0 +1,55 @@
+using System;
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Unit.DocumentProcessing;
+
+/// <summary>#3435 (SP4): the deterministic idempotency keys must be stable across region re-seed.</summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "3435")]
+public sealed class TableRegionKeyTests
+{
+    [Fact]
+    public void ComputeRegionHash_IsDeterministic_And64Hex()
+    {
+        var pdf = Guid.NewGuid();
+        var a = TableRegionKey.ComputeRegionHash(pdf, 3, 0.1, 0.2, 0.8, 0.3);
+        var b = TableRegionKey.ComputeRegionHash(pdf, 3, 0.1, 0.2, 0.8, 0.3);
+        a.Should().Be(b);
+        a.Length.Should().Be(64);
+    }
+
+    [Fact]
+    public void ComputeRegionHash_StableUnderSubQuantumFloatNoise()
+    {
+        // Re-seed jitter below the 1e-4 quantum must NOT change the key (the whole point: the
+        // region row id is regenerated on re-seed, so the key must ride the bbox values).
+        var pdf = Guid.NewGuid();
+        var a = TableRegionKey.ComputeRegionHash(pdf, 3, 0.10000, 0.20000, 0.80000, 0.30000);
+        var b = TableRegionKey.ComputeRegionHash(pdf, 3, 0.100004, 0.199997, 0.800002, 0.299996);
+        a.Should().Be(b);
+    }
+
+    [Fact]
+    public void ComputeRegionHash_DiffersByPdf_Page_And_Bbox()
+    {
+        var pdf = Guid.NewGuid();
+        var baseHash = TableRegionKey.ComputeRegionHash(pdf, 3, 0.1, 0.2, 0.8, 0.3);
+        TableRegionKey.ComputeRegionHash(pdf, 4, 0.1, 0.2, 0.8, 0.3).Should().NotBe(baseHash);
+        TableRegionKey.ComputeRegionHash(pdf, 3, 0.15, 0.2, 0.8, 0.3).Should().NotBe(baseHash);
+        TableRegionKey.ComputeRegionHash(Guid.NewGuid(), 3, 0.1, 0.2, 0.8, 0.3).Should().NotBe(baseHash);
+    }
+
+    [Fact]
+    public void ChunkIdFromRegionHash_IsDeterministic_DiffersByHash_AndNonEmpty()
+    {
+        var h1 = TableRegionKey.ComputeRegionHash(Guid.NewGuid(), 1, 0.1, 0.1, 0.5, 0.5);
+        var h2 = TableRegionKey.ComputeRegionHash(Guid.NewGuid(), 2, 0.2, 0.2, 0.4, 0.4);
+        TableRegionKey.ChunkIdFromRegionHash(h1).Should().Be(TableRegionKey.ChunkIdFromRegionHash(h1));
+        TableRegionKey.ChunkIdFromRegionHash(h1).Should().NotBe(TableRegionKey.ChunkIdFromRegionHash(h2));
+        TableRegionKey.ChunkIdFromRegionHash(h1).Should().NotBe(Guid.Empty);
+    }
+}

--- a/apps/api/tests/Api.Tests/Unit/KnowledgeBase/TextChunkSearchServiceAdjacencyTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/KnowledgeBase/TextChunkSearchServiceAdjacencyTests.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Api.BoundedContexts.KnowledgeBase.Infrastructure.Services;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Api.Tests.Unit.KnowledgeBase;
+
+/// <summary>
+/// #3435 (SP4): sentence-window adjacency must ignore table chunks. Table chunks are appended PAST
+/// the narrative reading-order range (ChunkIndex = maxNarrative + 1), so they are not
+/// linear-adjacency neighbours — a table seed has none, and a table must never be pulled into a
+/// narrative chunk's window (it would inject the last narrative chunk as if it were adjacent).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Issue", "3435")]
+public sealed class TextChunkSearchServiceAdjacencyTests
+{
+    private static TextChunkEntity Chunk(Guid pdf, int index, string element = "NarrativeText") => new()
+    {
+        Id = Guid.NewGuid(),
+        PdfDocumentId = pdf,
+        Content = $"c{index}",
+        ChunkIndex = index,
+        ElementType = element,
+    };
+
+    private static TextChunkSearchService Create(MeepleAiDbContext db)
+        => new(db, NullLogger<TextChunkSearchService>.Instance);
+
+    [Fact]
+    public async Task GetAdjacentChunksAsync_ExcludesTableChunk_FromNarrativeWindow()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext($"adj_{Guid.NewGuid():N}");
+        var pdf = Guid.NewGuid();
+        db.TextChunks.AddRange(
+            Chunk(pdf, 4),               // narrative seed
+            Chunk(pdf, 3),               // real narrative neighbour
+            Chunk(pdf, 5, "Table"));     // appended table at maxNarrative+1 — must be excluded
+        await db.SaveChangesAsync();
+
+        var adjacent = await Create(db).GetAdjacentChunksAsync(pdf, chunkIndex: 4, radius: 1, CancellationToken.None);
+
+        adjacent.Select(a => a.ChunkIndex).Should().Equal(3); // table (5) excluded, seed (4) excluded
+    }
+
+    [Fact]
+    public async Task GetAdjacentChunksAsync_ReturnsEmpty_WhenSeedIsTable()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext($"adj_{Guid.NewGuid():N}");
+        var pdf = Guid.NewGuid();
+        db.TextChunks.AddRange(
+            Chunk(pdf, 4),               // last narrative
+            Chunk(pdf, 5, "Table"));     // table seed
+        await db.SaveChangesAsync();
+
+        var adjacent = await Create(db).GetAdjacentChunksAsync(pdf, chunkIndex: 5, radius: 1, CancellationToken.None);
+
+        adjacent.Should().BeEmpty(); // a table has no narrative reading-order neighbours
+    }
+
+    [Fact]
+    public async Task GetAdjacentChunksAsync_NormalNarrativeAdjacency_StillWorks()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext($"adj_{Guid.NewGuid():N}");
+        var pdf = Guid.NewGuid();
+        db.TextChunks.AddRange(Chunk(pdf, 2), Chunk(pdf, 3), Chunk(pdf, 4));
+        await db.SaveChangesAsync();
+
+        var adjacent = await Create(db).GetAdjacentChunksAsync(pdf, chunkIndex: 3, radius: 1, CancellationToken.None);
+
+        adjacent.Select(a => a.ChunkIndex).Should().BeEquivalentTo(new[] { 2, 4 });
+    }
+}


### PR DESCRIPTION
## Cosa (SP4, epic #3435 — Metà C)

Job **asincrono, flag-gated** che chiude la Metà C: consuma il router SP2, renderizza+croppa le image-region candidate, chiama il crop-discriminator smoldocling (SP3, `POST /api/v1/extract-image`), e persiste le tabelle OTSL come **chunk RAG retrievabili e citation-groundable**.

### Pipeline
`RunTableExtractionJob` (Quartz `[DisallowConcurrentExecution]`) → `RunTableExtractionBatchCommandHandler`:
1. `GetTableRegionCandidatesQuery` (SP2) → PDF candidati (gate del router).
2. Carica le regioni (`pdf_image_regions`) + stato per-regione (`pdf_table_extractions`, sidecar nuovo).
3. `PdfRegionCropper` (Docnet/SkiaSharp) → crop della bbox `[0,1]` top-left → `POST /api/v1/extract-image`.
4. Per le tabelle: `TableChunkIndexer` → `text_chunks` (ElementType=Table + bbox in `bounding_boxes_json`) **+** `pgvector_embeddings` (wired via `source_chunk_id`, il JOIN che porta la bbox alla citazione).

### Idempotenza & robustezza
- Stato per-regione keyed su **region-hash bbox-stabile** (sopravvive al replace-by-pdf re-seed di SP1); retry-cap/dead-letter; per-item isolation (mirror di `RunImageRegionSeedBatchCommandHandler`).
- **Self-heal su reindex** (fix review): un reindex del documento cancella `text_chunks`/embeddings senza toccare il sidecar → l'handler ri-verifica la *liveness* della chunk prodotta e re-indicizza dal **markdown cached** (nessun re-run di crop/VLM).
- `IndexTableAsync` che ritorna null (no game/vectorDoc) = failure **transiente** (retry → dead-letter), mai terminale `extracted` (fix review).
- Copyright ereditato dal PDF (Full-gated ad answer-time), nessun wiring per-chunk.

### Osservabilità & config
- Prometheus `meepleai_table_vlm_total{outcome=extracted|not_table|failed|dead_letter}`.
- Config `PdfProcessing:TableExtraction:*` — **Enabled default `false`**, BatchSize, DelayMs, MaxAttempts, IntervalMinutes, VlmTimeoutSeconds.
- `IVectorStoreAdapter.DeleteBySourceChunkIdsAsync` (delete embedding scoped, per il replace idempotente).

### Verifica
- **65 test unit #3435 verdi** (SP1+SP4); **24 nuovi SP4**: chiavi deterministiche, client HTTP, cropper (edge-case), orchestrazione (incl. **self-heal** + **not-retrievable→retry**), indexer (`source_chunk_id` wiring, `ChunkIndex=max+1`, scoped replace, no-game/no-vectorDoc/embed-failure). `dotnet build` verde, migration `AddPdfTableExtractions` pulita (una tabella, FK cascade, unique index).
- **Review adversariale multi-agente** (6 lenti → verify che tenta di confutare): 4 finding confermati, **tutti recepiti** (self-heal su reindex, not-retrievable→retry, copertura `TableChunkIndexer`).
- **Blind-spot accettato** (come il gemello SP1): unique index + persistenza pgvector reale sono Postgres-only, coperti dal run flag-on su GPU locale.

### Fuori scope / prossimi
- Attivazione feature = deploy smoldocling su infra GPU + flag on (validazione E2E), **non** in questo diff.
- SP5-7.

Refs #3435

🤖 Generated with [Claude Code](https://claude.com/claude-code)
