### PR TITLE
fix(pdf): purge-stale persiste davvero lo stato Failed (#3564)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/PurgeStaleDocumentsCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/PurgeStaleDocumentsCommandHandler.cs
@@ -37,7 +37,11 @@ internal sealed class PurgeStaleDocumentsCommandHandler
         // Active states (non-terminal, excluding Pending)
         var activeStates = new[] { "Uploading", "Extracting", "Chunking", "Embedding", "Indexing" };
 
+        // Issue #3564: the DbContext default is QueryTrackingBehavior.NoTracking (PERF-06), so
+        // without .AsTracking() the mutations below never reach the ChangeTracker and
+        // SaveChangesAsync is a silent no-op — while the handler still reports the selected count.
         var staleDocs = await _dbContext.PdfDocuments
+            .AsTracking()
             .Where(p => activeStates.Contains(p.ProcessingState))
             .Where(p => p.UploadedAt < threshold)
             .ToListAsync(cancellationToken)

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Commands/PurgeStaleDocumentsCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Commands/PurgeStaleDocumentsCommandHandlerTests.cs
@@ -1,0 +1,152 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Commands;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Commands;
+
+/// <summary>
+/// Unit tests for PurgeStaleDocumentsCommandHandler.
+/// Issue #3564: the handler mutates entities loaded from the DbContext, whose production default is
+/// QueryTrackingBehavior.NoTracking (PERF-06, InfrastructureServiceExtensions). Without .AsTracking()
+/// SaveChangesAsync was a silent no-op while the handler still reported the selected count, leaving
+/// stale documents stuck in their in-flight state (and therefore un-reindexable, 409).
+/// The DbContext here is built with the SAME tracking behavior as production — a context left on the
+/// EF default (tracking) would make these tests pass even with the bug present.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+public class PurgeStaleDocumentsCommandHandlerTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 8, 5, 12, 0, 0, TimeSpan.Zero);
+
+    private static MeepleAiDbContext CreateDbContext(string databaseName)
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase(databaseName)
+            // Mirrors InfrastructureServiceExtensions (PERF-06). Required for these tests to be
+            // meaningful: the production default is what made the mutation a no-op.
+            .UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking)
+            .Options;
+
+        return new MeepleAiDbContext(
+            options,
+            new Mock<IMediator>().Object,
+            new Mock<IDomainEventCollector>().Object);
+    }
+
+    private static PurgeStaleDocumentsCommandHandler CreateHandler(MeepleAiDbContext ctx) =>
+        new(ctx,
+            new FakeTimeProvider(Now),
+            NullLogger<PurgeStaleDocumentsCommandHandler>.Instance);
+
+    private static PdfDocumentEntity Pdf(string fileName, string state, DateTime uploadedAt) => new()
+    {
+        Id = Guid.NewGuid(),
+        FileName = fileName,
+        FilePath = $"pdfs/{fileName}",
+        ContentType = "application/pdf",
+        ProcessingState = state,
+        UploadedAt = uploadedAt
+    };
+
+    [Fact]
+    public async Task Handle_WhenDocumentIsStale_PersistsFailedState()
+    {
+        // Arrange — a document stuck in an active state well beyond the 24h threshold
+        var dbName = Guid.NewGuid().ToString();
+        using var ctx = CreateDbContext(dbName);
+        var stale = Pdf("stuck.pdf", "Embedding", Now.UtcDateTime.AddDays(-20));
+        ctx.PdfDocuments.Add(stale);
+        await ctx.SaveChangesAsync();
+        ctx.ChangeTracker.Clear();
+
+        // Act
+        var result = await CreateHandler(ctx).Handle(new PurgeStaleDocumentsCommand(), default);
+
+        // Assert — the reported count must reflect what was actually written
+        result.PurgedCount.Should().Be(1);
+
+        using var verifyCtx = CreateDbContext(dbName);
+        var persisted = await verifyCtx.PdfDocuments.SingleAsync(p => p.Id == stale.Id);
+        persisted.ProcessingState.Should().Be("Failed");
+        persisted.ProcessingError.Should().Be("Processing timed out (stale) - purged by admin");
+        persisted.ErrorCategory.Should().Be("Service");
+        persisted.FailedAtState.Should().Be("Embedding");
+        persisted.ProcessedAt.Should().Be(Now.UtcDateTime);
+    }
+
+    [Theory]
+    [InlineData("Uploading")]
+    [InlineData("Extracting")]
+    [InlineData("Chunking")]
+    [InlineData("Embedding")]
+    [InlineData("Indexing")]
+    public async Task Handle_PersistsFailedState_ForEveryActiveState(string state)
+    {
+        var dbName = Guid.NewGuid().ToString();
+        using var ctx = CreateDbContext(dbName);
+        var stale = Pdf($"{state}.pdf", state, Now.UtcDateTime.AddDays(-2));
+        ctx.PdfDocuments.Add(stale);
+        await ctx.SaveChangesAsync();
+        ctx.ChangeTracker.Clear();
+
+        var result = await CreateHandler(ctx).Handle(new PurgeStaleDocumentsCommand(), default);
+
+        result.PurgedCount.Should().Be(1);
+
+        using var verifyCtx = CreateDbContext(dbName);
+        var persisted = await verifyCtx.PdfDocuments.SingleAsync(p => p.Id == stale.Id);
+        persisted.ProcessingState.Should().Be("Failed");
+        persisted.FailedAtState.Should().Be(state);
+    }
+
+    [Fact]
+    public async Task Handle_WhenDocumentIsRecent_LeavesItUntouched()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        using var ctx = CreateDbContext(dbName);
+        var recent = Pdf("recent.pdf", "Embedding", Now.UtcDateTime.AddHours(-1));
+        ctx.PdfDocuments.Add(recent);
+        await ctx.SaveChangesAsync();
+        ctx.ChangeTracker.Clear();
+
+        var result = await CreateHandler(ctx).Handle(new PurgeStaleDocumentsCommand(), default);
+
+        result.PurgedCount.Should().Be(0);
+
+        using var verifyCtx = CreateDbContext(dbName);
+        var persisted = await verifyCtx.PdfDocuments.SingleAsync(p => p.Id == recent.Id);
+        persisted.ProcessingState.Should().Be("Embedding");
+    }
+
+    [Fact]
+    public async Task Handle_LeavesTerminalAndPendingStatesUntouched()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        using var ctx = CreateDbContext(dbName);
+        var ready = Pdf("ready.pdf", "Ready", Now.UtcDateTime.AddDays(-30));
+        var failed = Pdf("failed.pdf", "Failed", Now.UtcDateTime.AddDays(-30));
+        var pending = Pdf("pending.pdf", "Pending", Now.UtcDateTime.AddDays(-30));
+        ctx.PdfDocuments.AddRange(ready, failed, pending);
+        await ctx.SaveChangesAsync();
+        ctx.ChangeTracker.Clear();
+
+        var result = await CreateHandler(ctx).Handle(new PurgeStaleDocumentsCommand(), default);
+
+        result.PurgedCount.Should().Be(0);
+
+        using var verifyCtx = CreateDbContext(dbName);
+        (await verifyCtx.PdfDocuments.SingleAsync(p => p.Id == ready.Id)).ProcessingState.Should().Be("Ready");
+        (await verifyCtx.PdfDocuments.SingleAsync(p => p.Id == failed.Id)).ProcessingState.Should().Be("Failed");
+        (await verifyCtx.PdfDocuments.SingleAsync(p => p.Id == pending.Id)).ProcessingState.Should().Be("Pending");
+    }
+}

--- a/docs/for-developers/operations/2026-08-04-image-table-vlm-activation-runbook.md
+++ b/docs/for-developers/operations/2026-08-04-image-table-vlm-activation-runbook.md
@@ -51,6 +51,10 @@ wipes a produced chunk is self-healed on the next run (re-index from the cached 
 - [ ] **Backend deployed with the #3435 code** (SP1–SP4 + gate, all on `main-dev`). Verify the target
   build actually contains it, e.g. `grep -c -a "run-table-extraction-batch" /app/Api.dll` in the API
   container — **merge ≠ deploy**; a flag can only activate code that is actually in the running build.
+- [ ] **The SP4 migration is applied.** Staging does not auto-apply EF migrations, so
+  `20260804173408_AddPdfTableExtractions` must be run manually (`pdf_table_extractions` + its two
+  indexes + the `__EFMigrationsHistory` row). Check with
+  `select to_regclass('pdf_table_extractions');` — a NULL means the batch will fail on every region.
 
 ---
 
@@ -111,7 +115,7 @@ PdfProcessing:ImageRegionSeeding:IntervalMinutes = 30 # Quartz auto-fire (or tri
 
 ```bash
 # manual trigger (admin session)
-POST /admin/pdfs/maintenance/seed-image-regions-batch   {"batchSize": 3}
+POST /api/v1/admin/pdfs/maintenance/seed-image-regions-batch   {"batchSize": 3}
 ```
 
 hi_res is ~200-300s/PDF and memory-heavy — seed on a box with headroom, small batches. Verify:
@@ -129,7 +133,7 @@ SELECT element_type, COUNT(*) FROM pdf_image_regions GROUP BY element_type;  -- 
 Confirm the router sees candidates (read-only, no side effects):
 
 ```
-GET /admin/pdfs/maintenance/table-region-candidates?minImageRegions=1&limit=50
+GET /api/v1/admin/pdfs/maintenance/table-region-candidates?minImageRegions=1&limit=50
 ```
 
 ---
@@ -148,7 +152,7 @@ PdfProcessing:TableExtraction:VlmTimeoutSeconds  = 120    # /extract-image HTTP 
 Trigger on demand (recommended for the first run so you can inspect the result immediately):
 
 ```
-POST /admin/pdfs/maintenance/run-table-extraction-batch   {"batchSize": 10}
+POST /api/v1/admin/pdfs/maintenance/run-table-extraction-batch   {"batchSize": 10}
 # -> { "enabled": true, "processed": N, "extracted": X, "notTable": Y, "failed": Z }
 ```
 
@@ -215,7 +219,7 @@ Turning the feature on only processes candidate PDFs going forward. To backfill 
 2. Re-extract the table-heavy PDFs (from the SP2 candidate list) via the reindex path — targeted, not
    the whole corpus:
    ```
-   POST /admin/pdfs/{pdfId}/reindex        # ReindexDocumentCommand, per candidate PDF
+   POST /api/v1/admin/pdfs/{pdfId}/reindex        # ReindexDocumentCommand, per candidate PDF
    ```
    or the corpus drain loop from the [corpus reindex runbook](./2026-07-26-corpus-reindex-runbook.md).
 3. The table-extraction job re-runs against the re-seeded regions. **Idempotency**: a reindex deletes a


### PR DESCRIPTION
## Contesto

Trovato eseguendo il runbook di attivazione di #3435 su staging: 4 rulebook fermi dal 2026-07-13 in stati in-flight (`Embedding`/`Chunking`/`Indexing`) non venivano recuperati. `POST /api/v1/admin/pdfs/maintenance/purge-stale` rispondeva `{"purgedCount":4}` senza scrivere nulla, e `POST /admin/pdfs/{id}/reindex` continuava a rispondere 409 → documenti irrecuperabili via API.

## Causa

`PurgeStaleDocumentsCommandHandler` caricava le entità senza `.AsTracking()`. Il DbContext ha default `QueryTrackingBehavior.NoTracking` (PERF-06, `InfrastructureServiceExtensions`), quindi le mutazioni non raggiungevano il ChangeTracker e `SaveChangesAsync` era un no-op silenzioso — mentre il valore di ritorno contava le righe **selezionate**, non quelle **scritte**.

Stesso pattern di #2660 / #888.

## Fix

`.AsTracking()` sulla query + 8 test.

**I test costruiscono il DbContext con lo stesso `QueryTrackingBehavior` della produzione**: con il default EF (tracking) passerebbero anche col bug presente. Verificato red/green — senza `.AsTracking()` 6/8 falliscono, con il fix 8/8 passano. Le asserzioni rileggono da un context separato, quindi verificano la persistenza e non lo stato in memoria.

## Verifica su dati reali

Applicato e rieseguito su staging: i 4 documenti sono passati a `Failed`, il reindex si è sbloccato e `a-feast-for-odin_rulebook.pdf` è tornato `Ready` con 531 chunk (era morto da tre settimane).

## Incluso anche

Due correzioni al runbook di #3435, emerse eseguendolo:
- i path admin erano documentati senza il prefisso `/api/v1` del gruppo (404 seguendo il runbook alla lettera);
- aggiunta la precondizione sulla migration `20260804173408_AddPdfTableExtractions`, che su staging va applicata a mano.

Closes #3564

🤖 Generated with [Claude Code](https://claude.com/claude-code)