### PR TITLE
fix(rag): alza il budget hi_res e distingue il timeout nel log (#3570)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/RunImageRegionSeedBatchCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/RunImageRegionSeedBatchCommandHandler.cs
@@ -213,8 +213,18 @@ internal sealed class RunImageRegionSeedBatchCommandHandler
             catch (Exception ex)
 #pragma warning restore CA1031
             {
+                // Issue #3570: a client timeout arrives here as an OperationCanceledException whose
+                // token is NOT the caller's (the caller's case is handled above), and it means
+                // something different from a parse/HTTP failure: the pass was still running when the
+                // budget ran out, so it is load-dependent and worth retrying — whereas a malformed
+                // response will fail identically every time. Both still count toward MaxSeedAttempts
+                // (a PDF that always times out must not starve the batch), but the log has to tell
+                // them apart or an operator reads "seed failed" and goes looking for the wrong cause.
+                var timedOut = ex is OperationCanceledException;
                 _logger.LogWarning(ex,
-                    "RunImageRegionSeedBatch: hi_res region seed failed for PDF {PdfId}; skipping (will retry)",
+                    timedOut
+                        ? "RunImageRegionSeedBatch: hi_res region seed TIMED OUT for PDF {PdfId} (client budget exhausted; consider raising PdfProcessing:Extractor:Unstructured:HiResTimeoutSeconds or reducing concurrent load); skipping (will retry)"
+                        : "RunImageRegionSeedBatch: hi_res region seed failed for PDF {PdfId}; skipping (will retry)",
                     candidate.Id);
                 outcome = await RecordSeedFailureAsync(candidate.Id, cancellationToken).ConfigureAwait(false);
                 failed++;

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/DependencyInjection/DocumentProcessingServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/DependencyInjection/DocumentProcessingServiceExtensions.cs
@@ -579,8 +579,16 @@ internal static class DocumentProcessingServiceExtensions
                              ?? "http://unstructured-service:8001";
                 client.BaseAddress = new Uri(apiUrl);
 
+                // Issue #3570: default raised from 300s. The timeout covers the WHOLE request, and
+                // 300s left no margin: on staging the seed batch lost descent, terraforming-mars and
+                // 7-wonders — the table-heavy rulebooks — all aborting at 302s while an unrelated
+                // reindex was competing for the same unstructured instance. Measured in isolation
+                // right after, 7-wonders completes its hi_res pass in 221s: the documents were not
+                // intrinsically too slow, the budget was simply too tight to absorb contention.
+                // A maintenance batch can afford to wait; being dead-lettered after 3 such aborts
+                // (MaxSeedAttempts) permanently excludes a PDF from the VLM pipeline, which is worse.
                 var hiResTimeoutSeconds = configuration.GetValue<int?>(
-                    "PdfProcessing:Extractor:Unstructured:HiResTimeoutSeconds") ?? 300;
+                    "PdfProcessing:Extractor:Unstructured:HiResTimeoutSeconds") ?? 900;
                 client.Timeout = TimeSpan.FromSeconds(hiResTimeoutSeconds);
 
                 client.DefaultRequestHeaders.Add("User-Agent", "MeepleAI-Backend/1.0");

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/DI/RawHiResExtractorRegistrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/DI/RawHiResExtractorRegistrationTests.cs
@@ -63,4 +63,61 @@ public sealed class RawHiResExtractorRegistrationTests
         extractor.Should().BeOfType<UnstructuredPdfTextExtractor>(
             "the seed-image-regions-batch endpoint injects IRawHiResExtractor regardless of the selected provider");
     }
+
+    /// <summary>
+    /// Issue #3570: the hi_res budget covers the whole request. At 300s it left no margin — on
+    /// staging the seed batch lost descent, terraforming-mars and 7-wonders (the table-heavy
+    /// rulebooks) at 302s under concurrent load, while 7-wonders measured 221s in isolation. Three
+    /// such aborts dead-letter a PDF out of the VLM pipeline for good, so the default must keep
+    /// headroom over the measured cost.
+    /// </summary>
+    [Fact]
+    public void HiResClient_DefaultTimeout_KeepsHeadroomOverMeasuredCost()
+    {
+        using var serviceProvider = BuildProviderWithoutTimeoutOverride();
+
+        var client = serviceProvider.GetRequiredService<IHttpClientFactory>()
+            .CreateClient(UnstructuredPdfTextExtractor.HiResClientName);
+
+        client.Timeout.Should().Be(TimeSpan.FromSeconds(900));
+    }
+
+    [Fact]
+    public void HiResClient_Timeout_IsConfigurable()
+    {
+        using var serviceProvider = BuildProviderWithoutTimeoutOverride(hiResTimeoutSeconds: 1200);
+
+        var client = serviceProvider.GetRequiredService<IHttpClientFactory>()
+            .CreateClient(UnstructuredPdfTextExtractor.HiResClientName);
+
+        client.Timeout.Should().Be(TimeSpan.FromSeconds(1200));
+    }
+
+    private static ServiceProvider BuildProviderWithoutTimeoutOverride(int? hiResTimeoutSeconds = null)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddHttpClient();
+
+        var settings = new Dictionary<string, string>
+        {
+            ["PdfProcessing:Extractor:Unstructured:ApiUrl"] = "http://test:8001",
+            ["PdfProcessing:Extractor:SmolDocling:ApiUrl"] = "http://test:8002",
+            ["PdfProcessing:MaxFileSizeBytes"] = "104857600",
+            ["PdfProcessing:Quality:MinimumThreshold"] = "0.80",
+            ["PdfProcessing:Quality:MinCharsPerPage"] = "500"
+        };
+        if (hiResTimeoutSeconds is not null)
+        {
+            settings["PdfProcessing:Extractor:Unstructured:HiResTimeoutSeconds"] =
+                hiResTimeoutSeconds.Value.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        }
+
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(settings!).Build();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddScoped<ITextChunkingService, TextChunkingService>();
+
+        services.AddDocumentProcessingContext(configuration);
+        return services.BuildServiceProvider();
+    }
 }

--- a/docs/for-developers/operations/2026-08-04-image-table-vlm-activation-runbook.md
+++ b/docs/for-developers/operations/2026-08-04-image-table-vlm-activation-runbook.md
@@ -118,6 +118,13 @@ PdfProcessing:ImageRegionSeeding:IntervalMinutes = 30 # Quartz auto-fire (or tri
 POST /api/v1/admin/pdfs/maintenance/seed-image-regions-batch   {"batchSize": 3}
 ```
 
+> **Call it from inside the network.** Both admin triggers run the whole batch synchronously inside
+> the HTTP request, and a single hi_res pass already takes minutes. Staging's public hostname is
+> fronted by Cloudflare, whose edge gives up on the origin after ~100s (524) — so the request dies
+> long before the first PDF finishes, even though the batch keeps running server-side. Trigger it
+> from within the container instead (`docker exec meepleai-api curl -X POST http://localhost:8080/...`),
+> or let the Quartz job fire on its interval and watch the tables in §6.
+
 hi_res is ~200-300s/PDF and memory-heavy — seed on a box with headroom, small batches. Verify:
 
 ```sql


### PR DESCRIPTION
## Diagnosi

Il seed batch delle regioni perdeva sistematicamente i rulebook table-heavy. Rileggendo i log di staging, i tre fallimenti sono avvenuti tutti a **302s** — cioè al timeout del client hi_res, non per un errore del servizio:

```
09:27:53  hi_res region seed failed for PDF a004ec53 (descent)
09:37:14  hi_res region seed failed for PDF 5b049513 (terraforming-mars)
09:42:16  hi_res region seed failed for PDF b15be3ef (7-wonders)
```

Nella stessa finestra girava un reindex che competeva per la stessa istanza di unstructured.

**Misura in isolamento, subito dopo**: 7-wonders completa il suo passaggio hi_res in **221s** (639 elementi estratti, fra cui — nota per #3565 — un elemento `Table`, la tabella delle Gilde di pagina 10). Gli stessi documenti che il batch aveva perso non sono quindi intrinsecamente troppo lenti: è il budget di 300s a non lasciare margine per assorbire la contesa.

Ecco perché wingspan (12 pagine) passava e 7-wonders (12 pagine, 8 MB) no: non è il conteggio pagine, è quanto margine resta sotto carico.

## Fix

Default a **900s**, sempre configurabile via `PdfProcessing:Extractor:Unstructured:HiResTimeoutSeconds`. Il costo di attendere di più in un job di manutenzione è basso; il costo di sbagliare è alto, perché tre abort consecutivi dead-letterano il PDF (`MaxSeedAttempts`) escludendolo per sempre dalla pipeline VLM — ed è esattamente la classe di documenti che #3435 deve vedere.

**Il dead-letter resta invariato**: serve a impedire che un documento che fallisce sempre affami il batch riprovando un passaggio da centinaia di secondi a ogni giro. Con un budget adeguato i timeout tornano a essere l'eccezione, che è il presupposto su cui quel cap è tarato.

Cambia invece il **log**: oggi un timeout e una risposta malformata producono lo stesso `"seed failed"`, e portano l'operatore a cercare la causa sbagliata. Ora il timeout è riconoscibile e suggerisce la manopola giusta.

## Test

Guard sul default (900s) e sulla configurabilità del valore, nel file che già presidia questo client.

Closes #3570
Refs #3435

🤖 Generated with [Claude Code](https://claude.com/claude-code)