### PR TITLE
fix(rag): seeda anche le regioni Table di hi_res (#3565)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/RunImageRegionSeedBatchCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/RunImageRegionSeedBatchCommandHandler.cs
@@ -13,7 +13,7 @@ namespace Api.BoundedContexts.DocumentProcessing.Application.Commands;
 
 /// <summary>
 /// #3435 (SP1): batch runner for automatic image-region seeding. For each Ready, never-seeded PDF it
-/// runs a dedicated hi_res pass (long-timeout client) and persists Image/FigureCaption regions via
+/// runs a dedicated hi_res pass (long-timeout client) and persists Image/FigureCaption/Table regions via
 /// <see cref="SeedPdfImageRegionsCommand"/>, then stamps <c>ImageRegionsSeededAt</c> so the PDF is
 /// processed exactly once (NFR1). Mirrors <c>BackfillPdfCoversJob</c>: small batch, inter-item delay,
 /// per-item try/catch-continue. hi_res is ~200s and NOT reproducible in CI — unit tests drive this

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/ImageRegionExtractor.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/ImageRegionExtractor.cs
@@ -4,8 +4,8 @@ using System.Text.Json.Serialization;
 namespace Api.BoundedContexts.DocumentProcessing.Application.Services;
 
 /// <summary>
-/// Image-table slice (#3447): extracts Image/FigureCaption regions (with bbox) from the raw Unstructured
-/// hi_res response. These are exactly the elements the normal pipeline drops (empty text) in
+/// Image-table slice (#3447): extracts Image/FigureCaption/Table regions (with bbox) from the raw
+/// Unstructured hi_res response. These are exactly the elements the normal pipeline drops (empty text) in
 /// <c>UnstructuredPdfTextExtractor.MapStructuredElements</c>, so we parse the wire format directly.
 /// Safe on null/empty/invalid input → empty. bbox clamped to [0,1].
 /// </summary>
@@ -15,8 +15,15 @@ public static class ImageRegionExtractor
     /// (Width*Height, fraction of page) is at least 3%. Filters out icons/glyphs.</summary>
     public const double DefaultMinAreaFraction = 0.03;
 
+    /// <summary>
+    /// Issue #3565: <c>Table</c> belongs here alongside the image categories. hi_res labels a table
+    /// that is drawn as graphics (the #3435 target) as <c>Table</c>, not <c>Image</c> — e.g. the
+    /// wingspan scorecard, whose extracted text is garbled because its labels are rotated. Excluding
+    /// it meant the VLM only ever saw illustrations and the pass extracted nothing on the real corpus.
+    /// False positives stay cheap: the crop-discriminator's <c>&lt;otsl&gt;</c> gate (SP3) still decides.
+    /// </summary>
     private static readonly HashSet<string> RegionCategories =
-        new(StringComparer.Ordinal) { "Image", "FigureCaption" };
+        new(StringComparer.Ordinal) { "Image", "FigureCaption", "Table" };
 
     public static IReadOnlyList<ExtractedImageRegion> FromHiResJson(
         string? hiResJson,

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Services/TableRegionRouting.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Services/TableRegionRouting.cs
@@ -10,9 +10,14 @@ namespace Api.BoundedContexts.DocumentProcessing.Domain.Services;
 /// </summary>
 /// <remarks>
 /// This mirrors the static-decider shape of <see cref="ExtractionStrategyDecider"/> but deliberately
-/// does NOT reuse its <c>Table</c> predicate: <c>ElementType="Table"</c> is inert on the real corpus
-/// (0 Tables across 52 PDFs — spec §1), whereas hi_res reliably emits bbox-bearing <c>Image</c>/
-/// <c>FigureCaption</c> elements for the same table graphics. Rejected alternatives (spec §5quinquies):
+/// does NOT reuse its <c>Table</c> predicate: that predicate reads the extractor's own table count,
+/// which was inert on the sampled corpus (0 Tables across 52 PDFs — spec §1), whereas hi_res reliably
+/// emits bbox-bearing <c>Image</c>/<c>FigureCaption</c> elements for the same table graphics.
+/// #3565 refined that premise: hi_res DOES occasionally emit a bbox-bearing <c>Table</c> element
+/// (1 in 699 on wingspan — the scorecard), and those are now seeded as regions too. The router is
+/// unaffected because it counts rows in <c>pdf_image_regions</c> without looking at
+/// <c>ElementType</c> — a <c>Table</c> region simply counts toward candidacy like any other.
+/// Rejected alternatives (spec §5quinquies):
 /// a <c>has_tables</c> VLM sample (would couple the router to the blocked Metà-C — the router must
 /// GATE the VLM, not depend on it) and a per-game manual flag (toil across 52 games, does not scale).
 /// The threshold is the single tunable knob; the query handler may override the MVP default of

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/External/UnstructuredPdfTextExtractor.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/External/UnstructuredPdfTextExtractor.cs
@@ -9,7 +9,7 @@ namespace Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
 /// <summary>
 /// Captures the RAW Unstructured hi_res wire JSON for a PDF — the response body that
 /// <see cref="Api.BoundedContexts.DocumentProcessing.Application.Services.ImageRegionExtractor"/>
-/// parses for Image/FigureCaption regions. The normal extraction path drops these
+/// parses for Image/FigureCaption/Table regions. The normal extraction path drops these
 /// (empty-text elements) so image-table region grounding (#3435) needs the raw body.
 /// </summary>
 internal interface IRawHiResExtractor
@@ -314,7 +314,7 @@ internal class UnstructuredPdfTextExtractor : IPdfTextExtractor, IRawHiResExtrac
         // Dedicated hi_res pass on the long-timeout client (#3435): forces strategy=hi_res
         // (the selector is inert on the real corpus) and returns the RAW response body —
         // the exact JSON discarded by ParseExtractionResponseAsync — so ImageRegionExtractor
-        // can parse Image/FigureCaption regions the normal path drops. Unlike the other methods
+        // can parse Image/FigureCaption/Table regions the normal path drops. Unlike the other methods
         // here it does NOT swallow failures: the batch runner needs to see timeouts/HTTP errors
         // to mark the item and continue (a swallowed "" would be indistinguishable from a
         // genuinely region-free PDF and would wrongly stamp the seed marker).

--- a/apps/api/tests/Api.Tests/Unit/DocumentProcessing/ImageRegionExtractorTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/DocumentProcessing/ImageRegionExtractorTests.cs
@@ -90,4 +90,42 @@ public sealed class ImageRegionExtractorTests
         var json = """{"elements":[{"text":"","page_number":1,"category":"Image","bbox":{"x":0.1,"y":0.1,"width":0.01,"height":0.01}}]}""";
         ImageRegionExtractor.FromHiResJson(json, minAreaFraction: 0.0).Should().HaveCount(1);
     }
+
+    /// <summary>
+    /// Issue #3565: hi_res labels a graphics-drawn table as category "Table", not "Image".
+    /// This is the real shape observed on wingspan_en_rulebook.pdf page 5 (the scorecard): the
+    /// text is present but garbled because the row labels are rotated. Excluding "Table" meant the
+    /// only genuine image-table of the rulebook never reached pdf_image_regions, so the VLM pass
+    /// examined illustrations only and extracted nothing.
+    /// </summary>
+    [Fact]
+    public void FromHiResJson_KeepsTableRegions()
+    {
+        var json = """
+        {"elements":[
+          {"text":"S Birds D R A C N Bonus cards O T N U O M End-of-round goals","page_number":5,"category":"Table","bbox":{"x":0.064,"y":0.769,"width":0.377,"height":0.187}}
+        ]}
+        """;
+
+        var regions = ImageRegionExtractor.FromHiResJson(json);
+
+        regions.Should().ContainSingle();
+        regions[0].ElementType.Should().Be("Table");
+        regions[0].Page.Should().Be(5);
+        regions[0].Width.Should().BeApproximately(0.377, 1e-9);
+    }
+
+    [Fact]
+    public void FromHiResJson_AppliesTheSameAreaAndBboxRulesToTableRegions()
+    {
+        var json = """
+        {"elements":[
+          {"text":"tiny","page_number":1,"category":"Table","bbox":{"x":0.1,"y":0.1,"width":0.05,"height":0.05}},
+          {"text":"no bbox","page_number":2,"category":"Table","bbox":null}
+        ]}
+        """;
+
+        // Table is not privileged: the anti-noise area floor and the bbox requirement still apply.
+        ImageRegionExtractor.FromHiResJson(json).Should().BeEmpty();
+    }
 }

--- a/apps/unstructured-service/src/main.py
+++ b/apps/unstructured-service/src/main.py
@@ -225,13 +225,19 @@ async def extract_pdf(
                 # Compute the bbox once per element (double-binding), then reuse it in both the
                 # filter and the schema below.
                 for el, bbox in ((e, normalized_bbox(e)) for e in result.elements)
-                # Keep text-bearing elements AND bbox-bearing Image/FigureCaption regions
-                # (which have empty text): the latter are the image-table regions the
+                # Keep text-bearing elements AND bbox-bearing Image/FigureCaption/Table regions
+                # (which may have empty text): the latter are the image-table regions the
                 # backend's ImageRegionExtractor needs for hi_res region grounding (#3435).
                 # Normal text ingestion is unaffected — the C# MapStructuredElements still
                 # drops empty-text elements before chunking.
+                # #3565: Table is in the set because hi_res labels a graphics-drawn table as
+                # Table; one whose text OCR fails entirely would otherwise be dropped here and
+                # never reach the VLM pass.
                 if getattr(el, "text", None)
-                or (getattr(el, "category", None) in ("Image", "FigureCaption") and bbox is not None)
+                or (
+                    getattr(el, "category", None) in ("Image", "FigureCaption", "Table")
+                    and bbox is not None
+                )
             ],
             quality_score=result.quality_score.total_score,
             page_count=result.page_count,

--- a/apps/unstructured-service/tests/test_api.py
+++ b/apps/unstructured-service/tests/test_api.py
@@ -140,6 +140,53 @@ class TestExtractEndpoint:
         caption = next(e for e in elements if e["category"] == "FigureCaption")
         assert caption["bbox"] is not None
 
+    @patch("src.main.pdf_service.extract")
+    def test_extract_keeps_bbox_bearing_table_regions(self, mock_extract, client, mock_pdf_content):
+        """#3565: a graphics-drawn table is labelled 'Table' by hi_res, and its text may be empty
+        (or garbled) when OCR cannot read rotated labels. It must survive the filter like the other
+        region categories, otherwise the image-table VLM pass (#3435) never sees a real table."""
+        from types import SimpleNamespace
+
+        def _el(text, category, page_number, points=None, system_wh=None):
+            coordinates = None
+            if points and system_wh:
+                coordinates = SimpleNamespace(
+                    points=points,
+                    system=SimpleNamespace(width=system_wh[0], height=system_wh[1]),
+                )
+            return SimpleNamespace(
+                text=text,
+                category=category,
+                metadata=SimpleNamespace(page_number=page_number, coordinates=coordinates),
+            )
+
+        els = [
+            _el("", "Table", 5, [(6, 76), (44, 95)], (100, 100)),  # empty Table + bbox → kept
+            _el("", "Table", 6, None, None),                       # Table w/o bbox → dropped
+        ]
+        mock_extract.return_value = ExtractionResult(
+            full_text="",
+            chunks=[TextChunk(text="c", page_number=1, element_type="CompositeElement")],
+            page_count=6,
+            elements=els,
+            tables=[],
+            detected_structures=["Table"],
+            extraction_duration_ms=1000,
+            quality_score=QualityScore(0.85, 0.40, 0.18, 0.15, 0.12),
+        )
+
+        response = client.post(
+            "/api/v1/extract",
+            files={"file": ("test.pdf", mock_pdf_content, "application/pdf")},
+            data={"strategy": "hi_res", "language": "ita"},
+        )
+
+        assert response.status_code == 200
+        elements = response.json()["elements"]
+        assert [e["category"] for e in elements] == ["Table"]
+        assert elements[0]["page_number"] == 5
+        assert elements[0]["bbox"] is not None
+
     def test_extract_missing_file(self, client):
         """Test extraction without file returns 422"""
         # Act

--- a/docs/for-developers/operations/2026-08-04-image-table-vlm-activation-runbook.md
+++ b/docs/for-developers/operations/2026-08-04-image-table-vlm-activation-runbook.md
@@ -22,7 +22,7 @@ runbook. Design: [`docs/superpowers/specs/2026-08-01-image-table-region-groundin
 ## 1. What it does (pipeline recap)
 
 ```
-pdf_image_regions (hi_res Image/FigureCaption bboxes, SP1)
+pdf_image_regions (hi_res Image/FigureCaption/Table bboxes, SP1)
    → GetTableRegionCandidatesQuery  (router: PDFs with ≥ N regions, SP2)
    → RunTableExtractionJob  (Quartz, [DisallowConcurrentExecution], SP4)
        per candidate PDF, per pending region:
@@ -122,7 +122,7 @@ hi_res is ~200-300s/PDF and memory-heavy — seed on a box with headroom, small 
 
 ```sql
 SELECT COUNT(*) AS regions, COUNT(DISTINCT pdf_document_id) AS pdfs FROM pdf_image_regions;
-SELECT element_type, COUNT(*) FROM pdf_image_regions GROUP BY element_type;  -- 'Image' | 'FigureCaption'
+SELECT element_type, COUNT(*) FROM pdf_image_regions GROUP BY element_type;  -- 'Image' | 'FigureCaption' | 'Table'
 ```
 
 > **Reality check**: most detected regions are illustrations/photos/cards, NOT tables. The `<otsl>`


### PR DESCRIPTION
## Contesto

Attivando la pipeline image-table di #3435 su staging (flag on, smoldocling su RTX 4070): **133 regioni processate su 3 rulebook → 0 tabelle estratte**. Non è il VLM: è l'ingestione che non fa mai arrivare una tabella al VLM.

`ImageRegionExtractor` accettava solo `Image`/`FigureCaption`, ma Unstructured hi_res etichetta **`Table`** proprio le tabelle disegnate come grafica — il bersaglio dell'epic. Probe reale su `wingspan_en_rulebook.pdf` (699 elementi):

```
{'Image': 143, 'UncategorizedText': 422, 'NarrativeText': 74, 'ListItem': 41,
 'FigureCaption': 8, 'Title': 8, 'Header': 2, 'Table': 1}
```

L'unico `Table` è la scorecard di pagina 5: tabella vera, testo garbled perché le etichette di riga sono ruotate (`"S Birds D R A C N Bonus cards O T N U O M End-of-round goals…"`). Esattamente il caso d'uso, scartato a monte. Il VLM cercava tabelle tra le illustrazioni.

## Fix

`Table` aggiunto alle categorie-regione su **entrambi** i lati del filtro:
- `ImageRegionExtractor.RegionCategories` (backend);
- il filtro elementi di `unstructured-service/src/main.py` — una tabella-immagine il cui OCR fallisce del tutto verrebbe altrimenti persa lì, prima ancora di raggiungere il backend.

Nessuna migration: `pdf_image_regions.element_type` non ha CHECK constraint (verificato su staging).

Il rischio di rumore resta basso: l'arbitro è sempre il gate `<otsl>` del crop-discriminator (SP3), le regioni `Table` sono rare, e la soglia anti-noise di area e il requisito bbox continuano ad applicarsi anche a `Table` (test dedicato).

## Test

- 13 test C# su `ImageRegionExtractor` (2 nuovi: `Table` tenuta; `Table` soggetta alle stesse regole di area/bbox).
- 34 test Python verdi, coverage 83.6% (1 nuovo: `Table` con bbox mantenuta, senza bbox scartata).

## Validazione end-to-end su staging (smoldocling GPU)

```
re-seed wingspan       → 73 regioni (72 Image + 1 Table)
batch VLM              → {"processed":1,"extracted":1,"notTable":0,"failed":0}
pdf_table_extractions  → status=extracted, reason=table-otsl, page 5, confidence 0.8
text_chunks            → ElementType='Table', PageNumber=5,
                         bounding_boxes_json=[{x:0.0644,y:0.7689,w:0.3770,h:0.1870,page:5}]
pgvector_embeddings    → 1 riga collegata via source_chunk_id
ricerca ibrida         → il chunk della tabella torna con score 0.925 (rank 1 per contenuto)
```

Prima estrazione reale della pipeline #3435 su corpus vero.

Closes #3565
Refs #3435

🤖 Generated with [Claude Code](https://claude.com/claude-code)