### PR TITLE
docs(rag): correggi il check "il codice e deployato" del runbook (#3435)

### DIFF
--- a/docs/for-developers/operations/2026-08-04-image-table-vlm-activation-runbook.md
+++ b/docs/for-developers/operations/2026-08-04-image-table-vlm-activation-runbook.md
@@ -48,9 +48,24 @@ wipes a produced chunk is self-healed on the next run (re-index from the cached 
   run smoldocling on a GPU box (dedicated node, or a local GPU during a batch window; DC-E).
 - [ ] **The corpus is indexed** (`IndexerVersion` set on Ready PDFs) — SP2's candidate selector
   requires it, and the RAG persistence reuses each PDF's existing `vector_documents` row.
-- [ ] **Backend deployed with the #3435 code** (SP1–SP4 + gate, all on `main-dev`). Verify the target
-  build actually contains it, e.g. `grep -c -a "run-table-extraction-batch" /app/Api.dll` in the API
-  container — **merge ≠ deploy**; a flag can only activate code that is actually in the running build.
+- [ ] **Backend deployed with the #3435 code** (SP1–SP4 + gate, all on `main-dev`) — **merge ≠ deploy**;
+  a flag can only activate code that is actually in the running build. The reliable check is a
+  functional one, because a route path is a .NET string **literal** and those are stored UTF-16 in the
+  assembly: a plain `grep -a "run-table-extraction-batch" /app/Api.dll` finds nothing even when the
+  code IS deployed (verified 2026-08-05 — it reports 0 while the endpoint answers 200). Either call
+  the read-only router endpoint, or grep the interleaved form:
+
+  ```bash
+  # functional (preferred): 200 means the code is there
+  docker exec meepleai-api curl -s -o /dev/null -w '%{http_code}\n' -b <admin-cookie> \
+    'http://localhost:8080/api/v1/admin/pdfs/maintenance/table-region-candidates?limit=1'
+
+  # binary check, if you must: match UTF-16 by letting . absorb the NUL bytes
+  docker exec meepleai-api grep -c -a "r.u.n.-.t.a.b.l.e" /app/Api.dll
+  ```
+
+  (Method *names* like `ResourceKeyFromPath` live in the UTF-8 metadata heap and DO grep normally —
+  which is why the naive check looks like it works until you try it on a route.)
 - [ ] **The SP4 migration is applied.** Staging does not auto-apply EF migrations, so
   `20260804173408_AddPdfTableExtractions` must be run manually (`pdf_table_extractions` + its two
   indexes + the `__EFMigrationsHistory` row). Check with


### PR DESCRIPTION
Il runbook suggeriva `grep -c -a "run-table-extraction-batch" /app/Api.dll` per verificare che il build contenesse il codice #3435.

**Quel comando mente.** I path delle route sono string literal .NET, memorizzate UTF-16 nell'assembly, quindi un grep ASCII non le trova mai. Verificato sul deploy di staging di oggi: riporta `0` mentre lo stesso container risponde `200` all'endpoint.

Il tranello e che i **nomi dei metodi** (es. `ResourceKeyFromPath`, grepato nella stessa sessione) stanno nell'heap dei metadata in UTF-8 e si trovano regolarmente: il metodo sembra affidabile finche non lo si prova su una route, ed e proprio quello il momento in cui il runbook viene letto.

Sostituito con la verifica funzionale (endpoint read-only del router, nessun effetto collaterale) e, per chi ha bisogno del check binario, col pattern interlacciato che lascia assorbire i NUL a `.`:

```bash
docker exec meepleai-api grep -c -a "r.u.n.-.t.a.b.l.e" /app/Api.dll
```

Refs #3435

🤖 Generated with [Claude Code](https://claude.com/claude-code)