### PR TITLE
fix(rag): renderizza i crop tabella a 300 DPI (#3571)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfRegionCropper.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfRegionCropper.cs
@@ -31,6 +31,18 @@ internal sealed class PdfRegionCropper : IPdfRegionCropper
     // rasterised before cropping, so 300 DPI is ~4x the pixels of 150 (an A4 page is ~2480x3508).
     internal const double DefaultRenderScale = 300.0 / 72.0;
 
+    /// <summary>
+    /// Ceiling on the rasterised page, in pixels. The whole page is decoded into a managed BGRA array
+    /// AND a native SKBitmap before the crop is extracted, i.e. ~8 bytes/pixel across both buffers, so
+    /// the render scale is a memory multiplier: an A4 at 300 DPI (~2480x3508 ≈ 8.7 MP) costs ~70 MB
+    /// transiently. Rulebooks do contain oversized fold-outs and board diagrams, and nothing else here
+    /// bounds the page size — a tabloid at 300 DPI is already ~17 MP (~134 MB). Above this ceiling the
+    /// scale is reduced for that page so the allocation stays bounded, trading crop resolution (which
+    /// #3571 measured as the quality knob) for not risking an OOM in a container with no memory limit.
+    /// 12 MP leaves A4 at full 300 DPI and only bites on genuinely oversized pages.
+    /// </summary>
+    internal const long MaxRenderPixels = 12_000_000;
+
     private readonly double _renderScale;
     private readonly ILogger<PdfRegionCropper> _logger;
 
@@ -58,7 +70,9 @@ internal sealed class PdfRegionCropper : IPdfRegionCropper
 
         try
         {
-            using var docReader = DocLib.Instance.GetDocReader(pdfBytes, new PageDimensions(_renderScale));
+            var effectiveScale = ResolveScaleWithinPixelBudget(pdfBytes, pageNumber);
+
+            using var docReader = DocLib.Instance.GetDocReader(pdfBytes, new PageDimensions(effectiveScale));
             var pageCount = docReader.GetPageCount();
             var pageIndex = pageNumber - 1; // region PageNumber is 1-based; Docnet is 0-based
             if (pageIndex < 0 || pageIndex >= pageCount)
@@ -115,6 +129,53 @@ internal sealed class PdfRegionCropper : IPdfRegionCropper
         {
             _logger.LogWarning(ex, "PdfRegionCropper: crop failed on page {Page}", pageNumber);
             return null;
+        }
+    }
+
+    /// <summary>
+    /// Returns the render scale to use for this page, reduced if rendering it at
+    /// <see cref="_renderScale"/> would exceed <see cref="MaxRenderPixels"/>. Measuring costs one
+    /// extra document open at scale 1.0, which parses but does NOT rasterise — the expensive call is
+    /// <c>GetImage()</c>, made once on the real reader.
+    /// </summary>
+    private double ResolveScaleWithinPixelBudget(byte[] pdfBytes, int pageNumber)
+    {
+        try
+        {
+            using var probeReader = DocLib.Instance.GetDocReader(pdfBytes, new PageDimensions(1.0));
+            var pageIndex = pageNumber - 1;
+            if (pageIndex < 0 || pageIndex >= probeReader.GetPageCount())
+            {
+                return _renderScale; // out-of-range is reported by the caller
+            }
+
+            using var probePage = probeReader.GetPageReader(pageIndex);
+            long nativeWidth = probePage.GetPageWidth();
+            long nativeHeight = probePage.GetPageHeight();
+            if (nativeWidth <= 0 || nativeHeight <= 0)
+            {
+                return _renderScale;
+            }
+
+            var projectedPixels = nativeWidth * nativeHeight * _renderScale * _renderScale;
+            if (projectedPixels <= MaxRenderPixels)
+            {
+                return _renderScale;
+            }
+
+            var reduced = Math.Sqrt(MaxRenderPixels / (double)(nativeWidth * nativeHeight));
+            _logger.LogInformation(
+                "PdfRegionCropper: page {Page} is {NativeWidth}x{NativeHeight}pt; rendering at {Reduced:F2}x "
+                + "instead of {Requested:F2}x to stay within the {Budget} pixel budget",
+                pageNumber, nativeWidth, nativeHeight, reduced, _renderScale, MaxRenderPixels);
+            return reduced;
+        }
+        catch (Exception ex)
+        {
+            // Measuring is best-effort: if the probe fails the real open will fail too and the caller
+            // reports it. Never let the guard itself break a crop that would otherwise work.
+            _logger.LogDebug(ex, "PdfRegionCropper: page-size probe failed on page {Page}", pageNumber);
+            return _renderScale;
         }
     }
 }

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfRegionCropper.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfRegionCropper.cs
@@ -16,9 +16,20 @@ namespace Api.BoundedContexts.DocumentProcessing.Application.Services;
 /// </summary>
 internal sealed class PdfRegionCropper : IPdfRegionCropper
 {
-    // Native-size scale factor for rendering. 150/72 ≈ 2.08 gives ~150 DPI — enough detail for the
-    // VLM to read a table crop without oversizing the raster.
-    private const double DefaultRenderScale = 150.0 / 72.0;
+    // Native-size scale factor for rendering: 300/72 ≈ 4.17 gives ~300 DPI.
+    //
+    // Issue #3571: this was 150 DPI, which is NOT enough for the VLM to transcribe a table crop.
+    // Measured on the wingspan scorecard (page 5, the region that motivated #3565), same model and
+    // same GPU, only the render DPI varying:
+    //   150 DPI → rows collapsed onto one line, characters corrupted ("OMUNIT", "10PONT EGF")
+    //   200 DPI → structure correct, one label per row
+    //   300 DPI → structure correct AND the trailing "TOTAL" row recovered
+    // The <otsl> gate fires in all three cases, so the loss is invisible in the metrics and shows up
+    // only in the content of the persisted chunk. Wall-clock was ~2.5-2.9s across all three: Idefics3
+    // consumes a fixed number of image tokens, so raising the DPI improves what the encoder sees
+    // without materially changing inference time. The cost is transient memory — the whole page is
+    // rasterised before cropping, so 300 DPI is ~4x the pixels of 150 (an A4 page is ~2480x3508).
+    internal const double DefaultRenderScale = 300.0 / 72.0;
 
     private readonly double _renderScale;
     private readonly ILogger<PdfRegionCropper> _logger;

--- a/apps/api/tests/Api.Tests/Unit/DocumentProcessing/PdfRegionCropperTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/DocumentProcessing/PdfRegionCropperTests.cs
@@ -55,4 +55,24 @@ public sealed class PdfRegionCropperTests
     {
         PdfRegionCropper.DefaultRenderScale.Should().BeApproximately(300.0 / 72.0, 1e-9);
     }
+
+    /// <summary>
+    /// Issue #3571: the render scale is a memory multiplier — the whole page is rasterised into a
+    /// managed BGRA array plus a native SKBitmap before the crop is taken. The pixel budget exists so
+    /// an oversized page (fold-out boards are common in rulebooks) cannot turn the 300 DPI bump into
+    /// an OOM. This pins the intent of the chosen value: a normal page renders at full resolution,
+    /// an oversized one is scaled down instead of being rendered at any cost.
+    /// </summary>
+    [Theory]
+    [InlineData(595, 842, false)]   // A4 → 2479x3508 ≈ 8.7 MP, within budget
+    [InlineData(612, 792, false)]   // US Letter → 2550x3300 ≈ 8.4 MP, within budget
+    [InlineData(792, 1224, true)]   // Tabloid → 3300x5100 ≈ 16.8 MP, over budget
+    [InlineData(1684, 2384, true)]  // A1 fold-out → ~7017x9933 ≈ 69.7 MP, well over
+    public void MaxRenderPixels_ClampsOnlyOversizedPages(int nativeWidthPt, int nativeHeightPt, bool expectedOverBudget)
+    {
+        var scale = PdfRegionCropper.DefaultRenderScale;
+        var projected = nativeWidthPt * nativeHeightPt * scale * scale;
+
+        (projected > PdfRegionCropper.MaxRenderPixels).Should().Be(expectedOverBudget);
+    }
 }

--- a/apps/api/tests/Api.Tests/Unit/DocumentProcessing/PdfRegionCropperTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/DocumentProcessing/PdfRegionCropperTests.cs
@@ -43,4 +43,16 @@ public sealed class PdfRegionCropperTests
         var act = () => _sut.CropRegion(pdfMagic, 1, 0.1, 0.2, 0.5, 0.3, cts.Token);
         act.Should().Throw<OperationCanceledException>();
     }
+
+    /// <summary>
+    /// Issue #3571: the render DPI is a silent quality knob — the &lt;otsl&gt; gate fires either way,
+    /// so a regression back to 150 DPI would not show up in any metric, only in the text of the
+    /// persisted table chunk (measured: rows collapsed and characters corrupted at 150 DPI).
+    /// Pin it like the region area threshold is pinned.
+    /// </summary>
+    [Fact]
+    public void DefaultRenderScale_Is300Dpi()
+    {
+        PdfRegionCropper.DefaultRenderScale.Should().BeApproximately(300.0 / 72.0, 1e-9);
+    }
 }


### PR DESCRIPTION
## Misura

Il VLM non riesce a trascrivere una tabella a 150 DPI. Misurato sulla scorecard di `wingspan_en_rulebook.pdf` (pagina 5, la regione che ha motivato #3565), stesso modello sulla stessa GPU, variando **solo** il DPI di rendering:

| DPI | Risultato |
|---|---|
| 150 (attuale) | righe collassate su una sola linea, caratteri corrotti: `OMUNIT`, `10PONT EGF` |
| 200 | struttura corretta, una etichetta per riga |
| 300 | struttura corretta **e** recupera la riga finale `TOTAL` |

A 150 DPI:
```
| BIRDS        | OMUNIT | BONUS CARDS | END-OF-ROUND GOALS | EGGS | FOOD ON CARDS |
| 10PONT EGF   |        |             |                    |      |               |
```

A 300 DPI:
```
| BIRDS              |  |  |  |  |  |
| BONUS CARDS        |  |  |  |  |  |
| END-OF-ROUND GOALS |  |  |  |  |  |
| EGGS               |  |  |  |  |  |
| FOOD ON CARDS      |  |  |  |  |  |
| TUCKED CARDS       |  |  |  |  |  |
| TOTAL              |  |  |  |  |  |
```

## Perché non si era visto

Il gate `<otsl>` scatta in tutti e tre i casi (`is_table: true`, `reason: table-otsl`), quindi la perdita **non compare in nessuna metrica**: si vede solo nel contenuto del chunk persistito, cioè in ciò che viene recuperato e citato.

## Costo

Tempo di parete ~2,5–2,9s in tutti e tre i casi: Idefics3 consuma un numero fisso di token-immagine, quindi alzare il DPI migliora ciò che l'encoder vede senza cambiare in modo sensibile l'inferenza. Il costo reale è memoria transitoria — `PdfRegionCropper` rasterizza l'intera pagina prima di ritagliare, quindi 300 DPI sono ~4x i pixel di 150 (una A4 diventa ~2480x3508).

## Test

Aggiunto un guard sul valore di default, sul modello di quello già presente per la soglia di area delle regioni: è una manopola di qualità silenziosa e una regressione a 150 non emergerebbe da nessun test o metrica esistente.

Closes #3571
Refs #3435

🤖 Generated with [Claude Code](https://claude.com/claude-code)