### PR TITLE
docs(rag): SP7 activation runbook + image-table golden set (#3435)

### DIFF
--- a/docs/for-developers/operations/2026-08-04-image-table-vlm-activation-runbook.md
+++ b/docs/for-developers/operations/2026-08-04-image-table-vlm-activation-runbook.md
@@ -1,0 +1,255 @@
+# Image-Table VLM Extraction — Activation Runbook (#3435)
+
+Operational runbook to **turn on** the async VLM image-table extraction pipeline of epic
+[#3435](https://github.com/meepleAi-app/meepleai-monorepo/issues/3435) (Metà C) on an environment.
+The pipeline extracts tables that live as **images** in rulebooks (not selectable text) into
+retrievable, citation-groundable RAG chunks.
+
+The feature is **code-complete and flag-gated OFF by default** — nothing runs until you follow this
+runbook. Design: [`docs/superpowers/specs/2026-08-01-image-table-region-grounding-design.md`](../../superpowers/specs/2026-08-01-image-table-region-grounding-design.md).
+
+| Sub-project | What | PR |
+|---|---|---|
+| SP1 | Image-region capture + auto ingestion (`pdf_image_regions`) | #3541 / #3547 |
+| SP2 | Table-region router (candidate PDFs for the VLM) | #3553 |
+| SP3 | smoldocling crop-discriminator `POST /api/v1/extract-image` | #3559 |
+| SP4 | Async VLM table-extraction job + RAG table-chunk persistence (SP5 folded) | #3560 |
+| — | Copyright-gate on the image-region viewer overlay (§5quinquies) | #3561 |
+| — | Admin trigger for the table-extraction batch | #3562 |
+
+---
+
+## 1. What it does (pipeline recap)
+
+```
+pdf_image_regions (hi_res Image/FigureCaption bboxes, SP1)
+   → GetTableRegionCandidatesQuery  (router: PDFs with ≥ N regions, SP2)
+   → RunTableExtractionJob  (Quartz, [DisallowConcurrentExecution], SP4)
+       per candidate PDF, per pending region:
+         render page (Docnet/PDFium) + crop bbox (SkiaSharp)
+         → POST /api/v1/extract-image  (smoldocling crop-discriminator, SP3)
+            → is_table? (<otsl> gate) — illustrations are discarded (pre-filter / no-otsl)
+         → if table: persist a table chunk
+              text_chunks (ElementType='Table', bounding_boxes_json = region bbox)
+              + pgvector_embeddings (source_chunk_id → the chunk, carries the region to the citation)
+         → record per-region state in pdf_table_extractions (idempotency + retry-cap/dead-letter)
+```
+
+Per-region state (`pdf_table_extractions`) is keyed by a **bbox-stable region hash** (survives the
+SP1 replace-by-pdf region re-seed). The job is idempotent + retry-capped; a document reindex that
+wipes a produced chunk is self-healed on the next run (re-index from the cached markdown, no VLM re-run).
+
+---
+
+## 2. Preconditions
+
+- [ ] **A GPU node for smoldocling.** The 256M model runs ~1.7–3s per table crop on an RTX 4070 but is
+  impractical on CPU (>95s/page). The staging 8GB box is NOT adequate for the always-on service —
+  run smoldocling on a GPU box (dedicated node, or a local GPU during a batch window; DC-E).
+- [ ] **The corpus is indexed** (`IndexerVersion` set on Ready PDFs) — SP2's candidate selector
+  requires it, and the RAG persistence reuses each PDF's existing `vector_documents` row.
+- [ ] **Backend deployed with the #3435 code** (SP1–SP4 + gate, all on `main-dev`). Verify the target
+  build actually contains it, e.g. `grep -c -a "run-table-extraction-batch" /app/Api.dll` in the API
+  container — **merge ≠ deploy**; a flag can only activate code that is actually in the running build.
+
+---
+
+## 3. Deploy smoldocling on GPU
+
+The smoldocling service hosts `/api/v1/extract-image` (SP3) alongside `/api/v1/extract` etc. on
+**port 8002**.
+
+```bash
+# From apps/smoldocling-service. IMPORTANT: rebuild from source — a locally-cached image predating
+# #3559 returns HTTP 404 on /api/v1/extract-image. The model-download layer is cached, so the COPY src
+# rebuild is fast.
+docker build -t meepleai-smoldocling-service:latest apps/smoldocling-service
+
+# GPU run (mirror of infra/compose.smoldocling.gpu.local.yml: DEVICE=cuda + nvidia reservation)
+docker run -d --name meepleai-smoldocling --gpus all -e DEVICE=cuda -p 8002:8002 \
+  meepleai-smoldocling-service:latest
+
+# Wait ~50-70s for model warmup, then confirm health + the endpoint exists.
+curl -s http://localhost:8002/health          # -> "status":"healthy", "model_initialized":"ok", gpu_info
+curl -s -o /dev/null -w '%{http_code}\n' -X POST http://localhost:8002/api/v1/extract-image  # 422 (needs a file) — NOT 404
+```
+
+**Smoke test the endpoint** (a clean B/W table crop must return `is_table:true` + `<otsl>` markdown; a
+saturated illustration must be pre-filtered):
+
+```python
+import io, httpx, numpy as np
+from PIL import Image, ImageDraw
+def table():
+    im=Image.new("RGB",(602,242),"white"); d=ImageDraw.Draw(im)
+    for r in range(5): d.line([(0,r*60),(600,r*60)],fill="black",width=2)
+    for c in range(4): d.line([(c*200,0),(c*200,240)],fill="black",width=2)
+    for r,row in enumerate([["Risorsa","Costo","Punti"],["Legno","2","1"],["Argilla","3","2"],["Grano","1","3"]]):
+        for c,v in enumerate(row): d.text((c*200+12,r*60+22),v,fill="black")
+    return im
+buf=io.BytesIO(); table().save(buf,"PNG")
+print(httpx.post("http://localhost:8002/api/v1/extract-image",
+      files={"image":("t.png",buf.getvalue(),"image/png")},timeout=180).json())
+# -> {"is_table": true, "reason": "table-otsl", "markdown": "| Risorsa | Costo | Punti | ...", "bbox":[...], ...}
+```
+
+Point the backend at it: config key **`PdfProcessing:Extractor:SmolDocling:ApiUrl`** (default
+`http://smoldocling-service:8002`).
+
+---
+
+## 4. Ensure image-regions are seeded (SP1)
+
+The VLM job only sees PDFs that already have rows in `pdf_image_regions`. If the corpus was seeded
+during SP1 validation you can skip this; otherwise enable seeding and run a batch:
+
+```
+# config
+PdfProcessing:ImageRegionSeeding:Enabled = true       # default false
+PdfProcessing:ImageRegionSeeding:IntervalMinutes = 30 # Quartz auto-fire (or trigger manually below)
+```
+
+```bash
+# manual trigger (admin session)
+POST /admin/pdfs/maintenance/seed-image-regions-batch   {"batchSize": 3}
+```
+
+hi_res is ~200-300s/PDF and memory-heavy — seed on a box with headroom, small batches. Verify:
+
+```sql
+SELECT COUNT(*) AS regions, COUNT(DISTINCT pdf_document_id) AS pdfs FROM pdf_image_regions;
+SELECT element_type, COUNT(*) FROM pdf_image_regions GROUP BY element_type;  -- 'Image' | 'FigureCaption'
+```
+
+> **Reality check**: most detected regions are illustrations/photos/cards, NOT tables. The `<otsl>`
+> gate (SP3) and the colorfulness pre-filter discard non-tables, so a batch may report mostly
+> `not_table`. To validate the happy path you need a PDF known to contain a real image-table (see the
+> [golden set](../testing/image-table-golden-set.md)).
+
+Confirm the router sees candidates (read-only, no side effects):
+
+```
+GET /admin/pdfs/maintenance/table-region-candidates?minImageRegions=1&limit=50
+```
+
+---
+
+## 5. Enable + run the table-extraction pass (SP4)
+
+```
+PdfProcessing:TableExtraction:Enabled            = true   # default false — THE master switch
+PdfProcessing:TableExtraction:BatchSize          = 10     # regions processed per run
+PdfProcessing:TableExtraction:DelayMs            = 200    # pacing between regions (throttles the GPU)
+PdfProcessing:TableExtraction:MaxAttempts        = 3      # per-region retries before dead-letter
+PdfProcessing:TableExtraction:IntervalMinutes    = 30     # Quartz cadence (set to 1 for a fast test)
+PdfProcessing:TableExtraction:VlmTimeoutSeconds  = 120    # /extract-image HTTP timeout
+```
+
+Trigger on demand (recommended for the first run so you can inspect the result immediately):
+
+```
+POST /admin/pdfs/maintenance/run-table-extraction-batch   {"batchSize": 10}
+# -> { "enabled": true, "processed": N, "extracted": X, "notTable": Y, "failed": Z }
+```
+
+…or let the Quartz job fire on its interval (no-op while the flag is off).
+
+---
+
+## 6. Verify
+
+```sql
+-- Per-region outcomes
+SELECT status, COUNT(*) FROM pdf_table_extractions GROUP BY status;
+-- 'extracted' | 'not_table' | 'failed' | 'dead_letter' | 'pending'
+
+-- Extracted table chunks are in the RAG corpus (retrievable + groundable)
+SELECT COUNT(*) FROM text_chunks WHERE element_type = 'Table';
+
+-- Each table chunk MUST have a pgvector row wired via source_chunk_id (else it's FTS-only, no vector recall)
+SELECT COUNT(*) AS table_chunks,
+       COUNT(*) FILTER (WHERE e.source_chunk_id IS NOT NULL) AS with_embedding
+FROM text_chunks tc
+LEFT JOIN pgvector_embeddings e ON e.source_chunk_id = tc.id
+WHERE tc.element_type = 'Table';
+
+-- The region bbox rode onto the chunk (draws the citation region)
+SELECT id, page_number, LEFT(content, 60) AS md, bounding_boxes_json
+FROM text_chunks WHERE element_type = 'Table' LIMIT 5;
+```
+
+Then ask a question whose answer is in an extracted table and confirm the grounded answer cites the
+table + highlights its region (SP6 is by-construction: the table chunk's `bounding_boxes_json` flows
+through `source_chunk_id` → `GroundedAnswerService` Full-gate → `CitationDto.Regions` → the FE
+`PdfBBoxOverlay`, exactly like a narrative citation). Quality-validate against the
+[golden set](../testing/image-table-golden-set.md).
+
+---
+
+## 7. Monitoring
+
+Prometheus counters (§8 NFR4):
+
+```promql
+# Give-ups (a region exhausted its retry budget) — investigate the PDF / the VLM service
+increase(meepleai_table_vlm_total{outcome="dead_letter"}[1h]) > 0
+
+# Broadly-failing VLM pass (service down / GPU OOM / timeouts)
+rate(meepleai_table_vlm_total{outcome="failed"}[15m]) / rate(meepleai_table_vlm_total[15m]) > 0.5
+
+# Throughput
+sum by (outcome) (increase(meepleai_table_vlm_total[1h]))   # extracted | not_table | failed | dead_letter
+```
+
+`outcome` semantics mirror `meepleai_image_region_seed_total`: **`failed`** is transient/retry-eligible,
+**`dead_letter`** is terminal. Alert on `dead_letter`, not `failed`.
+
+---
+
+## 8. Rollout / re-extract existing corpus (SP7)
+
+Turning the feature on only processes candidate PDFs going forward. To backfill table content into the
+**existing** corpus, bump the indexer version so table-heavy PDFs re-run:
+
+1. Bump **`IndexerVersionRegistry`** (the corpus now carries table content — a new semantic version).
+2. Re-extract the table-heavy PDFs (from the SP2 candidate list) via the reindex path — targeted, not
+   the whole corpus:
+   ```
+   POST /admin/pdfs/{pdfId}/reindex        # ReindexDocumentCommand, per candidate PDF
+   ```
+   or the corpus drain loop from the [corpus reindex runbook](./2026-07-26-corpus-reindex-runbook.md).
+3. The table-extraction job re-runs against the re-seeded regions. **Idempotency**: a reindex deletes a
+   PDF's `text_chunks` (incl. the table chunk) + all its embeddings; the SP4 job **self-heals** —
+   `pdf_table_extractions` still holds the extracted markdown, so the next run re-indexes the table
+   from cache **without** re-cropping / re-calling the VLM (only regions whose chunk is actually gone).
+
+---
+
+## 9. Rollback
+
+- Set `PdfProcessing:TableExtraction:Enabled = false`. The Quartz job becomes a one-config-check no-op.
+- Persisted table chunks + `pdf_table_extractions` rows **remain** (they are valid RAG content). To
+  remove them, delete `text_chunks WHERE element_type='Table'` + their pgvector rows (by
+  `source_chunk_id`) for the affected PDFs, and the `pdf_table_extractions` rows.
+- The image-region seeding (SP1) is a separate flag (`PdfProcessing:ImageRegionSeeding:Enabled`).
+
+---
+
+## 10. Gotchas
+
+- **Stale smoldocling image** → 404 on `/api/v1/extract-image`. Rebuild from source (§3).
+- **GPU OOM / init failure** → the endpoint degrades to a 200 non-table (`reason: init-failed`, R5); the
+  job records a transient failure and retries → dead-letters after `MaxAttempts`. Not a 500.
+- **Most regions are illustrations** → high `not_table` is normal; the pre-filter + `<otsl>` gate are
+  doing their job. `duration_ms: 0` on a `prefilter-colorful` region means the VLM was correctly
+  skipped.
+- **Copyright**: table chunks inherit the parent PDF's tier — a `Protected` PDF's verbatim table +
+  region are auto-hidden at answer time (Full-gate). The image-region viewer overlay is likewise
+  Full-gated (#3561). No per-chunk tier wiring needed.
+- **`no_repeat_ngram_size` is forbidden** in the discriminator (it fabricates spurious tables). If you
+  tune the VLM, keep the repetition early-stop, not `no_repeat`.
+
+---
+
+**Golden-set validation**: [`image-table-golden-set.md`](../testing/image-table-golden-set.md) · **Design**:
+[§10](../../superpowers/specs/2026-08-01-image-table-region-grounding-design.md).

--- a/docs/for-developers/testing/image-table-golden-set.md
+++ b/docs/for-developers/testing/image-table-golden-set.md
@@ -1,0 +1,110 @@
+# Image-Table Golden Set (#3435 §10)
+
+**Status**: spec (ground-truth authoring pending) · **Epic**: [#3435](https://github.com/meepleAi-app/meepleai-monorepo/issues/3435) (image-table region grounding) · **Gates**: SP6 quality (table citation opens page + highlights region + answers from table content)
+
+The image-table golden set is the **quality gate** for the VLM table-extraction pipeline. Unlike the
+[RAG golden eval set](./rag-golden-eval-set.md) (page-level citation accuracy over narrative text), this
+set measures whether **tables that live as images** are (1) detected, (2) transcribed faithfully, and
+(3) grounded to the correct on-page region. The VLM can hallucinate cell values, so every acceptance
+criterion here needs **human-authored ground truth** — it cannot be self-graded from the model output.
+
+Activation of the pipeline this validates: [image-table VLM activation runbook](../operations/2026-08-04-image-table-vlm-activation-runbook.md).
+
+## Why a separate set
+
+The narrative golden set grades page-level citation accuracy; it says nothing about whether an
+image-only table was transcribed correctly. A table extracted with a swapped column or a hallucinated
+value would still "cite the right page" and pass the narrative gate while giving a **wrong answer**.
+This set closes that gap: it grades transcription fidelity (cell values) + region fidelity (bbox) +
+answer correctness (a Q whose answer is only in the table).
+
+## The corpus: 5–10 known image-tables
+
+Draw from 3–4 rulebooks that contain **real image-tables** (scoring grids, action/cost tables rendered
+as graphics, resource-conversion charts). Candidate sources (confirm each table is image-only, not
+selectable text, before authoring):
+
+| Game | Example table (image) | Why it qualifies |
+| --- | --- | --- |
+| Agricola | End-game scoring table (fields/pastures/grain → points) | Dense grid, image-rendered, answer-bearing |
+| Ark Nova | Action-card cost / association-reward table | Multi-column, graphical |
+| Wingspan | Bonus-card / end-of-round goal scoring grid | Scoring matrix as image |
+| 7 Wonders | Military / science scoring reference | Compact reference table |
+
+> **Selection rule**: a table qualifies only if it is **not** already covered by the text extractor
+> (i.e. it is an image, so `<otsl>`-gated extraction is the *only* way its content enters the corpus).
+> Verify with the SP2 candidate list + a manual crop check before authoring ground truth.
+
+## Ground-truth schema
+
+One record per known image-table. Authored by a human from the rulebook; the VLM output is **graded
+against** it, never sourced from it.
+
+```jsonc
+{
+  "id": "agricola-scoring-endgame",
+  "game": "Agricola",
+  "pdf_hint": "agricola-rulebook",          // resolves to a PdfDocument at eval time
+  "region": {
+    "page": 11,                              // 1-based page in the PDF
+    "bbox": [0.08, 0.42, 0.90, 0.71],        // [x, y, x2, y2] normalized top-left; approx (IoU-matched)
+    "bbox_tolerance_iou": 0.5                 // min IoU vs the persisted region bbox to count as "same region"
+  },
+  "expected_content": {
+    "must_contain_cells": ["Fields", "0", "-1", "5+"],   // key cells that MUST appear in the markdown
+    "shape": { "min_rows": 4, "min_cols": 3 }            // structural floor (row/col count sanity)
+  },
+  "qa": [
+    { "q": "How many points is 5 or more grain worth at end game?", "a_contains": ["4"] },
+    { "q": "What is the penalty for an unused field space?", "a_contains": ["-1"] }
+  ]
+}
+```
+
+Store under `tests/llm-eval/golden-set/image-tables/` (JSON per game or one combined file), alongside
+the existing golden-set schema doc. Ground-truth authoring is a manual, one-time task per table.
+
+## Acceptance criteria
+
+Run after activation (runbook §5–6), against a corpus where the candidate PDFs have been through the
+table-extraction pass.
+
+| AC | What it checks | Source of truth | Pass condition |
+| --- | --- | --- | --- |
+| **AC1 — detection** | The image-table was recognized as a table | `pdf_table_extractions.status='extracted'` for the region matching `region.bbox` (IoU ≥ tolerance) | every golden table detected |
+| **AC2 — transcription fidelity** | The markdown contains the right cells | `text_chunks.content` (Table chunk) vs `expected_content.must_contain_cells` | all `must_contain_cells` present; shape ≥ floor |
+| **AC3 — region fidelity** | The citation highlights the right on-page area | persisted chunk `bounding_boxes_json` vs `region.bbox` | IoU ≥ `bbox_tolerance_iou` |
+| **AC4 — answer grounding** | A table-only question is answered correctly + cites the table | grounded answer (RAG) for each `qa.q` | answer contains `a_contains`; a citation resolves to the table chunk's page + region |
+
+AC2 uses **substring/cell-membership**, not exact-string equality — VLM whitespace/ordering varies, and
+demanding an exact table render is brittle. AC4 reuses the narrative citation matcher
+(`InlineCitationMatcherService`) plus a region-presence check (`CitationDto.Regions` non-empty for the
+cited table chunk).
+
+## Validation procedure
+
+1. **Activate** the pipeline for the golden PDFs (runbook §3–5), or trigger a targeted batch.
+2. **Detection + fidelity (AC1–AC3)** — for each golden record, query `pdf_table_extractions` +
+   `text_chunks` (SQL in runbook §6), match the region by IoU, assert cells + bbox.
+3. **Answer grounding (AC4)** — ask each `qa.q` against the game's agent; assert `a_contains` ⊆ answer
+   and that a returned citation resolves to the table chunk (page + non-empty region).
+4. **Report** — pass/fail per AC per table. A regression on any AC is a release blocker for the feature
+   flag, not the whole corpus.
+
+## Known limitations
+
+- **VLM non-determinism**: identical crops can yield slightly different whitespace/row order. Grade by
+  cell membership + structural floor, never exact string.
+- **Approximate bboxes**: SP1 region bboxes are detector output, not pixel-perfect; `bbox_tolerance_iou`
+  (default 0.5) absorbs the drift. Tighten per-table only if a table sits adjacent to another region.
+- **Not a recall gate**: this set validates *known* tables end-to-end; it does not measure how many of a
+  rulebook's tables were missed. Missed-table recall is a separate, later effort (needs exhaustive
+  per-page table labeling).
+- **Ground-truth cost**: authoring is manual per table. Keep the set small (5–10) and high-signal; grow
+  only when a real extraction bug escapes it.
+
+---
+
+**Pipeline**: [design §10](../../superpowers/specs/2026-08-01-image-table-region-grounding-design.md) ·
+**Activation**: [runbook](../operations/2026-08-04-image-table-vlm-activation-runbook.md) ·
+**Narrative counterpart**: [rag-golden-eval-set.md](./rag-golden-eval-set.md).


### PR DESCRIPTION
## Cosa

Ultimi due deliverable **autonomi** (docs-only) dell'epic image-table grounding #3435 — il codice della pipeline (SP1–SP4 + copyright-gate + trigger admin) è già mergiato su `main-dev`; mancava solo la documentazione operativa per attivarla e validarne la qualità.

### 1. Runbook di attivazione (SP7)
`docs/for-developers/operations/2026-08-04-image-table-vlm-activation-runbook.md`

- Precondizioni (nodo GPU per smoldocling, corpus indicizzato, backend con il codice #3435).
- Deploy smoldocling su GPU (`docker run --gpus all -e DEVICE=cuda -p 8002:8002`) **+ gotcha immagine stale** (immagine locale pre-#3559 → 404 su `/api/v1/extract-image`, ribuildare da sorgente).
- Attivazione flag `PdfProcessing:TableExtraction:Enabled` + trigger `POST /admin/pdfs/maintenance/run-table-extraction-batch`.
- SQL di verifica (`pdf_table_extractions` + `text_chunks` `ElementType='Table'` + join pgvector `source_chunk_id`).
- Monitoring: metrica `meepleai_table_vlm_total{outcome}` (alert su `dead_letter`, **non** su `failed` = transiente).
- Rollout SP7 (bump `IndexerVersionRegistry` + reindex mirato, self-heal idempotente), rollback (flag off), note R5/copyright.

### 2. Golden-set §10
`docs/for-developers/testing/image-table-golden-set.md`

- 5–10 tabelle-immagine note, human-authored (agricola/ark-nova/wingspan/7wonders).
- Schema ground-truth (region bbox + IoU tolerance, `must_contain_cells`, Q/A).
- **AC1–AC4**: detection / transcription (cell-membership, non exact-string per la non-determinatezza del VLM) / region fidelity (IoU) / answer grounding.
- Procedura di validazione + limiti espliciti (non è un recall-gate).

## Note

- **Solo documentazione** — nessun codice eseguibile toccato.
- Tutte le affermazioni tecniche (chiavi config, nome metrica, porta, forma risposta batch, path linkati) **verificate contro il codice**.
- `Refs #3435` (l'epic resta aperta per l'attivazione su infra reale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)