### PR TITLE
fix(pdf): purge-stale salva per-item e conta ciò che scrive (#3572)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/PurgeStaleDocumentsCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/PurgeStaleDocumentsCommandHandler.cs
@@ -37,34 +37,50 @@ internal sealed class PurgeStaleDocumentsCommandHandler
         // Active states (non-terminal, excluding Pending)
         var activeStates = new[] { "Uploading", "Extracting", "Chunking", "Embedding", "Indexing" };
 
-        // Issue #3564: the DbContext default is QueryTrackingBehavior.NoTracking (PERF-06), so
-        // without .AsTracking() the mutations below never reach the ChangeTracker and
-        // SaveChangesAsync is a silent no-op — while the handler still reports the selected count.
-        var staleDocs = await _dbContext.PdfDocuments
-            .AsTracking()
+        // Issue #3572: select the candidates untracked, then load-mutate-save ONE document per
+        // iteration. A single SaveChanges for the whole batch runs in one implicit transaction, so a
+        // concurrency conflict on any one row rolled back every other document — while the handler
+        // returned the selected count and reported success for a batch that persisted nothing (the
+        // same "the count lies" defect #3564 fixed, reached through the concurrency path instead).
+        // Per-item saves contain the blast radius to the conflicting document and let the returned
+        // count reflect what was actually written.
+        var staleIds = await _dbContext.PdfDocuments
             .Where(p => activeStates.Contains(p.ProcessingState))
             .Where(p => p.UploadedAt < threshold)
+            .Select(p => p.Id)
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        foreach (var doc in staleDocs)
-        {
-            var originalState = doc.ProcessingState;
-            doc.ProcessingState = nameof(PdfProcessingState.Failed);
-            doc.ProcessingError = "Processing timed out (stale) - purged by admin";
-            doc.ErrorCategory = "Service";
-            doc.FailedAtState = originalState;
-            doc.ProcessedAt = _timeProvider.GetUtcNow().UtcDateTime;
-        }
+        var purgedCount = 0;
 
-        if (staleDocs.Count > 0)
+        foreach (var pdfId in staleIds)
         {
             try
             {
+                // Issue #3564: .AsTracking() overrides the global QueryTrackingBehavior.NoTracking
+                // default (PERF-06) — without it the mutations below never reach the ChangeTracker
+                // and SaveChangesAsync is a silent no-op.
+                var doc = await _dbContext.PdfDocuments
+                    .AsTracking()
+                    .FirstOrDefaultAsync(p => p.Id == pdfId, cancellationToken)
+                    .ConfigureAwait(false);
+
+                // Re-check under tracking: the document may have been deleted, or may have left the
+                // active states on its own, between the candidate query and this iteration.
+                if (doc is null || !activeStates.Contains(doc.ProcessingState, StringComparer.Ordinal))
+                {
+                    continue;
+                }
+
+                var originalState = doc.ProcessingState;
+                doc.ProcessingState = nameof(PdfProcessingState.Failed);
+                doc.ProcessingError = "Processing timed out (stale) - purged by admin";
+                doc.ErrorCategory = "Service";
+                doc.FailedAtState = originalState;
+                doc.ProcessedAt = _timeProvider.GetUtcNow().UtcDateTime;
+
                 await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-                _logger.LogInformation(
-                    "Maintenance batch completed: {Count} items processed",
-                    staleDocs.Count);
+                purgedCount++;
             }
             catch (DbUpdateConcurrencyException ex)
             {
@@ -72,12 +88,26 @@ internal sealed class PurgeStaleDocumentsCommandHandler
                     nameof(PurgeStaleDocumentsCommandHandler),
                     MeepleAiMetrics.PdfConcurrencyCategories.C);
                 _logger.LogDebug(ex,
-                    "Concurrency conflict in {Handler} (Category C) — some items mutated concurrently by admin; batch partially applied",
-                    nameof(PurgeStaleDocumentsCommandHandler));
-                // No re-throw. Maintenance job is best-effort. Caller treats this as success.
+                    "Concurrency conflict in {Handler} (Category C) — PDF {PdfId} was mutated concurrently by admin; skipped, not counted as purged",
+                    nameof(PurgeStaleDocumentsCommandHandler), pdfId);
+                // No re-throw. Maintenance job is best-effort: the remaining documents still run,
+                // and the skipped one is left out of the returned count.
+            }
+            finally
+            {
+                // Per-item tracker reset (#534): a failed iteration must not leave a mutated entity
+                // in the ChangeTracker, or the NEXT SaveChangesAsync would try to flush it again.
+                _dbContext.ChangeTracker.Clear();
             }
         }
 
-        return new PurgeStaleResult(staleDocs.Count);
+        if (staleIds.Count > 0)
+        {
+            _logger.LogInformation(
+                "Maintenance batch completed: {Purged}/{Selected} items purged",
+                purgedCount, staleIds.Count);
+        }
+
+        return new PurgeStaleResult(purgedCount);
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Commands/PurgeStaleDocumentsCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Commands/PurgeStaleDocumentsCommandHandlerTests.cs
@@ -128,6 +128,74 @@ public class PurgeStaleDocumentsCommandHandlerTests
         persisted.ProcessingState.Should().Be("Embedding");
     }
 
+    /// <summary>
+    /// Issue #3572: the handler now saves one document per iteration and clears the ChangeTracker in
+    /// a finally block. This is the regression that refactor can introduce: if the candidates were
+    /// still loaded as a tracked list up front, the first Clear() would detach the rest and every
+    /// later mutation would be a silent no-op again — only the first document would persist.
+    /// </summary>
+    [Fact]
+    public async Task Handle_PersistsEveryDocumentInTheBatch_NotJustTheFirst()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        using var ctx = CreateDbContext(dbName);
+        var stale = Enumerable.Range(0, 5)
+            .Select(i => Pdf($"stuck-{i}.pdf", "Embedding", Now.UtcDateTime.AddDays(-10)))
+            .ToArray();
+        ctx.PdfDocuments.AddRange(stale);
+        await ctx.SaveChangesAsync();
+        ctx.ChangeTracker.Clear();
+
+        var result = await CreateHandler(ctx).Handle(new PurgeStaleDocumentsCommand(), default);
+
+        result.PurgedCount.Should().Be(5);
+
+        using var verifyCtx = CreateDbContext(dbName);
+        foreach (var doc in stale)
+        {
+            var persisted = await verifyCtx.PdfDocuments.SingleAsync(p => p.Id == doc.Id);
+            persisted.ProcessingState.Should().Be("Failed");
+            persisted.FailedAtState.Should().Be("Embedding");
+        }
+    }
+
+    /// <summary>
+    /// Issue #3572: the returned count must reflect what was WRITTEN. Here a document reaches a
+    /// terminal state before the handler runs, so it is neither purged nor counted.
+    /// NOTE the limit of this test: the transition happens before the call, so the document is
+    /// excluded by the candidate query itself — it does NOT exercise the tracked re-check inside the
+    /// loop (which covers a transition between the candidate query and that document's iteration).
+    /// That window, like the DbUpdateConcurrencyException branch, needs a real database with xmin
+    /// concurrency tokens: EF InMemory has no concurrency tokens, so neither is reachable here.
+    /// </summary>
+    [Fact]
+    public async Task Handle_DoesNotCountDocumentsThatLeftTheActiveStates()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        using var ctx = CreateDbContext(dbName);
+        var stale = Pdf("stuck.pdf", "Embedding", Now.UtcDateTime.AddDays(-10));
+        var alsoStale = Pdf("stuck-2.pdf", "Chunking", Now.UtcDateTime.AddDays(-10));
+        ctx.PdfDocuments.AddRange(stale, alsoStale);
+        await ctx.SaveChangesAsync();
+        ctx.ChangeTracker.Clear();
+
+        // Simulate the race: one candidate reaches a terminal state before the handler gets to it.
+        await using (var racingCtx = CreateDbContext(dbName))
+        {
+            var raced = await racingCtx.PdfDocuments.AsTracking().SingleAsync(p => p.Id == alsoStale.Id);
+            raced.ProcessingState = "Ready";
+            await racingCtx.SaveChangesAsync();
+        }
+
+        var result = await CreateHandler(ctx).Handle(new PurgeStaleDocumentsCommand(), default);
+
+        result.PurgedCount.Should().Be(1, "only the document still in an active state was purged");
+
+        using var verifyCtx = CreateDbContext(dbName);
+        (await verifyCtx.PdfDocuments.SingleAsync(p => p.Id == stale.Id)).ProcessingState.Should().Be("Failed");
+        (await verifyCtx.PdfDocuments.SingleAsync(p => p.Id == alsoStale.Id)).ProcessingState.Should().Be("Ready");
+    }
+
     [Fact]
     public async Task Handle_LeavesTerminalAndPendingStatesUntouched()
     {


### PR DESCRIPTION
Follow-up dalla code review di #3566.

## Problema

Con un unico `SaveChangesAsync` per l'intero batch, un conflitto di concorrenza su una sola riga faceva rollback di **tutti** gli altri documenti (transazione implicita EF), ma l'handler ingoiava l'eccezione e ritornava comunque il numero di righe **selezionate** — la stessa forma di "il conteggio mente" corretta in #3564, raggiunta per la via della concorrenza anziché per quella del NoTracking.

Quel ramo `catch` era irraggiungibile finché la query era NoTracking (nulla nel ChangeTracker ⇒ nessun `DbUpdateConcurrencyException` possibile): è diventato vivo proprio con la fix di #3564.

## Fix

Selezione dei candidati untracked, poi per ogni documento: load con `AsTracking()` → muta → salva, con `ChangeTracker.Clear()` in `finally` (#534). Un conflitto salta un solo documento, gli altri proseguono, e il conteggio ritornato riflette ciò che è stato davvero scritto.

Aggiunta la ri-verifica dello stato sotto tracking (il documento può essere sparito o uscito dagli stati attivi nel frattempo) e corretto il log, che diceva `"batch partially applied"` mentre il rollback era totale.

## Test

Il caso batch cattura l'errore classico di questo refactor — lista tracked caricata in anticipo più `Clear()` per-item, che farebbe persistere solo il primo documento — verificato red/green.

Limite dichiarato nel test: il ramo `DbUpdateConcurrencyException` e la finestra di ri-verifica **non** sono coperti, perché EF InMemory non ha token di concorrenza. Servirebbe Postgres con `xmin`.

Closes #3572

🤖 Generated with [Claude Code](https://claude.com/claude-code)