### PR TITLE
fix(security): redirect deadline + Wikimedia through the gate (#3495 Slice D)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloader.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloader.cs
@@ -1,4 +1,5 @@
-using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+using Api.Observability;
+using Api.SharedKernel.Infrastructure.Http;
 using Microsoft.Extensions.Logging;
 
 namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
@@ -34,20 +35,23 @@ internal sealed class BggCoverDownloader : IBggCoverDownloader
             return null;
         }
 
-        // SSRF guard: reject non-HTTPS / malformed URLs up front (fail-fast). The public-IP
+        // SSRF guard: reject non-HTTPS / non-default-port / malformed URLs up front (fail-fast),
+        // through the SAME validator the hardened fetch engine applies per hop (#3495 Slice D — one
+        // scheme/port rule for every sink, instead of a private copy that can drift). The public-IP
         // guarantee is enforced at connect time by the SSRF connect-pin on this client's handler
         // (ConfigureSsrfPin, #3495) — which, unlike a pre-connect DNS check, is not TOCTOU: every
         // connection (and each redirect hop) dials only a validated public address.
         try
         {
-            SsrfSafeHttpClient.ValidateUrlScheme(remoteImageUrl);
+            HardenedRedirectFetch.ResolveAndValidate(
+                remoteImageUrl, baseAddress: null, MeepleAiMetrics.EgressSinks.BggCover);
         }
-        catch (ArgumentException ex)
+        catch (HardenedFetchException ex)
         {
             _logger.LogWarning(
                 ex,
-                "BGG cover download blocked by SSRF guard: BggId={BggId}, Url={Url}",
-                bggId, remoteImageUrl);
+                "BGG cover download blocked by SSRF guard ({Reason}): BggId={BggId}, Url={Url}",
+                ex.Reason, bggId, remoteImageUrl);
             return null;
         }
 

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
@@ -539,14 +539,12 @@ internal static class SharedGameCatalogServiceExtensions
         // suppression below covers the public Commons API endpoint just like
         // the other catalog providers.
         //
-        // Issue #1823 M8 invariant: do NOT add a ConfigurePrimaryHttpMessageHandler
-        // that sets AllowAutoRedirect=false. FetchImageBytesAsync calls
-        // commons.wikimedia.org/wiki/Special:FilePath/{filename}, which returns
-        // a 302 redirect to upload.wikimedia.org/<cdn-url>. The default handler
-        // AllowAutoRedirect=true is what makes the image bytes accessible — a
-        // false setting would surface the 302 HTML body as bytes, which would
-        // then fail at WebP decoding (FailReasonImageProcessing) instead of the
-        // expected SkipReasonImageBytesNotAvailable on real 404s.
+        // #3495 Slice D (finding H1) — SUPERSEDES the #1823 M8 invariant "do NOT disable redirects".
+        // The Special:FilePath 302 → upload.wikimedia.org is STILL followed (the image bytes stay
+        // reachable), but by WikimediaCommonsClient through HardenedRedirectFetch instead of by the
+        // handler: every hop is re-validated (HTTPS-only, default port) and the body is read under a
+        // ceiling with a total wall-clock deadline. Auto-redirect must therefore be OFF, or the
+        // handler would follow a downgrade before the gate could refuse it.
 #pragma warning disable S1075 // URIs should not be hardcoded
         const string CommonsBaseUrl = "https://commons.wikimedia.org/";
 #pragma warning restore S1075
@@ -562,12 +560,11 @@ internal static class SharedGameCatalogServiceExtensions
         .AddHttpMessageHandler(sp => new WikimediaCircuitBreakerHandler(
             sp.GetRequiredService<ILogger<WikimediaCircuitBreakerHandler>>(),
             clientName: "commons-api"))
-        // #3495 follow-up: SSRF connect-pin. ConfigureSsrfPin sets AllowAutoRedirect=true, so the
-        // M8 invariant above (Special:FilePath 302 → upload.wikimedia.org MUST be auto-followed) still
-        // holds — and each redirect hop's host is independently re-resolved and SSRF-validated by the
-        // per-connection pin (upload.wikimedia.org is public → allowed). Do NOT add any other
+        // #3495 Slice D: the pin keeps owning the IP boundary per connection (each hop re-resolved,
+        // upload.wikimedia.org is public → allowed), and auto-redirect is now OFF so the 3xx surfaces
+        // in WikimediaCommonsClient and is followed through the hardened gate. Do NOT add any other
         // ConfigurePrimaryHttpMessageHandler here: it would override the pin.
-        .ConfigureSsrfPin(MeepleAiMetrics.EgressSinks.Wikimedia);
+        .ConfigureSsrfPin(MeepleAiMetrics.EgressSinks.Wikimedia, allowAutoRedirect: false);
 
         services.AddHttpClient<BggCatalogProvider>(client =>
         {

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfSafeHttpClient.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfSafeHttpClient.cs
@@ -1,4 +1,5 @@
-using System.Net;
+using Api.Observability;
+using Api.SharedKernel.Infrastructure.Http;
 
 namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 
@@ -6,133 +7,48 @@ namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 /// Hardened egress client for the manual / arbitrary-URL download path (epic #3470 Slice 3
 /// prerequisite, issue #3495 fix 5/N).
 /// <para>
-/// The IP boundary is the connect-pin (<see cref="Api.SharedKernel.Infrastructure.Http.SsrfPinnedConnect"/>,
-/// applied to this client's <see cref="HttpClient"/> via <c>ConfigureSsrfPin(allowAutoRedirect: false)</c>):
-/// every connection resolves the host once and dials a validated public IP, closing DNS-rebinding
-/// and redirect-to-internal by construction. This class adds the remaining arbitrary-URL guards the
-/// pin cannot express: HTTPS-only scheme re-validated on EVERY hop (blocks a redirect that downgrades
-/// to <c>http/file/gopher</c> or points at a non-HTTP scheme — the pin only re-checks the IP), a
-/// bounded manual redirect follow with loop detection, and a mid-stream byte ceiling.
+/// Two layers guard this sink and neither is optional:
 /// </para>
+/// <list type="bullet">
+///   <item>the connect-pin (<see cref="SsrfPinnedConnect"/>, applied via
+///   <c>ConfigureSsrfPin(allowAutoRedirect: false)</c>) owns the IP boundary — every connection
+///   resolves once and dials a validated public address, closing DNS-rebinding and
+///   redirect-to-internal by construction;</item>
+///   <item><see cref="HardenedRedirectFetch"/> owns everything the pin cannot express — per-hop
+///   HTTPS-only + default-port re-validation, bounded redirect follow with loop detection, a
+///   streamed byte ceiling, and a TOTAL wall-clock budget (#3495 Slice D, findings C4/H2).</item>
+/// </list>
 /// <para>
-/// Auto-redirect is DISABLED on the primary handler so 3xx responses surface here and are followed
-/// manually through the scheme gate — with <c>AllowAutoRedirect=true</c> the handler would follow a
-/// downgrade before this code could reject it.
+/// This type is the DI seam that binds the manual sink's <see cref="HttpClient"/> (and its
+/// <c>manual</c> metric label) to that engine; the fetch logic itself is shared, so the Commons
+/// sink is guarded by exactly the same code path.
 /// </para>
 /// </summary>
 internal sealed class SsrfSafeHttpClient
 {
     private readonly HttpClient _httpClient;
     private const long MaxImageSizeBytes = 10 * 1024 * 1024; // 10MB (cover images)
-    private const int MaxRedirectHops = 5;
 
     public SsrfSafeHttpClient(HttpClient httpClient)
     {
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
     }
 
-    // #3495 Slice E: the PDF variant of this fetch (DownloadPdfAsync + its 100MB ceiling) was dead
-    // code — no production caller ever reached it, so it was an unreviewed second egress entry point
-    // whose only exercise came from its own tests. Removed; the arbitrary-URL sink is images only.
-
     /// <summary>
     /// Epic #3470 Slice 3a — downloads an admin-supplied cover image through the hardened fetch path
-    /// (HTTPS-only per hop, bounded redirect follow, IP-pinned connection) under a 10MB streamed
-    /// ceiling. Returns the raw image bytes; the caller validates/re-encodes them.
+    /// under a 10MB streamed ceiling and the default total deadline. Returns the raw image bytes;
+    /// the caller validates/re-encodes them.
     /// </summary>
-    /// <exception cref="ArgumentException">The URL (or a redirect target) is not an absolute HTTPS URL.</exception>
-    /// <exception cref="InvalidOperationException">Redirect loop / too many hops, or oversize.</exception>
+    /// <exception cref="HardenedFetchException">A guard refused the fetch (scheme, port, redirect
+    /// budget, size ceiling or deadline) — <see cref="HardenedFetchException.Reason"/> says which.</exception>
+    /// <exception cref="HttpRequestException">The final hop answered a non-success status.</exception>
     public Task<byte[]> DownloadImageAsync(string url, CancellationToken ct) =>
-        FetchWithLimitAsync(url, MaxImageSizeBytes, ct);
-
-    /// <summary>
-    /// Hardened fetch shared by every arbitrary-URL sink on this client: validates the scheme on
-    /// the initial URL and on every redirect hop (HTTPS-only), follows up to
-    /// <see cref="MaxRedirectHops"/> redirects with loop detection, and reads the body under a
-    /// streamed <paramref name="maxBytes"/> ceiling (aborts at limit+1, before buffering the whole
-    /// payload). The connection-level IP validation is provided by the connect-pin. Returns the
-    /// fully-read, within-limit bytes; the response and its content stream are disposed on exit.
-    /// </summary>
-    internal async Task<byte[]> FetchWithLimitAsync(string url, long maxBytes, CancellationToken ct)
-    {
-        var current = ParseHttpsAbsolute(url);
-        var visited = new HashSet<string>(StringComparer.Ordinal);
-
-        // The initial request plus up to MaxRedirectHops redirect follows.
-        for (var hop = 0; hop <= MaxRedirectHops; hop++)
-        {
-            if (!visited.Add(current.AbsoluteUri))
-                throw new InvalidOperationException("Redirect loop detected");
-
-            using var request = new HttpRequestMessage(HttpMethod.Get, current);
-            using var response = await _httpClient
-                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct)
-                .ConfigureAwait(false);
-
-            if (!IsRedirect(response.StatusCode))
-            {
-                response.EnsureSuccessStatusCode();
-
-                // Reject early on an advertised over-cap length; Content-Length is spoofable/absent
-                // (chunked), so the ceiling is ALSO enforced during the streamed read below.
-                if (response.Content.Headers.ContentLength > maxBytes)
-                    throw new InvalidOperationException($"Response exceeds the maximum size of {maxBytes / (1024 * 1024)}MB");
-
-                return await ReadWithCeilingAsync(response, maxBytes, ct).ConfigureAwait(false);
-            }
-
-            var location = response.Headers.Location
-                ?? throw new InvalidOperationException("Redirect response had no Location header");
-
-            // Resolve relative → absolute against the current URL, then RE-VALIDATE the scheme:
-            // an absolute http/file/gopher Location or a relative-to-non-http target is rejected
-            // here (the pin only re-checks the IP, not the scheme).
-            current = ParseHttpsAbsolute(new Uri(current, location).AbsoluteUri);
-        }
-
-        throw new InvalidOperationException($"Exceeded the maximum of {MaxRedirectHops} redirects");
-    }
-
-    private static async Task<byte[]> ReadWithCeilingAsync(HttpResponseMessage response, long maxBytes, CancellationToken ct)
-    {
-        using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
-        using var buffer = new MemoryStream();
-
-        var chunk = new byte[81920];
-        long total = 0;
-        int read;
-        while ((read = await stream.ReadAsync(chunk, ct).ConfigureAwait(false)) > 0)
-        {
-            total += read;
-            if (total > maxBytes)
-                throw new InvalidOperationException($"Response exceeds the maximum size of {maxBytes / (1024 * 1024)}MB");
-
-            await buffer.WriteAsync(chunk.AsMemory(0, read), ct).ConfigureAwait(false);
-        }
-
-        return buffer.ToArray();
-    }
-
-    private static bool IsRedirect(HttpStatusCode code) => code is
-        HttpStatusCode.MovedPermanently or HttpStatusCode.Found or HttpStatusCode.SeeOther
-        or HttpStatusCode.TemporaryRedirect or HttpStatusCode.PermanentRedirect;
-
-    private static Uri ParseHttpsAbsolute(string url)
-    {
-        ValidateUrlScheme(url);
-        return new Uri(url, UriKind.Absolute);
-    }
-
-    /// <summary>
-    /// Validates that the URL is absolute and uses the HTTPS scheme. Applied to the initial URL and
-    /// re-applied to every redirect target.
-    /// </summary>
-    internal static void ValidateUrlScheme(string url)
-    {
-        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
-            throw new ArgumentException("Invalid URL", nameof(url));
-
-        if (!string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
-            throw new ArgumentException("Only HTTPS URLs are allowed", nameof(url));
-    }
+        HardenedRedirectFetch.FetchAsync(
+            _httpClient,
+            url,
+            MaxImageSizeBytes,
+            MeepleAiMetrics.EgressSinks.Manual,
+            HardenedRedirectFetch.DefaultDeadline,
+            configureRequest: null,
+            ct);
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WikimediaCommonsClient.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WikimediaCommonsClient.cs
@@ -1,6 +1,9 @@
 using System.Net.Http.Headers;
+using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using Api.Observability;
+using Api.SharedKernel.Infrastructure.Http;
 using Microsoft.Extensions.Logging;
 
 namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
@@ -31,6 +34,18 @@ namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 internal sealed class WikimediaCommonsClient : IWikimediaCommonsClient
 {
     private const string ApiPath = "w/api.php";
+
+    /// <summary>
+    /// #3495 Slice D (finding H1) — ceilings and budgets for the two Commons calls, enforced by
+    /// <see cref="HardenedRedirectFetch"/>. Before this slice the image download read the body with
+    /// no limit at all, so a hostile or accidental multi-GB file was an unbounded allocation.
+    /// The image cap is deliberately generous: Commons legitimately serves high-resolution
+    /// photographs, and the WebP re-encode downstream is what normalizes them.
+    /// </summary>
+    private const long MaxImageBytes = 32 * 1024 * 1024;
+    private const long MaxApiResponseBytes = 2 * 1024 * 1024;
+    private static readonly TimeSpan ImageDeadline = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan ApiDeadline = TimeSpan.FromSeconds(15);
 
     /// <summary>
     /// Strips HTML tags from the Commons <c>Artist</c> field, which is returned
@@ -80,23 +95,28 @@ internal sealed class WikimediaCommonsClient : IWikimediaCommonsClient
         {
             var path = $"{ApiPath}?action=query&prop=imageinfo&iiprop=extmetadata&titles={Uri.EscapeDataString(title)}&format=json";
 
-            using var req = new HttpRequestMessage(HttpMethod.Get, path);
-            req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            // #3495 Slice D: through the hardened gate — per-hop HTTPS/port re-validation, bounded
+            // redirect follow, capped body, total deadline (the API answers 200 directly, but a
+            // hijacked/misconfigured redirect must not be followed blindly either).
+            var body = await HardenedRedirectFetch.FetchAsync(
+                _http,
+                path,
+                MaxApiResponseBytes,
+                MeepleAiMetrics.EgressSinks.Wikimedia,
+                ApiDeadline,
+                configureRequest: req => req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json")),
+                ct).ConfigureAwait(false);
 
-            using var resp = await _http.SendAsync(req, ct).ConfigureAwait(false);
-
-            if (!resp.IsSuccessStatusCode)
-            {
-                _logger.LogWarning(
-                    "Commons imageinfo HTTP {Status} for file '{Filename}' (decoded='{Decoded}'). Caller decides retry.",
-                    (int)resp.StatusCode,
-                    filename,
-                    decoded);
-                return CommonsLicenseResult.NotAvailable();
-            }
-
-            var body = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
-            return ParseResponse(body, filename, decoded);
+            return ParseResponse(Encoding.UTF8.GetString(body), filename, decoded);
+        }
+        catch (HardenedFetchException ex)
+        {
+            _logger.LogWarning(ex,
+                "Commons imageinfo blocked by the egress gate ({Reason}) for file '{Filename}' (decoded='{Decoded}').",
+                ex.Reason,
+                filename,
+                decoded);
+            return CommonsLicenseResult.NotAvailable();
         }
         // Issue #2157: real caller cancellation propagates so the batch handler
         // can decide to abort. HttpClient.Timeout firing also raises
@@ -155,23 +175,21 @@ internal sealed class WikimediaCommonsClient : IWikimediaCommonsClient
 
         try
         {
-            using var req = new HttpRequestMessage(HttpMethod.Get, path);
-            // Accept any image content; Commons serves PNG/JPEG/GIF/WebP/SVG/TIFF.
-            req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("image/*"));
+            // #3495 Slice D (H1) — the Special:FilePath 302 to upload.wikimedia.org is now followed
+            // MANUALLY through the gate instead of by the handler: each hop is re-validated
+            // (HTTPS-only, default port) and the body is read under a ceiling with a total deadline.
+            // This REPLACES the #1823 M8 invariant "do NOT disable redirects": the redirect is still
+            // followed — the image bytes stay reachable — but through the guarded path.
+            var bytes = await HardenedRedirectFetch.FetchAsync(
+                _http,
+                path,
+                MaxImageBytes,
+                MeepleAiMetrics.EgressSinks.Wikimedia,
+                ImageDeadline,
+                // Accept any image content; Commons serves PNG/JPEG/GIF/WebP/SVG/TIFF.
+                configureRequest: req => req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("image/*")),
+                ct).ConfigureAwait(false);
 
-            using var resp = await _http.SendAsync(req, ct).ConfigureAwait(false);
-
-            if (!resp.IsSuccessStatusCode)
-            {
-                _logger.LogWarning(
-                    "Commons FilePath HTTP {Status} for file '{Filename}' (decoded='{Decoded}'). Caller decides retry.",
-                    (int)resp.StatusCode,
-                    filename,
-                    decoded);
-                return null;
-            }
-
-            var bytes = await resp.Content.ReadAsByteArrayAsync(ct).ConfigureAwait(false);
             if (bytes.Length == 0)
             {
                 _logger.LogWarning(
@@ -182,6 +200,18 @@ internal sealed class WikimediaCommonsClient : IWikimediaCommonsClient
             }
 
             return bytes;
+        }
+        // #3495 Slice D: the gate refused a hop (scheme/port downgrade), the body blew the ceiling,
+        // or the total deadline elapsed. Same fail-soft contract as the other failures here — the M9
+        // scheduler records "image bytes not available" and moves on.
+        catch (HardenedFetchException ex)
+        {
+            _logger.LogWarning(ex,
+                "Commons FilePath blocked by the egress gate ({Reason}) for file '{Filename}' (decoded='{Decoded}').",
+                ex.Reason,
+                filename,
+                decoded);
+            return null;
         }
         // Issue #2157: real caller cancellation propagates so the batch handler
         // can decide to abort. HttpClient.Timeout firing also raises

--- a/apps/api/src/Api/Middleware/ApiExceptionHandlerMiddleware.cs
+++ b/apps/api/src/Api/Middleware/ApiExceptionHandlerMiddleware.cs
@@ -414,6 +414,18 @@ internal class ApiExceptionHandlerMiddleware
                 "La copertina non è al momento disponibile per il rendering. Riprova più tardi."
             ),
 
+            // #3495 Slice D: the egress gate refused a caller-supplied URL (or its redirect chain).
+            // That is bad input, not a server bug — a 500 here would both mislead the caller and
+            // pollute the error-rate SLO. The deadline case is a gateway timeout. The message stays
+            // generic on purpose: the offending host/IP belongs in the log, never in the response.
+            Api.SharedKernel.Infrastructure.Http.HardenedFetchException fetchEx => (
+                fetchEx.Reason == Api.SharedKernel.Infrastructure.Http.HardenedFetchBlockReason.Timeout
+                    ? StatusCodes.Status504GatewayTimeout
+                    : StatusCodes.Status400BadRequest,
+                "egress_blocked",
+                "L'URL indicato non può essere scaricato in sicurezza."
+            ),
+
             // Domain exceptions (from SharedKernel)
             Api.SharedKernel.Domain.Exceptions.ValidationException validationEx => (
                 StatusCodes.Status400BadRequest,

--- a/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.Egress.cs
+++ b/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.Egress.cs
@@ -29,6 +29,8 @@ internal static partial class MeepleAiMetrics
     {
         public const string PrivateIp = "private_ip";
         public const string DenylistHit = "denylist_hit";
+        /// <summary>A hop targeted a non-default port — port-probing an internal service (#3495 H2).</summary>
+        public const string Port = "port";
         public const string RedirectExhausted = "redirect_exhausted";
         public const string SizeCap = "size_cap";
         public const string DecodeFail = "decode_fail";

--- a/apps/api/src/Api/SharedKernel/Infrastructure/Http/HardenedFetchException.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/Http/HardenedFetchException.cs
@@ -1,0 +1,41 @@
+namespace Api.SharedKernel.Infrastructure.Http;
+
+/// <summary>
+/// Why a hardened egress fetch was refused. Maps 1:1 onto the bounded
+/// <c>MeepleAiMetrics.EgressBlockReasons</c> labels (#3495 M2) — keep the two in sync so a blocked
+/// fetch is always countable without ever putting a host or IP in a metric tag.
+/// </summary>
+public enum HardenedFetchBlockReason
+{
+    /// <summary>A hop was not absolute HTTPS (downgrade to http/file/gopher, or a relative target).</summary>
+    Scheme,
+
+    /// <summary>A hop targeted a non-default port — probing an internal service by port (#3495 H2).</summary>
+    Port,
+
+    /// <summary>The redirect chain looped or exceeded the hop cap.</summary>
+    RedirectExhausted,
+
+    /// <summary>The body exceeded the caller's byte ceiling (advertised or mid-stream).</summary>
+    SizeCap,
+
+    /// <summary>The TOTAL wall-clock budget for the exchange elapsed (#3495 C4).</summary>
+    Timeout,
+}
+
+/// <summary>
+/// Raised when <see cref="HardenedRedirectFetch"/> refuses an egress fetch. Carries a bounded
+/// <see cref="Reason"/> so callers (and the API exception mapping) can react without string-matching
+/// a message. The message itself stays generic — the host/IP that triggered the block belongs in the
+/// log, never in a response body or a metric tag.
+/// </summary>
+public sealed class HardenedFetchException : Exception
+{
+    public HardenedFetchException(HardenedFetchBlockReason reason, string message)
+        : base(message) => Reason = reason;
+
+    public HardenedFetchException(HardenedFetchBlockReason reason, string message, Exception innerException)
+        : base(message, innerException) => Reason = reason;
+
+    public HardenedFetchBlockReason Reason { get; }
+}

--- a/apps/api/src/Api/SharedKernel/Infrastructure/Http/HardenedRedirectFetch.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/Http/HardenedRedirectFetch.cs
@@ -1,0 +1,247 @@
+using Api.Observability;
+
+namespace Api.SharedKernel.Infrastructure.Http;
+
+/// <summary>
+/// Issue #3495 Slice D — the hardened redirect engine shared by every egress sink that follows
+/// redirects or fetches a caller-supplied URL.
+/// <para>
+/// Division of responsibility: the connect-pin (<see cref="SsrfPinnedConnect"/>) owns the IP
+/// boundary — it resolves once per connection and dials only a validated public address, so
+/// DNS-rebinding and redirect-to-internal are closed by construction. This engine owns what the pin
+/// cannot express, on the initial URL AND on every hop:
+/// </para>
+/// <list type="bullet">
+///   <item>absolute <b>HTTPS-only</b> — a <c>302</c> to <c>http/file/gopher</c> is refused (C4/H2);</item>
+///   <item><b>default port only</b> — a redirect to <c>:8080</c> / <c>:22</c> is port-probing (H2);</item>
+///   <item>bounded hop count with loop detection;</item>
+///   <item>a streamed byte ceiling, enforced during the read rather than after buffering;</item>
+///   <item>a <b>total wall-clock deadline</b> across the whole exchange — a chain of individually
+///   fast hops must not be able to hold a request open indefinitely (C4).</item>
+/// </list>
+/// <para>
+/// Auto-redirect MUST be disabled on the client's handler (<c>ConfigureSsrfPin(allowAutoRedirect:
+/// false)</c>) for these guards to see the 3xx at all: with auto-redirect on, the handler follows a
+/// downgrade before this code can reject it.
+/// </para>
+/// </summary>
+internal static class HardenedRedirectFetch
+{
+    /// <summary>Redirect follows allowed after the initial request.</summary>
+    public const int MaxRedirectHops = 5;
+
+    /// <summary>Default total budget for an arbitrary-URL fetch (#3495 C4).</summary>
+    public static readonly TimeSpan DefaultDeadline = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Fetches <paramref name="url"/> under the guards described on the class, returning the fully
+    /// read, within-ceiling bytes.
+    /// </summary>
+    /// <param name="client">Client whose handler carries the SSRF connect-pin with auto-redirect disabled.
+    /// A relative <paramref name="url"/> is resolved against its <see cref="HttpClient.BaseAddress"/>.</param>
+    /// <param name="url">Absolute HTTPS URL, or a relative path against the client's base address.</param>
+    /// <param name="maxBytes">Byte ceiling for the response body.</param>
+    /// <param name="sink">Bounded <c>MeepleAiMetrics.EgressSinks</c> constant for the block counters.</param>
+    /// <param name="deadline">Total wall-clock budget for the whole exchange, hops included.</param>
+    /// <param name="configureRequest">Applied to every hop's request (headers such as Accept).</param>
+    /// <param name="ct">Caller cancellation. Distinct from the deadline: a caller cancel surfaces as
+    /// <see cref="OperationCanceledException"/>, an expired deadline as
+    /// <see cref="HardenedFetchException"/> with <see cref="HardenedFetchBlockReason.Timeout"/>.</param>
+    /// <exception cref="HardenedFetchException">A guard refused the fetch.</exception>
+    /// <exception cref="HttpRequestException">The final hop answered a non-success status.</exception>
+    /// <exception cref="OperationCanceledException">The CALLER cancelled.</exception>
+    public static async Task<byte[]> FetchAsync(
+        HttpClient client,
+        string url,
+        long maxBytes,
+        string sink,
+        TimeSpan deadline,
+        Action<HttpRequestMessage>? configureRequest,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+
+        var current = ResolveInitialTarget(url, client.BaseAddress, sink);
+        var visited = new HashSet<string>(StringComparer.Ordinal);
+
+        // One budget for the whole exchange. Linked to the caller token so a real cancel still wins,
+        // and disposed on exit so the timer never outlives the request.
+        using var budget = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        budget.CancelAfter(deadline);
+
+        try
+        {
+            // The initial request plus up to MaxRedirectHops redirect follows.
+            for (var hop = 0; hop <= MaxRedirectHops; hop++)
+            {
+                if (!visited.Add(current.AbsoluteUri))
+                {
+                    throw Blocked(sink, HardenedFetchBlockReason.RedirectExhausted, "Redirect loop detected");
+                }
+
+                using var request = new HttpRequestMessage(HttpMethod.Get, current);
+                configureRequest?.Invoke(request);
+
+                using var response = await client
+                    .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, budget.Token)
+                    .ConfigureAwait(false);
+
+                if (!IsRedirect(response.StatusCode))
+                {
+                    response.EnsureSuccessStatusCode();
+
+                    // Reject early on an advertised over-cap length; Content-Length is spoofable and
+                    // absent on chunked bodies, so the ceiling is ALSO enforced during the read.
+                    if (response.Content.Headers.ContentLength > maxBytes)
+                    {
+                        throw Blocked(sink, HardenedFetchBlockReason.SizeCap,
+                            $"Response exceeds the maximum size of {maxBytes} bytes");
+                    }
+
+                    return await ReadWithCeilingAsync(response, maxBytes, sink, budget.Token).ConfigureAwait(false);
+                }
+
+                var location = response.Headers.Location
+                    ?? throw Blocked(sink, HardenedFetchBlockReason.Scheme, "Redirect response had no Location header");
+
+                // Resolve relative → absolute against the CURRENT hop, then re-run the full gate on
+                // the target: the pin re-checks the IP of the next connection, nothing else.
+                current = ResolveAndValidate(new Uri(current, location).AbsoluteUri, baseAddress: null, sink);
+            }
+
+            throw Blocked(sink, HardenedFetchBlockReason.RedirectExhausted,
+                $"Exceeded the maximum of {MaxRedirectHops} redirects");
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            // The budget fired, not the caller: report a timeout rather than masquerading as a cancel.
+            throw Blocked(sink, HardenedFetchBlockReason.Timeout,
+                $"Egress fetch exceeded its {deadline.TotalSeconds:0.###}s budget");
+        }
+    }
+
+    /// <summary>
+    /// Resolves the FIRST target of an exchange.
+    /// <para>
+    /// Deliberate asymmetry: a <b>relative</b> path is our own configuration — the caller is a typed
+    /// client whose <see cref="HttpClient.BaseAddress"/> we set in DI — so it is resolved and dialled
+    /// without the scheme/port gate (the connect-pin still owns its IP). An <b>absolute</b> URL is
+    /// caller input (the manual cover sink, a stored webhook) and gets the full gate. Every REDIRECT
+    /// target is untrusted regardless of how the exchange started, so
+    /// <see cref="ResolveAndValidate"/> runs on each hop.
+    /// </para>
+    /// <para>
+    /// This is what lets a fixed-host client keep working against a local contract/test server on
+    /// <c>http://localhost:PORT</c> while a hostile 302 to that same address is still refused.
+    /// </para>
+    /// </summary>
+    private static Uri ResolveInitialTarget(string url, Uri? baseAddress, string sink)
+    {
+        if (!Uri.TryCreate(url, UriKind.RelativeOrAbsolute, out var parsed))
+        {
+            throw Blocked(sink, HardenedFetchBlockReason.Scheme, "Invalid URL");
+        }
+
+        if (parsed.IsAbsoluteUri)
+        {
+            return ResolveAndValidate(url, baseAddress, sink);
+        }
+
+        if (baseAddress is null)
+        {
+            throw Blocked(sink, HardenedFetchBlockReason.Scheme,
+                "Relative URL with no base address to resolve against");
+        }
+
+        return new Uri(baseAddress, parsed);
+    }
+
+    /// <summary>
+    /// Validates that a URL is an absolute HTTPS URL on the default port, resolving it against
+    /// <paramref name="baseAddress"/> when relative. Applied to every redirect hop, and available to
+    /// callers that want the same fail-fast on a caller-supplied URL before starting work.
+    /// </summary>
+    /// <exception cref="HardenedFetchException">The URL is not absolute HTTPS, or uses a non-default port.</exception>
+    public static Uri ResolveAndValidate(string url, Uri? baseAddress, string sink)
+    {
+        if (!Uri.TryCreate(url, UriKind.RelativeOrAbsolute, out var parsed))
+        {
+            throw Blocked(sink, HardenedFetchBlockReason.Scheme, "Invalid URL");
+        }
+
+        if (!parsed.IsAbsoluteUri)
+        {
+            if (baseAddress is null)
+            {
+                throw Blocked(sink, HardenedFetchBlockReason.Scheme,
+                    "Relative URL with no base address to resolve against");
+            }
+
+            parsed = new Uri(baseAddress, parsed);
+        }
+
+        if (!string.Equals(parsed.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            throw Blocked(sink, HardenedFetchBlockReason.Scheme, "Only HTTPS URLs are allowed");
+        }
+
+        // Default port only. An explicit ":443" is still the default port (IsDefaultPort is true), so
+        // this rejects exactly the port-probing shapes — :8080, :22, :6379 — and nothing legitimate.
+        if (!parsed.IsDefaultPort)
+        {
+            throw Blocked(sink, HardenedFetchBlockReason.Port,
+                "Only the default HTTPS port is allowed");
+        }
+
+        return parsed;
+    }
+
+    private static async Task<byte[]> ReadWithCeilingAsync(
+        HttpResponseMessage response, long maxBytes, string sink, CancellationToken ct)
+    {
+        using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+        using var buffer = new MemoryStream();
+
+        var chunk = new byte[81920];
+        long total = 0;
+        int read;
+        while ((read = await stream.ReadAsync(chunk, ct).ConfigureAwait(false)) > 0)
+        {
+            total += read;
+            if (total > maxBytes)
+            {
+                throw Blocked(sink, HardenedFetchBlockReason.SizeCap,
+                    $"Response exceeds the maximum size of {maxBytes} bytes");
+            }
+
+            await buffer.WriteAsync(chunk.AsMemory(0, read), ct).ConfigureAwait(false);
+        }
+
+        return buffer.ToArray();
+    }
+
+    /// <summary>
+    /// Counts the block on the bounded egress counters and builds the exception. Every refusal goes
+    /// through here so "blocked" is never silent (#3495 M2).
+    /// </summary>
+    private static HardenedFetchException Blocked(string sink, HardenedFetchBlockReason reason, string message)
+    {
+        MeepleAiMetrics.RecordEgressBlocked(sink, ToMetricReason(reason));
+        return new HardenedFetchException(reason, message);
+    }
+
+    private static string ToMetricReason(HardenedFetchBlockReason reason) => reason switch
+    {
+        HardenedFetchBlockReason.Scheme => MeepleAiMetrics.EgressBlockReasons.Scheme,
+        HardenedFetchBlockReason.Port => MeepleAiMetrics.EgressBlockReasons.Port,
+        HardenedFetchBlockReason.RedirectExhausted => MeepleAiMetrics.EgressBlockReasons.RedirectExhausted,
+        HardenedFetchBlockReason.SizeCap => MeepleAiMetrics.EgressBlockReasons.SizeCap,
+        HardenedFetchBlockReason.Timeout => MeepleAiMetrics.EgressBlockReasons.Timeout,
+        _ => MeepleAiMetrics.EgressBlockReasons.Scheme,
+    };
+
+    private static bool IsRedirect(System.Net.HttpStatusCode code) => code is
+        System.Net.HttpStatusCode.MovedPermanently or System.Net.HttpStatusCode.Found
+        or System.Net.HttpStatusCode.SeeOther or System.Net.HttpStatusCode.TemporaryRedirect
+        or System.Net.HttpStatusCode.PermanentRedirect;
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandlerTests.cs
@@ -204,6 +204,9 @@ public sealed class SetManualCoverCommandHandlerTests
     {
         // Defence in depth: the validator rejects non-HTTPS at 400, but the SSRF-safe fetch path
         // ALSO re-validates the scheme, so a handler invoked directly still refuses egress.
+        // #3495 Slice D: that refusal is now a typed HardenedFetchException carrying a bounded
+        // reason (still mapped to 400 by ApiExceptionHandlerMiddleware) instead of a bare
+        // ArgumentException whose meaning had to be inferred from its message.
         var game = NewGame();
         _repository.Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>())).ReturnsAsync(game);
 
@@ -211,7 +214,8 @@ public sealed class SetManualCoverCommandHandlerTests
             Command(game.Id) with { SourceUrl = "http://commons.example.org/cover.png" },
             CancellationToken.None);
 
-        await act.Should().ThrowAsync<ArgumentException>();
+        var thrown = await act.Should().ThrowAsync<Api.SharedKernel.Infrastructure.Http.HardenedFetchException>();
+        thrown.Which.Reason.Should().Be(Api.SharedKernel.Infrastructure.Http.HardenedFetchBlockReason.Scheme);
         _httpHandler.RequestCount.Should().Be(0);
         _unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfSafeHttpClientTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfSafeHttpClientTests.cs
@@ -1,99 +1,51 @@
 using System.Net;
 using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+using Api.SharedKernel.Infrastructure.Http;
 using Api.Tests.Constants;
 using FluentAssertions;
 using Xunit;
 
 namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 
+/// <summary>
+/// The manual / arbitrary-URL cover sink. Since #3495 Slice D the redirect, scheme, port, deadline
+/// and ceiling logic lives in <see cref="HardenedRedirectFetch"/> (covered exhaustively by
+/// <c>HardenedRedirectFetchTests</c>); what stays specific to this type — and is asserted here — is
+/// the binding: the manual sink's own client, its 10MB image ceiling, and the guarded behaviour
+/// surviving end-to-end through the wrapper.
+/// </summary>
 [Trait("Category", TestCategories.Unit)]
 [Trait("BoundedContext", "SharedGameCatalog")]
 public class SsrfSafeHttpClientTests
 {
-    #region ValidateUrlScheme Tests
-
-    [Theory]
-    [InlineData("https://example.com/file.pdf")]
-    [InlineData("https://cdn.boardgamegeek.com/rules/game.pdf")]
-    public void ValidateUrlScheme_ValidHttpsUrl_ShouldNotThrow(string url)
-    {
-        var act = () => SsrfSafeHttpClient.ValidateUrlScheme(url);
-
-        act.Should().NotThrow();
-    }
-
-    [Theory]
-    [InlineData("http://example.com/file.pdf")]
-    [InlineData("http://localhost/file.pdf")]
-    public void ValidateUrlScheme_HttpUrl_ShouldThrowArgumentException(string url)
-    {
-        var act = () => SsrfSafeHttpClient.ValidateUrlScheme(url);
-
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("Only HTTPS URLs are allowed*");
-    }
-
-    [Theory]
-    [InlineData("ftp://example.com/file.pdf")]
-    [InlineData("file:///etc/passwd")]
-    public void ValidateUrlScheme_NonHttpScheme_ShouldThrowArgumentException(string url)
-    {
-        var act = () => SsrfSafeHttpClient.ValidateUrlScheme(url);
-
-        act.Should().Throw<ArgumentException>();
-    }
-
-    [Theory]
-    [InlineData("not-a-url")]
-    [InlineData("")]
-    public void ValidateUrlScheme_InvalidUrl_ShouldThrowArgumentException(string url)
-    {
-        var act = () => SsrfSafeHttpClient.ValidateUrlScheme(url);
-
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("Invalid URL*");
-    }
-
-    #endregion
-
-    // IsPrivateOrReserved tests removed with the method (#3495 fix 5/N): the pre-connect DNS
-    // check was TOCTOU and is retired in favor of the connect-pin (SsrfPinnedConnect), whose
-    // IANA IP policy is covered by SsrfPolicyTests. The IP boundary is no longer this class's.
-
-    #region Redirect / scheme / size-cap tests (#3495 fix 5/N)
-
     private static HttpResponseMessage Redirect(HttpStatusCode code, string location)
     {
-        var r = new HttpResponseMessage(code);
-        r.Headers.Location = new Uri(location, UriKind.RelativeOrAbsolute);
-        return r;
+        var response = new HttpResponseMessage(code);
+        response.Headers.Location = new Uri(location, UriKind.RelativeOrAbsolute);
+        return response;
     }
-
-    private static HttpResponseMessage Payload() => new(HttpStatusCode.OK)
-    {
-        Content = new ByteArrayContent(System.Text.Encoding.ASCII.GetBytes("image-bytes")),
-    };
 
     [Fact]
     public async Task DownloadImageAsync_FollowsHttpsRedirect_ToFinalPayload()
     {
+        var payload = new byte[] { 0x89, 0x50, 0x4E, 0x47 };
         using var handler = new SequenceHttpMessageHandler(
             _ => Redirect(HttpStatusCode.Found, "https://cdn.example/final.png"),
-            _ => Payload());
+            _ => new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(payload) });
         using var httpClient = new HttpClient(handler);
         var sut = new SsrfSafeHttpClient(httpClient);
 
         var result = await sut.DownloadImageAsync("https://example.com/cover.png", CancellationToken.None);
 
-        System.Text.Encoding.ASCII.GetString(result).Should().Be("image-bytes");
+        result.Should().Equal(payload);
         handler.RequestedUris.Should().HaveCount(2);
         handler.RequestedUris[1].Should().Be(new Uri("https://cdn.example/final.png"));
     }
 
     [Theory]
-    [InlineData("http://cdn.example/final.png")]     // https → http downgrade
-    [InlineData("file:///etc/passwd")]                // scheme downgrade to file
-    [InlineData("gopher://internal/x")]               // exotic scheme
+    [InlineData("http://cdn.example/final.png")]      // https → http downgrade
+    [InlineData("file:///etc/passwd")]                 // scheme downgrade to file
+    [InlineData("gopher://internal/x")]                // exotic scheme
     public async Task DownloadImageAsync_RejectsSchemeDowngradeOnRedirect(string location)
     {
         using var handler = new SequenceHttpMessageHandler(_ => Redirect(HttpStatusCode.Found, location));
@@ -102,55 +54,60 @@ public class SsrfSafeHttpClientTests
 
         var act = () => sut.DownloadImageAsync("https://example.com/cover.png", CancellationToken.None);
 
-        await act.Should().ThrowAsync<ArgumentException>()
-            .WithMessage("Only HTTPS URLs are allowed*");
+        var thrown = await act.Should().ThrowAsync<HardenedFetchException>();
+        thrown.Which.Reason.Should().Be(HardenedFetchBlockReason.Scheme);
     }
 
     [Fact]
-    public async Task DownloadImageAsync_RejectsRedirectLoop()
+    public async Task DownloadImageAsync_RejectsARedirectToANonDefaultPort()
     {
         using var handler = new SequenceHttpMessageHandler(
-            _ => Redirect(HttpStatusCode.Found, "https://example.com/cover.png")); // → itself
+            _ => Redirect(HttpStatusCode.Found, "https://cdn.example:8080/final.png"));
         using var httpClient = new HttpClient(handler);
         var sut = new SsrfSafeHttpClient(httpClient);
 
         var act = () => sut.DownloadImageAsync("https://example.com/cover.png", CancellationToken.None);
 
-        await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*loop*");
+        var thrown = await act.Should().ThrowAsync<HardenedFetchException>();
+        thrown.Which.Reason.Should().Be(HardenedFetchBlockReason.Port);
     }
 
     [Fact]
-    public async Task DownloadImageAsync_RejectsTooManyRedirects()
+    public async Task DownloadImageAsync_EnforcesTheTenMegabyteCoverCeiling()
     {
-        var n = 0;
-        using var handler = new SequenceHttpMessageHandler(
-            _ => Redirect(HttpStatusCode.Found, $"https://example.com/hop{++n}.png"));
-        using var httpClient = new HttpClient(handler);
-        var sut = new SsrfSafeHttpClient(httpClient);
-
-        var act = () => sut.DownloadImageAsync("https://example.com/cover.png", CancellationToken.None);
-
-        await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*maximum*redirects*");
-    }
-
-    [Fact]
-    public async Task FetchWithLimitAsync_AbortsMidStreamOverCeiling()
-    {
-        // 2 KB body against a 1 KB ceiling → must throw before buffering the whole payload.
-        var body = new byte[2048];
+        // The ceiling is the wrapper's contract (the engine takes it as a parameter), so it belongs
+        // here rather than in the engine tests: 11MB must never come back as bytes.
         using var handler = new SequenceHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
         {
-            Content = new ByteArrayContent(body),
+            Content = new ByteArrayContent(new byte[11 * 1024 * 1024]),
         });
         using var httpClient = new HttpClient(handler);
         var sut = new SsrfSafeHttpClient(httpClient);
 
-        var act = () => sut.FetchWithLimitAsync("https://example.com/blob", 1024, CancellationToken.None);
+        var act = () => sut.DownloadImageAsync("https://example.com/huge.png", CancellationToken.None);
 
-        await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*exceeds*");
+        var thrown = await act.Should().ThrowAsync<HardenedFetchException>();
+        thrown.Which.Reason.Should().Be(HardenedFetchBlockReason.SizeCap);
+    }
+
+    [Fact]
+    public async Task DownloadImageAsync_DisposesResponseContentStream()
+    {
+        // Issue #3239 regression: the response content stream used to leak.
+        var payload = System.Text.Encoding.ASCII.GetBytes("fake-image-content");
+        var sourceStream = new DisposeTrackingStream(payload);
+        using var handler = new SequenceHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StreamContent(sourceStream),
+        });
+        using var httpClient = new HttpClient(handler);
+        var sut = new SsrfSafeHttpClient(httpClient);
+
+        var result = await sut.DownloadImageAsync("https://8.8.8.8/cover.png", CancellationToken.None);
+
+        System.Text.Encoding.ASCII.GetString(result).Should().Be("fake-image-content");
+        sourceStream.Disposed.Should().BeTrue(
+            "the hardened fetch must dispose the HttpResponseMessage and its content stream");
     }
 
     private sealed class SequenceHttpMessageHandler : HttpMessageHandler
@@ -168,45 +125,6 @@ public class SsrfSafeHttpClientTests
             var responder = _responders.Count > 1 ? _responders.Dequeue() : _responders.Peek();
             return Task.FromResult(responder(request));
         }
-    }
-
-    #endregion
-
-    #region DownloadImageAsync Disposal Tests (Issue #3239)
-
-    [Fact]
-    public async Task DownloadImageAsync_DisposesResponseContentStream()
-    {
-        var payload = System.Text.Encoding.ASCII.GetBytes("fake-image-content");
-        var sourceStream = new DisposeTrackingStream(payload);
-        using var handler = new StubHttpMessageHandler(() => new HttpResponseMessage(HttpStatusCode.OK)
-        {
-            Content = new StreamContent(sourceStream),
-        });
-        using var httpClient = new HttpClient(handler);
-        var sut = new SsrfSafeHttpClient(httpClient);
-
-        // The stub handler answers directly, so no connection (and no SSRF pin) is involved: this
-        // test is only about the response lifetime.
-        var result = await sut.DownloadImageAsync("https://8.8.8.8/cover.png", CancellationToken.None);
-
-        // The full payload is returned to the caller as an independent buffer...
-        System.Text.Encoding.ASCII.GetString(result).Should().Be("fake-image-content");
-
-        // ...and the source HttpResponseMessage content stream must be disposed (it was leaked before the fix).
-        sourceStream.Disposed.Should().BeTrue(
-            "the hardened fetch must dispose the HttpResponseMessage and its content stream");
-    }
-
-    private sealed class StubHttpMessageHandler : HttpMessageHandler
-    {
-        private readonly Func<HttpResponseMessage> _responder;
-
-        public StubHttpMessageHandler(Func<HttpResponseMessage> responder) => _responder = responder;
-
-        protected override Task<HttpResponseMessage> SendAsync(
-            HttpRequestMessage request,
-            CancellationToken cancellationToken) => Task.FromResult(_responder());
     }
 
     private sealed class DisposeTrackingStream : MemoryStream
@@ -229,6 +147,4 @@ public class SsrfSafeHttpClientTests
             return base.DisposeAsync();
         }
     }
-
-    #endregion
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WikimediaCommonsClientGateTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WikimediaCommonsClientGateTests.cs
@@ -1,0 +1,154 @@
+using System.Net;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+
+/// <summary>
+/// Issue #3495 Slice D (finding H1) — the Commons image download now follows the
+/// <c>Special:FilePath</c> 302 MANUALLY through <c>HardenedRedirectFetch</c> instead of letting the
+/// handler auto-follow it.
+/// <para>
+/// This supersedes the #1823 M8 invariant "do NOT disable redirects": the redirect is still
+/// followed, so the image bytes stay reachable, but each hop is re-validated (HTTPS-only, default
+/// port) and the body is bounded. Before this slice the download read the response with no ceiling
+/// at all and a hostile 302 could point anywhere the pin still considered public.
+/// </para>
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "3495")]
+public sealed class WikimediaCommonsClientGateTests
+{
+    private const string CommonsBaseUrl = "https://commons.wikimedia.org/";
+
+    private static WikimediaCommonsClient CreateClient(HttpMessageHandler handler) =>
+        new(new HttpClient(handler) { BaseAddress = new Uri(CommonsBaseUrl) },
+            new Mock<IWikimediaRateLimiter>().Object,
+            new Mock<ILogger<WikimediaCommonsClient>>().Object);
+
+    [Fact]
+    public async Task FetchImageBytesAsync_FollowsTheSpecialFilePathRedirect_ToUploadWikimedia()
+    {
+        var expected = new byte[] { 0xFF, 0xD8, 0xFF, 0xE0, 0x11 };
+        var seen = new List<Uri>();
+        using var handler = new DelegateHandler(request =>
+        {
+            seen.Add(request.RequestUri!);
+            return seen.Count == 1
+                ? new HttpResponseMessage(HttpStatusCode.Found)
+                {
+                    Headers = { Location = new Uri("https://upload.wikimedia.org/wikipedia/commons/a/b/Cover.jpg") },
+                }
+                : new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(expected) };
+        });
+        var client = CreateClient(handler);
+
+        var result = await client.FetchImageBytesAsync("Cover.jpg", CancellationToken.None);
+
+        result.Should().BeEquivalentTo(expected, "the M8 image path must keep working through the gate");
+        seen.Should().HaveCount(2);
+        seen[0].AbsolutePath.Should().StartWith("/wiki/Special:FilePath/");
+        seen[1].Host.Should().Be("upload.wikimedia.org");
+    }
+
+    [Fact]
+    public async Task FetchImageBytesAsync_RejectsARedirectThatDowngradesToHttp()
+    {
+        // Previously the handler auto-followed this before any of our code could see it.
+        using var handler = new DelegateHandler(_ => new HttpResponseMessage(HttpStatusCode.Found)
+        {
+            Headers = { Location = new Uri("http://upload.wikimedia.org/plain.jpg") },
+        });
+        var client = CreateClient(handler);
+
+        var result = await client.FetchImageBytesAsync("Cover.jpg", CancellationToken.None);
+
+        result.Should().BeNull("a scheme downgrade mid-chain must fail closed, fail-soft to the caller");
+    }
+
+    [Fact]
+    public async Task FetchImageBytesAsync_RejectsARedirectToANonDefaultPort()
+    {
+        using var handler = new DelegateHandler(_ => new HttpResponseMessage(HttpStatusCode.Found)
+        {
+            Headers = { Location = new Uri("https://upload.wikimedia.org:8080/internal.jpg") },
+        });
+        var client = CreateClient(handler);
+
+        var result = await client.FetchImageBytesAsync("Cover.jpg", CancellationToken.None);
+
+        result.Should().BeNull("a redirect to a non-default port is port-probing, not a CDN hop");
+    }
+
+    [Fact]
+    public async Task FetchImageBytesAsync_AbortsAnOversizeBody()
+    {
+        // 33MB against the 32MB Commons ceiling: before Slice D there was no ceiling at all.
+        using var handler = new DelegateHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(new byte[33 * 1024 * 1024]),
+        });
+        var client = CreateClient(handler);
+
+        var result = await client.FetchImageBytesAsync("Huge.jpg", CancellationToken.None);
+
+        result.Should().BeNull("an unbounded body is an unbounded allocation");
+    }
+
+    [Fact]
+    public async Task FetchLicenseAsync_StillParsesA200Response_ThroughTheGate()
+    {
+        const string Body = """
+            {"query":{"pages":{"123":{"imageinfo":[{"extmetadata":{
+              "LicenseShortName":{"value":"CC BY-SA 4.0"},"Artist":{"value":"<a href='#'>Jane</a>"}}}]}}}}
+            """;
+        using var handler = new DelegateHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(Body),
+        });
+        var client = CreateClient(handler);
+
+        var result = await client.FetchLicenseAsync("Cover.jpg", CancellationToken.None);
+
+        result.RawLicense.Should().Be("CC BY-SA 4.0");
+        result.Attribution.Should().Be("Jane");
+    }
+
+    [Fact]
+    public async Task CallerCancellation_StillPropagates_AndIsNotSwallowedAsAGateBlock()
+    {
+        using var cts = new CancellationTokenSource();
+        using var handler = new DelegateHandler(async (_, ct) =>
+        {
+            await cts.CancelAsync();
+            await Task.Delay(TimeSpan.FromSeconds(5), ct);
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        });
+        var client = CreateClient(handler);
+
+        var act = () => client.FetchImageBytesAsync("Cover.jpg", cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>(
+            "the #2157 contract keeps a batch-wide user abort distinguishable from a per-item failure");
+    }
+
+    private sealed class DelegateHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _responder;
+
+        public DelegateHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> responder)
+            => _responder = responder;
+
+        public DelegateHandler(Func<HttpRequestMessage, HttpResponseMessage> responder)
+            => _responder = (request, _) => Task.FromResult(responder(request));
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+            => _responder(request, cancellationToken);
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/SharedGameCatalog/WikimediaCircuitBreakerIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/SharedGameCatalog/WikimediaCircuitBreakerIntegrationTests.cs
@@ -42,9 +42,19 @@ public class WikimediaCircuitBreakerIntegrationTests
         Task<HttpResponseMessage> GetAsync(string path, CancellationToken ct);
     }
 
+    // #3495 Slice D — these two constructors are invoked ONLY by the typed-client factory, through
+    // reflection, so SonarAnalyzer S1144 reports them as unused and `dotnet format` (which applies
+    // analyzer fixes, not just whitespace) DELETES them. That is exactly what happened in 3cbec7f86
+    // ("chore(format): repo-wide whitespace drift cleanup", #2296): the field was left unassigned —
+    // CS0649 is a warning, not an error — and all three tests in this class have failed since with
+    // "A suitable constructor ... could not be located". They are Integration-category, so Backend
+    // Fast never ran them and the breakage stayed invisible. Restored AND pinned: without the
+    // suppression the next format sweep silently removes them again.
+#pragma warning disable S1144 // Constructor is resolved by the HttpClient typed-client factory
     private sealed class FakeWikidataClient : IFakeWikidataClient
     {
         private readonly HttpClient _client;
+        public FakeWikidataClient(HttpClient client) => _client = client;
         public Task<HttpResponseMessage> GetAsync(string path, CancellationToken ct) =>
             _client.GetAsync(path, ct);
     }
@@ -52,9 +62,11 @@ public class WikimediaCircuitBreakerIntegrationTests
     private sealed class FakeCommonsClient : IFakeCommonsClient
     {
         private readonly HttpClient _client;
+        public FakeCommonsClient(HttpClient client) => _client = client;
         public Task<HttpResponseMessage> GetAsync(string path, CancellationToken ct) =>
             _client.GetAsync(path, ct);
     }
+#pragma warning restore S1144
 
     private sealed class FixedResponseHandler : DelegatingHandler
     {

--- a/apps/api/tests/Api.Tests/Observability/EgressMetricsTests.cs
+++ b/apps/api/tests/Api.Tests/Observability/EgressMetricsTests.cs
@@ -77,15 +77,24 @@ public sealed class EgressMetricsTests
             }
         });
 
-        captured.Should().HaveCount(1);
-        var (value, tags) = captured[0];
+        // The MeterListener is process-wide and xUnit runs test classes in parallel, so the capture
+        // window can also see increments from other egress tests. Select this scenario's measurement
+        // by its tags instead of assuming the window is exclusively ours (#3495 Slice D: the new
+        // gate emits blocks from several sinks, which made the old HaveCount(1) flaky).
+        var mine = captured
+            .Where(c => Equals(c.Tags.GetValueOrDefault("sink"), "manual")
+                && Equals(c.Tags.GetValueOrDefault("reason"), "private_ip"))
+            .ToList();
+
+        mine.Should().NotBeEmpty("the guard must record the block before throwing");
+        var (value, tags) = mine[0];
         value.Should().Be(1);
         // Bounded cardinality: exactly {sink, reason}, both the intended constants.
         tags.Keys.Should().BeEquivalentTo("sink", "reason");
-        tags["sink"].Should().Be("manual");
-        tags["reason"].Should().Be("private_ip");
         // The host/IP must NEVER leak into a metric tag (unbounded cardinality + PII/SSRF-target leak).
         tags.Values.Should().NotContain("evil.example.com").And.NotContain("10.0.0.5");
+        // Every measurement in the window — whoever emitted it — must keep the tag set bounded.
+        captured.Should().AllSatisfy(c => c.Tags.Keys.Should().BeEquivalentTo("sink", "reason"));
     }
 
     [Fact]
@@ -98,10 +107,13 @@ public sealed class EgressMetricsTests
                     dns, "cdn.example.com", MeepleAiMetrics.EgressSinks.Manual, CancellationToken.None)
                 .GetAwaiter().GetResult());
 
-        captured.Should().HaveCount(1);
-        captured[0].Value.Should().Be(1);
-        captured[0].Tags.Keys.Should().BeEquivalentTo("sink");
-        captured[0].Tags["sink"].Should().Be("manual");
+        // Same parallel-capture caveat as the blocked counter above: select by tag, don't assume the
+        // window is exclusively ours.
+        var mine = captured.Where(c => Equals(c.Tags.GetValueOrDefault("sink"), "manual")).ToList();
+
+        mine.Should().NotBeEmpty("a validated public address must count towards the allowed denominator");
+        mine[0].Value.Should().Be(1);
+        captured.Should().AllSatisfy(c => c.Tags.Keys.Should().BeEquivalentTo("sink"));
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/SharedKernel/Infrastructure/Http/HardenedRedirectFetchTests.cs
+++ b/apps/api/tests/Api.Tests/SharedKernel/Infrastructure/Http/HardenedRedirectFetchTests.cs
@@ -1,0 +1,342 @@
+using System.Diagnostics;
+using System.Net;
+using Api.SharedKernel.Infrastructure.Http;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.SharedKernel.Infrastructure.Http;
+
+/// <summary>
+/// Issue #3495 Slice D — the hardened redirect engine shared by every arbitrary-URL / redirecting
+/// egress sink (findings C4 wall-clock deadline, H2 per-hop scheme + port re-validation).
+/// <para>
+/// The connect-pin owns the IP boundary; this engine owns everything the pin cannot express:
+/// a bounded manual redirect follow, per-hop scheme/port re-validation, a streamed byte ceiling,
+/// and a TOTAL wall-clock budget across all hops (a chain of individually-fast hops must not be
+/// able to hold a request open indefinitely).
+/// </para>
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedKernel")]
+[Trait("Issue", "3495")]
+public sealed class HardenedRedirectFetchTests
+{
+    private const string Sink = "test_sink";
+
+    private static HttpResponseMessage Redirect(string location) =>
+        new(HttpStatusCode.Found) { Headers = { Location = new Uri(location, UriKind.RelativeOrAbsolute) } };
+
+    private static HttpResponseMessage Ok(byte[] body) =>
+        new(HttpStatusCode.OK) { Content = new ByteArrayContent(body) };
+
+    // ------------------------------------------------------------------
+    // C4 — total wall-clock deadline
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task Deadline_IsCumulativeAcrossHops_NotPerHop()
+    {
+        // Each hop is comfortably inside the budget on its own; together they exceed it. A per-hop
+        // timeout would let this chain run forever — the deadline must be wall-clock TOTAL.
+        var hop = 0;
+        using var handler = new DelegateHandler(async (_, ct) =>
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(120), ct);
+            return Redirect($"https://example.com/hop{++hop}");
+        });
+        using var client = new HttpClient(handler);
+
+        var act = () => HardenedRedirectFetch.FetchAsync(
+            client, "https://example.com/start", maxBytes: 1024, sink: Sink,
+            deadline: TimeSpan.FromMilliseconds(250), configureRequest: null, ct: CancellationToken.None);
+
+        var thrown = await act.Should().ThrowAsync<HardenedFetchException>();
+        thrown.Which.Reason.Should().Be(HardenedFetchBlockReason.Timeout);
+        hop.Should().BeLessThan(5, "the deadline must cut the chain short before the hop cap");
+    }
+
+    [Fact]
+    public async Task Deadline_AbortsASlowBody_AndFailsClosed()
+    {
+        using var handler = new DelegateHandler(async (_, ct) =>
+        {
+            await Task.Delay(TimeSpan.FromSeconds(30), ct);
+            return Ok(new byte[] { 1 });
+        });
+        using var client = new HttpClient(handler);
+        var stopwatch = Stopwatch.StartNew();
+
+        var act = () => HardenedRedirectFetch.FetchAsync(
+            client, "https://example.com/slow", maxBytes: 1024, sink: Sink,
+            deadline: TimeSpan.FromMilliseconds(200), configureRequest: null, ct: CancellationToken.None);
+
+        var thrown = await act.Should().ThrowAsync<HardenedFetchException>();
+        thrown.Which.Reason.Should().Be(HardenedFetchBlockReason.Timeout);
+        stopwatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(10), "the deadline must fire, not the client timeout");
+    }
+
+    [Fact]
+    public async Task CallerCancellation_PropagatesAsOperationCanceled_NotAsTimeout()
+    {
+        // A caller cancel and an expired deadline both surface as a cancelled token inside the
+        // engine; they MUST stay distinguishable, or a batch handler mistakes a per-item budget for
+        // a user abort (the #2157 lesson on the Commons client).
+        using var cts = new CancellationTokenSource();
+        using var handler = new DelegateHandler(async (_, ct) =>
+        {
+            await cts.CancelAsync();
+            await Task.Delay(TimeSpan.FromSeconds(5), ct);
+            return Ok(new byte[] { 1 });
+        });
+        using var client = new HttpClient(handler);
+
+        var act = () => HardenedRedirectFetch.FetchAsync(
+            client, "https://example.com/x", maxBytes: 1024, sink: Sink,
+            deadline: TimeSpan.FromSeconds(30), configureRequest: null, ct: cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    // ------------------------------------------------------------------
+    // H2 — per-hop scheme and port re-validation
+    // ------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("https://example.com:8080/x")]   // app-server port
+    [InlineData("https://example.com:22/x")]     // ssh
+    [InlineData("https://example.com:6379/x")]   // redis
+    public async Task RedirectToAnomalousPort_IsBlocked(string location)
+    {
+        using var handler = new DelegateHandler((_, _) => Task.FromResult(Redirect(location)));
+        using var client = new HttpClient(handler);
+
+        var act = () => HardenedRedirectFetch.FetchAsync(
+            client, "https://example.com/start", maxBytes: 1024, sink: Sink,
+            deadline: TimeSpan.FromSeconds(5), configureRequest: null, ct: CancellationToken.None);
+
+        var thrown = await act.Should().ThrowAsync<HardenedFetchException>();
+        thrown.Which.Reason.Should().Be(HardenedFetchBlockReason.Port);
+    }
+
+    [Fact]
+    public async Task ExplicitDefaultHttpsPort_IsAllowed()
+    {
+        using var handler = new DelegateHandler(request =>
+            request.RequestUri!.AbsoluteUri.Contains("cdn", StringComparison.Ordinal)
+                ? Ok(new byte[] { 7 })
+                : Redirect("https://cdn.example.com:443/final"));
+        using var client = new HttpClient(handler);
+
+        var result = await HardenedRedirectFetch.FetchAsync(
+            client, "https://example.com/start", maxBytes: 1024, sink: Sink,
+            deadline: TimeSpan.FromSeconds(5), configureRequest: null, ct: CancellationToken.None);
+
+        result.Should().Equal(new byte[] { 7 });
+    }
+
+    [Fact]
+    public async Task InitialUrlWithAnomalousPort_IsBlockedBeforeAnyRequest()
+    {
+        var requests = 0;
+        using var handler = new DelegateHandler((_, _) =>
+        {
+            requests++;
+            return Task.FromResult(Ok(new byte[] { 1 }));
+        });
+        using var client = new HttpClient(handler);
+
+        var act = () => HardenedRedirectFetch.FetchAsync(
+            client, "https://example.com:9000/x", maxBytes: 1024, sink: Sink,
+            deadline: TimeSpan.FromSeconds(5), configureRequest: null, ct: CancellationToken.None);
+
+        var thrown = await act.Should().ThrowAsync<HardenedFetchException>();
+        thrown.Which.Reason.Should().Be(HardenedFetchBlockReason.Port);
+        requests.Should().Be(0, "the port gate must reject before dialling");
+    }
+
+    [Theory]
+    [InlineData("http://example.com/x")]
+    [InlineData("file:///etc/passwd")]
+    [InlineData("gopher://internal/x")]
+    public async Task RedirectToNonHttpsScheme_IsBlocked(string location)
+    {
+        using var handler = new DelegateHandler((_, _) => Task.FromResult(Redirect(location)));
+        using var client = new HttpClient(handler);
+
+        var act = () => HardenedRedirectFetch.FetchAsync(
+            client, "https://example.com/start", maxBytes: 1024, sink: Sink,
+            deadline: TimeSpan.FromSeconds(5), configureRequest: null, ct: CancellationToken.None);
+
+        var thrown = await act.Should().ThrowAsync<HardenedFetchException>();
+        thrown.Which.Reason.Should().Be(HardenedFetchBlockReason.Scheme);
+    }
+
+    // ------------------------------------------------------------------
+    // Redirect bounds, relative resolution, size ceiling
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task RelativeLocation_ResolvesAgainstTheCurrentHop()
+    {
+        var seen = new List<Uri>();
+        using var handler = new DelegateHandler(request =>
+        {
+            seen.Add(request.RequestUri!);
+            return seen.Count == 1 ? Redirect("/images/final.png") : Ok(new byte[] { 42 });
+        });
+        using var client = new HttpClient(handler);
+
+        var result = await HardenedRedirectFetch.FetchAsync(
+            client, "https://cdn.example.com/a/b/start", maxBytes: 1024, sink: Sink,
+            deadline: TimeSpan.FromSeconds(5), configureRequest: null, ct: CancellationToken.None);
+
+        result.Should().Equal(new byte[] { 42 });
+        seen[1].Should().Be(new Uri("https://cdn.example.com/images/final.png"));
+    }
+
+    [Fact]
+    public async Task RedirectLoop_IsBlocked()
+    {
+        using var handler = new DelegateHandler((_, _) => Task.FromResult(Redirect("https://example.com/start")));
+        using var client = new HttpClient(handler);
+
+        var act = () => HardenedRedirectFetch.FetchAsync(
+            client, "https://example.com/start", maxBytes: 1024, sink: Sink,
+            deadline: TimeSpan.FromSeconds(5), configureRequest: null, ct: CancellationToken.None);
+
+        var thrown = await act.Should().ThrowAsync<HardenedFetchException>();
+        thrown.Which.Reason.Should().Be(HardenedFetchBlockReason.RedirectExhausted);
+    }
+
+    [Fact]
+    public async Task TooManyHops_AreBlocked()
+    {
+        var hop = 0;
+        using var handler = new DelegateHandler((_, _) => Task.FromResult(Redirect($"https://example.com/hop{++hop}")));
+        using var client = new HttpClient(handler);
+
+        var act = () => HardenedRedirectFetch.FetchAsync(
+            client, "https://example.com/start", maxBytes: 1024, sink: Sink,
+            deadline: TimeSpan.FromSeconds(5), configureRequest: null, ct: CancellationToken.None);
+
+        var thrown = await act.Should().ThrowAsync<HardenedFetchException>();
+        thrown.Which.Reason.Should().Be(HardenedFetchBlockReason.RedirectExhausted);
+    }
+
+    [Fact]
+    public async Task BodyOverCeiling_IsAbortedMidStream()
+    {
+        using var handler = new DelegateHandler((_, _) => Task.FromResult(Ok(new byte[2048])));
+        using var client = new HttpClient(handler);
+
+        var act = () => HardenedRedirectFetch.FetchAsync(
+            client, "https://example.com/blob", maxBytes: 1024, sink: Sink,
+            deadline: TimeSpan.FromSeconds(5), configureRequest: null, ct: CancellationToken.None);
+
+        var thrown = await act.Should().ThrowAsync<HardenedFetchException>();
+        thrown.Which.Reason.Should().Be(HardenedFetchBlockReason.SizeCap);
+    }
+
+    [Fact]
+    public async Task RelativeRequestUri_ResolvesAgainstTheClientBaseAddress()
+    {
+        // Typed clients (Commons) issue relative paths against their BaseAddress; the engine must
+        // honour that instead of forcing every caller to build absolute URLs.
+        var seen = new List<Uri>();
+        using var handler = new DelegateHandler(request =>
+        {
+            seen.Add(request.RequestUri!);
+            return Ok(new byte[] { 9 });
+        });
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://commons.wikimedia.org/") };
+
+        var result = await HardenedRedirectFetch.FetchAsync(
+            client, "wiki/Special:FilePath/Cover.jpg", maxBytes: 1024, sink: Sink,
+            deadline: TimeSpan.FromSeconds(5), configureRequest: null, ct: CancellationToken.None);
+
+        result.Should().Equal(new byte[] { 9 });
+        seen[0].Should().Be(new Uri("https://commons.wikimedia.org/wiki/Special:FilePath/Cover.jpg"));
+    }
+
+    [Fact]
+    public async Task RelativePathOnANonHttpsBaseAddress_IsDialled_ButItsRedirectsAreStillGated()
+    {
+        // A relative path is OUR configuration (a typed client's BaseAddress), so the first hop is
+        // dialled as configured — this is what keeps fixed-host clients working against a local
+        // contract server. The redirect target is untrusted input all the same and stays gated.
+        var seen = new List<Uri>();
+        using var handler = new DelegateHandler(request =>
+        {
+            seen.Add(request.RequestUri!);
+            return seen.Count == 1 ? Redirect("http://localhost:1234/next") : Ok(new byte[] { 1 });
+        });
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("http://localhost:1234/") };
+
+        var act = () => HardenedRedirectFetch.FetchAsync(
+            client, "probe", maxBytes: 1024, sink: Sink,
+            deadline: TimeSpan.FromSeconds(5), configureRequest: null, ct: CancellationToken.None);
+
+        var thrown = await act.Should().ThrowAsync<HardenedFetchException>();
+        thrown.Which.Reason.Should().Be(HardenedFetchBlockReason.Scheme);
+        seen.Should().ContainSingle("the configured first hop is dialled, its redirect is not");
+    }
+
+    [Fact]
+    public async Task AbsoluteNonHttpsUrl_IsRefused_EvenWithABaseAddress()
+    {
+        // Caller input never inherits the base address's trust.
+        var requests = 0;
+        using var handler = new DelegateHandler((_, _) =>
+        {
+            requests++;
+            return Task.FromResult(Ok(new byte[] { 1 }));
+        });
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("http://localhost:1234/") };
+
+        var act = () => HardenedRedirectFetch.FetchAsync(
+            client, "http://localhost:1234/probe", maxBytes: 1024, sink: Sink,
+            deadline: TimeSpan.FromSeconds(5), configureRequest: null, ct: CancellationToken.None);
+
+        var thrown = await act.Should().ThrowAsync<HardenedFetchException>();
+        thrown.Which.Reason.Should().Be(HardenedFetchBlockReason.Scheme);
+        requests.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ConfigureRequest_AppliesToEveryHop()
+    {
+        var accepts = new List<string?>();
+        using var handler = new DelegateHandler(request =>
+        {
+            accepts.Add(request.Headers.Accept.ToString());
+            return accepts.Count == 1 ? Redirect("https://cdn.example.com/final") : Ok(new byte[] { 3 });
+        });
+        using var client = new HttpClient(handler);
+
+        await HardenedRedirectFetch.FetchAsync(
+            client, "https://example.com/start", maxBytes: 1024, sink: Sink,
+            deadline: TimeSpan.FromSeconds(5),
+            configureRequest: r => r.Headers.Accept.ParseAdd("image/*"),
+            ct: CancellationToken.None);
+
+        accepts.Should().HaveCount(2);
+        accepts.Should().AllSatisfy(a => a.Should().Contain("image/*",
+            "a redirected hop must carry the same headers as the first request"));
+    }
+
+    private sealed class DelegateHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _responder;
+
+        public DelegateHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> responder)
+            => _responder = responder;
+
+        public DelegateHandler(Func<HttpRequestMessage, HttpResponseMessage> responder)
+            => _responder = (request, _) => Task.FromResult(responder(request));
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+            => _responder(request, cancellationToken);
+    }
+}


### PR DESCRIPTION
## Sommario

Slice D del sub-epic **#3495** — findings **C4** (deadline wall-clock totale), **H2** (scheme + porta per-hop), **H1** (Commons dentro il gate), più la chiusura del debito `ValidateUrlScheme` lasciato aperto da Slice E.

## Cosa cambia

### 1. `HardenedRedirectFetch` — motore condiviso (C4/H2)
Il multi-hop manuale esce da `SsrfSafeHttpClient` e diventa un componente del SharedKernel usabile da qualsiasi sink che segua redirect o scarichi URL forniti dal chiamante:

- **deadline wall-clock TOTALE** via `CancellationTokenSource` linked: non è un timeout per-hop, quindi una catena di hop singolarmente veloci non può più tenere aperta una richiesta a tempo indefinito;
- **scheme HTTPS + porta di default ri-validati su ogni hop** (il pin ri-controlla solo l'IP);
- loop detection, hop cap, ceiling **streamed** sul body;
- deadline scaduta e cancellazione del chiamante restano **distinguibili** (`HardenedFetchException(Timeout)` vs `OperationCanceledException`) — la lezione #2157 sul client Commons.

**Asimmetria voluta sul primo hop**, documentata nel codice: un path *relativo* è configurazione nostra (la `BaseAddress` di un typed client) e viene composto senza gate; un URL *assoluto* è input del chiamante e passa il gate completo. Ogni target di **redirect** è non fidato in entrambi i casi. È ciò che permette a un client fixed-host di continuare a funzionare contro un contract server locale su `http://localhost:PORT` mentre un 302 verso quello stesso indirizzo resta rifiutato.

### 2. Port-anomaly (H2)
`:8080`, `:22`, `:6379` su un hop ora sono un blocco esplicito con reason `port` (nuova label bounded). `:443` esplicito resta valido (`IsDefaultPort`).

### 3. Wikimedia Commons dentro il gate (H1)
`FetchImageBytesAsync` segue il `302` `Special:FilePath` → `upload.wikimedia.org` **manualmente attraverso il gate**; la registrazione passa a `allowAutoRedirect: false`. Questo **sostituisce** l'invariante #1823 M8 ("do NOT disable redirects"): il redirect si segue ancora — le immagini restano raggiungibili — ma ogni hop è ri-validato.

Nota di sicurezza sostanziale: quel download leggeva il body con `ReadAsByteArrayAsync` **senza alcun ceiling**. Ora 32MB + deadline 30s (cap generoso: Commons serve legittimamente foto ad alta risoluzione); l'API imageinfo passa dal gate con 2MB + 15s.

### 4. Errori tipizzati invece di 500 generici
`HardenedFetchException` porta un `Reason` bounded ed è mappata in `ApiExceptionHandlerMiddleware` a **400** (**504** sulla deadline) invece del 500 di prima — coerente con il pitfall #2568. Il messaggio in risposta resta generico: host e IP restano nel log.

### 5. Debito di Slice E chiuso
`SsrfSafeHttpClient.ValidateUrlScheme` eliminato; `BggCoverDownloader` usa lo stesso validatore del gate, quindi la regola scheme/porta è una sola e non può più divergere.

## Fix collaterale: 3 test Integration rotti da mesi

`3cbec7f86` (*"chore(format): repo-wide whitespace drift cleanup"*, #2296) aveva **cancellato i costruttori** dei due fake typed client in `WikimediaCircuitBreakerIntegrationTests`. Causa: `dotnet format` applica anche i fix degli analyzer, e **SonarAnalyzer S1144** considera morto un costruttore invocato solo via reflection dalla typed-client factory. Il campo `readonly` restava non assegnato (CS0649 è warning, non errore), quindi il progetto compilava e i 3 test fallivano con *"A suitable constructor could not be located"*. Essendo `Category=Integration`, Backend Fast non li esegue mai e la rottura è rimasta invisibile.

Ripristinati **e bloccati** con una soppressione S1144 mirata: senza quella, il prossimo format sweep li ricancella (l'ho verificato — sono stati rimossi di nuovo appena ho eseguito `dotnet format`).

## Test

691 unit verdi nello scope SSRF / egress / Wikimedia / cover, più i 3 Integration riparati. Nuovi: 17 test del motore (deadline cumulativa, port-anomaly, scheme, loop, hop cap, size cap, risoluzione relativa, header per-hop, cancellazione) e 6 sul gate Commons (redirect seguito, downgrade http rifiutato, porta anomala rifiutata, body oversize, parsing licenza, cancellazione).

`EgressMetricsTests` non assume più che la finestra del `MeterListener` sia esclusiva: seleziona per tag. Il listener è process-wide e xUnit parallelizza le classi, quindi i blocchi emessi dal nuovo gate lo rendevano flaky.

## Note

- Restano di #3495: **Slice F** (SsrfPolicy completeness: decode IPv4 embedded, versione registro IANA, pin `Content-Encoding`) e il follow-up reason signals sui throw site rimanenti.
- `dotnet format` è stato eseguito **solo** sui file di questa slice (`--include`), non repo-wide.

Resolves parte di #3495 (Slice D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)