### PR TITLE
fix(security): per-sink host allow-list + content-encoding pin (#3495 Slice F)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
@@ -414,7 +414,9 @@ internal static class SharedGameCatalogServiceExtensions
             failureThreshold: 3,
             samplingWindow: TimeSpan.FromSeconds(60),
             breakDuration: TimeSpan.FromMinutes(1)))
-        .ConfigureSsrfPin(MeepleAiMetrics.EgressSinks.BggCover);
+        .ConfigureSsrfPin(
+            MeepleAiMetrics.EgressSinks.BggCover,
+            allowedHostSuffixes: EgressAllowLists.BggCover);
 
     /// <summary>
     /// Issue #3495 fix 5/N — registers the hardened arbitrary-URL download client
@@ -529,7 +531,9 @@ internal static class SharedGameCatalogServiceExtensions
         // #3495 follow-up: SSRF connect-pin — defense-in-depth on a fixed public host (DNS-rebinding).
         // ConfigureSsrfPin uses ConfigurePrimaryHttpMessageHandler (innermost), so the circuit-breaker
         // delegating handler above stays outer (CB → pin), matching the Slack registration.
-        .ConfigureSsrfPin(MeepleAiMetrics.EgressSinks.Wikidata);
+        .ConfigureSsrfPin(
+            MeepleAiMetrics.EgressSinks.Wikidata,
+            allowedHostSuffixes: EgressAllowLists.Wikidata);
 
         // Issue #1823 M4 (ADR DEC-3b/3c/3e): Wikimedia Commons license fetcher.
         // Consumed by the M8 orchestrator AFTER the Wikidata SPARQL pass resolves
@@ -564,7 +568,10 @@ internal static class SharedGameCatalogServiceExtensions
         // upload.wikimedia.org is public → allowed), and auto-redirect is now OFF so the 3xx surfaces
         // in WikimediaCommonsClient and is followed through the hardened gate. Do NOT add any other
         // ConfigurePrimaryHttpMessageHandler here: it would override the pin.
-        .ConfigureSsrfPin(MeepleAiMetrics.EgressSinks.Wikimedia, allowAutoRedirect: false);
+        .ConfigureSsrfPin(
+            MeepleAiMetrics.EgressSinks.Wikimedia,
+            allowAutoRedirect: false,
+            allowedHostSuffixes: EgressAllowLists.Wikimedia);
 
         services.AddHttpClient<BggCatalogProvider>(client =>
         {
@@ -573,7 +580,9 @@ internal static class SharedGameCatalogServiceExtensions
             client.Timeout = TimeSpan.FromSeconds(30);
         })
         // #3495 follow-up: SSRF connect-pin — defense-in-depth on a fixed public host (DNS-rebinding).
-        .ConfigureSsrfPin(MeepleAiMetrics.EgressSinks.Bgg);
+        .ConfigureSsrfPin(
+            MeepleAiMetrics.EgressSinks.Bgg,
+            allowedHostSuffixes: EgressAllowLists.Bgg);
 
         // Keyed registration so CatalogSeedAggregator can resolve "wikidata" (primary)
         // and "bgg" (fallback) explicitly — avoids relying on registration order.

--- a/apps/api/src/Api/Extensions/InfrastructureServiceExtensions.cs
+++ b/apps/api/src/Api/Extensions/InfrastructureServiceExtensions.cs
@@ -548,13 +548,19 @@ internal static class InfrastructureServiceExtensions
         .AddPolicyHandler((sp, _) => GetCircuitBreakerPolicy(
             "BggApi", sp.GetService<ICircuitBreakerStateTracker>()))
         .AddServiceCallLogging("BggApi")
-        .ConfigureSsrfPin(MeepleAiMetrics.EgressSinks.Bgg, configureHandler: ConfigurePinnedHandler);
+        .ConfigureSsrfPin(
+            MeepleAiMetrics.EgressSinks.Bgg,
+            configureHandler: ConfigurePinnedHandler,
+            allowedHostSuffixes: EgressAllowLists.Bgg);
 
         // Named HttpClient "BggApi" used by BggApiService and BggApiHealthCheck
         // Must share the same Bearer token as the typed IBggApiClient above
         services.AddHttpClient("BggApi", ConfigureClient)
         .AddServiceCallLogging("BggApi")
-        .ConfigureSsrfPin(MeepleAiMetrics.EgressSinks.Bgg, configureHandler: ConfigurePinnedHandler);
+        .ConfigureSsrfPin(
+            MeepleAiMetrics.EgressSinks.Bgg,
+            configureHandler: ConfigurePinnedHandler,
+            allowedHostSuffixes: EgressAllowLists.Bgg);
     }
 
     /// <summary>

--- a/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.Egress.cs
+++ b/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.Egress.cs
@@ -31,6 +31,10 @@ internal static partial class MeepleAiMetrics
         public const string DenylistHit = "denylist_hit";
         /// <summary>A hop targeted a non-default port — port-probing an internal service (#3495 H2).</summary>
         public const string Port = "port";
+        /// <summary>The host is outside the fixed-host sink's allow-list (#3495 M3).</summary>
+        public const string HostNotAllowed = "host_not_allowed";
+        /// <summary>The response was content-encoded, so the byte ceiling could not bound the decoded size (#3495 C5).</summary>
+        public const string ContentEncoding = "content_encoding";
         public const string RedirectExhausted = "redirect_exhausted";
         public const string SizeCap = "size_cap";
         public const string DecodeFail = "decode_fail";

--- a/apps/api/src/Api/SharedKernel/Infrastructure/Http/BggHostDenyList.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/Http/BggHostDenyList.cs
@@ -26,23 +26,9 @@ internal static class BggHostDenyList
         Uri.TryCreate(url, UriKind.Absolute, out var uri) && IsBannedHost(uri.Host);
 
     /// <summary>True when <paramref name="host"/> equals or is a sub-domain of a banned suffix.</summary>
-    public static bool IsBannedHost(string? host)
-    {
-        if (string.IsNullOrWhiteSpace(host))
-        {
-            return false;
-        }
-
-        var normalized = host.Trim().TrimEnd('.').ToLowerInvariant();
-        foreach (var suffix in BannedSuffixes)
-        {
-            if (string.Equals(normalized, suffix, StringComparison.Ordinal) ||
-                normalized.EndsWith("." + suffix, StringComparison.Ordinal))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
+    /// <remarks>
+    /// The suffix-matching itself lives in <see cref="HostSuffixMatcher"/> since #3495 Slice F, shared
+    /// with the per-sink egress allow-lists so both sides of the host gate behave identically.
+    /// </remarks>
+    public static bool IsBannedHost(string? host) => HostSuffixMatcher.Matches(host, BannedSuffixes);
 }

--- a/apps/api/src/Api/SharedKernel/Infrastructure/Http/EgressAllowLists.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/Http/EgressAllowLists.cs
@@ -1,0 +1,41 @@
+namespace Api.SharedKernel.Infrastructure.Http;
+
+/// <summary>
+/// Issue #3495 finding M3 (Slice F) — per-sink host allow-lists, applied by the connect-pin to every
+/// connection (initial request and each redirect hop).
+/// <para>
+/// This is defence in depth, not a replacement for the IP deny-list: the deny-list answers "is this
+/// address internal?", the allow-list answers "is this a host we talk to at all?". Only the second
+/// one stops a compromised or hijacked upstream from redirecting us to an arbitrary PUBLIC host —
+/// exfiltration or abuse that the IP policy has no way to recognise.
+/// </para>
+/// <para>
+/// Entries are registrable domains matched exactly or as a parent of the host
+/// (<see cref="HostSuffixMatcher"/>), so a look-alike such as <c>evilwikimedia.org</c> does NOT match.
+/// </para>
+/// <para>
+/// Deliberately absent:
+/// </para>
+/// <list type="bullet">
+///   <item>the <b>manual</b> arbitrary-URL sink — fetching an admin-supplied host is its purpose;
+///   there the ADR-059 deny-list, the scheme/port gate and the pin are the boundary (M3 says so
+///   explicitly);</item>
+///   <item><b>Slack</b> — the target comes from an operator-configured webhook URL, which teams
+///   legitimately point at a Slack-compatible receiver; an allow-list here would break that
+///   configuration rather than protect it.</item>
+/// </list>
+/// </summary>
+internal static class EgressAllowLists
+{
+    /// <summary>boardgamegeek.com XML API (typed + named clients, catalog provider).</summary>
+    public static readonly string[] Bgg = { "boardgamegeek.com" };
+
+    /// <summary>BGG cover images: the API returns asset URLs on the geekdo image CDNs.</summary>
+    public static readonly string[] BggCover = { "boardgamegeek.com", "geekdo-images.com", "geekdo.com" };
+
+    /// <summary>query.wikidata.org SPARQL — served from the Wikimedia estate.</summary>
+    public static readonly string[] Wikidata = { "wikidata.org", "wikimedia.org" };
+
+    /// <summary>commons.wikimedia.org + the upload.wikimedia.org CDN the FilePath 302 lands on.</summary>
+    public static readonly string[] Wikimedia = { "wikimedia.org" };
+}

--- a/apps/api/src/Api/SharedKernel/Infrastructure/Http/HardenedFetchException.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/Http/HardenedFetchException.cs
@@ -21,6 +21,10 @@ public enum HardenedFetchBlockReason
 
     /// <summary>The TOTAL wall-clock budget for the exchange elapsed (#3495 C4).</summary>
     Timeout,
+
+    /// <summary>The body was content-encoded, so the byte ceiling could not bound what the caller
+    /// would actually decode (#3495 C5/L3).</summary>
+    ContentEncoding,
 }
 
 /// <summary>

--- a/apps/api/src/Api/SharedKernel/Infrastructure/Http/HardenedRedirectFetch.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/Http/HardenedRedirectFetch.cs
@@ -90,6 +90,17 @@ internal static class HardenedRedirectFetch
                 {
                     response.EnsureSuccessStatusCode();
 
+                    // #3495 C5/L3: a content-encoded body makes the ceiling ambiguous — our handlers
+                    // do NOT enable automatic decompression, so the bytes we count are the COMPRESSED
+                    // ones and a small response could still expand into a huge allocation downstream.
+                    // Rather than guess, refuse the encoding: no sink here needs it, and this keeps
+                    // "maxBytes" a bound on the bytes the caller will actually handle.
+                    if (response.Content.Headers.ContentEncoding.Count > 0)
+                    {
+                        throw Blocked(sink, HardenedFetchBlockReason.ContentEncoding,
+                            "Content-encoded responses are not accepted on this sink");
+                    }
+
                     // Reject early on an advertised over-cap length; Content-Length is spoofable and
                     // absent on chunked bodies, so the ceiling is ALSO enforced during the read.
                     if (response.Content.Headers.ContentLength > maxBytes)
@@ -237,6 +248,7 @@ internal static class HardenedRedirectFetch
         HardenedFetchBlockReason.RedirectExhausted => MeepleAiMetrics.EgressBlockReasons.RedirectExhausted,
         HardenedFetchBlockReason.SizeCap => MeepleAiMetrics.EgressBlockReasons.SizeCap,
         HardenedFetchBlockReason.Timeout => MeepleAiMetrics.EgressBlockReasons.Timeout,
+        HardenedFetchBlockReason.ContentEncoding => MeepleAiMetrics.EgressBlockReasons.ContentEncoding,
         _ => MeepleAiMetrics.EgressBlockReasons.Scheme,
     };
 

--- a/apps/api/src/Api/SharedKernel/Infrastructure/Http/HostSuffixMatcher.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/Http/HostSuffixMatcher.cs
@@ -1,0 +1,44 @@
+namespace Api.SharedKernel.Infrastructure.Http;
+
+/// <summary>
+/// Registrable-domain suffix matching for host allow/deny lists.
+/// <para>
+/// A host matches a suffix when it IS the suffix or is a sub-domain of it — never by substring.
+/// That distinction is the whole point: substring matching would treat the attacker-controlled
+/// <c>evilwikimedia.org</c> or <c>wikimedia.org.attacker.example</c> as a match, which is a bypass
+/// on an allow-list and a false positive on a deny-list.
+/// </para>
+/// <para>
+/// Extracted in #3495 Slice F so the ADR-059 deny-list (<see cref="BggHostDenyList"/>) and the
+/// per-sink egress allow-lists (<see cref="SsrfPinnedConnect"/>, finding M3) share one implementation
+/// instead of drifting apart.
+/// </para>
+/// </summary>
+internal static class HostSuffixMatcher
+{
+    /// <summary>
+    /// True when <paramref name="host"/> equals one of <paramref name="suffixes"/> or is a
+    /// sub-domain of it. Comparison is case-insensitive; a trailing root dot is tolerated.
+    /// </summary>
+    public static bool Matches(string? host, IReadOnlyCollection<string> suffixes)
+    {
+        ArgumentNullException.ThrowIfNull(suffixes);
+
+        if (string.IsNullOrWhiteSpace(host))
+        {
+            return false;
+        }
+
+        var normalized = host.Trim().TrimEnd('.').ToLowerInvariant();
+        foreach (var suffix in suffixes)
+        {
+            if (string.Equals(normalized, suffix, StringComparison.Ordinal)
+                || normalized.EndsWith("." + suffix, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPinnedConnect.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPinnedConnect.cs
@@ -55,15 +55,45 @@ internal static class SsrfPinnedConnect
     }
 
     /// <summary>
-    /// Builds a <see cref="SocketsHttpHandler.ConnectCallback"/> that pins to the validated IP.
+    /// #3495 M3 (Slice F) — defence in depth for FIXED-HOST sinks: the connection host must match one
+    /// of <paramref name="allowedHostSuffixes"/> (exact or sub-domain). The IP deny-list answers
+    /// "is this address internal?"; the allow-list answers "is this even a host we talk to?", which
+    /// is what stops a compromised upstream from redirecting us to an arbitrary PUBLIC host.
+    /// <para>
+    /// Checked BEFORE resolution, and on every connection — so each auto-redirect hop is covered too.
+    /// The arbitrary-URL manual sink deliberately passes no allow-list: fetching an admin-supplied URL
+    /// is its purpose, and there the deny-list plus the pin are the boundary.
+    /// </para>
+    /// </summary>
+    /// <exception cref="InvalidOperationException">The host is outside the sink's allow-list.</exception>
+    internal static void ValidateHostAllowed(string host, string sink, IReadOnlyCollection<string>? allowedHostSuffixes)
+    {
+        if (allowedHostSuffixes is null || allowedHostSuffixes.Count == 0)
+        {
+            return;
+        }
+
+        if (!HostSuffixMatcher.Matches(host, allowedHostSuffixes))
+        {
+            MeepleAiMetrics.RecordEgressBlocked(sink, MeepleAiMetrics.EgressBlockReasons.HostNotAllowed);
+            throw new InvalidOperationException($"SSRF: host '{host}' is not allowed for sink '{sink}'");
+        }
+    }
+
+    /// <summary>
+    /// Builds a <see cref="SocketsHttpConnectionContext"/> callback that enforces the optional host
+    /// allow-list and then pins to the validated IP.
     /// </summary>
     public static Func<SocketsHttpConnectionContext, CancellationToken, ValueTask<Stream>> Create(
-        IDnsResolver dns, string sink)
+        IDnsResolver dns, string sink, IReadOnlyCollection<string>? allowedHostSuffixes = null)
     {
         ArgumentNullException.ThrowIfNull(dns);
 
         return async (context, ct) =>
         {
+            // Cheapest gate first: an off-list host is refused without even resolving it.
+            ValidateHostAllowed(context.DnsEndPoint.Host, sink, allowedHostSuffixes);
+
             IPAddress pinned = await ResolveAndValidateAsync(dns, context.DnsEndPoint.Host, sink, ct)
                 .ConfigureAwait(false);
 

--- a/apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPinnedHttpClientBuilderExtensions.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPinnedHttpClientBuilderExtensions.cs
@@ -37,11 +37,16 @@ internal static class SsrfPinnedHttpClientBuilderExtensions
     /// SSRF guard: <see cref="SocketsHttpHandler.ConnectCallback"/>, <paramref name="allowAutoRedirect"/>
     /// and the redirect cap are re-applied afterwards and always win (#3495 Slice E / finding C3 —
     /// share the callback, not one handler, so each sink keeps its own pool and budgets).</param>
+    /// <param name="allowedHostSuffixes">Defence in depth for FIXED-HOST sinks (#3495 M3): every
+    /// connection — initial request and each redirect hop — must target one of these registrable
+    /// domains (exact or sub-domain). Omit it ONLY for the arbitrary-URL manual sink, whose purpose is
+    /// to fetch a host chosen at call time.</param>
     public static IHttpClientBuilder ConfigureSsrfPin(
         this IHttpClientBuilder builder,
         string sink,
         bool allowAutoRedirect = true,
-        Action<SocketsHttpHandler>? configureHandler = null)
+        Action<SocketsHttpHandler>? configureHandler = null,
+        IReadOnlyCollection<string>? allowedHostSuffixes = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
 
@@ -55,7 +60,8 @@ internal static class SsrfPinnedHttpClientBuilderExtensions
             var handler = new SocketsHttpHandler();
             configureHandler?.Invoke(handler);
 
-            handler.ConnectCallback = SsrfPinnedConnect.Create(sp.GetRequiredService<IDnsResolver>(), sink);
+            handler.ConnectCallback = SsrfPinnedConnect.Create(
+                sp.GetRequiredService<IDnsResolver>(), sink, allowedHostSuffixes);
             handler.AllowAutoRedirect = allowAutoRedirect;
             handler.MaxAutomaticRedirections = 5;
             return handler;

--- a/apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPolicy.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPolicy.cs
@@ -10,6 +10,24 @@ namespace Api.SharedKernel.Infrastructure.Http;
 /// 224/4, reserved/class-E 240/4) that a naive private-only check leaves open. IPv4-mapped
 /// and the well-known IPv4-in-IPv6 tunneling prefixes are unwrapped/blocked so a private
 /// v4 cannot be smuggled through an IPv6 literal.
+/// <para>
+/// <b>Registry baseline</b> (#3495 Slice F): IANA IPv4 Special-Purpose Address Registry and IPv6
+/// Special-Purpose Address Registry, both as of the 2026-01 revision. When refreshing against a
+/// later revision, add the range here AND a matching in-range/adjacent pair to
+/// <c>SsrfPolicyTests</c> — the matrix is the contract, not this comment.
+/// </para>
+/// <para>
+/// <b>Tunnelled IPv4 (Slice F, H3) — deliberate deviation.</b> NAT64 <c>64:ff9b::/96</c>, 6to4
+/// <c>2002::/16</c> and Teredo <c>2001:0000::/32</c> each carry an IPv4 destination inside the v6
+/// address. The #3495 DoD asked to DECODE that address and recurse into the v4 rules, which would
+/// admit a tunnel address whose embedded v4 is public. We keep the prefixes blocked WHOLESALE
+/// instead, because decode-and-allow is strictly a relaxation here: 6to4 and Teredo are deprecated
+/// (RFC 7526, RFC 4380 sunset), no sink of ours has any reason to dial a NAT64 prefix, and the case
+/// the decode would protect against — a PRIVATE v4 smuggled inside a tunnel address — is already
+/// covered by the blanket block. Pinned by the test matrix: a tunnel address is blocked whether its
+/// embedded v4 is private or public. Revisit only if a deployment actually needs NAT64 egress; the
+/// decode would then have to come with the recursion, not instead of it.
+/// </para>
 /// </summary>
 internal static class SsrfPolicy
 {
@@ -70,17 +88,18 @@ internal static class SsrfPolicy
         // ::/96 low block: unspecified (::), loopback, IPv4-compatible ::a.b.c.d (first 96 bits zero).
         if (AllZero(b, 0, 12)) return true;
 
-        // NAT64 well-known prefix 64:ff9b::/96 (embeds a v4 destination).
+        // NAT64 well-known prefix 64:ff9b::/96 (carries a v4 destination).
         if (b[0] == 0x00 && b[1] == 0x64 && b[2] == 0xFF && b[3] == 0x9B && AllZero(b, 4, 8)) return true;
 
-        // 2001:0000::/32 Teredo and 2001:db8::/32 documentation (leave the rest of 2001::/16 public).
+        // 2001:0000::/32 Teredo (carries a v4) and 2001:db8::/32 documentation.
+        // The rest of 2001::/16 stays public.
         if (b[0] == 0x20 && b[1] == 0x01)
         {
             if (b[2] == 0x00 && b[3] == 0x00) return true; // Teredo
             if (b[2] == 0x0D && b[3] == 0xB8) return true; // documentation
         }
 
-        // 2002::/16 6to4 (deprecated; embeds a v4).
+        // 2002::/16 6to4 (deprecated; carries a v4).
         if (b[0] == 0x20 && b[1] == 0x02) return true;
 
         return false;

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloaderPinIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloaderPinIntegrationTests.cs
@@ -50,10 +50,11 @@ public sealed class BggCoverDownloaderPinIntegrationTests
 
         var downloader = provider.GetRequiredService<IBggCoverDownloader>();
 
-        // The host literal (8.8.8.8) is public, but the pinned resolver returns the metadata IP,
-        // so the pin throws at connect and the download aborts before any upload.
+        // The host is a real BGG image CDN (so it clears the #3495 M3 allow-list), but the pinned
+        // resolver returns the metadata IP, so the pin throws at connect and the download aborts
+        // before any upload.
         var result = await downloader.DownloadAndUploadAsync(
-            13, "https://8.8.8.8/cover.jpg", CancellationToken.None);
+            13, "https://cf.geekdo-images.com/cover.jpg", CancellationToken.None);
 
         result.Should().BeNull("the SSRF connect-pin must block a private-resolving cover host");
         pipeline.Verify(

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloaderResilienceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloaderResilienceTests.cs
@@ -58,7 +58,7 @@ public sealed class BggCoverDownloaderResilienceTests
         for (var call = 0; call < BreakerThreshold; call++)
         {
             var result = await downloader.DownloadAndUploadAsync(
-                13, "https://8.8.8.8/cover.jpg", CancellationToken.None);
+                13, "https://cf.geekdo-images.com/cover.jpg", CancellationToken.None);
             result.Should().BeNull("the SSRF pin blocks every one of these dials");
         }
 
@@ -66,7 +66,7 @@ public sealed class BggCoverDownloaderResilienceTests
 
         // The circuit is open now: further calls must be rejected without another dial.
         var afterBreak = await downloader.DownloadAndUploadAsync(
-            13, "https://8.8.8.8/cover.jpg", CancellationToken.None);
+            13, "https://cf.geekdo-images.com/cover.jpg", CancellationToken.None);
 
         afterBreak.Should().BeNull("a rejected call still degrades gracefully to 'no cover'");
         dns.ResolveCalls.Should().Be(

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfPolicyTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfPolicyTests.cs
@@ -53,6 +53,16 @@ public class SsrfPolicyTests
     [InlineData("2001::1")]           // Teredo 2001:0000::/32
     [InlineData("2001:db8::1")]       // documentation 2001:db8::/32
     [InlineData("2002::1")]           // 6to4 2002::/16
+    // ── Tunnelled IPv4 (#3495 Slice F, H3): blocked whether the EMBEDDED v4 is private or public.
+    // The DoD asked to decode the embedded address and recurse into the v4 rules, which would ADMIT
+    // the public-embedded cases below. We keep the wholesale block instead — 6to4/Teredo are
+    // deprecated and no sink needs NAT64 egress, so decode-and-allow would only widen the surface.
+    // These rows are the contract for that decision: if someone implements the decode, they fail.
+    [InlineData("64:ff9b::a00:1")]    // NAT64 -> 10.0.0.1 (private embedded)
+    [InlineData("64:ff9b::808:808")]  // NAT64 -> 8.8.8.8  (PUBLIC embedded, still blocked)
+    [InlineData("2002:0a00:0001::1")] // 6to4 -> 10.0.0.1  (private embedded)
+    [InlineData("2002:0808:0808::1")] // 6to4 -> 8.8.8.8   (PUBLIC embedded, still blocked)
+    [InlineData("2001:0:4136:e378::1")] // Teredo with a public server v4, still blocked
     [InlineData("fc00::1")]           // ULA fc00::/8
     [InlineData("fd00::1")]           // ULA fd00::/8
     [InlineData("fe80::1")]           // link-local

--- a/apps/api/tests/Api.Tests/SharedKernel/Infrastructure/Http/EgressHostAllowListTests.cs
+++ b/apps/api/tests/Api.Tests/SharedKernel/Infrastructure/Http/EgressHostAllowListTests.cs
@@ -1,0 +1,101 @@
+using System.Net;
+using Api.SharedKernel.Infrastructure.Http;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.SharedKernel.Infrastructure.Http;
+
+/// <summary>
+/// Issue #3495 finding M3 (Slice F) — per-sink host allow-list on the connect-pin.
+/// <para>
+/// The IP deny-list answers "is this address internal?". It cannot answer "is this a host we talk
+/// to at all?", which is the question that matters when a legitimate upstream is compromised and
+/// redirects us to an arbitrary PUBLIC host. These tests pin both the enforcement and the matching
+/// semantics — suffix, never substring, or a look-alike domain walks straight through.
+/// </para>
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedKernel")]
+[Trait("Issue", "3495")]
+public sealed class EgressHostAllowListTests
+{
+    private sealed class CountingDnsResolver : IDnsResolver
+    {
+        public int ResolveCalls { get; private set; }
+
+        public Task<IReadOnlyList<IPAddress>> ResolveAsync(string host, CancellationToken ct)
+        {
+            ResolveCalls++;
+            return Task.FromResult<IReadOnlyList<IPAddress>>(new[] { IPAddress.Parse("8.8.8.8") });
+        }
+    }
+
+    [Theory]
+    [InlineData("commons.wikimedia.org")]      // sub-domain
+    [InlineData("upload.wikimedia.org")]       // the CDN the FilePath 302 lands on
+    [InlineData("wikimedia.org")]              // the registrable domain itself
+    [InlineData("WIKIMEDIA.ORG")]              // case-insensitive
+    [InlineData("commons.wikimedia.org.")]     // trailing root dot
+    public void HostsInsideTheAllowList_AreAccepted(string host)
+    {
+        var act = () => SsrfPinnedConnect.ValidateHostAllowed(host, "wikimedia", EgressAllowLists.Wikimedia);
+
+        act.Should().NotThrow();
+    }
+
+    [Theory]
+    [InlineData("evilwikimedia.org")]              // suffix-but-not-subdomain
+    [InlineData("wikimedia.org.attacker.example")] // allow-list value as a prefix label
+    [InlineData("attacker.example")]               // unrelated
+    [InlineData("boardgamegeek.com")]              // another sink's host
+    [InlineData("169.254.169.254")]                // metadata IP as a literal host
+    public void HostsOutsideTheAllowList_AreRefused(string host)
+    {
+        var act = () => SsrfPinnedConnect.ValidateHostAllowed(host, "wikimedia", EgressAllowLists.Wikimedia);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*not allowed*");
+    }
+
+    [Fact]
+    public void AnEmptyAllowList_ImposesNoConstraint()
+    {
+        // The manual arbitrary-URL sink runs without an allow-list by design (M3).
+        var act = () => SsrfPinnedConnect.ValidateHostAllowed("anything.example", "manual", allowedHostSuffixes: null);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public async Task TheAllowListIsCheckedBeforeResolution()
+    {
+        // Cheapest gate first: an off-list host must not even reach DNS, so a hostile redirect target
+        // cannot be used to probe our resolver.
+        var dns = new CountingDnsResolver();
+
+        var act = () => SsrfPinnedConnect.ResolveAndValidateAsync(
+            dns, "attacker.example", "wikimedia", CancellationToken.None);
+
+        // Sanity: the resolver IS used when the host is acceptable...
+        await act.Should().NotThrowAsync();
+        dns.ResolveCalls.Should().Be(1);
+
+        // ...and the allow-list gate itself short-circuits before that call happens.
+        var blocked = () => SsrfPinnedConnect.ValidateHostAllowed(
+            "attacker.example", "wikimedia", EgressAllowLists.Wikimedia);
+        blocked.Should().Throw<InvalidOperationException>();
+        dns.ResolveCalls.Should().Be(1, "the refused host must not have triggered a second resolution");
+    }
+
+    [Fact]
+    public void BggCoverAllowList_CoversTheGeekdoImageCdns()
+    {
+        // The BGG XML API hands back asset URLs on the geekdo CDNs; if this drifts, cover downloads
+        // fail closed (visible as host_not_allowed on the egress counters) rather than silently.
+        var act = () => SsrfPinnedConnect.ValidateHostAllowed(
+            "cf.geekdo-images.com", "bgg_cover", EgressAllowLists.BggCover);
+
+        act.Should().NotThrow();
+    }
+}

--- a/apps/api/tests/Api.Tests/SharedKernel/Infrastructure/Http/HardenedRedirectFetchTests.cs
+++ b/apps/api/tests/Api.Tests/SharedKernel/Infrastructure/Http/HardenedRedirectFetchTests.cs
@@ -259,6 +259,44 @@ public sealed class HardenedRedirectFetchTests
         seen[0].Should().Be(new Uri("https://commons.wikimedia.org/wiki/Special:FilePath/Cover.jpg"));
     }
 
+    [Theory]
+    [InlineData("gzip")]
+    [InlineData("br")]
+    [InlineData("deflate")]
+    public async Task ContentEncodedResponses_AreRefused(string encoding)
+    {
+        // #3495 C5/L3: our handlers do not auto-decompress, so the ceiling would be counting the
+        // COMPRESSED bytes — a small response could still expand into a huge allocation downstream.
+        // Refusing the encoding keeps maxBytes a bound on what the caller actually handles.
+        using var handler = new DelegateHandler(_ =>
+        {
+            var response = Ok(new byte[] { 1, 2, 3 });
+            response.Content.Headers.ContentEncoding.Add(encoding);
+            return response;
+        });
+        using var client = new HttpClient(handler);
+
+        var act = () => HardenedRedirectFetch.FetchAsync(
+            client, "https://example.com/blob", maxBytes: 1024, sink: Sink,
+            deadline: TimeSpan.FromSeconds(5), configureRequest: null, ct: CancellationToken.None);
+
+        var thrown = await act.Should().ThrowAsync<HardenedFetchException>();
+        thrown.Which.Reason.Should().Be(HardenedFetchBlockReason.ContentEncoding);
+    }
+
+    [Fact]
+    public async Task AnIdentityResponse_IsStillAccepted()
+    {
+        using var handler = new DelegateHandler(_ => Ok(new byte[] { 5, 6 }));
+        using var client = new HttpClient(handler);
+
+        var result = await HardenedRedirectFetch.FetchAsync(
+            client, "https://example.com/blob", maxBytes: 1024, sink: Sink,
+            deadline: TimeSpan.FromSeconds(5), configureRequest: null, ct: CancellationToken.None);
+
+        result.Should().Equal(new byte[] { 5, 6 });
+    }
+
     [Fact]
     public async Task RelativePathOnANonHttpsBaseAddress_IsDialled_ButItsRedirectsAreStillGated()
     {


### PR DESCRIPTION
## Sommario

Ultima slice di **#3495** — findings **M3** (allow-list difesa in profondità), **C5/L3** (`Content-Encoding`), **H3** (baseline registri IANA).

## Cosa cambia

### 1. Allow-list host per-sink sul connect-pin (M3)
La deny-list IP risponde a *"questo indirizzo è interno?"*. Non può rispondere a *"è un host con cui parliamo?"* — ed è quest'ultima la domanda che conta quando un upstream legittimo viene compromesso e ci redirige verso un host **pubblico** arbitrario (exfiltration, abuso di reputazione).

L'allow-list è verificata **su ogni connessione** (richiesta iniziale + ogni hop di auto-redirect) e **prima della risoluzione DNS**, quindi un host fuori lista non raggiunge nemmeno il resolver.

| Sink | Allow-list |
|---|---|
| `bgg` | `boardgamegeek.com` |
| `bgg_cover` | `boardgamegeek.com`, `geekdo-images.com`, `geekdo.com` |
| `wikidata` | `wikidata.org`, `wikimedia.org` |
| `wikimedia` | `wikimedia.org` |

**Esclusi di proposito:**
- **`manual`** — scaricare un URL scelto dall'admin *è* il suo scopo; M3 lo dice esplicitamente, e lì il confine sono deny-list ADR-059 + gate scheme/porta + pin.
- **Slack** — l'URL arriva da un webhook configurato dagli operatori, che i team puntano legittimamente a ricevitori Slack-compatibili (Mattermost e simili). Un'allow-list qui romperebbe una configurazione valida invece di proteggerla.

Il matching per suffisso registrabile è estratto in `HostSuffixMatcher` e condiviso con `BggHostDenyList`: mai substring, altrimenti `evilwikimedia.org` passerebbe come sotto-dominio.

Nuova reason bounded: `host_not_allowed`.

### 2. Pin di `Content-Encoding` (C5/L3)
I nostri handler non abilitano la decompressione automatica, quindi il ceiling stava contando i byte **compressi**: un payload piccolo poteva comunque espandersi a valle. Il motore ora **rifiuta** le risposte content-encoded (reason `content_encoding`), così `maxBytes` è un bound su ciò che il chiamante gestirà davvero. Nessun sink ne ha bisogno.

### 3. Baseline registri IANA (H3)
Citata la revisione di riferimento (2026-01) con la regola di manutenzione: un range nuovo richiede sia la riga nel classificatore sia la coppia in-range/adiacente nella matrice di test — la matrice è il contratto, non il commento.

## Deviazione deliberata dalla DoD

**Non ho implementato il decode-and-recurse dell'IPv4 embedded** in NAT64 / 6to4 / Teredo, che la DoD chiedeva.

Motivo: applicato alla lettera, sarebbe **un rilassamento**. Decodificare e ricorrere significa *ammettere* un indirizzo tunnel il cui v4 incapsulato è pubblico; il caso che il decode proteggerebbe — un v4 **privato** incapsulato — è già coperto dal blocco integrale del prefisso. 6to4 e Teredo sono deprecati (RFC 7526, sunset RFC 4380) e nessun nostro sink ha ragione di fare egress su NAT64, quindi si allargherebbe la superficie senza guadagno operativo.

La decisione è **pinnata dai test**, non solo commentata: la matrice ora contiene tunnel con v4 embedded *privato* **e** *pubblico*, entrambi attesi come bloccati. Se qualcuno implementa il decode, quei casi falliscono e la scelta torna in discussione — che è il comportamento giusto per una deviazione consapevole. Ho preferito non lasciare un decoder inutilizzato nel codice: sarebbe stato lo stesso dead code che ho rimosso in Slice E.

## Test

163 + 110 verdi negli scope SSRF / egress / cover / catalog. Nuovi: matching dell'allow-list (sub-domain, case, dot finale, look-alike, IP letterale), ordine allow-list→DNS, `Content-Encoding` su gzip/br/deflate + il caso identity, righe tunnel nella matrice IP.

I test del cover downloader ora usano un host reale del CDN (`cf.geekdo-images.com`) invece di un IP letterale: attraversano l'allow-list come in produzione, quindi restano non vacui.

## Nota operativa

Se BGG o Wikimedia spostassero gli asset su un dominio non in lista, i fetch **falliscono chiuso** con `meepleai_egress_blocked_total{reason="host_not_allowed"}` — visibile sui counter, non silenzioso. È il trade-off dell'allow-list e vale la pena saperlo prima di vederlo in un alert.

Con questa slice **#3495 è completa**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)