### PR TITLE
fix(rag): Full-gate image-region viewer overlay (#3435 §5quinquies)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetPdfImageRegionsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetPdfImageRegionsQuery.cs
@@ -5,7 +5,9 @@ namespace Api.BoundedContexts.DocumentProcessing.Application.Queries;
 /// <summary>
 /// #3447 slice: returns the persisted hi_res image-table regions for a PDF (for the viewer overlay).
 /// Owner-or-shared-game scoped (mirror <c>GetPdfTextQuery</c> #3222): shared-game PDFs are public,
-/// private PDFs require ownership, admins bypass. Copyright-tier gating remains deferred (slice spec S-4).
+/// private PDFs require ownership, admins bypass. Additionally copyright-tier gated to <c>Full</c>
+/// (#3435 §5quinquies): the handler returns an empty overlay for non-Full tiers so a Protected PDF's
+/// region layout does not leak, matching the grounded-citation region gate.
 /// </summary>
 internal sealed record GetPdfImageRegionsQuery(Guid PdfId, Guid UserId, bool IsAdmin)
     : IQuery<IReadOnlyList<ImageRegionDto>>;

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetPdfImageRegionsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetPdfImageRegionsQueryHandler.cs
@@ -1,5 +1,8 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Queries;
+using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
 using Api.Infrastructure;
 using Api.SharedKernel.Application.Interfaces;
+using MediatR;
 using Microsoft.EntityFrameworkCore;
 
 namespace Api.BoundedContexts.DocumentProcessing.Application.Queries;
@@ -8,10 +11,12 @@ internal class GetPdfImageRegionsQueryHandler
     : IQueryHandler<GetPdfImageRegionsQuery, IReadOnlyList<ImageRegionDto>>
 {
     private readonly MeepleAiDbContext _dbContext;
+    private readonly IMediator _mediator;
 
-    public GetPdfImageRegionsQueryHandler(MeepleAiDbContext dbContext)
+    public GetPdfImageRegionsQueryHandler(MeepleAiDbContext dbContext, IMediator mediator)
     {
         _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
     }
 
     public async Task<IReadOnlyList<ImageRegionDto>> Handle(
@@ -36,6 +41,19 @@ internal class GetPdfImageRegionsQueryHandler
         var isSharedGamePdf = pdf.SharedGameId.HasValue;
         var isOwner = pdf.UploadedByUserId == query.UserId;
         if (!query.IsAdmin && !isSharedGamePdf && !isOwner)
+        {
+            return Array.Empty<ImageRegionDto>();
+        }
+
+        // #3435 §5quinquies: region boxes are Full-tier-only, matching the grounded-citation gate
+        // (GroundedAnswerService emits CitationRegion only for CopyrightTier.Full). A Protected PDF's
+        // region layout must not leak through this viewer-overlay path. Copyright-tier resolution is
+        // owned by KnowledgeBase and consumed via IMediator (ADR-090); the tier is NOT admin-bypassed
+        // (copyright, not access-control) — consistent with the grounded path.
+        var tier = await _mediator
+            .Send(new ResolvePdfCopyrightTierQuery(query.PdfId.ToString(), query.UserId), cancellationToken)
+            .ConfigureAwait(false);
+        if (tier != CopyrightTier.Full)
         {
             return Array.Empty<ImageRegionDto>();
         }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/ResolvePdfCopyrightTierQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/ResolvePdfCopyrightTierQuery.cs
@@ -1,0 +1,14 @@
+using System;
+using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries;
+
+/// <summary>
+/// #3435 (§5quinquies): resolves one PDF's <see cref="CopyrightTier"/> for a user, so non-citation
+/// surfaces can Full-gate consistently with grounded citations. Copyright-tier resolution is owned by
+/// KnowledgeBase; other bounded contexts (e.g. the DocumentProcessing image-region viewer overlay)
+/// consume it via <c>IMediator</c> rather than injecting the resolver (ADR-090 boundary).
+/// </summary>
+internal sealed record ResolvePdfCopyrightTierQuery(string DocumentId, Guid UserId)
+    : IQuery<CopyrightTier>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/ResolvePdfCopyrightTierQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/ResolvePdfCopyrightTierQueryHandler.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries;
+
+internal sealed class ResolvePdfCopyrightTierQueryHandler
+    : IQueryHandler<ResolvePdfCopyrightTierQuery, CopyrightTier>
+{
+    private readonly ICopyrightTierResolver _resolver;
+
+    public ResolvePdfCopyrightTierQueryHandler(ICopyrightTierResolver resolver)
+        => _resolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
+
+    public Task<CopyrightTier> Handle(ResolvePdfCopyrightTierQuery query, CancellationToken cancellationToken)
+        => _resolver.ResolveTierAsync(query.DocumentId, query.UserId, cancellationToken);
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/CopyrightTierResolver.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/CopyrightTierResolver.cs
@@ -59,15 +59,41 @@ internal sealed class CopyrightTierResolver : ICopyrightTierResolver
         if (!pdfInfos.TryGetValue(citation.DocumentId, out var info))
             return citation with { CopyrightTier = CopyrightTier.Protected, IsPublic = false };
 
-        var isPublic = info.IsPublic;
+        var tier = ResolveTierCore(info, userId, ownership);
+        return citation with { CopyrightTier = tier, IsPublic = info.IsPublic };
+    }
 
+    /// <inheritdoc />
+    public async Task<CopyrightTier> ResolveTierAsync(string documentId, Guid userId, CancellationToken ct)
+    {
+        var pdfInfos = await _projection.GetPdfCopyrightInfoAsync(new[] { documentId }, ct).ConfigureAwait(false);
+        if (!pdfInfos.TryGetValue(documentId, out var info))
+        {
+            // Unknown / missing document -> safe fallback (no verbatim, no region highlight).
+            return CopyrightTier.Protected;
+        }
+
+        var gameId = info.GameId ?? info.PrivateGameId;
+        var ownership = userId != Guid.Empty && gameId.HasValue
+            ? await _projection.CheckOwnershipAsync(userId, new[] { gameId.Value }, ct).ConfigureAwait(false)
+            : new Dictionary<Guid, bool>();
+
+        return ResolveTierCore(info, userId, ownership);
+    }
+
+    // Tier cascade — single source of truth shared by ResolveSingle + ResolveTierAsync:
+    // 1. copyright-free license -> Full; 2. non-protected category -> Full; 3. uploader AND game
+    // owner -> Full; 4. otherwise Protected.
+    private static CopyrightTier ResolveTierCore(
+        PdfCopyrightInfo info, Guid userId, IReadOnlyDictionary<Guid, bool> ownership)
+    {
         // Rule 1: Copyright-free license (CreativeCommons, PublicDomain)
         if (info.LicenseType.IsCopyrightFree())
-            return citation with { CopyrightTier = CopyrightTier.Full, IsPublic = isPublic };
+            return CopyrightTier.Full;
 
         // Rule 2: Non-protected document category
         if (!ProtectedCategories.Contains(info.DocumentCategory))
-            return citation with { CopyrightTier = CopyrightTier.Full, IsPublic = isPublic };
+            return CopyrightTier.Full;
 
         // Rule 3: User uploaded AND owns the game (BOTH conditions required)
         if (userId != Guid.Empty)
@@ -78,11 +104,11 @@ internal sealed class CopyrightTierResolver : ICopyrightTierResolver
                 && ownership.TryGetValue(gameId.Value, out var isOwned)
                 && isOwned)
             {
-                return citation with { CopyrightTier = CopyrightTier.Full, IsPublic = isPublic };
+                return CopyrightTier.Full;
             }
         }
 
         // Default: Protected
-        return citation with { CopyrightTier = CopyrightTier.Protected, IsPublic = isPublic };
+        return CopyrightTier.Protected;
     }
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/ICopyrightTierResolver.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/ICopyrightTierResolver.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.KnowledgeBase.Application.Models;
+using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
 
 namespace Api.BoundedContexts.KnowledgeBase.Application.Services;
 
@@ -25,4 +26,12 @@ internal interface ICopyrightTierResolver
         IReadOnlyList<ChunkCitation> citations,
         Guid userId,
         CancellationToken ct);
+
+    /// <summary>
+    /// Resolves the copyright tier for a single document (same cascade as <see cref="ResolveAsync"/>).
+    /// Used to gate non-citation surfaces that must match citation copyright semantics — e.g. the
+    /// image-region viewer overlay, whose region boxes are <c>Full</c>-only (#3435 §5quinquies).
+    /// Returns <see cref="CopyrightTier.Protected"/> for an unknown document.
+    /// </summary>
+    Task<CopyrightTier> ResolveTierAsync(string documentId, Guid userId, CancellationToken ct);
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/CopyrightTierResolverTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/CopyrightTierResolverTests.cs
@@ -305,4 +305,70 @@ public sealed class CopyrightTierResolverTests
             p => p.GetPdfCopyrightInfoAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
+
+    // ── #3435 §5quinquies: ResolveTierAsync (single-doc tier, same cascade) ──
+
+    [Fact]
+    [Trait("Issue", "3435")]
+    public async Task ResolveTierAsync_CreativeCommons_ReturnsFull()
+    {
+        SetupProjection(MakeInfo(license: LicenseType.CreativeCommons, category: DocumentCategory.Rulebook));
+        SetupOwnership();
+
+        var tier = await _sut.ResolveTierAsync("doc-1", _userId, CancellationToken.None);
+
+        Assert.Equal(CopyrightTier.Full, tier);
+    }
+
+    [Fact]
+    [Trait("Issue", "3435")]
+    public async Task ResolveTierAsync_NonProtectedCategory_ReturnsFull()
+    {
+        SetupProjection(MakeInfo(license: LicenseType.Copyrighted, category: DocumentCategory.Other));
+
+        var tier = await _sut.ResolveTierAsync("doc-1", _userId, CancellationToken.None);
+
+        Assert.Equal(CopyrightTier.Full, tier);
+    }
+
+    [Fact]
+    [Trait("Issue", "3435")]
+    public async Task ResolveTierAsync_ProtectedRulebook_NotOwner_ReturnsProtected()
+    {
+        SetupProjection(MakeInfo(
+            license: LicenseType.Copyrighted, category: DocumentCategory.Rulebook,
+            uploadedBy: Guid.NewGuid(), gameId: _gameId));
+        SetupOwnership((_gameId, false));
+
+        var tier = await _sut.ResolveTierAsync("doc-1", _userId, CancellationToken.None);
+
+        Assert.Equal(CopyrightTier.Protected, tier);
+    }
+
+    [Fact]
+    [Trait("Issue", "3435")]
+    public async Task ResolveTierAsync_ProtectedRulebook_UploaderAndOwner_ReturnsFull()
+    {
+        SetupProjection(MakeInfo(
+            license: LicenseType.Copyrighted, category: DocumentCategory.Rulebook,
+            uploadedBy: _userId, gameId: _gameId));
+        SetupOwnership((_gameId, true));
+
+        var tier = await _sut.ResolveTierAsync("doc-1", _userId, CancellationToken.None);
+
+        Assert.Equal(CopyrightTier.Full, tier);
+    }
+
+    [Fact]
+    [Trait("Issue", "3435")]
+    public async Task ResolveTierAsync_UnknownDocument_ReturnsProtected()
+    {
+        _projection
+            .Setup(p => p.GetPdfCopyrightInfoAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, PdfCopyrightInfo>());
+
+        var tier = await _sut.ResolveTierAsync("unknown-doc", _userId, CancellationToken.None);
+
+        Assert.Equal(CopyrightTier.Protected, tier);
+    }
 }

--- a/apps/api/tests/Api.Tests/Unit/DocumentProcessing/GetPdfImageRegionsQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/DocumentProcessing/GetPdfImageRegionsQueryHandlerTests.cs
@@ -1,9 +1,13 @@
 using Api.BoundedContexts.DocumentProcessing.Application.Queries;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries;
+using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
 using Api.Tests.Constants;
 using Api.Tests.TestHelpers;
 using FluentAssertions;
+using MediatR;
+using Moq;
 using Xunit;
 
 namespace Api.Tests.Unit.DocumentProcessing;
@@ -28,6 +32,18 @@ public sealed class GetPdfImageRegionsQueryHandlerTests
         });
     }
 
+    // #3435 §5quinquies: the handler now resolves the PDF copyright tier via IMediator and gates the
+    // region overlay to Full-tier. The KB resolution is mocked here (Full by default) so the existing
+    // owner/shared/admin SCOPING tests still exercise the return-regions path.
+    private static GetPdfImageRegionsQueryHandler Handler(MeepleAiDbContext db, CopyrightTier tier = CopyrightTier.Full)
+    {
+        var mediator = new Mock<IMediator>();
+        mediator
+            .Setup(m => m.Send(It.IsAny<ResolvePdfCopyrightTierQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tier);
+        return new GetPdfImageRegionsQueryHandler(db, mediator.Object);
+    }
+
     [Fact]
     public async Task Handle_ReturnsRegionsForOwner_OrderedByPage()
     {
@@ -41,8 +57,7 @@ public sealed class GetPdfImageRegionsQueryHandlerTests
             new PdfImageRegionEntity { PdfDocumentId = Guid.NewGuid(), PageNumber = 1, X = 0, Y = 0, Width = 1, Height = 1, ElementType = "Image" });
         await db.SaveChangesAsync();
 
-        var handler = new GetPdfImageRegionsQueryHandler(db);
-        var result = await handler.Handle(new GetPdfImageRegionsQuery(pdfId, ownerId, IsAdmin: false), CancellationToken.None);
+        var result = await Handler(db).Handle(new GetPdfImageRegionsQuery(pdfId, ownerId, IsAdmin: false), CancellationToken.None);
 
         result.Should().HaveCount(2);
         result.Select(r => r.Page).Should().ContainInOrder(4, 5); // ordered by page
@@ -53,8 +68,7 @@ public sealed class GetPdfImageRegionsQueryHandlerTests
     public async Task Handle_UnknownPdf_ReturnsEmpty()
     {
         using var db = TestDbContextFactory.CreateInMemoryDbContext($"getimg_{Guid.NewGuid():N}");
-        var handler = new GetPdfImageRegionsQueryHandler(db);
-        var result = await handler.Handle(
+        var result = await Handler(db).Handle(
             new GetPdfImageRegionsQuery(Guid.NewGuid(), Guid.NewGuid(), IsAdmin: false), CancellationToken.None);
         result.Should().BeEmpty();
     }
@@ -68,8 +82,7 @@ public sealed class GetPdfImageRegionsQueryHandlerTests
         db.PdfImageRegions.Add(new PdfImageRegionEntity { PdfDocumentId = pdfId, PageNumber = 1, X = 0, Y = 0, Width = 0.5, Height = 0.5, ElementType = "Image" });
         await db.SaveChangesAsync();
 
-        var handler = new GetPdfImageRegionsQueryHandler(db);
-        var result = await handler.Handle(
+        var result = await Handler(db).Handle(
             new GetPdfImageRegionsQuery(pdfId, Guid.NewGuid(), IsAdmin: false), CancellationToken.None);
 
         result.Should().BeEmpty(); // non-owner of a private PDF gets an empty overlay, no existence leak
@@ -84,11 +97,10 @@ public sealed class GetPdfImageRegionsQueryHandlerTests
         db.PdfImageRegions.Add(new PdfImageRegionEntity { PdfDocumentId = pdfId, PageNumber = 1, X = 0, Y = 0, Width = 0.5, Height = 0.5, ElementType = "Image" });
         await db.SaveChangesAsync();
 
-        var handler = new GetPdfImageRegionsQueryHandler(db);
-        var result = await handler.Handle(
+        var result = await Handler(db).Handle(
             new GetPdfImageRegionsQuery(pdfId, Guid.NewGuid(), IsAdmin: false), CancellationToken.None);
 
-        result.Should().HaveCount(1); // shared-game PDFs are public (citation viewer)
+        result.Should().HaveCount(1); // shared-game PDFs are public (citation viewer) + Full tier here
     }
 
     [Fact]
@@ -100,10 +112,62 @@ public sealed class GetPdfImageRegionsQueryHandlerTests
         db.PdfImageRegions.Add(new PdfImageRegionEntity { PdfDocumentId = pdfId, PageNumber = 1, X = 0, Y = 0, Width = 0.5, Height = 0.5, ElementType = "Image" });
         await db.SaveChangesAsync();
 
-        var handler = new GetPdfImageRegionsQueryHandler(db);
-        var result = await handler.Handle(
+        var result = await Handler(db).Handle(
             new GetPdfImageRegionsQuery(pdfId, Guid.NewGuid(), IsAdmin: true), CancellationToken.None);
 
-        result.Should().HaveCount(1); // admin bypasses ownership
+        result.Should().HaveCount(1); // admin bypasses OWNERSHIP scoping (tier still Full here)
+    }
+
+    // ── #3435 §5quinquies: copyright-tier gate on the region overlay ──
+
+    [Fact]
+    [Trait("Issue", "3435")]
+    public async Task Handle_ProtectedTier_ReturnsEmpty_NoRegionLeak()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext($"getimg_{Guid.NewGuid():N}");
+        var pdfId = Guid.NewGuid();
+        SeedPdf(db, pdfId, ownerId: Guid.NewGuid(), sharedGameId: Guid.NewGuid()); // scoping passes (public)
+        db.PdfImageRegions.Add(new PdfImageRegionEntity { PdfDocumentId = pdfId, PageNumber = 1, X = 0, Y = 0, Width = 0.5, Height = 0.5, ElementType = "Image" });
+        await db.SaveChangesAsync();
+
+        var result = await Handler(db, CopyrightTier.Protected).Handle(
+            new GetPdfImageRegionsQuery(pdfId, Guid.NewGuid(), IsAdmin: false), CancellationToken.None);
+
+        result.Should().BeEmpty(); // Protected region layout must not leak via the viewer overlay
+    }
+
+    [Fact]
+    [Trait("Issue", "3435")]
+    public async Task Handle_FullTier_ReturnsRegions()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext($"getimg_{Guid.NewGuid():N}");
+        var pdfId = Guid.NewGuid();
+        var ownerId = Guid.NewGuid();
+        SeedPdf(db, pdfId, ownerId);
+        db.PdfImageRegions.Add(new PdfImageRegionEntity { PdfDocumentId = pdfId, PageNumber = 1, X = 0, Y = 0, Width = 0.5, Height = 0.5, ElementType = "Image" });
+        await db.SaveChangesAsync();
+
+        var result = await Handler(db, CopyrightTier.Full).Handle(
+            new GetPdfImageRegionsQuery(pdfId, ownerId, IsAdmin: false), CancellationToken.None);
+
+        result.Should().HaveCount(1);
+    }
+
+    [Fact]
+    [Trait("Issue", "3435")]
+    public async Task Handle_ProtectedTier_NotBypassedByAdmin()
+    {
+        // The copyright tier is NOT admin-bypassed (copyright, not access-control) — consistent with
+        // the grounded-citation gate.
+        using var db = TestDbContextFactory.CreateInMemoryDbContext($"getimg_{Guid.NewGuid():N}");
+        var pdfId = Guid.NewGuid();
+        SeedPdf(db, pdfId, ownerId: Guid.NewGuid(), sharedGameId: Guid.NewGuid());
+        db.PdfImageRegions.Add(new PdfImageRegionEntity { PdfDocumentId = pdfId, PageNumber = 1, X = 0, Y = 0, Width = 0.5, Height = 0.5, ElementType = "Image" });
+        await db.SaveChangesAsync();
+
+        var result = await Handler(db, CopyrightTier.Protected).Handle(
+            new GetPdfImageRegionsQuery(pdfId, Guid.NewGuid(), IsAdmin: true), CancellationToken.None);
+
+        result.Should().BeEmpty();
     }
 }

--- a/apps/api/tests/Api.Tests/Unit/DocumentProcessing/GetPdfImageRegionsQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/DocumentProcessing/GetPdfImageRegionsQueryHandlerTests.cs
@@ -170,4 +170,29 @@ public sealed class GetPdfImageRegionsQueryHandlerTests
 
         result.Should().BeEmpty();
     }
+
+    [Fact]
+    [Trait("Issue", "3435")]
+    public async Task Handle_ResolvesTier_WithThisPdfIdAndUserId()
+    {
+        // #3517-class guard: the tier must be resolved for THIS pdf + user, not a swapped id — a wrong
+        // argument would gate the wrong document's copyright and silently leak/hide regions.
+        using var db = TestDbContextFactory.CreateInMemoryDbContext($"getimg_{Guid.NewGuid():N}");
+        var pdfId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        SeedPdf(db, pdfId, ownerId: userId); // owner -> scoping passes, tier gate is reached
+        await db.SaveChangesAsync();
+
+        var mediator = new Mock<IMediator>();
+        mediator
+            .Setup(m => m.Send(It.IsAny<ResolvePdfCopyrightTierQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CopyrightTier.Full);
+        var handler = new GetPdfImageRegionsQueryHandler(db, mediator.Object);
+
+        await handler.Handle(new GetPdfImageRegionsQuery(pdfId, userId, IsAdmin: false), CancellationToken.None);
+
+        mediator.Verify(m => m.Send(
+            It.Is<ResolvePdfCopyrightTierQuery>(q => q.DocumentId == pdfId.ToString() && q.UserId == userId),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
 }


### PR DESCRIPTION
## Cosa (§5quinquies open risk — epic #3435)

Chiude il **copyright-gate divergence** flaggato nella spec. L'endpoint image-region del viewer-overlay (`GET /pdf/{pdfId}/image-regions`, SP1 #3447, **già live**) restituiva i box delle regioni a qualunque utente con accesso owner/shared-game, mentre il path grounded emette una `CitationRegion` **solo** per `CopyrightTier.Full`. Quindi il layout delle regioni di un PDF shared-game **`Protected`** leakava tramite l'overlay, mentre la risposta grounded lo nascondeva.

### Fix
- **DocumentProcessing** — `GetPdfImageRegionsQueryHandler` risolve il copyright-tier del PDF via `IMediator` (ADR-090: il tier è di KnowledgeBase; **non** admin-bypassato — è copyright, non access-control, coerente col path grounded) e ritorna overlay **vuoto** per tier non-Full.
- **KnowledgeBase** — nuova query `ResolvePdfCopyrightTierQuery` + handler; `ICopyrightTierResolver.ResolveTierAsync` (tier single-doc, condivide la cascade di `ResolveSingle` via un `ResolveTierCore` estratto — DRY, nessuna duplicazione della logica di tier).

### Verifica
- **31 test verdi**: cascade single-doc del resolver (5 nuovi: CC/categoria-non-protetta/owner→Full, rulebook-non-owner/unknown→Protected) + handler DP (Protected→vuoto, Full→regioni, admin-non-bypassato — 3 nuovi). I **12 test esistenti** del resolver guardano il refactor → path grounded invariato. `dotnet build` verde.
- **FE**: nessuna modifica (il viewer già gestisce un overlay vuoto → nessun box).
- **DocumentId format** verificato: `PdfDocument.Id.ToString()` ("D") == chiave del `CopyrightDataProjection`.

Refs #3435

🤖 Generated with [Claude Code](https://claude.com/claude-code)
