### PR TITLE
fix(security): egress arch-gate + per-sink resilience (#3495 Slice E)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
@@ -400,8 +400,20 @@ internal static class SharedGameCatalogServiceExtensions
     private static void AddBggCoverDownloader(IServiceCollection services) =>
         services.AddHttpClient<IBggCoverDownloader, BggCoverDownloader>(client =>
         {
-            client.Timeout = TimeSpan.FromSeconds(10);
+            // Outer wall-clock ceiling for the whole exchange, INCLUDING the streamed 10MB body read
+            // (HttpClient.Timeout keeps running under ResponseHeadersRead). The tight budget on the
+            // connect + headers is the per-try timeout below.
+            client.Timeout = TimeSpan.FromSeconds(30);
         })
+        // #3495 H8/C3 (Slice E): per-sink budget + breaker. A BGG CDN outage degrades cover fetching
+        // alone — it cannot open the breaker of any other sink, and the pin below stays innermost.
+        .AddHttpMessageHandler(sp => new EgressResilienceHandler(
+            sp.GetRequiredService<ILogger<EgressResilienceHandler>>(),
+            sink: MeepleAiMetrics.EgressSinks.BggCover,
+            perTryTimeout: TimeSpan.FromSeconds(10),
+            failureThreshold: 3,
+            samplingWindow: TimeSpan.FromSeconds(60),
+            breakDuration: TimeSpan.FromMinutes(1)))
         .ConfigureSsrfPin(MeepleAiMetrics.EgressSinks.BggCover);
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Resilience/CircuitBreakerExceptionDetector.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Resilience/CircuitBreakerExceptionDetector.cs
@@ -16,19 +16,12 @@ internal static class CircuitBreakerExceptionDetector
     /// Returns <see langword="true"/> when the supplied exception is a
     /// Polly broken-circuit exception (either generic or non-generic variant).
     /// </summary>
-    public static bool IsBrokenCircuit(Exception ex)
-    {
-        if (ex is null) return false;
-
-        var t = ex.GetType();
-        if (!string.Equals(t.Namespace, "Polly.CircuitBreaker", StringComparison.Ordinal))
-        {
-            return false;
-        }
-
-        // BrokenCircuitException (non-generic) + BrokenCircuitException`1 (Polly v8
-        // generic variant returning a captured result on open).
-        return string.Equals(t.Name, "BrokenCircuitException", StringComparison.Ordinal)
-            || t.Name.StartsWith("BrokenCircuitException`", StringComparison.Ordinal);
-    }
+    /// <remarks>
+    /// The detection itself now lives in
+    /// <see cref="Api.SharedKernel.Infrastructure.Resilience.PollyRejectionDetector"/> (#3495 Slice E)
+    /// so egress infrastructure outside this bounded context can classify the same rejection; this
+    /// entry point stays for the catalog callers that already depend on it.
+    /// </remarks>
+    public static bool IsBrokenCircuit(Exception ex) =>
+        Api.SharedKernel.Infrastructure.Resilience.PollyRejectionDetector.IsBrokenCircuit(ex);
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfSafeHttpClient.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfSafeHttpClient.cs
@@ -23,7 +23,6 @@ namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 internal sealed class SsrfSafeHttpClient
 {
     private readonly HttpClient _httpClient;
-    private const long MaxPdfSizeBytes = 100 * 1024 * 1024; // 100MB
     private const long MaxImageSizeBytes = 10 * 1024 * 1024; // 10MB (cover images)
     private const int MaxRedirectHops = 5;
 
@@ -32,23 +31,9 @@ internal sealed class SsrfSafeHttpClient
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
     }
 
-    /// <summary>
-    /// Downloads a PDF from the given URL through the hardened fetch path (HTTPS-only per hop,
-    /// bounded redirect follow, mid-stream 100MB ceiling, IP-pinned connection), then validates
-    /// the payload is a PDF.
-    /// </summary>
-    /// <exception cref="ArgumentException">The URL (or a redirect target) is not an absolute HTTPS URL.</exception>
-    /// <exception cref="InvalidOperationException">Redirect loop / too many hops, oversize, or non-PDF content.</exception>
-    public async Task<Stream> DownloadPdfAsync(string url, CancellationToken ct)
-    {
-        var bytes = await FetchWithLimitAsync(url, MaxPdfSizeBytes, ct).ConfigureAwait(false);
-
-        // Validate PDF magic bytes (%PDF).
-        if (bytes.Length < 4 || bytes[0] != 0x25 || bytes[1] != 0x50 || bytes[2] != 0x44 || bytes[3] != 0x46)
-            throw new InvalidOperationException("Downloaded content is not a valid PDF file");
-
-        return new MemoryStream(bytes, writable: false);
-    }
+    // #3495 Slice E: the PDF variant of this fetch (DownloadPdfAsync + its 100MB ceiling) was dead
+    // code — no production caller ever reached it, so it was an unreviewed second egress entry point
+    // whose only exercise came from its own tests. Removed; the arbitrary-URL sink is images only.
 
     /// <summary>
     /// Epic #3470 Slice 3a — downloads an admin-supplied cover image through the hardened fetch path

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/DependencyInjection/UserNotificationsServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/DependencyInjection/UserNotificationsServiceExtensions.cs
@@ -6,6 +6,8 @@ using Api.BoundedContexts.UserNotifications.Infrastructure.Persistence;
 using Api.BoundedContexts.UserNotifications.Infrastructure.Scheduling;
 using Api.BoundedContexts.UserNotifications.Infrastructure.Services;
 using Api.BoundedContexts.UserNotifications.Infrastructure.Slack;
+using Api.Observability;
+using Api.SharedKernel.Infrastructure.Http;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -57,17 +59,7 @@ internal static class UserNotificationsServiceExtensions
         services.AddSingleton<GenericEmailBuilder>();
         services.AddSingleton<EmailMessageBuilderFactory>();
 
-        // Named HttpClient for Slack API with 10s timeout and circuit breaker.
-        // Circuit breaker opens after 5 consecutive 5xx/timeout errors, stays open 2 minutes.
-        services.AddHttpClient("SlackApi", client =>
-        {
-            client.Timeout = TimeSpan.FromSeconds(10);
-        })
-        .AddPolicyHandler(HttpPolicyExtensions
-            .HandleTransientHttpError()
-            .CircuitBreakerAsync(
-                handledEventsAllowedBeforeBreaking: 5,
-                durationOfBreak: TimeSpan.FromMinutes(2)));
+        AddSlackApiClient(services);
 
         // Register services
         services.AddScoped<INotificationDispatcher, NotificationDispatcher>(); // Multi-channel dispatch
@@ -200,5 +192,39 @@ internal static class UserNotificationsServiceExtensions
         // No need to duplicate - jobs from all contexts share the same Quartz scheduler
 
         return services;
+    }
+
+    /// <summary>
+    /// Named HttpClient for the Slack API with a 10s timeout and a circuit breaker (opens after 5
+    /// consecutive 5xx/timeout errors, stays open 2 minutes).
+    /// <para>
+    /// #3495 Slice E: the target URL comes from a stored Slack connection (webhook / API URL), so this
+    /// is user-influenced external egress and dials through the SSRF connect-pin. The pin is the
+    /// primary handler (innermost) and re-validates every auto-redirect hop; the circuit breaker sits
+    /// outside it and keeps its own per-sink state.
+    /// </para>
+    /// </summary>
+    private static void AddSlackApiClient(IServiceCollection services) =>
+        services.AddHttpClient("SlackApi", client =>
+        {
+            client.Timeout = TimeSpan.FromSeconds(10);
+        })
+        .AddPolicyHandler(HttpPolicyExtensions
+            .HandleTransientHttpError()
+            .CircuitBreakerAsync(
+                handledEventsAllowedBeforeBreaking: 5,
+                durationOfBreak: TimeSpan.FromMinutes(2)))
+        .ConfigureSsrfPin(MeepleAiMetrics.EgressSinks.Slack);
+
+    /// <summary>
+    /// Test seam (#3495 Slice E): registers ONLY the Slack API named client so a DI-resolution test
+    /// can prove a Slack host resolving to a private address fails closed at the connect-pin. The
+    /// caller MUST register an <see cref="Api.SharedKernel.Infrastructure.Http.IDnsResolver"/> on the
+    /// same collection BEFORE calling this (the pin's own TryAdd default would otherwise win).
+    /// </summary>
+    internal static void AddSlackApiClientForTests(IServiceCollection services)
+    {
+        services.AddLogging();
+        AddSlackApiClient(services);
     }
 }

--- a/apps/api/src/Api/Extensions/InfrastructureServiceExtensions.cs
+++ b/apps/api/src/Api/Extensions/InfrastructureServiceExtensions.cs
@@ -22,7 +22,9 @@ using Api.Services.Providers.Probe;
 using Api.Services.Providers.Quota;
 using Api.Configuration;
 using Api.Models;
+using Api.Observability;
 using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Infrastructure.Http;
 using Microsoft.Extensions.Options;
 using Pgvector.EntityFrameworkCore; // ISSUE-3493: pgvector support
 
@@ -486,58 +488,7 @@ internal static class InfrastructureServiceExtensions
             required: false
         ) ?? Environment.GetEnvironmentVariable("BGG_API_TOKEN");
 
-        services.AddHttpClient<Infrastructure.ExternalServices.BoardGameGeek.IBggApiClient,
-            Infrastructure.ExternalServices.BoardGameGeek.BggApiClient>(client =>
-        {
-#pragma warning disable S1075 // URIs should not be hardcoded - Official BGG API endpoint
-            client.BaseAddress = new Uri("https://boardgamegeek.com/xmlapi2/");
-#pragma warning restore S1075
-            client.Timeout = TimeSpan.FromSeconds(30);
-            client.DefaultRequestHeaders.Add("User-Agent", "MeepleAI/1.0");
-
-            // Add Bearer token if configured (REQUIRED as of Jan 2026)
-            if (!string.IsNullOrWhiteSpace(bggTokenForClient))
-            {
-                client.DefaultRequestHeaders.Add("Authorization", $"Bearer {bggTokenForClient}");
-            }
-        })
-        .AddTransientHttpErrorPolicy(policy =>
-            policy.WaitAndRetryAsync(3, retryAttempt =>
-                TimeSpan.FromSeconds(Math.Pow(2, retryAttempt))))
-        .AddPolicyHandler((sp, _) => GetCircuitBreakerPolicy(
-            "BggApi", sp.GetService<ICircuitBreakerStateTracker>()))
-        .AddServiceCallLogging("BggApi")
-        .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
-        {
-            PooledConnectionLifetime = TimeSpan.FromMinutes(5),
-            PooledConnectionIdleTimeout = TimeSpan.FromMinutes(2),
-            MaxConnectionsPerServer = 20,
-            EnableMultipleHttp2Connections = true
-        });
-
-        // Named HttpClient "BggApi" used by BggApiService and BggApiHealthCheck
-        // Must share the same Bearer token as the typed IBggApiClient above
-        services.AddHttpClient("BggApi", client =>
-        {
-#pragma warning disable S1075 // URIs should not be hardcoded - Official BGG API endpoint
-            client.BaseAddress = new Uri("https://boardgamegeek.com/xmlapi2/");
-#pragma warning restore S1075
-            client.Timeout = TimeSpan.FromSeconds(30);
-            client.DefaultRequestHeaders.Add("User-Agent", "MeepleAI/1.0");
-
-            if (!string.IsNullOrWhiteSpace(bggTokenForClient))
-            {
-                client.DefaultRequestHeaders.Add("Authorization", $"Bearer {bggTokenForClient}");
-            }
-        })
-        .AddServiceCallLogging("BggApi")
-        .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
-        {
-            PooledConnectionLifetime = TimeSpan.FromMinutes(5),
-            PooledConnectionIdleTimeout = TimeSpan.FromMinutes(2),
-            MaxConnectionsPerServer = 20,
-            EnableMultipleHttp2Connections = true
-        });
+        AddBoardGameGeekClients(services, bggTokenForClient);
 
         // Configure BGG settings from appsettings.json
         services.Configure<BggConfiguration>(configuration.GetSection("Bgg"));
@@ -550,6 +501,72 @@ internal static class InfrastructureServiceExtensions
         });
 
         return services;
+    }
+
+    /// <summary>
+    /// Issue #3120 / #3495 Slice E — registers both BoardGameGeek egress clients (the typed
+    /// <c>IBggApiClient</c> and the named <c>BggApi</c> used by <c>BggApiService</c> and the health
+    /// check) behind the SSRF connect-pin. Extracted so production and the DI test seam
+    /// (<see cref="AddBoardGameGeekClientsForTests"/>) share the exact same pin wiring — drop the pin
+    /// here and both prod and the fail-closed test lose it.
+    /// </summary>
+    private static void AddBoardGameGeekClients(IServiceCollection services, string? bearerToken)
+    {
+#pragma warning disable S1075 // URIs should not be hardcoded - Official BGG API endpoint
+        const string BggApiBaseUrl = "https://boardgamegeek.com/xmlapi2/";
+#pragma warning restore S1075
+
+        void ConfigureClient(HttpClient client)
+        {
+            client.BaseAddress = new Uri(BggApiBaseUrl);
+            client.Timeout = TimeSpan.FromSeconds(30);
+            client.DefaultRequestHeaders.Add("User-Agent", "MeepleAI/1.0");
+
+            // Add Bearer token if configured (REQUIRED as of Jan 2026)
+            if (!string.IsNullOrWhiteSpace(bearerToken))
+            {
+                client.DefaultRequestHeaders.Add("Authorization", $"Bearer {bearerToken}");
+            }
+        }
+
+        // #3495 Slice E: boardgamegeek.com is external egress — dial through the SSRF connect-pin so
+        // a rebound or redirected BGG host cannot reach an internal address. The pooling tuning moves
+        // INTO the pinned handler; a second ConfigurePrimaryHttpMessageHandler would drop the pin.
+        static void ConfigurePinnedHandler(SocketsHttpHandler handler)
+        {
+            handler.PooledConnectionLifetime = TimeSpan.FromMinutes(5);
+            handler.PooledConnectionIdleTimeout = TimeSpan.FromMinutes(2);
+            handler.MaxConnectionsPerServer = 20;
+            handler.EnableMultipleHttp2Connections = true;
+        }
+
+        services.AddHttpClient<Infrastructure.ExternalServices.BoardGameGeek.IBggApiClient,
+            Infrastructure.ExternalServices.BoardGameGeek.BggApiClient>(ConfigureClient)
+        .AddTransientHttpErrorPolicy(policy =>
+            policy.WaitAndRetryAsync(3, retryAttempt =>
+                TimeSpan.FromSeconds(Math.Pow(2, retryAttempt))))
+        .AddPolicyHandler((sp, _) => GetCircuitBreakerPolicy(
+            "BggApi", sp.GetService<ICircuitBreakerStateTracker>()))
+        .AddServiceCallLogging("BggApi")
+        .ConfigureSsrfPin(MeepleAiMetrics.EgressSinks.Bgg, configureHandler: ConfigurePinnedHandler);
+
+        // Named HttpClient "BggApi" used by BggApiService and BggApiHealthCheck
+        // Must share the same Bearer token as the typed IBggApiClient above
+        services.AddHttpClient("BggApi", ConfigureClient)
+        .AddServiceCallLogging("BggApi")
+        .ConfigureSsrfPin(MeepleAiMetrics.EgressSinks.Bgg, configureHandler: ConfigurePinnedHandler);
+    }
+
+    /// <summary>
+    /// Test seam (#3495 Slice E): registers ONLY the BoardGameGeek egress clients so a DI-resolution
+    /// test can prove a BGG host resolving to a private address fails closed at the connect-pin. The
+    /// caller MUST register an <see cref="Api.SharedKernel.Infrastructure.Http.IDnsResolver"/> on the
+    /// same collection BEFORE calling this (the pin's own TryAdd default would otherwise win).
+    /// </summary>
+    internal static void AddBoardGameGeekClientsForTests(IServiceCollection services)
+    {
+        services.AddLogging();
+        AddBoardGameGeekClients(services, bearerToken: null);
     }
 
     private static AsyncCircuitBreakerPolicy<HttpResponseMessage> GetCircuitBreakerPolicy(

--- a/apps/api/src/Api/SharedKernel/Infrastructure/Http/EgressResilienceHandler.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/Http/EgressResilienceHandler.cs
@@ -1,0 +1,117 @@
+using Api.Observability;
+using Api.SharedKernel.Infrastructure.Resilience;
+using Microsoft.Extensions.Logging;
+using Polly;
+using Polly.CircuitBreaker;
+
+namespace Api.SharedKernel.Infrastructure.Http;
+
+/// <summary>
+/// Issue #3495 findings H8/C3 (Slice E) — per-sink resilience for an outbound egress client: a
+/// per-try timeout budget wrapped in a circuit breaker, both owned by THIS client only.
+/// <para>
+/// C3 is the reason this is a handler and not a shared <c>HttpClient</c>: the SSRF policy is shared
+/// (one connect-pin callback), the budgets are not. A BGG CDN outage must not open the breaker of
+/// the Slack or Commons sink, and a slow sink must not eat another sink's budget.
+/// </para>
+/// <para>
+/// The timeout is a Polly PER-TRY budget rather than <see cref="HttpClient.Timeout"/>: the client
+/// timeout is a single wall-clock ceiling shared by the whole exchange (including the streamed body
+/// read), so it cannot express "give up on a stalled connect/headers quickly, but still allow a slow
+/// large body". The client timeout stays on as the outer ceiling.
+/// </para>
+/// <para>
+/// Rejections are counted on the egress metrics with their own bounded reason (<c>timeout</c> /
+/// <c>breaker_open</c>, #3495 M2) BEFORE propagating, so a sink that silently degrades is visible
+/// next to the SSRF blocks instead of being hidden inside a caller's catch-all.
+/// </para>
+/// </summary>
+internal sealed class EgressResilienceHandler : DelegatingHandler
+{
+    private readonly ResiliencePipeline<HttpResponseMessage> _pipeline;
+    private readonly ILogger<EgressResilienceHandler> _logger;
+    private readonly string _sink;
+
+    /// <param name="logger">Logger for breaker state transitions.</param>
+    /// <param name="sink">A bounded <c>MeepleAiMetrics.EgressSinks</c> constant — the metric label
+    /// and the breaker's identity in the logs. Never a host or IP.</param>
+    /// <param name="perTryTimeout">Budget for a single attempt (connect + response headers).</param>
+    /// <param name="failureThreshold">Failures inside <paramref name="samplingWindow"/> that open the circuit.</param>
+    /// <param name="samplingWindow">Rolling window the threshold is measured over.</param>
+    /// <param name="breakDuration">How long the circuit stays open before probing again. Keep it at or
+    /// below the client's handler lifetime: the factory recycles the handler chain (and with it this
+    /// breaker's state) on that cadence, so a longer break would be cut short anyway.</param>
+    public EgressResilienceHandler(
+        ILogger<EgressResilienceHandler> logger,
+        string sink,
+        TimeSpan perTryTimeout,
+        int failureThreshold,
+        TimeSpan samplingWindow,
+        TimeSpan breakDuration)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _sink = string.IsNullOrWhiteSpace(sink)
+            ? throw new ArgumentException("Sink required.", nameof(sink))
+            : sink;
+
+        _pipeline = new ResiliencePipelineBuilder<HttpResponseMessage>()
+            // Outer: the breaker observes the outcome of the timed attempt below, so a run of
+            // timeouts opens the circuit just like a run of 5xx.
+            .AddCircuitBreaker(new CircuitBreakerStrategyOptions<HttpResponseMessage>
+            {
+                FailureRatio = 1.0,
+                MinimumThroughput = failureThreshold,
+                SamplingDuration = samplingWindow,
+                BreakDuration = breakDuration,
+                // Polly v7 and v8 both export TimeoutRejectedException, so it is matched by shape
+                // rather than by symbolic type (CS0433) — see PollyRejectionDetector.
+                ShouldHandle = new PredicateBuilder<HttpResponseMessage>()
+                    .Handle<HttpRequestException>()
+                    .Handle<Exception>(static ex => PollyRejectionDetector.IsTimeoutRejected(ex))
+                    .HandleResult(static r => (int)r.StatusCode >= 500),
+                OnOpened = args =>
+                {
+                    _logger.LogError(
+                        "Egress circuit breaker OPENED for sink '{Sink}' after {Threshold} failures in {Window}s; breaking for {BreakSeconds}s.",
+                        _sink, failureThreshold, samplingWindow.TotalSeconds, args.BreakDuration.TotalSeconds);
+                    return ValueTask.CompletedTask;
+                },
+                OnClosed = _ =>
+                {
+                    _logger.LogInformation("Egress circuit breaker CLOSED for sink '{Sink}' — upstream recovered.", _sink);
+                    return ValueTask.CompletedTask;
+                },
+                OnHalfOpened = _ =>
+                {
+                    _logger.LogInformation("Egress circuit breaker HALF-OPENED for sink '{Sink}' — probing upstream.", _sink);
+                    return ValueTask.CompletedTask;
+                },
+            })
+            // Inner: per-attempt budget. Optimistic strategy — it cancels the token the inner send
+            // observes, so the socket work actually stops instead of being abandoned.
+            .AddTimeout(perTryTimeout)
+            .Build();
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await _pipeline.ExecuteAsync(
+                async token => await base.SendAsync(request, token).ConfigureAwait(false),
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (PollyRejectionDetector.IsBrokenCircuit(ex))
+        {
+            MeepleAiMetrics.RecordEgressBlocked(_sink, MeepleAiMetrics.EgressBlockReasons.BreakerOpen);
+            throw;
+        }
+        catch (Exception ex) when (PollyRejectionDetector.IsTimeoutRejected(ex))
+        {
+            MeepleAiMetrics.RecordEgressBlocked(_sink, MeepleAiMetrics.EgressBlockReasons.Timeout);
+            throw;
+        }
+    }
+}

--- a/apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPinnedHttpClientBuilderExtensions.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPinnedHttpClientBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Api.SharedKernel.Infrastructure.Http;
 
@@ -31,16 +32,33 @@ internal static class SsrfPinnedHttpClientBuilderExtensions
     /// <param name="sink">A bounded <c>MeepleAiMetrics.EgressSinks</c> constant identifying this client
     /// (a compile-time value, never a host/IP) — the label on the egress blocked/allowed counters (#3495 M2).</param>
     /// <param name="allowAutoRedirect">See the summary — <see langword="false"/> only for the arbitrary-URL manual sink.</param>
+    /// <param name="configureHandler">Optional per-sink tuning of the pinned handler (connection pooling,
+    /// concurrency, HTTP/2). Runs BEFORE the pin fields are written, so a caller can never weaken the
+    /// SSRF guard: <see cref="SocketsHttpHandler.ConnectCallback"/>, <paramref name="allowAutoRedirect"/>
+    /// and the redirect cap are re-applied afterwards and always win (#3495 Slice E / finding C3 —
+    /// share the callback, not one handler, so each sink keeps its own pool and budgets).</param>
     public static IHttpClientBuilder ConfigureSsrfPin(
-        this IHttpClientBuilder builder, string sink, bool allowAutoRedirect = true)
+        this IHttpClientBuilder builder,
+        string sink,
+        bool allowAutoRedirect = true,
+        Action<SocketsHttpHandler>? configureHandler = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        return builder.ConfigurePrimaryHttpMessageHandler(sp => new SocketsHttpHandler
+        // The pin needs a resolver; registering it here means a new pinned sink cannot fail at
+        // runtime because its context forgot the TryAdd (contexts registering their own stub/impl
+        // BEFORE this call still win — TryAdd never overwrites).
+        builder.Services.TryAddSingleton<IDnsResolver, SystemDnsResolver>();
+
+        return builder.ConfigurePrimaryHttpMessageHandler(sp =>
         {
-            ConnectCallback = SsrfPinnedConnect.Create(sp.GetRequiredService<IDnsResolver>(), sink),
-            AllowAutoRedirect = allowAutoRedirect,
-            MaxAutomaticRedirections = 5,
+            var handler = new SocketsHttpHandler();
+            configureHandler?.Invoke(handler);
+
+            handler.ConnectCallback = SsrfPinnedConnect.Create(sp.GetRequiredService<IDnsResolver>(), sink);
+            handler.AllowAutoRedirect = allowAutoRedirect;
+            handler.MaxAutomaticRedirections = 5;
+            return handler;
         });
     }
 }

--- a/apps/api/src/Api/SharedKernel/Infrastructure/Resilience/PollyRejectionDetector.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/Resilience/PollyRejectionDetector.cs
@@ -1,0 +1,56 @@
+namespace Api.SharedKernel.Infrastructure.Resilience;
+
+/// <summary>
+/// Detects Polly rejection exceptions by shape instead of by symbolic type catch.
+/// <para>
+/// Polly v8 (<c>Polly.Core</c>) and Polly v7 (transitive of <c>Microsoft.Extensions.Http.Polly</c>)
+/// both export <c>Polly.CircuitBreaker.BrokenCircuitException</c> and
+/// <c>Polly.Timeout.TimeoutRejectedException</c>, so a symbolic catch triggers CS0433 (the type
+/// exists in two assemblies). Reflection-based detection avoids extern-aliasing the whole Polly
+/// namespace, which would cascade through every consumer in the codebase.
+/// </para>
+/// <para>
+/// Promoted to the SharedKernel in #3495 Slice E so egress infrastructure can classify rejections
+/// without depending on a bounded context; <c>SharedGameCatalog</c>'s
+/// <c>CircuitBreakerExceptionDetector</c> now delegates here (issue #1823 Wave 3 M13 originally).
+/// </para>
+/// </summary>
+internal static class PollyRejectionDetector
+{
+    /// <summary>
+    /// Returns <see langword="true"/> when the exception is a Polly broken-circuit exception
+    /// (either the non-generic or the v8 generic variant).
+    /// </summary>
+    public static bool IsBrokenCircuit(Exception? ex)
+    {
+        if (ex is null)
+        {
+            return false;
+        }
+
+        var type = ex.GetType();
+        if (!string.Equals(type.Namespace, "Polly.CircuitBreaker", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        return string.Equals(type.Name, "BrokenCircuitException", StringComparison.Ordinal)
+            || type.Name.StartsWith("BrokenCircuitException`", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when the exception is a Polly timeout rejection (the per-try
+    /// budget elapsed), as opposed to a caller cancellation.
+    /// </summary>
+    public static bool IsTimeoutRejected(Exception? ex)
+    {
+        if (ex is null)
+        {
+            return false;
+        }
+
+        var type = ex.GetType();
+        return string.Equals(type.Namespace, "Polly.Timeout", StringComparison.Ordinal)
+            && string.Equals(type.Name, "TimeoutRejectedException", StringComparison.Ordinal);
+    }
+}

--- a/apps/api/tests/Api.Tests/Architecture/EgressHttpClientPinArchitectureTests.cs
+++ b/apps/api/tests/Api.Tests/Architecture/EgressHttpClientPinArchitectureTests.cs
@@ -1,0 +1,433 @@
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Architecture;
+
+/// <summary>
+/// Issue #3495 finding H7 (Slice E) — architecture gate: <b>no egress <c>HttpClient</c> may reach the
+/// public internet without the SSRF connect-pin</b>.
+/// <para>
+/// The pin (<c>ConfigureSsrfPin</c> → <c>SsrfPinnedConnect</c>) is the ONLY place where DNS-rebinding
+/// and redirect-to-internal are closed. A new <c>AddHttpClient</c> that forgets it re-opens the hole
+/// silently, and no runtime test covers a client nobody wrote a test for. This gate enumerates EVERY
+/// <c>AddHttpClient</c> registration in the API source and forces each one into exactly one of two
+/// explicit buckets:
+/// </para>
+/// <list type="bullet">
+/// <item><see cref="MustBePinned"/> — external egress: the registration chain MUST call
+/// <c>ConfigureSsrfPin</c>.</item>
+/// <item><see cref="Exempt"/> — internal/trusted targets (compose services, sidecars, monitoring)
+/// with a written reason.</item>
+/// </list>
+/// <para>
+/// A registration in neither bucket fails the test: adding an egress client is a security decision
+/// that must be made deliberately, not by omission.
+/// </para>
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Architecture")]
+[Trait("Issue", "3495")]
+public sealed class EgressHttpClientPinArchitectureTests
+{
+    /// <summary>
+    /// External egress clients: they dial hosts outside our infrastructure, so every connection MUST
+    /// go through the SSRF connect-pin. Key = the client identifier as written at the registration
+    /// site (the named-client string, or the implementation type for a typed client — which is the
+    /// name <c>AddHttpClient&lt;TClient, TImpl&gt;</c> registers under).
+    /// </summary>
+    private static readonly Dictionary<string, string> MustBePinned = new(StringComparer.Ordinal)
+    {
+        ["BggCoverDownloader"] = "cover image fetched from a BGG-supplied URL (#3495 fix 3/N)",
+        ["SsrfSafeHttpClient"] = "arbitrary admin-supplied URL, the manual cover sink (#3495 fix 5/N)",
+        ["BggCatalogProvider"] = "boardgamegeek.com catalog XML",
+        ["BggApiClient"] = "boardgamegeek.com XML API v2 (typed client)",
+        ["BggApi"] = "boardgamegeek.com XML API v2 (named client shared by BggApiService/health check)",
+        ["WikidataCatalogProvider"] = "query.wikidata.org SPARQL",
+        ["WikimediaCommonsClient"] = "commons.wikimedia.org + upload.wikimedia.org",
+        ["SlackWebhookClient"] = "admin-configured Slack webhook URL (#3495 fix 3/N)",
+        ["SlackApi"] = "Slack API/webhook URLs stored per connection — caller-supplied absolute URI",
+    };
+
+    /// <summary>
+    /// Registrations exempt from the pin, each with the reason it is not external egress. Internal
+    /// compose/VPC services and sidecars are trusted by design: pinning them would break the very
+    /// private addresses they are supposed to dial.
+    /// </summary>
+    private static readonly Dictionary<string, string> Exempt = new(StringComparer.Ordinal)
+    {
+        ["(default)"] = "IHttpClientFactory default client — no ambient egress of its own; every "
+            + "security-relevant sink uses a named/typed registration above",
+        ["Ollama"] = "self-hosted LLM runtime, private/compose address by design",
+        ["ai-ollama"] = "health probe for the same self-hosted Ollama runtime",
+        ["OpenRouter"] = "SaaS gateway on a hardcoded public endpoint; no user/DB input reaches the URL",
+        ["OpenRouterService"] = "same hardcoded OpenRouter endpoint (typed admin client)",
+        ["HuggingFace"] = "SaaS inference endpoint from static configuration; no user input in the URL",
+        ["ResendClient"] = "Resend SaaS SDK endpoint, static configuration",
+        ["Infisical"] = "secrets backend from static configuration",
+        ["EmbeddingService"] = "internal Python microservice (compose network)",
+        ["ai-embedding"] = "health probe for the internal embedding microservice",
+        ["ai-reranker"] = "health probe for the internal reranker microservice",
+        ["CrossEncoderRerankerClient"] = "internal reranker microservice (compose network)",
+        ["ai-unstructured"] = "health probe for the internal unstructured microservice",
+        ["UnstructuredService"] = "internal unstructured microservice (compose network)",
+        ["UnstructuredPdfTextExtractor.HiResClientName"] = "internal unstructured microservice, hi-res profile",
+        ["ai-orchestrator"] = "health probe for the internal orchestration microservice",
+        ["OrchestrationService"] = "internal orchestration microservice (compose network)",
+        ["SmolDoclingService"] = "internal SmolDocling microservice (compose network)",
+        ["smoldocling-photo-preprocessor"] = "internal SmolDocling microservice, photo pre-processing profile",
+        ["SmoldoclingTableExtractor.NamedClientKey"] = "internal SmolDocling microservice, table-extraction profile",
+        ["DockerProxyService"] = "docker socket proxy sidecar (private address by design)",
+        ["SeqQueryClient"] = "internal Seq log server (compose network)",
+        ["PrometheusHttpClient"] = "internal Prometheus (compose network)",
+        ["PrometheusLabelsClient"] = "internal Prometheus (compose network)",
+        ["PrometheusClientService"] = "internal Prometheus (compose network)",
+        ["SshTunnelSidecar"] = "SSH tunnel sidecar on the compose network",
+        ["provider-probe"] = "admin-configured AI provider probe: admin-only surface with a hard 5s "
+            + "budget; pinning it is tracked separately, it is not part of the user-reachable path",
+    };
+
+    private const string PinCall = "ConfigureSsrfPin";
+    private const string PrimaryHandlerCall = "ConfigurePrimaryHttpMessageHandler";
+
+    [Fact]
+    public void EveryHttpClientRegistration_IsClassified()
+    {
+        var registrations = ScanRegistrations();
+
+        registrations.Should().NotBeEmpty("the scanner must find the API's AddHttpClient registrations");
+
+        var unclassified = registrations
+            .Select(r => r.Name)
+            .Where(name => !MustBePinned.ContainsKey(name) && !Exempt.ContainsKey(name))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToList();
+
+        unclassified.Should().BeEmpty(
+            "every AddHttpClient registration is a security decision (#3495 H7): add the client to "
+            + "MustBePinned and call ConfigureSsrfPin if it dials the public internet, or to Exempt "
+            + "with the reason it targets internal/trusted infrastructure. Unclassified:\n"
+            + string.Join('\n', unclassified));
+    }
+
+    [Fact]
+    public void EveryExternalEgressRegistration_IsPinned()
+    {
+        var unpinned = ScanRegistrations()
+            .Where(r => MustBePinned.ContainsKey(r.Name) && !r.Statement.Contains(PinCall, StringComparison.Ordinal))
+            .Select(r => $"{r.Location}  {r.Name} — {MustBePinned[r.Name]}")
+            .OrderBy(entry => entry, StringComparer.Ordinal)
+            .ToList();
+
+        unpinned.Should().BeEmpty(
+            "external egress clients must dial through the SSRF connect-pin, otherwise DNS-rebinding "
+            + "and redirect-to-internal are open on that sink (#3495 C1/H7). Missing ConfigureSsrfPin:\n"
+            + string.Join('\n', unpinned));
+    }
+
+    [Fact]
+    public void PinnedRegistrations_DoNotOverrideTheirOwnPrimaryHandler()
+    {
+        var conflicts = ScanRegistrations()
+            .Where(r => r.Statement.Contains(PinCall, StringComparison.Ordinal)
+                && r.Statement.Contains(PrimaryHandlerCall, StringComparison.Ordinal))
+            .Select(r => $"{r.Location}  {r.Name}")
+            .OrderBy(entry => entry, StringComparer.Ordinal)
+            .ToList();
+
+        conflicts.Should().BeEmpty(
+            "ConfigureSsrfPin IS the primary handler: a second ConfigurePrimaryHttpMessageHandler on "
+            + "the same builder wins by last-registration and silently drops the pin. Pass the handler "
+            + "tuning to ConfigureSsrfPin instead. Conflicts:\n" + string.Join('\n', conflicts));
+    }
+
+    // -----------------------------------------------------------------------
+    // Source scanning
+    // -----------------------------------------------------------------------
+
+    private sealed record Registration(string Name, string Statement, string Location);
+
+    private static List<Registration> ScanRegistrations()
+    {
+        var apiSrc = LocateApiSrc();
+        var registrations = new List<Registration>();
+
+        foreach (var path in Directory.EnumerateFiles(apiSrc, "*.cs", SearchOption.AllDirectories))
+        {
+            var relative = Path.GetRelativePath(apiSrc, path).Replace('\\', '/');
+            if (relative.StartsWith("bin/", StringComparison.Ordinal)
+                || relative.StartsWith("obj/", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var text = File.ReadAllText(path);
+            foreach (var offset in FindCodeOccurrences(text, "AddHttpClient"))
+            {
+                var after = offset + "AddHttpClient".Length;
+
+                // Skip AddHttpClientInstrumentation and friends: only an exact call site counts.
+                if (after < text.Length && (char.IsLetterOrDigit(text[after]) || text[after] == '_'))
+                {
+                    continue;
+                }
+
+                var statement = ReadStatement(text, offset);
+                var line = text.Take(offset).Count(c => c == '\n') + 1;
+                registrations.Add(new Registration(
+                    ParseClientName(text, after),
+                    statement,
+                    $"{relative}:{line}"));
+            }
+        }
+
+        return registrations;
+    }
+
+    /// <summary>
+    /// The identifier the registration is keyed by: the named-client literal, the implementation type
+    /// of a typed client (what <c>AddHttpClient&lt;TClient, TImpl&gt;</c> names it), the verbatim
+    /// expression when the name is a constant, or <c>(default)</c> for the factory default client.
+    /// </summary>
+    private static string ParseClientName(string text, int afterCall)
+    {
+        var index = SkipWhitespace(text, afterCall);
+        if (index >= text.Length)
+        {
+            return "(default)";
+        }
+
+        if (text[index] == '<')
+        {
+            var end = MatchAngleBracket(text, index);
+            var typeArguments = text[(index + 1)..end].Split(',');
+            var last = typeArguments[^1].Trim();
+            var dot = last.LastIndexOf('.');
+            return dot >= 0 ? last[(dot + 1)..] : last;
+        }
+
+        if (text[index] != '(')
+        {
+            return "(default)";
+        }
+
+        var argument = SkipWhitespace(text, index + 1);
+        if (argument >= text.Length || text[argument] == ')')
+        {
+            return "(default)";
+        }
+
+        if (text[argument] == '"')
+        {
+            var close = text.IndexOf('"', argument + 1);
+            return close < 0 ? "(default)" : text[(argument + 1)..close];
+        }
+
+        // A non-literal first argument is either a name constant or the configure lambda. Lambdas and
+        // service-collection arguments mean "default client"; anything else is a name expression.
+        var token = ReadIdentifierLike(text, argument);
+        return token.Length == 0 || token.Contains("=>", StringComparison.Ordinal)
+            ? "(default)"
+            : token;
+    }
+
+    private static string ReadIdentifierLike(string text, int start)
+    {
+        var end = start;
+        while (end < text.Length && (char.IsLetterOrDigit(text[end]) || text[end] == '_' || text[end] == '.'))
+        {
+            end++;
+        }
+
+        var token = text[start..end];
+        // "client" / "sp" and other lambda parameters are not client names.
+        return token.Contains('.', StringComparison.Ordinal) ? token : string.Empty;
+    }
+
+    /// <summary>
+    /// Returns the whole fluent registration statement starting at <paramref name="start"/>: every
+    /// chained call up to the terminating semicolon at bracket depth zero (so a lambda body's
+    /// semicolons do not cut the chain short). Comments and string literals are STRIPPED from the
+    /// returned text — the callers match method names against it, and this file's own registrations
+    /// mention <c>ConfigurePrimaryHttpMessageHandler</c> in prose right next to the real call.
+    /// </summary>
+    private static string ReadStatement(string text, int start)
+    {
+        var code = new System.Text.StringBuilder();
+        var depth = 0;
+        for (var i = start; i < text.Length; i++)
+        {
+            var skipped = SkipTrivia(text, i);
+            if (skipped != i)
+            {
+                // Comment or literal: keep a separator so adjacent identifiers don't fuse.
+                code.Append(' ');
+                i = skipped - 1;
+                continue;
+            }
+
+            var c = text[i];
+            if (c is '(' or '{' or '[')
+            {
+                depth++;
+            }
+            else if (c is ')' or '}' or ']')
+            {
+                depth--;
+            }
+            else if (c == ';' && depth <= 0)
+            {
+                break;
+            }
+
+            code.Append(c);
+        }
+
+        return code.ToString();
+    }
+
+    /// <summary>
+    /// Offsets of <paramref name="needle"/> that sit in real code — occurrences inside comments,
+    /// string literals or char literals are ignored (the codebase mentions AddHttpClient in prose).
+    /// </summary>
+    private static List<int> FindCodeOccurrences(string text, string needle)
+    {
+        var found = new List<int>();
+        for (var i = 0; i < text.Length; i++)
+        {
+            var skipped = SkipTrivia(text, i);
+            if (skipped != i)
+            {
+                i = skipped - 1;
+                continue;
+            }
+
+            if (string.CompareOrdinal(text, i, needle, 0, needle.Length) == 0)
+            {
+                found.Add(i);
+                i += needle.Length - 1;
+            }
+        }
+
+        return found;
+    }
+
+    /// <summary>
+    /// If <paramref name="index"/> starts a comment or a string/char literal, returns the offset just
+    /// past it; otherwise returns <paramref name="index"/> unchanged.
+    /// </summary>
+    private static int SkipTrivia(string text, int index)
+    {
+        if (index + 1 < text.Length && text[index] == '/' && text[index + 1] == '/')
+        {
+            var end = text.IndexOf('\n', index);
+            return end < 0 ? text.Length : end + 1;
+        }
+
+        if (index + 1 < text.Length && text[index] == '/' && text[index + 1] == '*')
+        {
+            var end = text.IndexOf("*/", index + 2, StringComparison.Ordinal);
+            return end < 0 ? text.Length : end + 2;
+        }
+
+        if (index + 1 < text.Length && text[index] == '@' && text[index + 1] == '"')
+        {
+            var i = index + 2;
+            while (i < text.Length)
+            {
+                if (text[i] == '"')
+                {
+                    if (i + 1 < text.Length && text[i + 1] == '"')
+                    {
+                        i += 2;
+                        continue;
+                    }
+
+                    return i + 1;
+                }
+
+                i++;
+            }
+
+            return text.Length;
+        }
+
+        if (text[index] is '"' or '\'')
+        {
+            var quote = text[index];
+            var i = index + 1;
+            while (i < text.Length)
+            {
+                if (text[i] == '\\')
+                {
+                    i += 2;
+                    continue;
+                }
+
+                if (text[i] == quote)
+                {
+                    return i + 1;
+                }
+
+                if (text[i] == '\n')
+                {
+                    // Unterminated on this line — treat as ordinary text rather than swallowing the file.
+                    return index;
+                }
+
+                i++;
+            }
+
+            return index;
+        }
+
+        return index;
+    }
+
+    private static int SkipWhitespace(string text, int index)
+    {
+        while (index < text.Length && char.IsWhiteSpace(text[index]))
+        {
+            index++;
+        }
+
+        return index;
+    }
+
+    private static int MatchAngleBracket(string text, int open)
+    {
+        var depth = 0;
+        for (var i = open; i < text.Length; i++)
+        {
+            if (text[i] == '<')
+            {
+                depth++;
+            }
+            else if (text[i] == '>')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    return i;
+                }
+            }
+        }
+
+        return text.Length - 1;
+    }
+
+    private static string LocateApiSrc()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, ".git")))
+        {
+            dir = dir.Parent;
+        }
+
+        dir.Should().NotBeNull("the test binary must live inside the meepleai-monorepo repo");
+        var apiSrc = Path.Combine(dir!.FullName, "apps", "api", "src", "Api");
+        Directory.Exists(apiSrc).Should().BeTrue($"Api source must exist at {apiSrc}");
+        return apiSrc;
+    }
+}

--- a/apps/api/tests/Api.Tests/Architecture/PinnedEgressClientWiringTests.cs
+++ b/apps/api/tests/Api.Tests/Architecture/PinnedEgressClientWiringTests.cs
@@ -1,0 +1,91 @@
+using System.Net;
+using Api.BoundedContexts.UserNotifications.Infrastructure.DependencyInjection;
+using Api.Extensions;
+using Api.SharedKernel.Infrastructure.Http;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Architecture;
+
+/// <summary>
+/// Issue #3495 Slice E — behavioural counterpart to
+/// <see cref="EgressHttpClientPinArchitectureTests"/>: the source gate proves
+/// <c>ConfigureSsrfPin</c> is written at the registration site, these tests prove the resulting
+/// client actually dials through the pin.
+/// <para>
+/// Each test resolves the client from the REAL registration seam and asserts two things: the request
+/// fails closed when the host resolves to a private/reserved address, and the injected resolver was
+/// consulted. The second assertion is what makes the test non-vacuous — without the pin the default
+/// handler would do its own DNS and never touch the stub, so a silently dropped pin fails this
+/// deterministically. Mirrors <c>BggCoverDownloaderPinIntegrationTests</c> (#3495 fix 3/N).
+/// </para>
+/// <para>
+/// The typed <c>IBggApiClient</c> is exercised through the same registration helper as the named
+/// client below, but is not driven end-to-end here: its transient-error retry policy would sleep
+/// 2+4+8s on the blocked connect. Its pin is enforced by the source gate, which covers both call
+/// sites.
+/// </para>
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Architecture")]
+[Trait("Issue", "3495")]
+public sealed class PinnedEgressClientWiringTests
+{
+    private sealed class StubDnsResolver : IDnsResolver
+    {
+        private readonly IPAddress _address;
+        public int ResolveCalls { get; private set; }
+
+        public StubDnsResolver(string ip) => _address = IPAddress.Parse(ip);
+
+        public Task<IReadOnlyList<IPAddress>> ResolveAsync(string host, CancellationToken ct)
+        {
+            ResolveCalls++;
+            return Task.FromResult<IReadOnlyList<IPAddress>>(new[] { _address });
+        }
+    }
+
+    [Fact]
+    public async Task BggApiClient_FailsClosed_WhenTheBggHostResolvesToAPrivateAddress()
+    {
+        // 169.254.169.254 is the cloud metadata endpoint: the canonical SSRF target.
+        var dns = new StubDnsResolver("169.254.169.254");
+        var services = new ServiceCollection();
+        // Registered BEFORE the seam so ConfigureSsrfPin's TryAddSingleton does not override the stub.
+        services.AddSingleton<IDnsResolver>(dns);
+        InfrastructureServiceExtensions.AddBoardGameGeekClientsForTests(services);
+        using var provider = services.BuildServiceProvider();
+
+        var client = provider.GetRequiredService<IHttpClientFactory>().CreateClient("BggApi");
+
+        var act = () => client.GetAsync(new Uri("search?query=catan", UriKind.Relative), CancellationToken.None);
+
+        await act.Should().ThrowAsync<HttpRequestException>(
+            "the SSRF connect-pin must block a BGG host that resolves to a reserved address");
+        dns.ResolveCalls.Should().BeGreaterThan(0, "the connect-pin must consult the injected resolver");
+    }
+
+    [Fact]
+    public async Task SlackApiClient_FailsClosed_WhenTheWebhookHostResolvesToAPrivateAddress()
+    {
+        var dns = new StubDnsResolver("127.0.0.1");
+        var services = new ServiceCollection();
+        services.AddSingleton<IDnsResolver>(dns);
+        UserNotificationsServiceExtensions.AddSlackApiClientForTests(services);
+        using var provider = services.BuildServiceProvider();
+
+        var client = provider.GetRequiredService<IHttpClientFactory>().CreateClient("SlackApi");
+
+        // The URL is public, but the stored Slack connection could point anywhere — the pin decides
+        // on the RESOLVED address, which is loopback here.
+        using var body = new StringContent("{}");
+        var act = () => client.PostAsync(
+            new Uri("https://hooks.slack.com/services/T000/B000/xxx"), body, CancellationToken.None);
+
+        await act.Should().ThrowAsync<HttpRequestException>(
+            "the SSRF connect-pin must block a Slack target that resolves to loopback");
+        dns.ResolveCalls.Should().BeGreaterThan(0, "the connect-pin must consult the injected resolver");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloaderResilienceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloaderResilienceTests.cs
@@ -1,0 +1,79 @@
+using System.Net;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.DependencyInjection;
+using Api.SharedKernel.Infrastructure.Http;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Services;
+
+/// <summary>
+/// Issue #3495 findings H8/C3 (Slice E) — the BGG cover sink carries its OWN circuit breaker, so a
+/// failing cover CDN stops being dialled instead of costing every caller a full connect budget.
+/// <para>
+/// The test drives the real DI registration and counts DNS resolutions: the pin resolves once per
+/// dial attempt, so "resolutions stop increasing while calls keep coming" is direct evidence the
+/// breaker short-circuits BEFORE the connect. Failures are produced by the pin itself (a host that
+/// resolves to a reserved address), which keeps the test offline and deterministic.
+/// </para>
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "3495")]
+public sealed class BggCoverDownloaderResilienceTests
+{
+    /// <summary>Matches the failureThreshold configured on the cover client's resilience handler.</summary>
+    private const int BreakerThreshold = 3;
+
+    private sealed class StubDnsResolver : IDnsResolver
+    {
+        private readonly IPAddress _address;
+        public int ResolveCalls { get; private set; }
+
+        public StubDnsResolver(string ip) => _address = IPAddress.Parse(ip);
+
+        public Task<IReadOnlyList<IPAddress>> ResolveAsync(string host, CancellationToken ct)
+        {
+            ResolveCalls++;
+            return Task.FromResult<IReadOnlyList<IPAddress>>(new[] { _address });
+        }
+    }
+
+    [Fact]
+    public async Task CoverSink_OpensItsCircuit_AndStopsDialling_AfterConsecutiveFailures()
+    {
+        var dns = new StubDnsResolver("169.254.169.254");
+        var pipeline = new Mock<IBggCoverUploadPipeline>();
+        var services = new ServiceCollection();
+        services.AddSingleton<IDnsResolver>(dns);
+        services.AddSingleton(pipeline.Object);
+        SharedGameCatalogServiceExtensions.AddBggCoverDownloaderForTests(services);
+        using var provider = services.BuildServiceProvider();
+
+        var downloader = provider.GetRequiredService<IBggCoverDownloader>();
+
+        for (var call = 0; call < BreakerThreshold; call++)
+        {
+            var result = await downloader.DownloadAndUploadAsync(
+                13, "https://8.8.8.8/cover.jpg", CancellationToken.None);
+            result.Should().BeNull("the SSRF pin blocks every one of these dials");
+        }
+
+        dns.ResolveCalls.Should().Be(BreakerThreshold, "each pre-breaker call dials once through the pin");
+
+        // The circuit is open now: further calls must be rejected without another dial.
+        var afterBreak = await downloader.DownloadAndUploadAsync(
+            13, "https://8.8.8.8/cover.jpg", CancellationToken.None);
+
+        afterBreak.Should().BeNull("a rejected call still degrades gracefully to 'no cover'");
+        dns.ResolveCalls.Should().Be(
+            BreakerThreshold,
+            "the open circuit must short-circuit before the connect-pin resolves anything again");
+        pipeline.Verify(
+            p => p.UploadAsync(It.IsAny<int>(), It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfSafeHttpClientPinIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfSafeHttpClientPinIntegrationTests.cs
@@ -49,7 +49,7 @@ public sealed class SsrfSafeHttpClientPinIntegrationTests
 
         // The host literal (8.8.8.8) is public and passes the scheme check, but the pinned resolver
         // returns the metadata IP, so the pin throws at connect and the download aborts.
-        var act = () => client.DownloadPdfAsync("https://8.8.8.8/rules.pdf", CancellationToken.None);
+        var act = () => client.DownloadImageAsync("https://8.8.8.8/cover.jpg", CancellationToken.None);
 
         await act.Should().ThrowAsync<Exception>("the SSRF connect-pin must block a private-resolving host");
         // The stub is consulted ONLY by the pin's ConnectCallback — a non-zero count proves

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfSafeHttpClientTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfSafeHttpClientTests.cs
@@ -69,68 +69,67 @@ public class SsrfSafeHttpClientTests
         return r;
     }
 
-    private static HttpResponseMessage Pdf() => new(HttpStatusCode.OK)
+    private static HttpResponseMessage Payload() => new(HttpStatusCode.OK)
     {
-        Content = new ByteArrayContent(System.Text.Encoding.ASCII.GetBytes("%PDF-1.4\nok")),
+        Content = new ByteArrayContent(System.Text.Encoding.ASCII.GetBytes("image-bytes")),
     };
 
     [Fact]
-    public async Task DownloadPdfAsync_FollowsHttpsRedirect_ToFinalPayload()
+    public async Task DownloadImageAsync_FollowsHttpsRedirect_ToFinalPayload()
     {
         using var handler = new SequenceHttpMessageHandler(
-            _ => Redirect(HttpStatusCode.Found, "https://cdn.example/final.pdf"),
-            _ => Pdf());
+            _ => Redirect(HttpStatusCode.Found, "https://cdn.example/final.png"),
+            _ => Payload());
         using var httpClient = new HttpClient(handler);
         var sut = new SsrfSafeHttpClient(httpClient);
 
-        var result = await sut.DownloadPdfAsync("https://example.com/rules.pdf", CancellationToken.None);
+        var result = await sut.DownloadImageAsync("https://example.com/cover.png", CancellationToken.None);
 
-        using var reader = new StreamReader(result);
-        (await reader.ReadToEndAsync()).Should().StartWith("%PDF");
+        System.Text.Encoding.ASCII.GetString(result).Should().Be("image-bytes");
         handler.RequestedUris.Should().HaveCount(2);
-        handler.RequestedUris[1].Should().Be(new Uri("https://cdn.example/final.pdf"));
+        handler.RequestedUris[1].Should().Be(new Uri("https://cdn.example/final.png"));
     }
 
     [Theory]
-    [InlineData("http://cdn.example/final.pdf")]     // https → http downgrade
+    [InlineData("http://cdn.example/final.png")]     // https → http downgrade
     [InlineData("file:///etc/passwd")]                // scheme downgrade to file
     [InlineData("gopher://internal/x")]               // exotic scheme
-    public async Task DownloadPdfAsync_RejectsSchemeDowngradeOnRedirect(string location)
+    public async Task DownloadImageAsync_RejectsSchemeDowngradeOnRedirect(string location)
     {
         using var handler = new SequenceHttpMessageHandler(_ => Redirect(HttpStatusCode.Found, location));
         using var httpClient = new HttpClient(handler);
         var sut = new SsrfSafeHttpClient(httpClient);
 
-        var act = () => sut.DownloadPdfAsync("https://example.com/rules.pdf", CancellationToken.None);
+        var act = () => sut.DownloadImageAsync("https://example.com/cover.png", CancellationToken.None);
 
         await act.Should().ThrowAsync<ArgumentException>()
             .WithMessage("Only HTTPS URLs are allowed*");
     }
 
     [Fact]
-    public async Task DownloadPdfAsync_RejectsRedirectLoop()
+    public async Task DownloadImageAsync_RejectsRedirectLoop()
     {
         using var handler = new SequenceHttpMessageHandler(
-            _ => Redirect(HttpStatusCode.Found, "https://example.com/rules.pdf")); // → itself
+            _ => Redirect(HttpStatusCode.Found, "https://example.com/cover.png")); // → itself
         using var httpClient = new HttpClient(handler);
         var sut = new SsrfSafeHttpClient(httpClient);
 
-        var act = () => sut.DownloadPdfAsync("https://example.com/rules.pdf", CancellationToken.None);
+        var act = () => sut.DownloadImageAsync("https://example.com/cover.png", CancellationToken.None);
 
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*loop*");
     }
 
     [Fact]
-    public async Task DownloadPdfAsync_RejectsTooManyRedirects()
+    public async Task DownloadImageAsync_RejectsTooManyRedirects()
     {
         var n = 0;
         using var handler = new SequenceHttpMessageHandler(
-            _ => Redirect(HttpStatusCode.Found, $"https://example.com/hop{++n}.pdf"));
+            _ => Redirect(HttpStatusCode.Found, $"https://example.com/hop{++n}.png"));
         using var httpClient = new HttpClient(handler);
         var sut = new SsrfSafeHttpClient(httpClient);
 
-        var act = () => sut.DownloadPdfAsync("https://example.com/rules.pdf", CancellationToken.None);
+        var act = () => sut.DownloadImageAsync("https://example.com/cover.png", CancellationToken.None);
 
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*maximum*redirects*");
@@ -173,14 +172,13 @@ public class SsrfSafeHttpClientTests
 
     #endregion
 
-    #region DownloadPdfAsync Disposal Tests (Issue #3239)
+    #region DownloadImageAsync Disposal Tests (Issue #3239)
 
     [Fact]
-    public async Task DownloadPdfAsync_DisposesResponseContentStream()
+    public async Task DownloadImageAsync_DisposesResponseContentStream()
     {
-        // %PDF magic bytes so the download passes the PDF-signature validation.
-        var pdfBytes = System.Text.Encoding.ASCII.GetBytes("%PDF-1.4\nfake-content");
-        var sourceStream = new DisposeTrackingStream(pdfBytes);
+        var payload = System.Text.Encoding.ASCII.GetBytes("fake-image-content");
+        var sourceStream = new DisposeTrackingStream(payload);
         using var handler = new StubHttpMessageHandler(() => new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StreamContent(sourceStream),
@@ -188,17 +186,16 @@ public class SsrfSafeHttpClientTests
         using var httpClient = new HttpClient(handler);
         var sut = new SsrfSafeHttpClient(httpClient);
 
-        // Host is a public IP literal: Dns.GetHostAddressesAsync short-circuits (no network call),
-        // and IsPrivateOrReserved(8.8.8.8) is false, so the SSRF guard passes hermetically.
-        var result = await sut.DownloadPdfAsync("https://8.8.8.8/rules.pdf", CancellationToken.None);
+        // The stub handler answers directly, so no connection (and no SSRF pin) is involved: this
+        // test is only about the response lifetime.
+        var result = await sut.DownloadImageAsync("https://8.8.8.8/cover.png", CancellationToken.None);
 
-        // The full payload is copied into an independent stream returned to the caller...
-        using var reader = new StreamReader(result);
-        (await reader.ReadToEndAsync()).Should().Be("%PDF-1.4\nfake-content");
+        // The full payload is returned to the caller as an independent buffer...
+        System.Text.Encoding.ASCII.GetString(result).Should().Be("fake-image-content");
 
         // ...and the source HttpResponseMessage content stream must be disposed (it was leaked before the fix).
         sourceStream.Disposed.Should().BeTrue(
-            "DownloadPdfAsync must dispose the HttpResponseMessage and its content stream");
+            "the hardened fetch must dispose the HttpResponseMessage and its content stream");
     }
 
     private sealed class StubHttpMessageHandler : HttpMessageHandler


### PR DESCRIPTION
## Sommario

Slice E del sub-epic **#3495** (SSRF egress hardening) — findings **H7** (architecture gate), **H8/C3** (resilience per-sink) e la rimozione del dead `DownloadPdfAsync`.

## Cosa cambia

### 1. Architecture gate (H7)
`EgressHttpClientPinArchitectureTests` enumera **ogni** `AddHttpClient` nel sorgente `apps/api/src/Api` (scanner che salta commenti e stringhe) e impone una classificazione esplicita:

- `MustBePinned` → egress esterno: la catena DEVE chiamare `ConfigureSsrfPin`;
- `Exempt` → target interni/fidati (compose, sidecar, monitoring) **con motivazione scritta**.

Un client nuovo non classificato fallisce il gate: aggiungere un egress torna a essere una decisione deliberata, non un'omissione. Secondo gate: un client pinnato non può dichiarare anche un `ConfigurePrimaryHttpMessageHandler` proprio (vincerebbe per last-registration e **droppa il pin** silenziosamente).

### 2. I 3 sink scoperti dal gate, ora pinnati
| Client | Perché è egress esterno |
|---|---|
| `IBggApiClient` (typed) | `boardgamegeek.com` XML API |
| `BggApi` (named) | stesso host, usato da `BggApiService` + health check |
| `SlackApi` (named) | URL preso dalla `SlackConnection` memorizzata → **user-influenced** |

`ConfigureSsrfPin` ora accetta un `configureHandler` opzionale per il tuning per-sink (pooling / HTTP2 / concorrenza): il tuning gira **prima**, i campi del pin (`ConnectCallback`, `AllowAutoRedirect`, cap redirect) sono riapplicati **dopo** — il chiamante non può indebolire la guardia. L'helper registra anche `TryAddSingleton<IDnsResolver>`, così un nuovo sink pinnato non può fallire a runtime perché il suo contesto ha dimenticato il TryAdd.

### 3. Resilience per-sink (H8/C3)
Nuovo `EgressResilienceHandler`: **timeout per-try Polly** + **circuit breaker con stato proprio**, montato sul cover downloader BGG (soglia 3/60s, break 1min ≤ handler lifetime). C3 è il motivo per cui è un handler e non un client condiviso: la policy SSRF è condivisa, i budget no — un'outage del CDN BGG non deve aprire il breaker di Slack o Commons.

Il `client.Timeout` passa da 10s a 30s come ceiling wall-clock (copre anche la lettura streamed del body); il budget stretto su connect+headers è il per-try da 10s.

Le rejection incrementano `meepleai_egress_blocked_total` con reason `timeout` / `breaker_open` — parte del follow-up Slice C sui reason signals.

### 4. Dead code
`SsrfSafeHttpClient.DownloadPdfAsync` (+ ceiling 100MB) non aveva **alcun caller di produzione**: era un secondo entry point di egress esercitato solo dai suoi test. Rimosso; i test di redirect / scheme-downgrade / loop / size migrano sul sink immagini reale.

### 5. Chore
`PollyRejectionDetector` promosso nel SharedKernel (workaround CS0433 Polly v7/v8, già esistente nel BC catalog); `CircuitBreakerExceptionDetector` ora delega — zero duplicazione, zero rotture per i caller esistenti.

## Test

151 unit test verdi nello scope SSRF/egress. Nuovi:
- `PinnedEgressClientWiringTests` — fail-closed su BggApi/SlackApi con `StubDnsResolver`; l'assert `ResolveCalls > 0` rende il test **non vacuo** (senza pin l'handler di default farebbe DNS proprio e non toccherebbe lo stub).
- `BggCoverDownloaderResilienceTests` — dopo 3 fallimenti il breaker taglia **prima del dial**: le risoluzioni DNS smettono di crescere mentre le chiamate continuano.

## Note

- `dotnet format` su Windows tocca ~180 file estranei (artefatto CRLF noto): il diff è stato riportato ai soli file di questa slice.
- Restano di #3495: **Slice D** (deadline wall-clock multi-hop + Wikimedia nel gate manuale), **Slice F** (SsrfPolicy completeness), follow-up reason signals sugli altri throw site.
- Follow-up emerso dal gate: `provider-probe` è admin-configurabile e resta exempt con motivazione — vale la pena valutarne il pin a parte.

Resolves parte di #3495 (Slice E).

🤖 Generated with [Claude Code](https://claude.com/claude-code)