### PR TITLE
fix(docprocessing): stuck = inattivo, non lento (#3585)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
@@ -779,6 +779,33 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
         return chunks.Where(c => c != null && !string.IsNullOrWhiteSpace(c.Text)).ToList();
     }
 
+    /// <summary>
+    /// #3585 — records forward progress on the active processing job for this PDF, so
+    /// <c>ProcessingQueueMonitorService</c> measures INACTIVITY rather than total elapsed time.
+    /// <para>
+    /// Written with <c>ExecuteUpdateAsync</c> on purpose: it is a direct UPDATE that bypasses the
+    /// change tracker, so a heartbeat can never flush unrelated pending pipeline state mid-ingest.
+    /// Best-effort — a failed heartbeat must never abort an otherwise healthy ingest (and the
+    /// InMemory provider used by some tests does not support ExecuteUpdate at all).
+    /// </para>
+    /// </summary>
+    private async Task ReportProgressAsync(Guid pdfDocumentId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var now = _timeProvider.GetUtcNow();
+            await _db.Set<Api.Infrastructure.Entities.DocumentProcessing.ProcessingJobEntity>()
+                .Where(j => j.PdfDocumentId == pdfDocumentId && j.Status == "Processing")
+                .ExecuteUpdateAsync(s => s.SetProperty(j => j.LastProgressAt, now), cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogDebug(ex,
+                "[PdfPipeline] progress heartbeat failed for PDF {PdfId} (non-fatal)", pdfDocumentId);
+        }
+    }
+
     private async Task<List<float[]>> GenerateEmbeddingsAsync(
         PdfDocumentEntity pdfDoc,
         List<DocumentChunkInput> chunks,
@@ -827,6 +854,11 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
             }
 
             allEmbeddings.AddRange(batchResult.Embeddings);
+
+            // #3585: embedding is the long phase — a large rulebook runs >100 batches — and it is
+            // where the stuck-job monitor used to kill a healthy ingest. Report progress after every
+            // completed batch so "inactive" and "slow" stay distinguishable.
+            await ReportProgressAsync(pdfDoc.Id, cancellationToken).ConfigureAwait(false);
         }
 
         if (allEmbeddings.Count != chunks.Count)

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/ProcessingQueueMonitorService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/ProcessingQueueMonitorService.cs
@@ -111,14 +111,23 @@ internal sealed class ProcessingQueueMonitorService : BackgroundService
     {
         var cutoff = DateTimeOffset.UtcNow - StuckJobTimeout;
 
+        // #3585: "stuck" means INACTIVE, not long-running. Measuring from StartedAt classified a
+        // perfectly healthy ingest as stuck — a 118-batch rulebook takes ~40 minutes of real work —
+        // and degraded it to Failed; it then restarted from zero and hit the same wall, so no
+        // document slower than the recovery timeout could ever complete. The pipeline reports
+        // forward progress in LastProgressAt, so the clock now starts from the last sign of life
+        // and falls back to StartedAt only for a job that has not reported yet.
         var stuckJobs = await db.Set<ProcessingJobEntity>()
-            .Where(j => j.Status == "Processing" && j.StartedAt != null && j.StartedAt < cutoff)
+            .Where(j => j.Status == "Processing"
+                     && j.StartedAt != null
+                     && (j.LastProgressAt ?? j.StartedAt) < cutoff)
             .Select(j => new
             {
                 j.Id,
                 j.PdfDocumentId,
                 FileName = j.PdfDocument.FileName,
                 j.StartedAt,
+                j.LastProgressAt,
             })
             .ToListAsync(ct)
             .ConfigureAwait(false);
@@ -127,7 +136,8 @@ internal sealed class ProcessingQueueMonitorService : BackgroundService
 
         foreach (var job in stuckJobs)
         {
-            var stuckMinutes = (DateTimeOffset.UtcNow - job.StartedAt!.Value).TotalMinutes;
+            var idleSince = job.LastProgressAt ?? job.StartedAt!.Value;
+            var stuckMinutes = (DateTimeOffset.UtcNow - idleSince).TotalMinutes;
 
             _logger.LogWarning(
                 "Stuck document detected: Job {JobId} (PDF: {FileName}) stuck for {Minutes:F1} minutes",

--- a/apps/api/src/Api/Infrastructure/Entities/DocumentProcessing/ProcessingJobEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/DocumentProcessing/ProcessingJobEntity.cs
@@ -14,6 +14,20 @@ public class ProcessingJobEntity
     public string? CurrentStep { get; set; }
     public DateTimeOffset CreatedAt { get; set; }
     public DateTimeOffset? StartedAt { get; set; }
+
+    /// <summary>
+    /// #3585 — last time the pipeline reported forward progress on this job (a completed embedding
+    /// batch, a phase transition). The stuck-job monitor measures INACTIVITY from here, falling back
+    /// to <see cref="StartedAt"/> when a job has not reported yet.
+    /// <para>
+    /// Without it the monitor could only measure total elapsed time, so a large rulebook — 118
+    /// embedding batches at ~20s each — was classified "stuck" while it was working perfectly, and
+    /// degraded to Failed. It then restarted from zero and hit the same wall, so no document longer
+    /// than the recovery timeout could ever complete.
+    /// </para>
+    /// </summary>
+    public DateTimeOffset? LastProgressAt { get; set; }
+
     public DateTimeOffset? CompletedAt { get; set; }
     public string? ErrorMessage { get; set; }
     public int RetryCount { get; set; }

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/DocumentProcessing/ProcessingJobEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/DocumentProcessing/ProcessingJobEntityConfiguration.cs
@@ -45,6 +45,10 @@ internal class ProcessingJobEntityConfiguration : IEntityTypeConfiguration<Proce
         builder.Property(e => e.StartedAt)
             .HasColumnName("started_at");
 
+        // #3585: progress heartbeat - see ProcessingJobEntity.LastProgressAt.
+        builder.Property(e => e.LastProgressAt)
+            .HasColumnName("last_progress_at");
+
         builder.Property(e => e.CompletedAt)
             .HasColumnName("completed_at");
 

--- a/apps/api/src/Api/Infrastructure/Migrations/20260806092826_AddProcessingJobLastProgressAt.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260806092826_AddProcessingJobLastProgressAt.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260806092826_AddProcessingJobLastProgressAt")]
+    partial class AddProcessingJobLastProgressAt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260806092826_AddProcessingJobLastProgressAt.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260806092826_AddProcessingJobLastProgressAt.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProcessingJobLastProgressAt : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "last_progress_at",
+                table: "processing_jobs",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "last_progress_at",
+                table: "processing_jobs");
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/Unit/DocumentProcessing/StuckJobDetectionTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/DocumentProcessing/StuckJobDetectionTests.cs
@@ -1,0 +1,133 @@
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.DocumentProcessing;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Api.Tests.Unit.DocumentProcessing;
+
+/// <summary>
+/// Issue #3585 — "stuck" must mean INACTIVE, not long-running.
+/// <para>
+/// <c>ProcessingQueueMonitorService</c> measured elapsed time from <c>StartedAt</c> and degraded
+/// anything past the threshold to <c>Failed</c>. On staging that classified a healthy ingest of
+/// <c>frosthaven_rulebook.pdf</c> — 118 embedding batches, ~40 minutes of real work — as stuck and
+/// tried to kill it (it survived only by losing a concurrency race). Worse, the victim then
+/// restarted from zero and hit the same wall: no document slower than the recovery timeout could
+/// ever finish.
+/// </para>
+/// <para>
+/// The pipeline now stamps <c>LastProgressAt</c> after each embedding batch and the monitor starts
+/// its clock from the last sign of life. These tests pin that selection.
+/// </para>
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "3585")]
+public sealed class StuckJobDetectionTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 8, 6, 12, 0, 0, TimeSpan.Zero);
+    private static readonly TimeSpan StuckThreshold = TimeSpan.FromMinutes(10);
+
+    /// <summary>Mirrors the monitor's selection predicate (#3585).</summary>
+    private static IQueryable<ProcessingJobEntity> StuckJobs(MeepleAiDbContext db)
+    {
+        var cutoff = Now - StuckThreshold;
+        return db.Set<ProcessingJobEntity>()
+            .Where(j => j.Status == "Processing"
+                     && j.StartedAt != null
+                     && (j.LastProgressAt ?? j.StartedAt) < cutoff);
+    }
+
+    private static async Task<MeepleAiDbContext> WithJobAsync(
+        DateTimeOffset startedAt, DateTimeOffset? lastProgressAt, string status = "Processing")
+    {
+        var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var pdfId = Guid.NewGuid();
+        db.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = pdfId,
+            FileName = "frosthaven_rulebook.pdf",
+            FilePath = "pdfs/frosthaven.pdf",
+            UploadedByUserId = Guid.NewGuid(),
+        });
+        db.Set<ProcessingJobEntity>().Add(new ProcessingJobEntity
+        {
+            Id = Guid.NewGuid(),
+            PdfDocumentId = pdfId,
+            UserId = Guid.NewGuid(),
+            Status = status,
+            CreatedAt = startedAt,
+            StartedAt = startedAt,
+            LastProgressAt = lastProgressAt,
+        });
+        await db.SaveChangesAsync(CancellationToken.None);
+        return db;
+    }
+
+    [Fact]
+    public async Task ALongRunningJobThatKeepsReportingProgress_IsNotStuck()
+    {
+        // The Frosthaven case: started 40 minutes ago, last batch finished 30 seconds ago.
+        using var db = await WithJobAsync(
+            startedAt: Now.AddMinutes(-40),
+            lastProgressAt: Now.AddSeconds(-30));
+
+        var stuck = await StuckJobs(db).ToListAsync(CancellationToken.None);
+
+        stuck.Should().BeEmpty(
+            "a job reporting progress is working, however long it has been running — degrading it "
+            + "made documents above the timeout impossible to ingest at all");
+    }
+
+    [Fact]
+    public async Task AJobThatStoppedReporting_IsStuck()
+    {
+        // Genuinely hung: last sign of life is older than the threshold.
+        using var db = await WithJobAsync(
+            startedAt: Now.AddMinutes(-40),
+            lastProgressAt: Now.AddMinutes(-25));
+
+        var stuck = await StuckJobs(db).ToListAsync(CancellationToken.None);
+
+        stuck.Should().ContainSingle("silence past the threshold is exactly what the monitor is for");
+    }
+
+    [Fact]
+    public async Task AJobThatNeverReported_FallsBackToStartedAt()
+    {
+        // No heartbeat yet (pre-#3585 row, or a job that hung before its first batch).
+        using var db = await WithJobAsync(startedAt: Now.AddMinutes(-40), lastProgressAt: null);
+
+        var stuck = await StuckJobs(db).ToListAsync(CancellationToken.None);
+
+        stuck.Should().ContainSingle("without a heartbeat the start time is the only signal available");
+    }
+
+    [Fact]
+    public async Task AFreshJobWithoutProgressYet_IsNotStuck()
+    {
+        using var db = await WithJobAsync(startedAt: Now.AddMinutes(-2), lastProgressAt: null);
+
+        var stuck = await StuckJobs(db).ToListAsync(CancellationToken.None);
+
+        stuck.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("Queued")]
+    [InlineData("Completed")]
+    [InlineData("Failed")]
+    public async Task NonProcessingJobs_AreNeverStuck(string status)
+    {
+        using var db = await WithJobAsync(
+            startedAt: Now.AddMinutes(-90), lastProgressAt: null, status: status);
+
+        var stuck = await StuckJobs(db).ToListAsync(CancellationToken.None);
+
+        stuck.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
Chiude #3585, scoperto durante il popolamento cover di #3454.

## Il difetto

`ProcessingQueueMonitorService` misurava il tempo trascorso da `StartedAt` e degradava a `Failed` qualsiasi job oltre la soglia di recovery (30 min di default). Nessuna nozione di **progresso**: un job che lavora benissimo da 40 minuti era indistinguibile da uno appeso.

Evidenza dai log di staging, con il degrade e il lavoro reale a 12 secondi di distanza:

```
08:38:33 [WRN] Stuck document detected: Job 3c9cbca6... (PDF: frosthaven_rulebook.pdf) stuck for 38.3 minutes
08:38:33 [WRN] [DegradeStuckJob] Concurrency conflict degrading job 3c9cbca6...; skipping
08:38:45 [INF] [PdfPipeline] Embedding batch 34/118 (20 texts)
08:38:57 [INF] [PdfPipeline] Embedding batch 35/118 (20 texts)
```

118 batch a ~12-25s ⇒ ~40 minuti di lavoro **legittimo**. Il documento è sopravvissuto solo perché il degrade ha perso una race di concorrenza contro il worker.

## Perché conta più del singolo caso

Un documento che richiede più della soglia veniva degradato → ritentato → **riavviato da zero** → ucciso di nuovo, fino a esaurire i 3 tentativi. **Nessun rulebook grande poteva completare l'ingest**, mai.

È con ogni probabilità la causa originaria dei fallimenti trovati in #3454, che riportavano proprio `Embedding batch 16/50 failed` e `Embedding batch 12/49 failed` — interruzioni a metà embedding, non errori del provider.

## Il fix

"Stuck" significa **inattivo**, non long-running.

- nuova colonna `processing_jobs.last_progress_at` (migration additiva, nullable, nessun backfill);
- la pipeline la aggiorna **dopo ogni batch di embedding** — la fase lunga, e quella dove il monitor uccideva;
- il monitor calcola l'inattività da `COALESCE(last_progress_at, started_at)`, così un job che non ha ancora riportato ricade esattamente sul comportamento precedente.

Due scelte implementative che vale la pena evidenziare in review:

**`ExecuteUpdateAsync` invece di caricare-e-salvare**: è un UPDATE diretto che bypassa il change tracker. Un heartbeat non deve poter flushare stato pendente della pipeline a metà ingest — con `SaveChanges` avrebbe potuto.

**Best-effort**: l'heartbeat è in `try/catch` (escludendo `OperationCanceledException`). Un fallimento nello scrivere il battito non deve mai abortire un ingest che sta andando bene; nel caso peggiore si ricade sul comportamento pre-fix per quel job.

## Test

7 unit sulla selezione del monitor: long-running **con** progressi non è stuck (il caso Frosthaven), silenzio oltre soglia è stuck, fallback su `StartedAt` quando manca l'heartbeat, job fresco non stuck, stati non-`Processing` mai selezionati.

## Nota di deploy

La migration è additiva su una colonna nullable: nessun lock significativo, nessun backfill, retrocompatibile con l'API attualmente in esecuzione (che semplicemente ignora la colonna).

🤖 Generated with [Claude Code](https://claude.com/claude-code)