### PR TITLE
release: promuovi main-dev su main-staging (SSRF hardening #3495 + fix pipeline #3454/#3585)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/RetryFailedPdfsJob.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/RetryFailedPdfsJob.cs
@@ -54,11 +54,17 @@ internal sealed class RetryFailedPdfsJob : IJob
         {
             // Find failed PDFs with retriable errors that haven't exceeded max retries
             // Note: Using == instead of string.Equals in LINQ to Entities (EF Core limitation)
+            // #3454: an UNCATEGORISED failure counts as Unknown, which IS retriable. The previous
+            // `ErrorCategory != null` filter made those rows invisible to this job FOREVER — no
+            // automatic retry, and no operator path short of a per-id reindex. Staging had 13 such
+            // PDFs (transient Unstructured/embedding failures, retry_count=0) stuck since before
+            // the category column existed, which also kept their covers ungenerated.
+            // The deprecated MarkAsFailed(error) overload assigns Unknown for exactly this reason,
+            // so NULL and Unknown must be treated alike. The retry stays bounded by RetryCount < 3.
             var failedPdfs = await _dbContext.PdfDocuments
                 .Where(p => p.ProcessingState == PdfProcessingState.Failed.ToString()
                          && p.RetryCount < 3
-                         && p.ErrorCategory != null
-                         && RetriableCategories.Contains(p.ErrorCategory))
+                         && (p.ErrorCategory == null || RetriableCategories.Contains(p.ErrorCategory)))
                 .Select(p => new
                 {
                     p.Id,

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
@@ -779,6 +779,33 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
         return chunks.Where(c => c != null && !string.IsNullOrWhiteSpace(c.Text)).ToList();
     }
 
+    /// <summary>
+    /// #3585 — records forward progress on the active processing job for this PDF, so
+    /// <c>ProcessingQueueMonitorService</c> measures INACTIVITY rather than total elapsed time.
+    /// <para>
+    /// Written with <c>ExecuteUpdateAsync</c> on purpose: it is a direct UPDATE that bypasses the
+    /// change tracker, so a heartbeat can never flush unrelated pending pipeline state mid-ingest.
+    /// Best-effort — a failed heartbeat must never abort an otherwise healthy ingest (and the
+    /// InMemory provider used by some tests does not support ExecuteUpdate at all).
+    /// </para>
+    /// </summary>
+    private async Task ReportProgressAsync(Guid pdfDocumentId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var now = _timeProvider.GetUtcNow();
+            await _db.Set<Api.Infrastructure.Entities.DocumentProcessing.ProcessingJobEntity>()
+                .Where(j => j.PdfDocumentId == pdfDocumentId && j.Status == "Processing")
+                .ExecuteUpdateAsync(s => s.SetProperty(j => j.LastProgressAt, now), cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogDebug(ex,
+                "[PdfPipeline] progress heartbeat failed for PDF {PdfId} (non-fatal)", pdfDocumentId);
+        }
+    }
+
     private async Task<List<float[]>> GenerateEmbeddingsAsync(
         PdfDocumentEntity pdfDoc,
         List<DocumentChunkInput> chunks,
@@ -827,6 +854,11 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
             }
 
             allEmbeddings.AddRange(batchResult.Embeddings);
+
+            // #3585: embedding is the long phase — a large rulebook runs >100 batches — and it is
+            // where the stuck-job monitor used to kill a healthy ingest. Report progress after every
+            // completed batch so "inactive" and "slow" stay distinguishable.
+            await ReportProgressAsync(pdfDoc.Id, cancellationToken).ConfigureAwait(false);
         }
 
         if (allEmbeddings.Count != chunks.Count)

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/ProcessingQueueMonitorService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/ProcessingQueueMonitorService.cs
@@ -111,14 +111,23 @@ internal sealed class ProcessingQueueMonitorService : BackgroundService
     {
         var cutoff = DateTimeOffset.UtcNow - StuckJobTimeout;
 
+        // #3585: "stuck" means INACTIVE, not long-running. Measuring from StartedAt classified a
+        // perfectly healthy ingest as stuck — a 118-batch rulebook takes ~40 minutes of real work —
+        // and degraded it to Failed; it then restarted from zero and hit the same wall, so no
+        // document slower than the recovery timeout could ever complete. The pipeline reports
+        // forward progress in LastProgressAt, so the clock now starts from the last sign of life
+        // and falls back to StartedAt only for a job that has not reported yet.
         var stuckJobs = await db.Set<ProcessingJobEntity>()
-            .Where(j => j.Status == "Processing" && j.StartedAt != null && j.StartedAt < cutoff)
+            .Where(j => j.Status == "Processing"
+                     && j.StartedAt != null
+                     && (j.LastProgressAt ?? j.StartedAt) < cutoff)
             .Select(j => new
             {
                 j.Id,
                 j.PdfDocumentId,
                 FileName = j.PdfDocument.FileName,
                 j.StartedAt,
+                j.LastProgressAt,
             })
             .ToListAsync(ct)
             .ConfigureAwait(false);
@@ -127,7 +136,8 @@ internal sealed class ProcessingQueueMonitorService : BackgroundService
 
         foreach (var job in stuckJobs)
         {
-            var stuckMinutes = (DateTimeOffset.UtcNow - job.StartedAt!.Value).TotalMinutes;
+            var idleSince = job.LastProgressAt ?? job.StartedAt!.Value;
+            var stuckMinutes = (DateTimeOffset.UtcNow - idleSince).TotalMinutes;
 
             _logger.LogWarning(
                 "Stuck document detected: Job {JobId} (PDF: {FileName}) stuck for {Minutes:F1} minutes",

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloader.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloader.cs
@@ -1,4 +1,5 @@
-using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+using Api.Observability;
+using Api.SharedKernel.Infrastructure.Http;
 using Microsoft.Extensions.Logging;
 
 namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
@@ -34,20 +35,23 @@ internal sealed class BggCoverDownloader : IBggCoverDownloader
             return null;
         }
 
-        // SSRF guard: reject non-HTTPS / malformed URLs up front (fail-fast). The public-IP
+        // SSRF guard: reject non-HTTPS / non-default-port / malformed URLs up front (fail-fast),
+        // through the SAME validator the hardened fetch engine applies per hop (#3495 Slice D — one
+        // scheme/port rule for every sink, instead of a private copy that can drift). The public-IP
         // guarantee is enforced at connect time by the SSRF connect-pin on this client's handler
         // (ConfigureSsrfPin, #3495) — which, unlike a pre-connect DNS check, is not TOCTOU: every
         // connection (and each redirect hop) dials only a validated public address.
         try
         {
-            SsrfSafeHttpClient.ValidateUrlScheme(remoteImageUrl);
+            HardenedRedirectFetch.ResolveAndValidate(
+                remoteImageUrl, baseAddress: null, MeepleAiMetrics.EgressSinks.BggCover);
         }
-        catch (ArgumentException ex)
+        catch (HardenedFetchException ex)
         {
             _logger.LogWarning(
                 ex,
-                "BGG cover download blocked by SSRF guard: BggId={BggId}, Url={Url}",
-                bggId, remoteImageUrl);
+                "BGG cover download blocked by SSRF guard ({Reason}): BggId={BggId}, Url={Url}",
+                ex.Reason, bggId, remoteImageUrl);
             return null;
         }
 

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
@@ -539,14 +539,12 @@ internal static class SharedGameCatalogServiceExtensions
         // suppression below covers the public Commons API endpoint just like
         // the other catalog providers.
         //
-        // Issue #1823 M8 invariant: do NOT add a ConfigurePrimaryHttpMessageHandler
-        // that sets AllowAutoRedirect=false. FetchImageBytesAsync calls
-        // commons.wikimedia.org/wiki/Special:FilePath/{filename}, which returns
-        // a 302 redirect to upload.wikimedia.org/<cdn-url>. The default handler
-        // AllowAutoRedirect=true is what makes the image bytes accessible — a
-        // false setting would surface the 302 HTML body as bytes, which would
-        // then fail at WebP decoding (FailReasonImageProcessing) instead of the
-        // expected SkipReasonImageBytesNotAvailable on real 404s.
+        // #3495 Slice D (finding H1) — SUPERSEDES the #1823 M8 invariant "do NOT disable redirects".
+        // The Special:FilePath 302 → upload.wikimedia.org is STILL followed (the image bytes stay
+        // reachable), but by WikimediaCommonsClient through HardenedRedirectFetch instead of by the
+        // handler: every hop is re-validated (HTTPS-only, default port) and the body is read under a
+        // ceiling with a total wall-clock deadline. Auto-redirect must therefore be OFF, or the
+        // handler would follow a downgrade before the gate could refuse it.
 #pragma warning disable S1075 // URIs should not be hardcoded
         const string CommonsBaseUrl = "https://commons.wikimedia.org/";
 #pragma warning restore S1075
@@ -562,12 +560,11 @@ internal static class SharedGameCatalogServiceExtensions
         .AddHttpMessageHandler(sp => new WikimediaCircuitBreakerHandler(
             sp.GetRequiredService<ILogger<WikimediaCircuitBreakerHandler>>(),
             clientName: "commons-api"))
-        // #3495 follow-up: SSRF connect-pin. ConfigureSsrfPin sets AllowAutoRedirect=true, so the
-        // M8 invariant above (Special:FilePath 302 → upload.wikimedia.org MUST be auto-followed) still
-        // holds — and each redirect hop's host is independently re-resolved and SSRF-validated by the
-        // per-connection pin (upload.wikimedia.org is public → allowed). Do NOT add any other
+        // #3495 Slice D: the pin keeps owning the IP boundary per connection (each hop re-resolved,
+        // upload.wikimedia.org is public → allowed), and auto-redirect is now OFF so the 3xx surfaces
+        // in WikimediaCommonsClient and is followed through the hardened gate. Do NOT add any other
         // ConfigurePrimaryHttpMessageHandler here: it would override the pin.
-        .ConfigureSsrfPin(MeepleAiMetrics.EgressSinks.Wikimedia);
+        .ConfigureSsrfPin(MeepleAiMetrics.EgressSinks.Wikimedia, allowAutoRedirect: false);
 
         services.AddHttpClient<BggCatalogProvider>(client =>
         {

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
@@ -400,8 +400,20 @@ internal static class SharedGameCatalogServiceExtensions
     private static void AddBggCoverDownloader(IServiceCollection services) =>
         services.AddHttpClient<IBggCoverDownloader, BggCoverDownloader>(client =>
         {
-            client.Timeout = TimeSpan.FromSeconds(10);
+            // Outer wall-clock ceiling for the whole exchange, INCLUDING the streamed 10MB body read
+            // (HttpClient.Timeout keeps running under ResponseHeadersRead). The tight budget on the
+            // connect + headers is the per-try timeout below.
+            client.Timeout = TimeSpan.FromSeconds(30);
         })
+        // #3495 H8/C3 (Slice E): per-sink budget + breaker. A BGG CDN outage degrades cover fetching
+        // alone — it cannot open the breaker of any other sink, and the pin below stays innermost.
+        .AddHttpMessageHandler(sp => new EgressResilienceHandler(
+            sp.GetRequiredService<ILogger<EgressResilienceHandler>>(),
+            sink: MeepleAiMetrics.EgressSinks.BggCover,
+            perTryTimeout: TimeSpan.FromSeconds(10),
+            failureThreshold: 3,
+            samplingWindow: TimeSpan.FromSeconds(60),
+            breakDuration: TimeSpan.FromMinutes(1)))
         .ConfigureSsrfPin(MeepleAiMetrics.EgressSinks.BggCover);
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
@@ -414,7 +414,9 @@ internal static class SharedGameCatalogServiceExtensions
             failureThreshold: 3,
             samplingWindow: TimeSpan.FromSeconds(60),
             breakDuration: TimeSpan.FromMinutes(1)))
-        .ConfigureSsrfPin(MeepleAiMetrics.EgressSinks.BggCover);
+        .ConfigureSsrfPin(
+            MeepleAiMetrics.EgressSinks.BggCover,
+            allowedHostSuffixes: EgressAllowLists.BggCover);
 
     /// <summary>
     /// Issue #3495 fix 5/N — registers the hardened arbitrary-URL download client
@@ -529,7 +531,9 @@ internal static class SharedGameCatalogServiceExtensions
         // #3495 follow-up: SSRF connect-pin — defense-in-depth on a fixed public host (DNS-rebinding).
         // ConfigureSsrfPin uses ConfigurePrimaryHttpMessageHandler (innermost), so the circuit-breaker
         // delegating handler above stays outer (CB → pin), matching the Slack registration.
-        .ConfigureSsrfPin(MeepleAiMetrics.EgressSinks.Wikidata);
+        .ConfigureSsrfPin(
+            MeepleAiMetrics.EgressSinks.Wikidata,
+            allowedHostSuffixes: EgressAllowLists.Wikidata);
 
         // Issue #1823 M4 (ADR DEC-3b/3c/3e): Wikimedia Commons license fetcher.
         // Consumed by the M8 orchestrator AFTER the Wikidata SPARQL pass resolves
@@ -564,7 +568,10 @@ internal static class SharedGameCatalogServiceExtensions
         // upload.wikimedia.org is public → allowed), and auto-redirect is now OFF so the 3xx surfaces
         // in WikimediaCommonsClient and is followed through the hardened gate. Do NOT add any other
         // ConfigurePrimaryHttpMessageHandler here: it would override the pin.
-        .ConfigureSsrfPin(MeepleAiMetrics.EgressSinks.Wikimedia, allowAutoRedirect: false);
+        .ConfigureSsrfPin(
+            MeepleAiMetrics.EgressSinks.Wikimedia,
+            allowAutoRedirect: false,
+            allowedHostSuffixes: EgressAllowLists.Wikimedia);
 
         services.AddHttpClient<BggCatalogProvider>(client =>
         {
@@ -573,7 +580,9 @@ internal static class SharedGameCatalogServiceExtensions
             client.Timeout = TimeSpan.FromSeconds(30);
         })
         // #3495 follow-up: SSRF connect-pin — defense-in-depth on a fixed public host (DNS-rebinding).
-        .ConfigureSsrfPin(MeepleAiMetrics.EgressSinks.Bgg);
+        .ConfigureSsrfPin(
+            MeepleAiMetrics.EgressSinks.Bgg,
+            allowedHostSuffixes: EgressAllowLists.Bgg);
 
         // Keyed registration so CatalogSeedAggregator can resolve "wikidata" (primary)
         // and "bgg" (fallback) explicitly — avoids relying on registration order.

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Resilience/CircuitBreakerExceptionDetector.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Resilience/CircuitBreakerExceptionDetector.cs
@@ -16,19 +16,12 @@ internal static class CircuitBreakerExceptionDetector
     /// Returns <see langword="true"/> when the supplied exception is a
     /// Polly broken-circuit exception (either generic or non-generic variant).
     /// </summary>
-    public static bool IsBrokenCircuit(Exception ex)
-    {
-        if (ex is null) return false;
-
-        var t = ex.GetType();
-        if (!string.Equals(t.Namespace, "Polly.CircuitBreaker", StringComparison.Ordinal))
-        {
-            return false;
-        }
-
-        // BrokenCircuitException (non-generic) + BrokenCircuitException`1 (Polly v8
-        // generic variant returning a captured result on open).
-        return string.Equals(t.Name, "BrokenCircuitException", StringComparison.Ordinal)
-            || t.Name.StartsWith("BrokenCircuitException`", StringComparison.Ordinal);
-    }
+    /// <remarks>
+    /// The detection itself now lives in
+    /// <see cref="Api.SharedKernel.Infrastructure.Resilience.PollyRejectionDetector"/> (#3495 Slice E)
+    /// so egress infrastructure outside this bounded context can classify the same rejection; this
+    /// entry point stays for the catalog callers that already depend on it.
+    /// </remarks>
+    public static bool IsBrokenCircuit(Exception ex) =>
+        Api.SharedKernel.Infrastructure.Resilience.PollyRejectionDetector.IsBrokenCircuit(ex);
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfSafeHttpClient.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfSafeHttpClient.cs
@@ -23,7 +23,6 @@ namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 internal sealed class SsrfSafeHttpClient
 {
     private readonly HttpClient _httpClient;
-    private const long MaxPdfSizeBytes = 100 * 1024 * 1024; // 100MB
     private const long MaxImageSizeBytes = 10 * 1024 * 1024; // 10MB (cover images)
     private const int MaxRedirectHops = 5;
 
@@ -32,23 +31,9 @@ internal sealed class SsrfSafeHttpClient
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
     }
 
-    /// <summary>
-    /// Downloads a PDF from the given URL through the hardened fetch path (HTTPS-only per hop,
-    /// bounded redirect follow, mid-stream 100MB ceiling, IP-pinned connection), then validates
-    /// the payload is a PDF.
-    /// </summary>
-    /// <exception cref="ArgumentException">The URL (or a redirect target) is not an absolute HTTPS URL.</exception>
-    /// <exception cref="InvalidOperationException">Redirect loop / too many hops, oversize, or non-PDF content.</exception>
-    public async Task<Stream> DownloadPdfAsync(string url, CancellationToken ct)
-    {
-        var bytes = await FetchWithLimitAsync(url, MaxPdfSizeBytes, ct).ConfigureAwait(false);
-
-        // Validate PDF magic bytes (%PDF).
-        if (bytes.Length < 4 || bytes[0] != 0x25 || bytes[1] != 0x50 || bytes[2] != 0x44 || bytes[3] != 0x46)
-            throw new InvalidOperationException("Downloaded content is not a valid PDF file");
-
-        return new MemoryStream(bytes, writable: false);
-    }
+    // #3495 Slice E: the PDF variant of this fetch (DownloadPdfAsync + its 100MB ceiling) was dead
+    // code — no production caller ever reached it, so it was an unreviewed second egress entry point
+    // whose only exercise came from its own tests. Removed; the arbitrary-URL sink is images only.
 
     /// <summary>
     /// Epic #3470 Slice 3a — downloads an admin-supplied cover image through the hardened fetch path

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfSafeHttpClient.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfSafeHttpClient.cs
@@ -1,4 +1,5 @@
-using System.Net;
+using Api.Observability;
+using Api.SharedKernel.Infrastructure.Http;
 
 namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 
@@ -6,133 +7,48 @@ namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 /// Hardened egress client for the manual / arbitrary-URL download path (epic #3470 Slice 3
 /// prerequisite, issue #3495 fix 5/N).
 /// <para>
-/// The IP boundary is the connect-pin (<see cref="Api.SharedKernel.Infrastructure.Http.SsrfPinnedConnect"/>,
-/// applied to this client's <see cref="HttpClient"/> via <c>ConfigureSsrfPin(allowAutoRedirect: false)</c>):
-/// every connection resolves the host once and dials a validated public IP, closing DNS-rebinding
-/// and redirect-to-internal by construction. This class adds the remaining arbitrary-URL guards the
-/// pin cannot express: HTTPS-only scheme re-validated on EVERY hop (blocks a redirect that downgrades
-/// to <c>http/file/gopher</c> or points at a non-HTTP scheme — the pin only re-checks the IP), a
-/// bounded manual redirect follow with loop detection, and a mid-stream byte ceiling.
+/// Two layers guard this sink and neither is optional:
 /// </para>
+/// <list type="bullet">
+///   <item>the connect-pin (<see cref="SsrfPinnedConnect"/>, applied via
+///   <c>ConfigureSsrfPin(allowAutoRedirect: false)</c>) owns the IP boundary — every connection
+///   resolves once and dials a validated public address, closing DNS-rebinding and
+///   redirect-to-internal by construction;</item>
+///   <item><see cref="HardenedRedirectFetch"/> owns everything the pin cannot express — per-hop
+///   HTTPS-only + default-port re-validation, bounded redirect follow with loop detection, a
+///   streamed byte ceiling, and a TOTAL wall-clock budget (#3495 Slice D, findings C4/H2).</item>
+/// </list>
 /// <para>
-/// Auto-redirect is DISABLED on the primary handler so 3xx responses surface here and are followed
-/// manually through the scheme gate — with <c>AllowAutoRedirect=true</c> the handler would follow a
-/// downgrade before this code could reject it.
+/// This type is the DI seam that binds the manual sink's <see cref="HttpClient"/> (and its
+/// <c>manual</c> metric label) to that engine; the fetch logic itself is shared, so the Commons
+/// sink is guarded by exactly the same code path.
 /// </para>
 /// </summary>
 internal sealed class SsrfSafeHttpClient
 {
     private readonly HttpClient _httpClient;
     private const long MaxImageSizeBytes = 10 * 1024 * 1024; // 10MB (cover images)
-    private const int MaxRedirectHops = 5;
 
     public SsrfSafeHttpClient(HttpClient httpClient)
     {
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
     }
 
-    // #3495 Slice E: the PDF variant of this fetch (DownloadPdfAsync + its 100MB ceiling) was dead
-    // code — no production caller ever reached it, so it was an unreviewed second egress entry point
-    // whose only exercise came from its own tests. Removed; the arbitrary-URL sink is images only.
-
     /// <summary>
     /// Epic #3470 Slice 3a — downloads an admin-supplied cover image through the hardened fetch path
-    /// (HTTPS-only per hop, bounded redirect follow, IP-pinned connection) under a 10MB streamed
-    /// ceiling. Returns the raw image bytes; the caller validates/re-encodes them.
+    /// under a 10MB streamed ceiling and the default total deadline. Returns the raw image bytes;
+    /// the caller validates/re-encodes them.
     /// </summary>
-    /// <exception cref="ArgumentException">The URL (or a redirect target) is not an absolute HTTPS URL.</exception>
-    /// <exception cref="InvalidOperationException">Redirect loop / too many hops, or oversize.</exception>
+    /// <exception cref="HardenedFetchException">A guard refused the fetch (scheme, port, redirect
+    /// budget, size ceiling or deadline) — <see cref="HardenedFetchException.Reason"/> says which.</exception>
+    /// <exception cref="HttpRequestException">The final hop answered a non-success status.</exception>
     public Task<byte[]> DownloadImageAsync(string url, CancellationToken ct) =>
-        FetchWithLimitAsync(url, MaxImageSizeBytes, ct);
-
-    /// <summary>
-    /// Hardened fetch shared by every arbitrary-URL sink on this client: validates the scheme on
-    /// the initial URL and on every redirect hop (HTTPS-only), follows up to
-    /// <see cref="MaxRedirectHops"/> redirects with loop detection, and reads the body under a
-    /// streamed <paramref name="maxBytes"/> ceiling (aborts at limit+1, before buffering the whole
-    /// payload). The connection-level IP validation is provided by the connect-pin. Returns the
-    /// fully-read, within-limit bytes; the response and its content stream are disposed on exit.
-    /// </summary>
-    internal async Task<byte[]> FetchWithLimitAsync(string url, long maxBytes, CancellationToken ct)
-    {
-        var current = ParseHttpsAbsolute(url);
-        var visited = new HashSet<string>(StringComparer.Ordinal);
-
-        // The initial request plus up to MaxRedirectHops redirect follows.
-        for (var hop = 0; hop <= MaxRedirectHops; hop++)
-        {
-            if (!visited.Add(current.AbsoluteUri))
-                throw new InvalidOperationException("Redirect loop detected");
-
-            using var request = new HttpRequestMessage(HttpMethod.Get, current);
-            using var response = await _httpClient
-                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct)
-                .ConfigureAwait(false);
-
-            if (!IsRedirect(response.StatusCode))
-            {
-                response.EnsureSuccessStatusCode();
-
-                // Reject early on an advertised over-cap length; Content-Length is spoofable/absent
-                // (chunked), so the ceiling is ALSO enforced during the streamed read below.
-                if (response.Content.Headers.ContentLength > maxBytes)
-                    throw new InvalidOperationException($"Response exceeds the maximum size of {maxBytes / (1024 * 1024)}MB");
-
-                return await ReadWithCeilingAsync(response, maxBytes, ct).ConfigureAwait(false);
-            }
-
-            var location = response.Headers.Location
-                ?? throw new InvalidOperationException("Redirect response had no Location header");
-
-            // Resolve relative → absolute against the current URL, then RE-VALIDATE the scheme:
-            // an absolute http/file/gopher Location or a relative-to-non-http target is rejected
-            // here (the pin only re-checks the IP, not the scheme).
-            current = ParseHttpsAbsolute(new Uri(current, location).AbsoluteUri);
-        }
-
-        throw new InvalidOperationException($"Exceeded the maximum of {MaxRedirectHops} redirects");
-    }
-
-    private static async Task<byte[]> ReadWithCeilingAsync(HttpResponseMessage response, long maxBytes, CancellationToken ct)
-    {
-        using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
-        using var buffer = new MemoryStream();
-
-        var chunk = new byte[81920];
-        long total = 0;
-        int read;
-        while ((read = await stream.ReadAsync(chunk, ct).ConfigureAwait(false)) > 0)
-        {
-            total += read;
-            if (total > maxBytes)
-                throw new InvalidOperationException($"Response exceeds the maximum size of {maxBytes / (1024 * 1024)}MB");
-
-            await buffer.WriteAsync(chunk.AsMemory(0, read), ct).ConfigureAwait(false);
-        }
-
-        return buffer.ToArray();
-    }
-
-    private static bool IsRedirect(HttpStatusCode code) => code is
-        HttpStatusCode.MovedPermanently or HttpStatusCode.Found or HttpStatusCode.SeeOther
-        or HttpStatusCode.TemporaryRedirect or HttpStatusCode.PermanentRedirect;
-
-    private static Uri ParseHttpsAbsolute(string url)
-    {
-        ValidateUrlScheme(url);
-        return new Uri(url, UriKind.Absolute);
-    }
-
-    /// <summary>
-    /// Validates that the URL is absolute and uses the HTTPS scheme. Applied to the initial URL and
-    /// re-applied to every redirect target.
-    /// </summary>
-    internal static void ValidateUrlScheme(string url)
-    {
-        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
-            throw new ArgumentException("Invalid URL", nameof(url));
-
-        if (!string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
-            throw new ArgumentException("Only HTTPS URLs are allowed", nameof(url));
-    }
+        HardenedRedirectFetch.FetchAsync(
+            _httpClient,
+            url,
+            MaxImageSizeBytes,
+            MeepleAiMetrics.EgressSinks.Manual,
+            HardenedRedirectFetch.DefaultDeadline,
+            configureRequest: null,
+            ct);
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WikimediaCommonsClient.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WikimediaCommonsClient.cs
@@ -1,6 +1,9 @@
 using System.Net.Http.Headers;
+using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using Api.Observability;
+using Api.SharedKernel.Infrastructure.Http;
 using Microsoft.Extensions.Logging;
 
 namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
@@ -31,6 +34,18 @@ namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 internal sealed class WikimediaCommonsClient : IWikimediaCommonsClient
 {
     private const string ApiPath = "w/api.php";
+
+    /// <summary>
+    /// #3495 Slice D (finding H1) — ceilings and budgets for the two Commons calls, enforced by
+    /// <see cref="HardenedRedirectFetch"/>. Before this slice the image download read the body with
+    /// no limit at all, so a hostile or accidental multi-GB file was an unbounded allocation.
+    /// The image cap is deliberately generous: Commons legitimately serves high-resolution
+    /// photographs, and the WebP re-encode downstream is what normalizes them.
+    /// </summary>
+    private const long MaxImageBytes = 32 * 1024 * 1024;
+    private const long MaxApiResponseBytes = 2 * 1024 * 1024;
+    private static readonly TimeSpan ImageDeadline = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan ApiDeadline = TimeSpan.FromSeconds(15);
 
     /// <summary>
     /// Strips HTML tags from the Commons <c>Artist</c> field, which is returned
@@ -80,23 +95,28 @@ internal sealed class WikimediaCommonsClient : IWikimediaCommonsClient
         {
             var path = $"{ApiPath}?action=query&prop=imageinfo&iiprop=extmetadata&titles={Uri.EscapeDataString(title)}&format=json";
 
-            using var req = new HttpRequestMessage(HttpMethod.Get, path);
-            req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            // #3495 Slice D: through the hardened gate — per-hop HTTPS/port re-validation, bounded
+            // redirect follow, capped body, total deadline (the API answers 200 directly, but a
+            // hijacked/misconfigured redirect must not be followed blindly either).
+            var body = await HardenedRedirectFetch.FetchAsync(
+                _http,
+                path,
+                MaxApiResponseBytes,
+                MeepleAiMetrics.EgressSinks.Wikimedia,
+                ApiDeadline,
+                configureRequest: req => req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json")),
+                ct).ConfigureAwait(false);
 
-            using var resp = await _http.SendAsync(req, ct).ConfigureAwait(false);
-
-            if (!resp.IsSuccessStatusCode)
-            {
-                _logger.LogWarning(
-                    "Commons imageinfo HTTP {Status} for file '{Filename}' (decoded='{Decoded}'). Caller decides retry.",
-                    (int)resp.StatusCode,
-                    filename,
-                    decoded);
-                return CommonsLicenseResult.NotAvailable();
-            }
-
-            var body = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
-            return ParseResponse(body, filename, decoded);
+            return ParseResponse(Encoding.UTF8.GetString(body), filename, decoded);
+        }
+        catch (HardenedFetchException ex)
+        {
+            _logger.LogWarning(ex,
+                "Commons imageinfo blocked by the egress gate ({Reason}) for file '{Filename}' (decoded='{Decoded}').",
+                ex.Reason,
+                filename,
+                decoded);
+            return CommonsLicenseResult.NotAvailable();
         }
         // Issue #2157: real caller cancellation propagates so the batch handler
         // can decide to abort. HttpClient.Timeout firing also raises
@@ -155,23 +175,21 @@ internal sealed class WikimediaCommonsClient : IWikimediaCommonsClient
 
         try
         {
-            using var req = new HttpRequestMessage(HttpMethod.Get, path);
-            // Accept any image content; Commons serves PNG/JPEG/GIF/WebP/SVG/TIFF.
-            req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("image/*"));
+            // #3495 Slice D (H1) — the Special:FilePath 302 to upload.wikimedia.org is now followed
+            // MANUALLY through the gate instead of by the handler: each hop is re-validated
+            // (HTTPS-only, default port) and the body is read under a ceiling with a total deadline.
+            // This REPLACES the #1823 M8 invariant "do NOT disable redirects": the redirect is still
+            // followed — the image bytes stay reachable — but through the guarded path.
+            var bytes = await HardenedRedirectFetch.FetchAsync(
+                _http,
+                path,
+                MaxImageBytes,
+                MeepleAiMetrics.EgressSinks.Wikimedia,
+                ImageDeadline,
+                // Accept any image content; Commons serves PNG/JPEG/GIF/WebP/SVG/TIFF.
+                configureRequest: req => req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("image/*")),
+                ct).ConfigureAwait(false);
 
-            using var resp = await _http.SendAsync(req, ct).ConfigureAwait(false);
-
-            if (!resp.IsSuccessStatusCode)
-            {
-                _logger.LogWarning(
-                    "Commons FilePath HTTP {Status} for file '{Filename}' (decoded='{Decoded}'). Caller decides retry.",
-                    (int)resp.StatusCode,
-                    filename,
-                    decoded);
-                return null;
-            }
-
-            var bytes = await resp.Content.ReadAsByteArrayAsync(ct).ConfigureAwait(false);
             if (bytes.Length == 0)
             {
                 _logger.LogWarning(
@@ -182,6 +200,18 @@ internal sealed class WikimediaCommonsClient : IWikimediaCommonsClient
             }
 
             return bytes;
+        }
+        // #3495 Slice D: the gate refused a hop (scheme/port downgrade), the body blew the ceiling,
+        // or the total deadline elapsed. Same fail-soft contract as the other failures here — the M9
+        // scheduler records "image bytes not available" and moves on.
+        catch (HardenedFetchException ex)
+        {
+            _logger.LogWarning(ex,
+                "Commons FilePath blocked by the egress gate ({Reason}) for file '{Filename}' (decoded='{Decoded}').",
+                ex.Reason,
+                filename,
+                decoded);
+            return null;
         }
         // Issue #2157: real caller cancellation propagates so the batch handler
         // can decide to abort. HttpClient.Timeout firing also raises

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/DependencyInjection/UserNotificationsServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/DependencyInjection/UserNotificationsServiceExtensions.cs
@@ -6,6 +6,8 @@ using Api.BoundedContexts.UserNotifications.Infrastructure.Persistence;
 using Api.BoundedContexts.UserNotifications.Infrastructure.Scheduling;
 using Api.BoundedContexts.UserNotifications.Infrastructure.Services;
 using Api.BoundedContexts.UserNotifications.Infrastructure.Slack;
+using Api.Observability;
+using Api.SharedKernel.Infrastructure.Http;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -57,17 +59,7 @@ internal static class UserNotificationsServiceExtensions
         services.AddSingleton<GenericEmailBuilder>();
         services.AddSingleton<EmailMessageBuilderFactory>();
 
-        // Named HttpClient for Slack API with 10s timeout and circuit breaker.
-        // Circuit breaker opens after 5 consecutive 5xx/timeout errors, stays open 2 minutes.
-        services.AddHttpClient("SlackApi", client =>
-        {
-            client.Timeout = TimeSpan.FromSeconds(10);
-        })
-        .AddPolicyHandler(HttpPolicyExtensions
-            .HandleTransientHttpError()
-            .CircuitBreakerAsync(
-                handledEventsAllowedBeforeBreaking: 5,
-                durationOfBreak: TimeSpan.FromMinutes(2)));
+        AddSlackApiClient(services);
 
         // Register services
         services.AddScoped<INotificationDispatcher, NotificationDispatcher>(); // Multi-channel dispatch
@@ -200,5 +192,39 @@ internal static class UserNotificationsServiceExtensions
         // No need to duplicate - jobs from all contexts share the same Quartz scheduler
 
         return services;
+    }
+
+    /// <summary>
+    /// Named HttpClient for the Slack API with a 10s timeout and a circuit breaker (opens after 5
+    /// consecutive 5xx/timeout errors, stays open 2 minutes).
+    /// <para>
+    /// #3495 Slice E: the target URL comes from a stored Slack connection (webhook / API URL), so this
+    /// is user-influenced external egress and dials through the SSRF connect-pin. The pin is the
+    /// primary handler (innermost) and re-validates every auto-redirect hop; the circuit breaker sits
+    /// outside it and keeps its own per-sink state.
+    /// </para>
+    /// </summary>
+    private static void AddSlackApiClient(IServiceCollection services) =>
+        services.AddHttpClient("SlackApi", client =>
+        {
+            client.Timeout = TimeSpan.FromSeconds(10);
+        })
+        .AddPolicyHandler(HttpPolicyExtensions
+            .HandleTransientHttpError()
+            .CircuitBreakerAsync(
+                handledEventsAllowedBeforeBreaking: 5,
+                durationOfBreak: TimeSpan.FromMinutes(2)))
+        .ConfigureSsrfPin(MeepleAiMetrics.EgressSinks.Slack);
+
+    /// <summary>
+    /// Test seam (#3495 Slice E): registers ONLY the Slack API named client so a DI-resolution test
+    /// can prove a Slack host resolving to a private address fails closed at the connect-pin. The
+    /// caller MUST register an <see cref="Api.SharedKernel.Infrastructure.Http.IDnsResolver"/> on the
+    /// same collection BEFORE calling this (the pin's own TryAdd default would otherwise win).
+    /// </summary>
+    internal static void AddSlackApiClientForTests(IServiceCollection services)
+    {
+        services.AddLogging();
+        AddSlackApiClient(services);
     }
 }

--- a/apps/api/src/Api/Extensions/InfrastructureServiceExtensions.cs
+++ b/apps/api/src/Api/Extensions/InfrastructureServiceExtensions.cs
@@ -22,7 +22,9 @@ using Api.Services.Providers.Probe;
 using Api.Services.Providers.Quota;
 using Api.Configuration;
 using Api.Models;
+using Api.Observability;
 using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Infrastructure.Http;
 using Microsoft.Extensions.Options;
 using Pgvector.EntityFrameworkCore; // ISSUE-3493: pgvector support
 
@@ -486,58 +488,7 @@ internal static class InfrastructureServiceExtensions
             required: false
         ) ?? Environment.GetEnvironmentVariable("BGG_API_TOKEN");
 
-        services.AddHttpClient<Infrastructure.ExternalServices.BoardGameGeek.IBggApiClient,
-            Infrastructure.ExternalServices.BoardGameGeek.BggApiClient>(client =>
-        {
-#pragma warning disable S1075 // URIs should not be hardcoded - Official BGG API endpoint
-            client.BaseAddress = new Uri("https://boardgamegeek.com/xmlapi2/");
-#pragma warning restore S1075
-            client.Timeout = TimeSpan.FromSeconds(30);
-            client.DefaultRequestHeaders.Add("User-Agent", "MeepleAI/1.0");
-
-            // Add Bearer token if configured (REQUIRED as of Jan 2026)
-            if (!string.IsNullOrWhiteSpace(bggTokenForClient))
-            {
-                client.DefaultRequestHeaders.Add("Authorization", $"Bearer {bggTokenForClient}");
-            }
-        })
-        .AddTransientHttpErrorPolicy(policy =>
-            policy.WaitAndRetryAsync(3, retryAttempt =>
-                TimeSpan.FromSeconds(Math.Pow(2, retryAttempt))))
-        .AddPolicyHandler((sp, _) => GetCircuitBreakerPolicy(
-            "BggApi", sp.GetService<ICircuitBreakerStateTracker>()))
-        .AddServiceCallLogging("BggApi")
-        .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
-        {
-            PooledConnectionLifetime = TimeSpan.FromMinutes(5),
-            PooledConnectionIdleTimeout = TimeSpan.FromMinutes(2),
-            MaxConnectionsPerServer = 20,
-            EnableMultipleHttp2Connections = true
-        });
-
-        // Named HttpClient "BggApi" used by BggApiService and BggApiHealthCheck
-        // Must share the same Bearer token as the typed IBggApiClient above
-        services.AddHttpClient("BggApi", client =>
-        {
-#pragma warning disable S1075 // URIs should not be hardcoded - Official BGG API endpoint
-            client.BaseAddress = new Uri("https://boardgamegeek.com/xmlapi2/");
-#pragma warning restore S1075
-            client.Timeout = TimeSpan.FromSeconds(30);
-            client.DefaultRequestHeaders.Add("User-Agent", "MeepleAI/1.0");
-
-            if (!string.IsNullOrWhiteSpace(bggTokenForClient))
-            {
-                client.DefaultRequestHeaders.Add("Authorization", $"Bearer {bggTokenForClient}");
-            }
-        })
-        .AddServiceCallLogging("BggApi")
-        .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
-        {
-            PooledConnectionLifetime = TimeSpan.FromMinutes(5),
-            PooledConnectionIdleTimeout = TimeSpan.FromMinutes(2),
-            MaxConnectionsPerServer = 20,
-            EnableMultipleHttp2Connections = true
-        });
+        AddBoardGameGeekClients(services, bggTokenForClient);
 
         // Configure BGG settings from appsettings.json
         services.Configure<BggConfiguration>(configuration.GetSection("Bgg"));
@@ -550,6 +501,72 @@ internal static class InfrastructureServiceExtensions
         });
 
         return services;
+    }
+
+    /// <summary>
+    /// Issue #3120 / #3495 Slice E — registers both BoardGameGeek egress clients (the typed
+    /// <c>IBggApiClient</c> and the named <c>BggApi</c> used by <c>BggApiService</c> and the health
+    /// check) behind the SSRF connect-pin. Extracted so production and the DI test seam
+    /// (<see cref="AddBoardGameGeekClientsForTests"/>) share the exact same pin wiring — drop the pin
+    /// here and both prod and the fail-closed test lose it.
+    /// </summary>
+    private static void AddBoardGameGeekClients(IServiceCollection services, string? bearerToken)
+    {
+#pragma warning disable S1075 // URIs should not be hardcoded - Official BGG API endpoint
+        const string BggApiBaseUrl = "https://boardgamegeek.com/xmlapi2/";
+#pragma warning restore S1075
+
+        void ConfigureClient(HttpClient client)
+        {
+            client.BaseAddress = new Uri(BggApiBaseUrl);
+            client.Timeout = TimeSpan.FromSeconds(30);
+            client.DefaultRequestHeaders.Add("User-Agent", "MeepleAI/1.0");
+
+            // Add Bearer token if configured (REQUIRED as of Jan 2026)
+            if (!string.IsNullOrWhiteSpace(bearerToken))
+            {
+                client.DefaultRequestHeaders.Add("Authorization", $"Bearer {bearerToken}");
+            }
+        }
+
+        // #3495 Slice E: boardgamegeek.com is external egress — dial through the SSRF connect-pin so
+        // a rebound or redirected BGG host cannot reach an internal address. The pooling tuning moves
+        // INTO the pinned handler; a second ConfigurePrimaryHttpMessageHandler would drop the pin.
+        static void ConfigurePinnedHandler(SocketsHttpHandler handler)
+        {
+            handler.PooledConnectionLifetime = TimeSpan.FromMinutes(5);
+            handler.PooledConnectionIdleTimeout = TimeSpan.FromMinutes(2);
+            handler.MaxConnectionsPerServer = 20;
+            handler.EnableMultipleHttp2Connections = true;
+        }
+
+        services.AddHttpClient<Infrastructure.ExternalServices.BoardGameGeek.IBggApiClient,
+            Infrastructure.ExternalServices.BoardGameGeek.BggApiClient>(ConfigureClient)
+        .AddTransientHttpErrorPolicy(policy =>
+            policy.WaitAndRetryAsync(3, retryAttempt =>
+                TimeSpan.FromSeconds(Math.Pow(2, retryAttempt))))
+        .AddPolicyHandler((sp, _) => GetCircuitBreakerPolicy(
+            "BggApi", sp.GetService<ICircuitBreakerStateTracker>()))
+        .AddServiceCallLogging("BggApi")
+        .ConfigureSsrfPin(MeepleAiMetrics.EgressSinks.Bgg, configureHandler: ConfigurePinnedHandler);
+
+        // Named HttpClient "BggApi" used by BggApiService and BggApiHealthCheck
+        // Must share the same Bearer token as the typed IBggApiClient above
+        services.AddHttpClient("BggApi", ConfigureClient)
+        .AddServiceCallLogging("BggApi")
+        .ConfigureSsrfPin(MeepleAiMetrics.EgressSinks.Bgg, configureHandler: ConfigurePinnedHandler);
+    }
+
+    /// <summary>
+    /// Test seam (#3495 Slice E): registers ONLY the BoardGameGeek egress clients so a DI-resolution
+    /// test can prove a BGG host resolving to a private address fails closed at the connect-pin. The
+    /// caller MUST register an <see cref="Api.SharedKernel.Infrastructure.Http.IDnsResolver"/> on the
+    /// same collection BEFORE calling this (the pin's own TryAdd default would otherwise win).
+    /// </summary>
+    internal static void AddBoardGameGeekClientsForTests(IServiceCollection services)
+    {
+        services.AddLogging();
+        AddBoardGameGeekClients(services, bearerToken: null);
     }
 
     private static AsyncCircuitBreakerPolicy<HttpResponseMessage> GetCircuitBreakerPolicy(

--- a/apps/api/src/Api/Extensions/InfrastructureServiceExtensions.cs
+++ b/apps/api/src/Api/Extensions/InfrastructureServiceExtensions.cs
@@ -548,13 +548,19 @@ internal static class InfrastructureServiceExtensions
         .AddPolicyHandler((sp, _) => GetCircuitBreakerPolicy(
             "BggApi", sp.GetService<ICircuitBreakerStateTracker>()))
         .AddServiceCallLogging("BggApi")
-        .ConfigureSsrfPin(MeepleAiMetrics.EgressSinks.Bgg, configureHandler: ConfigurePinnedHandler);
+        .ConfigureSsrfPin(
+            MeepleAiMetrics.EgressSinks.Bgg,
+            configureHandler: ConfigurePinnedHandler,
+            allowedHostSuffixes: EgressAllowLists.Bgg);
 
         // Named HttpClient "BggApi" used by BggApiService and BggApiHealthCheck
         // Must share the same Bearer token as the typed IBggApiClient above
         services.AddHttpClient("BggApi", ConfigureClient)
         .AddServiceCallLogging("BggApi")
-        .ConfigureSsrfPin(MeepleAiMetrics.EgressSinks.Bgg, configureHandler: ConfigurePinnedHandler);
+        .ConfigureSsrfPin(
+            MeepleAiMetrics.EgressSinks.Bgg,
+            configureHandler: ConfigurePinnedHandler,
+            allowedHostSuffixes: EgressAllowLists.Bgg);
     }
 
     /// <summary>

--- a/apps/api/src/Api/Infrastructure/Entities/DocumentProcessing/ProcessingJobEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/DocumentProcessing/ProcessingJobEntity.cs
@@ -14,6 +14,20 @@ public class ProcessingJobEntity
     public string? CurrentStep { get; set; }
     public DateTimeOffset CreatedAt { get; set; }
     public DateTimeOffset? StartedAt { get; set; }
+
+    /// <summary>
+    /// #3585 — last time the pipeline reported forward progress on this job (a completed embedding
+    /// batch, a phase transition). The stuck-job monitor measures INACTIVITY from here, falling back
+    /// to <see cref="StartedAt"/> when a job has not reported yet.
+    /// <para>
+    /// Without it the monitor could only measure total elapsed time, so a large rulebook — 118
+    /// embedding batches at ~20s each — was classified "stuck" while it was working perfectly, and
+    /// degraded to Failed. It then restarted from zero and hit the same wall, so no document longer
+    /// than the recovery timeout could ever complete.
+    /// </para>
+    /// </summary>
+    public DateTimeOffset? LastProgressAt { get; set; }
+
     public DateTimeOffset? CompletedAt { get; set; }
     public string? ErrorMessage { get; set; }
     public int RetryCount { get; set; }

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/DocumentProcessing/ProcessingJobEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/DocumentProcessing/ProcessingJobEntityConfiguration.cs
@@ -45,6 +45,10 @@ internal class ProcessingJobEntityConfiguration : IEntityTypeConfiguration<Proce
         builder.Property(e => e.StartedAt)
             .HasColumnName("started_at");
 
+        // #3585: progress heartbeat - see ProcessingJobEntity.LastProgressAt.
+        builder.Property(e => e.LastProgressAt)
+            .HasColumnName("last_progress_at");
+
         builder.Property(e => e.CompletedAt)
             .HasColumnName("completed_at");
 

--- a/apps/api/src/Api/Infrastructure/Migrations/20260806092826_AddProcessingJobLastProgressAt.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260806092826_AddProcessingJobLastProgressAt.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260806092826_AddProcessingJobLastProgressAt")]
+    partial class AddProcessingJobLastProgressAt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260806092826_AddProcessingJobLastProgressAt.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260806092826_AddProcessingJobLastProgressAt.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProcessingJobLastProgressAt : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "last_progress_at",
+                table: "processing_jobs",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "last_progress_at",
+                table: "processing_jobs");
+        }
+    }
+}

--- a/apps/api/src/Api/Middleware/ApiExceptionHandlerMiddleware.cs
+++ b/apps/api/src/Api/Middleware/ApiExceptionHandlerMiddleware.cs
@@ -414,6 +414,18 @@ internal class ApiExceptionHandlerMiddleware
                 "La copertina non è al momento disponibile per il rendering. Riprova più tardi."
             ),
 
+            // #3495 Slice D: the egress gate refused a caller-supplied URL (or its redirect chain).
+            // That is bad input, not a server bug — a 500 here would both mislead the caller and
+            // pollute the error-rate SLO. The deadline case is a gateway timeout. The message stays
+            // generic on purpose: the offending host/IP belongs in the log, never in the response.
+            Api.SharedKernel.Infrastructure.Http.HardenedFetchException fetchEx => (
+                fetchEx.Reason == Api.SharedKernel.Infrastructure.Http.HardenedFetchBlockReason.Timeout
+                    ? StatusCodes.Status504GatewayTimeout
+                    : StatusCodes.Status400BadRequest,
+                "egress_blocked",
+                "L'URL indicato non può essere scaricato in sicurezza."
+            ),
+
             // Domain exceptions (from SharedKernel)
             Api.SharedKernel.Domain.Exceptions.ValidationException validationEx => (
                 StatusCodes.Status400BadRequest,

--- a/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.Egress.cs
+++ b/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.Egress.cs
@@ -31,6 +31,10 @@ internal static partial class MeepleAiMetrics
         public const string DenylistHit = "denylist_hit";
         /// <summary>A hop targeted a non-default port — port-probing an internal service (#3495 H2).</summary>
         public const string Port = "port";
+        /// <summary>The host is outside the fixed-host sink's allow-list (#3495 M3).</summary>
+        public const string HostNotAllowed = "host_not_allowed";
+        /// <summary>The response was content-encoded, so the byte ceiling could not bound the decoded size (#3495 C5).</summary>
+        public const string ContentEncoding = "content_encoding";
         public const string RedirectExhausted = "redirect_exhausted";
         public const string SizeCap = "size_cap";
         public const string DecodeFail = "decode_fail";

--- a/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.Egress.cs
+++ b/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.Egress.cs
@@ -29,6 +29,8 @@ internal static partial class MeepleAiMetrics
     {
         public const string PrivateIp = "private_ip";
         public const string DenylistHit = "denylist_hit";
+        /// <summary>A hop targeted a non-default port — port-probing an internal service (#3495 H2).</summary>
+        public const string Port = "port";
         public const string RedirectExhausted = "redirect_exhausted";
         public const string SizeCap = "size_cap";
         public const string DecodeFail = "decode_fail";

--- a/apps/api/src/Api/SharedKernel/Infrastructure/Http/BggHostDenyList.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/Http/BggHostDenyList.cs
@@ -26,23 +26,9 @@ internal static class BggHostDenyList
         Uri.TryCreate(url, UriKind.Absolute, out var uri) && IsBannedHost(uri.Host);
 
     /// <summary>True when <paramref name="host"/> equals or is a sub-domain of a banned suffix.</summary>
-    public static bool IsBannedHost(string? host)
-    {
-        if (string.IsNullOrWhiteSpace(host))
-        {
-            return false;
-        }
-
-        var normalized = host.Trim().TrimEnd('.').ToLowerInvariant();
-        foreach (var suffix in BannedSuffixes)
-        {
-            if (string.Equals(normalized, suffix, StringComparison.Ordinal) ||
-                normalized.EndsWith("." + suffix, StringComparison.Ordinal))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
+    /// <remarks>
+    /// The suffix-matching itself lives in <see cref="HostSuffixMatcher"/> since #3495 Slice F, shared
+    /// with the per-sink egress allow-lists so both sides of the host gate behave identically.
+    /// </remarks>
+    public static bool IsBannedHost(string? host) => HostSuffixMatcher.Matches(host, BannedSuffixes);
 }

--- a/apps/api/src/Api/SharedKernel/Infrastructure/Http/EgressAllowLists.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/Http/EgressAllowLists.cs
@@ -1,0 +1,41 @@
+namespace Api.SharedKernel.Infrastructure.Http;
+
+/// <summary>
+/// Issue #3495 finding M3 (Slice F) — per-sink host allow-lists, applied by the connect-pin to every
+/// connection (initial request and each redirect hop).
+/// <para>
+/// This is defence in depth, not a replacement for the IP deny-list: the deny-list answers "is this
+/// address internal?", the allow-list answers "is this a host we talk to at all?". Only the second
+/// one stops a compromised or hijacked upstream from redirecting us to an arbitrary PUBLIC host —
+/// exfiltration or abuse that the IP policy has no way to recognise.
+/// </para>
+/// <para>
+/// Entries are registrable domains matched exactly or as a parent of the host
+/// (<see cref="HostSuffixMatcher"/>), so a look-alike such as <c>evilwikimedia.org</c> does NOT match.
+/// </para>
+/// <para>
+/// Deliberately absent:
+/// </para>
+/// <list type="bullet">
+///   <item>the <b>manual</b> arbitrary-URL sink — fetching an admin-supplied host is its purpose;
+///   there the ADR-059 deny-list, the scheme/port gate and the pin are the boundary (M3 says so
+///   explicitly);</item>
+///   <item><b>Slack</b> — the target comes from an operator-configured webhook URL, which teams
+///   legitimately point at a Slack-compatible receiver; an allow-list here would break that
+///   configuration rather than protect it.</item>
+/// </list>
+/// </summary>
+internal static class EgressAllowLists
+{
+    /// <summary>boardgamegeek.com XML API (typed + named clients, catalog provider).</summary>
+    public static readonly string[] Bgg = { "boardgamegeek.com" };
+
+    /// <summary>BGG cover images: the API returns asset URLs on the geekdo image CDNs.</summary>
+    public static readonly string[] BggCover = { "boardgamegeek.com", "geekdo-images.com", "geekdo.com" };
+
+    /// <summary>query.wikidata.org SPARQL — served from the Wikimedia estate.</summary>
+    public static readonly string[] Wikidata = { "wikidata.org", "wikimedia.org" };
+
+    /// <summary>commons.wikimedia.org + the upload.wikimedia.org CDN the FilePath 302 lands on.</summary>
+    public static readonly string[] Wikimedia = { "wikimedia.org" };
+}

--- a/apps/api/src/Api/SharedKernel/Infrastructure/Http/EgressResilienceHandler.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/Http/EgressResilienceHandler.cs
@@ -1,0 +1,117 @@
+using Api.Observability;
+using Api.SharedKernel.Infrastructure.Resilience;
+using Microsoft.Extensions.Logging;
+using Polly;
+using Polly.CircuitBreaker;
+
+namespace Api.SharedKernel.Infrastructure.Http;
+
+/// <summary>
+/// Issue #3495 findings H8/C3 (Slice E) — per-sink resilience for an outbound egress client: a
+/// per-try timeout budget wrapped in a circuit breaker, both owned by THIS client only.
+/// <para>
+/// C3 is the reason this is a handler and not a shared <c>HttpClient</c>: the SSRF policy is shared
+/// (one connect-pin callback), the budgets are not. A BGG CDN outage must not open the breaker of
+/// the Slack or Commons sink, and a slow sink must not eat another sink's budget.
+/// </para>
+/// <para>
+/// The timeout is a Polly PER-TRY budget rather than <see cref="HttpClient.Timeout"/>: the client
+/// timeout is a single wall-clock ceiling shared by the whole exchange (including the streamed body
+/// read), so it cannot express "give up on a stalled connect/headers quickly, but still allow a slow
+/// large body". The client timeout stays on as the outer ceiling.
+/// </para>
+/// <para>
+/// Rejections are counted on the egress metrics with their own bounded reason (<c>timeout</c> /
+/// <c>breaker_open</c>, #3495 M2) BEFORE propagating, so a sink that silently degrades is visible
+/// next to the SSRF blocks instead of being hidden inside a caller's catch-all.
+/// </para>
+/// </summary>
+internal sealed class EgressResilienceHandler : DelegatingHandler
+{
+    private readonly ResiliencePipeline<HttpResponseMessage> _pipeline;
+    private readonly ILogger<EgressResilienceHandler> _logger;
+    private readonly string _sink;
+
+    /// <param name="logger">Logger for breaker state transitions.</param>
+    /// <param name="sink">A bounded <c>MeepleAiMetrics.EgressSinks</c> constant — the metric label
+    /// and the breaker's identity in the logs. Never a host or IP.</param>
+    /// <param name="perTryTimeout">Budget for a single attempt (connect + response headers).</param>
+    /// <param name="failureThreshold">Failures inside <paramref name="samplingWindow"/> that open the circuit.</param>
+    /// <param name="samplingWindow">Rolling window the threshold is measured over.</param>
+    /// <param name="breakDuration">How long the circuit stays open before probing again. Keep it at or
+    /// below the client's handler lifetime: the factory recycles the handler chain (and with it this
+    /// breaker's state) on that cadence, so a longer break would be cut short anyway.</param>
+    public EgressResilienceHandler(
+        ILogger<EgressResilienceHandler> logger,
+        string sink,
+        TimeSpan perTryTimeout,
+        int failureThreshold,
+        TimeSpan samplingWindow,
+        TimeSpan breakDuration)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _sink = string.IsNullOrWhiteSpace(sink)
+            ? throw new ArgumentException("Sink required.", nameof(sink))
+            : sink;
+
+        _pipeline = new ResiliencePipelineBuilder<HttpResponseMessage>()
+            // Outer: the breaker observes the outcome of the timed attempt below, so a run of
+            // timeouts opens the circuit just like a run of 5xx.
+            .AddCircuitBreaker(new CircuitBreakerStrategyOptions<HttpResponseMessage>
+            {
+                FailureRatio = 1.0,
+                MinimumThroughput = failureThreshold,
+                SamplingDuration = samplingWindow,
+                BreakDuration = breakDuration,
+                // Polly v7 and v8 both export TimeoutRejectedException, so it is matched by shape
+                // rather than by symbolic type (CS0433) — see PollyRejectionDetector.
+                ShouldHandle = new PredicateBuilder<HttpResponseMessage>()
+                    .Handle<HttpRequestException>()
+                    .Handle<Exception>(static ex => PollyRejectionDetector.IsTimeoutRejected(ex))
+                    .HandleResult(static r => (int)r.StatusCode >= 500),
+                OnOpened = args =>
+                {
+                    _logger.LogError(
+                        "Egress circuit breaker OPENED for sink '{Sink}' after {Threshold} failures in {Window}s; breaking for {BreakSeconds}s.",
+                        _sink, failureThreshold, samplingWindow.TotalSeconds, args.BreakDuration.TotalSeconds);
+                    return ValueTask.CompletedTask;
+                },
+                OnClosed = _ =>
+                {
+                    _logger.LogInformation("Egress circuit breaker CLOSED for sink '{Sink}' — upstream recovered.", _sink);
+                    return ValueTask.CompletedTask;
+                },
+                OnHalfOpened = _ =>
+                {
+                    _logger.LogInformation("Egress circuit breaker HALF-OPENED for sink '{Sink}' — probing upstream.", _sink);
+                    return ValueTask.CompletedTask;
+                },
+            })
+            // Inner: per-attempt budget. Optimistic strategy — it cancels the token the inner send
+            // observes, so the socket work actually stops instead of being abandoned.
+            .AddTimeout(perTryTimeout)
+            .Build();
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await _pipeline.ExecuteAsync(
+                async token => await base.SendAsync(request, token).ConfigureAwait(false),
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (PollyRejectionDetector.IsBrokenCircuit(ex))
+        {
+            MeepleAiMetrics.RecordEgressBlocked(_sink, MeepleAiMetrics.EgressBlockReasons.BreakerOpen);
+            throw;
+        }
+        catch (Exception ex) when (PollyRejectionDetector.IsTimeoutRejected(ex))
+        {
+            MeepleAiMetrics.RecordEgressBlocked(_sink, MeepleAiMetrics.EgressBlockReasons.Timeout);
+            throw;
+        }
+    }
+}

--- a/apps/api/src/Api/SharedKernel/Infrastructure/Http/HardenedFetchException.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/Http/HardenedFetchException.cs
@@ -1,0 +1,41 @@
+namespace Api.SharedKernel.Infrastructure.Http;
+
+/// <summary>
+/// Why a hardened egress fetch was refused. Maps 1:1 onto the bounded
+/// <c>MeepleAiMetrics.EgressBlockReasons</c> labels (#3495 M2) — keep the two in sync so a blocked
+/// fetch is always countable without ever putting a host or IP in a metric tag.
+/// </summary>
+public enum HardenedFetchBlockReason
+{
+    /// <summary>A hop was not absolute HTTPS (downgrade to http/file/gopher, or a relative target).</summary>
+    Scheme,
+
+    /// <summary>A hop targeted a non-default port — probing an internal service by port (#3495 H2).</summary>
+    Port,
+
+    /// <summary>The redirect chain looped or exceeded the hop cap.</summary>
+    RedirectExhausted,
+
+    /// <summary>The body exceeded the caller's byte ceiling (advertised or mid-stream).</summary>
+    SizeCap,
+
+    /// <summary>The TOTAL wall-clock budget for the exchange elapsed (#3495 C4).</summary>
+    Timeout,
+}
+
+/// <summary>
+/// Raised when <see cref="HardenedRedirectFetch"/> refuses an egress fetch. Carries a bounded
+/// <see cref="Reason"/> so callers (and the API exception mapping) can react without string-matching
+/// a message. The message itself stays generic — the host/IP that triggered the block belongs in the
+/// log, never in a response body or a metric tag.
+/// </summary>
+public sealed class HardenedFetchException : Exception
+{
+    public HardenedFetchException(HardenedFetchBlockReason reason, string message)
+        : base(message) => Reason = reason;
+
+    public HardenedFetchException(HardenedFetchBlockReason reason, string message, Exception innerException)
+        : base(message, innerException) => Reason = reason;
+
+    public HardenedFetchBlockReason Reason { get; }
+}

--- a/apps/api/src/Api/SharedKernel/Infrastructure/Http/HardenedFetchException.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/Http/HardenedFetchException.cs
@@ -21,6 +21,10 @@ public enum HardenedFetchBlockReason
 
     /// <summary>The TOTAL wall-clock budget for the exchange elapsed (#3495 C4).</summary>
     Timeout,
+
+    /// <summary>The body was content-encoded, so the byte ceiling could not bound what the caller
+    /// would actually decode (#3495 C5/L3).</summary>
+    ContentEncoding,
 }
 
 /// <summary>

--- a/apps/api/src/Api/SharedKernel/Infrastructure/Http/HardenedRedirectFetch.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/Http/HardenedRedirectFetch.cs
@@ -1,0 +1,247 @@
+using Api.Observability;
+
+namespace Api.SharedKernel.Infrastructure.Http;
+
+/// <summary>
+/// Issue #3495 Slice D — the hardened redirect engine shared by every egress sink that follows
+/// redirects or fetches a caller-supplied URL.
+/// <para>
+/// Division of responsibility: the connect-pin (<see cref="SsrfPinnedConnect"/>) owns the IP
+/// boundary — it resolves once per connection and dials only a validated public address, so
+/// DNS-rebinding and redirect-to-internal are closed by construction. This engine owns what the pin
+/// cannot express, on the initial URL AND on every hop:
+/// </para>
+/// <list type="bullet">
+///   <item>absolute <b>HTTPS-only</b> — a <c>302</c> to <c>http/file/gopher</c> is refused (C4/H2);</item>
+///   <item><b>default port only</b> — a redirect to <c>:8080</c> / <c>:22</c> is port-probing (H2);</item>
+///   <item>bounded hop count with loop detection;</item>
+///   <item>a streamed byte ceiling, enforced during the read rather than after buffering;</item>
+///   <item>a <b>total wall-clock deadline</b> across the whole exchange — a chain of individually
+///   fast hops must not be able to hold a request open indefinitely (C4).</item>
+/// </list>
+/// <para>
+/// Auto-redirect MUST be disabled on the client's handler (<c>ConfigureSsrfPin(allowAutoRedirect:
+/// false)</c>) for these guards to see the 3xx at all: with auto-redirect on, the handler follows a
+/// downgrade before this code can reject it.
+/// </para>
+/// </summary>
+internal static class HardenedRedirectFetch
+{
+    /// <summary>Redirect follows allowed after the initial request.</summary>
+    public const int MaxRedirectHops = 5;
+
+    /// <summary>Default total budget for an arbitrary-URL fetch (#3495 C4).</summary>
+    public static readonly TimeSpan DefaultDeadline = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Fetches <paramref name="url"/> under the guards described on the class, returning the fully
+    /// read, within-ceiling bytes.
+    /// </summary>
+    /// <param name="client">Client whose handler carries the SSRF connect-pin with auto-redirect disabled.
+    /// A relative <paramref name="url"/> is resolved against its <see cref="HttpClient.BaseAddress"/>.</param>
+    /// <param name="url">Absolute HTTPS URL, or a relative path against the client's base address.</param>
+    /// <param name="maxBytes">Byte ceiling for the response body.</param>
+    /// <param name="sink">Bounded <c>MeepleAiMetrics.EgressSinks</c> constant for the block counters.</param>
+    /// <param name="deadline">Total wall-clock budget for the whole exchange, hops included.</param>
+    /// <param name="configureRequest">Applied to every hop's request (headers such as Accept).</param>
+    /// <param name="ct">Caller cancellation. Distinct from the deadline: a caller cancel surfaces as
+    /// <see cref="OperationCanceledException"/>, an expired deadline as
+    /// <see cref="HardenedFetchException"/> with <see cref="HardenedFetchBlockReason.Timeout"/>.</param>
+    /// <exception cref="HardenedFetchException">A guard refused the fetch.</exception>
+    /// <exception cref="HttpRequestException">The final hop answered a non-success status.</exception>
+    /// <exception cref="OperationCanceledException">The CALLER cancelled.</exception>
+    public static async Task<byte[]> FetchAsync(
+        HttpClient client,
+        string url,
+        long maxBytes,
+        string sink,
+        TimeSpan deadline,
+        Action<HttpRequestMessage>? configureRequest,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+
+        var current = ResolveInitialTarget(url, client.BaseAddress, sink);
+        var visited = new HashSet<string>(StringComparer.Ordinal);
+
+        // One budget for the whole exchange. Linked to the caller token so a real cancel still wins,
+        // and disposed on exit so the timer never outlives the request.
+        using var budget = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        budget.CancelAfter(deadline);
+
+        try
+        {
+            // The initial request plus up to MaxRedirectHops redirect follows.
+            for (var hop = 0; hop <= MaxRedirectHops; hop++)
+            {
+                if (!visited.Add(current.AbsoluteUri))
+                {
+                    throw Blocked(sink, HardenedFetchBlockReason.RedirectExhausted, "Redirect loop detected");
+                }
+
+                using var request = new HttpRequestMessage(HttpMethod.Get, current);
+                configureRequest?.Invoke(request);
+
+                using var response = await client
+                    .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, budget.Token)
+                    .ConfigureAwait(false);
+
+                if (!IsRedirect(response.StatusCode))
+                {
+                    response.EnsureSuccessStatusCode();
+
+                    // Reject early on an advertised over-cap length; Content-Length is spoofable and
+                    // absent on chunked bodies, so the ceiling is ALSO enforced during the read.
+                    if (response.Content.Headers.ContentLength > maxBytes)
+                    {
+                        throw Blocked(sink, HardenedFetchBlockReason.SizeCap,
+                            $"Response exceeds the maximum size of {maxBytes} bytes");
+                    }
+
+                    return await ReadWithCeilingAsync(response, maxBytes, sink, budget.Token).ConfigureAwait(false);
+                }
+
+                var location = response.Headers.Location
+                    ?? throw Blocked(sink, HardenedFetchBlockReason.Scheme, "Redirect response had no Location header");
+
+                // Resolve relative → absolute against the CURRENT hop, then re-run the full gate on
+                // the target: the pin re-checks the IP of the next connection, nothing else.
+                current = ResolveAndValidate(new Uri(current, location).AbsoluteUri, baseAddress: null, sink);
+            }
+
+            throw Blocked(sink, HardenedFetchBlockReason.RedirectExhausted,
+                $"Exceeded the maximum of {MaxRedirectHops} redirects");
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            // The budget fired, not the caller: report a timeout rather than masquerading as a cancel.
+            throw Blocked(sink, HardenedFetchBlockReason.Timeout,
+                $"Egress fetch exceeded its {deadline.TotalSeconds:0.###}s budget");
+        }
+    }
+
+    /// <summary>
+    /// Resolves the FIRST target of an exchange.
+    /// <para>
+    /// Deliberate asymmetry: a <b>relative</b> path is our own configuration — the caller is a typed
+    /// client whose <see cref="HttpClient.BaseAddress"/> we set in DI — so it is resolved and dialled
+    /// without the scheme/port gate (the connect-pin still owns its IP). An <b>absolute</b> URL is
+    /// caller input (the manual cover sink, a stored webhook) and gets the full gate. Every REDIRECT
+    /// target is untrusted regardless of how the exchange started, so
+    /// <see cref="ResolveAndValidate"/> runs on each hop.
+    /// </para>
+    /// <para>
+    /// This is what lets a fixed-host client keep working against a local contract/test server on
+    /// <c>http://localhost:PORT</c> while a hostile 302 to that same address is still refused.
+    /// </para>
+    /// </summary>
+    private static Uri ResolveInitialTarget(string url, Uri? baseAddress, string sink)
+    {
+        if (!Uri.TryCreate(url, UriKind.RelativeOrAbsolute, out var parsed))
+        {
+            throw Blocked(sink, HardenedFetchBlockReason.Scheme, "Invalid URL");
+        }
+
+        if (parsed.IsAbsoluteUri)
+        {
+            return ResolveAndValidate(url, baseAddress, sink);
+        }
+
+        if (baseAddress is null)
+        {
+            throw Blocked(sink, HardenedFetchBlockReason.Scheme,
+                "Relative URL with no base address to resolve against");
+        }
+
+        return new Uri(baseAddress, parsed);
+    }
+
+    /// <summary>
+    /// Validates that a URL is an absolute HTTPS URL on the default port, resolving it against
+    /// <paramref name="baseAddress"/> when relative. Applied to every redirect hop, and available to
+    /// callers that want the same fail-fast on a caller-supplied URL before starting work.
+    /// </summary>
+    /// <exception cref="HardenedFetchException">The URL is not absolute HTTPS, or uses a non-default port.</exception>
+    public static Uri ResolveAndValidate(string url, Uri? baseAddress, string sink)
+    {
+        if (!Uri.TryCreate(url, UriKind.RelativeOrAbsolute, out var parsed))
+        {
+            throw Blocked(sink, HardenedFetchBlockReason.Scheme, "Invalid URL");
+        }
+
+        if (!parsed.IsAbsoluteUri)
+        {
+            if (baseAddress is null)
+            {
+                throw Blocked(sink, HardenedFetchBlockReason.Scheme,
+                    "Relative URL with no base address to resolve against");
+            }
+
+            parsed = new Uri(baseAddress, parsed);
+        }
+
+        if (!string.Equals(parsed.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            throw Blocked(sink, HardenedFetchBlockReason.Scheme, "Only HTTPS URLs are allowed");
+        }
+
+        // Default port only. An explicit ":443" is still the default port (IsDefaultPort is true), so
+        // this rejects exactly the port-probing shapes — :8080, :22, :6379 — and nothing legitimate.
+        if (!parsed.IsDefaultPort)
+        {
+            throw Blocked(sink, HardenedFetchBlockReason.Port,
+                "Only the default HTTPS port is allowed");
+        }
+
+        return parsed;
+    }
+
+    private static async Task<byte[]> ReadWithCeilingAsync(
+        HttpResponseMessage response, long maxBytes, string sink, CancellationToken ct)
+    {
+        using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+        using var buffer = new MemoryStream();
+
+        var chunk = new byte[81920];
+        long total = 0;
+        int read;
+        while ((read = await stream.ReadAsync(chunk, ct).ConfigureAwait(false)) > 0)
+        {
+            total += read;
+            if (total > maxBytes)
+            {
+                throw Blocked(sink, HardenedFetchBlockReason.SizeCap,
+                    $"Response exceeds the maximum size of {maxBytes} bytes");
+            }
+
+            await buffer.WriteAsync(chunk.AsMemory(0, read), ct).ConfigureAwait(false);
+        }
+
+        return buffer.ToArray();
+    }
+
+    /// <summary>
+    /// Counts the block on the bounded egress counters and builds the exception. Every refusal goes
+    /// through here so "blocked" is never silent (#3495 M2).
+    /// </summary>
+    private static HardenedFetchException Blocked(string sink, HardenedFetchBlockReason reason, string message)
+    {
+        MeepleAiMetrics.RecordEgressBlocked(sink, ToMetricReason(reason));
+        return new HardenedFetchException(reason, message);
+    }
+
+    private static string ToMetricReason(HardenedFetchBlockReason reason) => reason switch
+    {
+        HardenedFetchBlockReason.Scheme => MeepleAiMetrics.EgressBlockReasons.Scheme,
+        HardenedFetchBlockReason.Port => MeepleAiMetrics.EgressBlockReasons.Port,
+        HardenedFetchBlockReason.RedirectExhausted => MeepleAiMetrics.EgressBlockReasons.RedirectExhausted,
+        HardenedFetchBlockReason.SizeCap => MeepleAiMetrics.EgressBlockReasons.SizeCap,
+        HardenedFetchBlockReason.Timeout => MeepleAiMetrics.EgressBlockReasons.Timeout,
+        _ => MeepleAiMetrics.EgressBlockReasons.Scheme,
+    };
+
+    private static bool IsRedirect(System.Net.HttpStatusCode code) => code is
+        System.Net.HttpStatusCode.MovedPermanently or System.Net.HttpStatusCode.Found
+        or System.Net.HttpStatusCode.SeeOther or System.Net.HttpStatusCode.TemporaryRedirect
+        or System.Net.HttpStatusCode.PermanentRedirect;
+}

--- a/apps/api/src/Api/SharedKernel/Infrastructure/Http/HardenedRedirectFetch.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/Http/HardenedRedirectFetch.cs
@@ -90,6 +90,17 @@ internal static class HardenedRedirectFetch
                 {
                     response.EnsureSuccessStatusCode();
 
+                    // #3495 C5/L3: a content-encoded body makes the ceiling ambiguous — our handlers
+                    // do NOT enable automatic decompression, so the bytes we count are the COMPRESSED
+                    // ones and a small response could still expand into a huge allocation downstream.
+                    // Rather than guess, refuse the encoding: no sink here needs it, and this keeps
+                    // "maxBytes" a bound on the bytes the caller will actually handle.
+                    if (response.Content.Headers.ContentEncoding.Count > 0)
+                    {
+                        throw Blocked(sink, HardenedFetchBlockReason.ContentEncoding,
+                            "Content-encoded responses are not accepted on this sink");
+                    }
+
                     // Reject early on an advertised over-cap length; Content-Length is spoofable and
                     // absent on chunked bodies, so the ceiling is ALSO enforced during the read.
                     if (response.Content.Headers.ContentLength > maxBytes)
@@ -237,6 +248,7 @@ internal static class HardenedRedirectFetch
         HardenedFetchBlockReason.RedirectExhausted => MeepleAiMetrics.EgressBlockReasons.RedirectExhausted,
         HardenedFetchBlockReason.SizeCap => MeepleAiMetrics.EgressBlockReasons.SizeCap,
         HardenedFetchBlockReason.Timeout => MeepleAiMetrics.EgressBlockReasons.Timeout,
+        HardenedFetchBlockReason.ContentEncoding => MeepleAiMetrics.EgressBlockReasons.ContentEncoding,
         _ => MeepleAiMetrics.EgressBlockReasons.Scheme,
     };
 

--- a/apps/api/src/Api/SharedKernel/Infrastructure/Http/HostSuffixMatcher.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/Http/HostSuffixMatcher.cs
@@ -1,0 +1,44 @@
+namespace Api.SharedKernel.Infrastructure.Http;
+
+/// <summary>
+/// Registrable-domain suffix matching for host allow/deny lists.
+/// <para>
+/// A host matches a suffix when it IS the suffix or is a sub-domain of it — never by substring.
+/// That distinction is the whole point: substring matching would treat the attacker-controlled
+/// <c>evilwikimedia.org</c> or <c>wikimedia.org.attacker.example</c> as a match, which is a bypass
+/// on an allow-list and a false positive on a deny-list.
+/// </para>
+/// <para>
+/// Extracted in #3495 Slice F so the ADR-059 deny-list (<see cref="BggHostDenyList"/>) and the
+/// per-sink egress allow-lists (<see cref="SsrfPinnedConnect"/>, finding M3) share one implementation
+/// instead of drifting apart.
+/// </para>
+/// </summary>
+internal static class HostSuffixMatcher
+{
+    /// <summary>
+    /// True when <paramref name="host"/> equals one of <paramref name="suffixes"/> or is a
+    /// sub-domain of it. Comparison is case-insensitive; a trailing root dot is tolerated.
+    /// </summary>
+    public static bool Matches(string? host, IReadOnlyCollection<string> suffixes)
+    {
+        ArgumentNullException.ThrowIfNull(suffixes);
+
+        if (string.IsNullOrWhiteSpace(host))
+        {
+            return false;
+        }
+
+        var normalized = host.Trim().TrimEnd('.').ToLowerInvariant();
+        foreach (var suffix in suffixes)
+        {
+            if (string.Equals(normalized, suffix, StringComparison.Ordinal)
+                || normalized.EndsWith("." + suffix, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPinnedConnect.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPinnedConnect.cs
@@ -55,15 +55,45 @@ internal static class SsrfPinnedConnect
     }
 
     /// <summary>
-    /// Builds a <see cref="SocketsHttpHandler.ConnectCallback"/> that pins to the validated IP.
+    /// #3495 M3 (Slice F) — defence in depth for FIXED-HOST sinks: the connection host must match one
+    /// of <paramref name="allowedHostSuffixes"/> (exact or sub-domain). The IP deny-list answers
+    /// "is this address internal?"; the allow-list answers "is this even a host we talk to?", which
+    /// is what stops a compromised upstream from redirecting us to an arbitrary PUBLIC host.
+    /// <para>
+    /// Checked BEFORE resolution, and on every connection — so each auto-redirect hop is covered too.
+    /// The arbitrary-URL manual sink deliberately passes no allow-list: fetching an admin-supplied URL
+    /// is its purpose, and there the deny-list plus the pin are the boundary.
+    /// </para>
+    /// </summary>
+    /// <exception cref="InvalidOperationException">The host is outside the sink's allow-list.</exception>
+    internal static void ValidateHostAllowed(string host, string sink, IReadOnlyCollection<string>? allowedHostSuffixes)
+    {
+        if (allowedHostSuffixes is null || allowedHostSuffixes.Count == 0)
+        {
+            return;
+        }
+
+        if (!HostSuffixMatcher.Matches(host, allowedHostSuffixes))
+        {
+            MeepleAiMetrics.RecordEgressBlocked(sink, MeepleAiMetrics.EgressBlockReasons.HostNotAllowed);
+            throw new InvalidOperationException($"SSRF: host '{host}' is not allowed for sink '{sink}'");
+        }
+    }
+
+    /// <summary>
+    /// Builds a <see cref="SocketsHttpConnectionContext"/> callback that enforces the optional host
+    /// allow-list and then pins to the validated IP.
     /// </summary>
     public static Func<SocketsHttpConnectionContext, CancellationToken, ValueTask<Stream>> Create(
-        IDnsResolver dns, string sink)
+        IDnsResolver dns, string sink, IReadOnlyCollection<string>? allowedHostSuffixes = null)
     {
         ArgumentNullException.ThrowIfNull(dns);
 
         return async (context, ct) =>
         {
+            // Cheapest gate first: an off-list host is refused without even resolving it.
+            ValidateHostAllowed(context.DnsEndPoint.Host, sink, allowedHostSuffixes);
+
             IPAddress pinned = await ResolveAndValidateAsync(dns, context.DnsEndPoint.Host, sink, ct)
                 .ConfigureAwait(false);
 

--- a/apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPinnedHttpClientBuilderExtensions.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPinnedHttpClientBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Api.SharedKernel.Infrastructure.Http;
 
@@ -31,16 +32,33 @@ internal static class SsrfPinnedHttpClientBuilderExtensions
     /// <param name="sink">A bounded <c>MeepleAiMetrics.EgressSinks</c> constant identifying this client
     /// (a compile-time value, never a host/IP) — the label on the egress blocked/allowed counters (#3495 M2).</param>
     /// <param name="allowAutoRedirect">See the summary — <see langword="false"/> only for the arbitrary-URL manual sink.</param>
+    /// <param name="configureHandler">Optional per-sink tuning of the pinned handler (connection pooling,
+    /// concurrency, HTTP/2). Runs BEFORE the pin fields are written, so a caller can never weaken the
+    /// SSRF guard: <see cref="SocketsHttpHandler.ConnectCallback"/>, <paramref name="allowAutoRedirect"/>
+    /// and the redirect cap are re-applied afterwards and always win (#3495 Slice E / finding C3 —
+    /// share the callback, not one handler, so each sink keeps its own pool and budgets).</param>
     public static IHttpClientBuilder ConfigureSsrfPin(
-        this IHttpClientBuilder builder, string sink, bool allowAutoRedirect = true)
+        this IHttpClientBuilder builder,
+        string sink,
+        bool allowAutoRedirect = true,
+        Action<SocketsHttpHandler>? configureHandler = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        return builder.ConfigurePrimaryHttpMessageHandler(sp => new SocketsHttpHandler
+        // The pin needs a resolver; registering it here means a new pinned sink cannot fail at
+        // runtime because its context forgot the TryAdd (contexts registering their own stub/impl
+        // BEFORE this call still win — TryAdd never overwrites).
+        builder.Services.TryAddSingleton<IDnsResolver, SystemDnsResolver>();
+
+        return builder.ConfigurePrimaryHttpMessageHandler(sp =>
         {
-            ConnectCallback = SsrfPinnedConnect.Create(sp.GetRequiredService<IDnsResolver>(), sink),
-            AllowAutoRedirect = allowAutoRedirect,
-            MaxAutomaticRedirections = 5,
+            var handler = new SocketsHttpHandler();
+            configureHandler?.Invoke(handler);
+
+            handler.ConnectCallback = SsrfPinnedConnect.Create(sp.GetRequiredService<IDnsResolver>(), sink);
+            handler.AllowAutoRedirect = allowAutoRedirect;
+            handler.MaxAutomaticRedirections = 5;
+            return handler;
         });
     }
 }

--- a/apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPinnedHttpClientBuilderExtensions.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPinnedHttpClientBuilderExtensions.cs
@@ -37,11 +37,16 @@ internal static class SsrfPinnedHttpClientBuilderExtensions
     /// SSRF guard: <see cref="SocketsHttpHandler.ConnectCallback"/>, <paramref name="allowAutoRedirect"/>
     /// and the redirect cap are re-applied afterwards and always win (#3495 Slice E / finding C3 —
     /// share the callback, not one handler, so each sink keeps its own pool and budgets).</param>
+    /// <param name="allowedHostSuffixes">Defence in depth for FIXED-HOST sinks (#3495 M3): every
+    /// connection — initial request and each redirect hop — must target one of these registrable
+    /// domains (exact or sub-domain). Omit it ONLY for the arbitrary-URL manual sink, whose purpose is
+    /// to fetch a host chosen at call time.</param>
     public static IHttpClientBuilder ConfigureSsrfPin(
         this IHttpClientBuilder builder,
         string sink,
         bool allowAutoRedirect = true,
-        Action<SocketsHttpHandler>? configureHandler = null)
+        Action<SocketsHttpHandler>? configureHandler = null,
+        IReadOnlyCollection<string>? allowedHostSuffixes = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
 
@@ -55,7 +60,8 @@ internal static class SsrfPinnedHttpClientBuilderExtensions
             var handler = new SocketsHttpHandler();
             configureHandler?.Invoke(handler);
 
-            handler.ConnectCallback = SsrfPinnedConnect.Create(sp.GetRequiredService<IDnsResolver>(), sink);
+            handler.ConnectCallback = SsrfPinnedConnect.Create(
+                sp.GetRequiredService<IDnsResolver>(), sink, allowedHostSuffixes);
             handler.AllowAutoRedirect = allowAutoRedirect;
             handler.MaxAutomaticRedirections = 5;
             return handler;

--- a/apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPolicy.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPolicy.cs
@@ -10,6 +10,24 @@ namespace Api.SharedKernel.Infrastructure.Http;
 /// 224/4, reserved/class-E 240/4) that a naive private-only check leaves open. IPv4-mapped
 /// and the well-known IPv4-in-IPv6 tunneling prefixes are unwrapped/blocked so a private
 /// v4 cannot be smuggled through an IPv6 literal.
+/// <para>
+/// <b>Registry baseline</b> (#3495 Slice F): IANA IPv4 Special-Purpose Address Registry and IPv6
+/// Special-Purpose Address Registry, both as of the 2026-01 revision. When refreshing against a
+/// later revision, add the range here AND a matching in-range/adjacent pair to
+/// <c>SsrfPolicyTests</c> — the matrix is the contract, not this comment.
+/// </para>
+/// <para>
+/// <b>Tunnelled IPv4 (Slice F, H3) — deliberate deviation.</b> NAT64 <c>64:ff9b::/96</c>, 6to4
+/// <c>2002::/16</c> and Teredo <c>2001:0000::/32</c> each carry an IPv4 destination inside the v6
+/// address. The #3495 DoD asked to DECODE that address and recurse into the v4 rules, which would
+/// admit a tunnel address whose embedded v4 is public. We keep the prefixes blocked WHOLESALE
+/// instead, because decode-and-allow is strictly a relaxation here: 6to4 and Teredo are deprecated
+/// (RFC 7526, RFC 4380 sunset), no sink of ours has any reason to dial a NAT64 prefix, and the case
+/// the decode would protect against — a PRIVATE v4 smuggled inside a tunnel address — is already
+/// covered by the blanket block. Pinned by the test matrix: a tunnel address is blocked whether its
+/// embedded v4 is private or public. Revisit only if a deployment actually needs NAT64 egress; the
+/// decode would then have to come with the recursion, not instead of it.
+/// </para>
 /// </summary>
 internal static class SsrfPolicy
 {
@@ -70,17 +88,18 @@ internal static class SsrfPolicy
         // ::/96 low block: unspecified (::), loopback, IPv4-compatible ::a.b.c.d (first 96 bits zero).
         if (AllZero(b, 0, 12)) return true;
 
-        // NAT64 well-known prefix 64:ff9b::/96 (embeds a v4 destination).
+        // NAT64 well-known prefix 64:ff9b::/96 (carries a v4 destination).
         if (b[0] == 0x00 && b[1] == 0x64 && b[2] == 0xFF && b[3] == 0x9B && AllZero(b, 4, 8)) return true;
 
-        // 2001:0000::/32 Teredo and 2001:db8::/32 documentation (leave the rest of 2001::/16 public).
+        // 2001:0000::/32 Teredo (carries a v4) and 2001:db8::/32 documentation.
+        // The rest of 2001::/16 stays public.
         if (b[0] == 0x20 && b[1] == 0x01)
         {
             if (b[2] == 0x00 && b[3] == 0x00) return true; // Teredo
             if (b[2] == 0x0D && b[3] == 0xB8) return true; // documentation
         }
 
-        // 2002::/16 6to4 (deprecated; embeds a v4).
+        // 2002::/16 6to4 (deprecated; carries a v4).
         if (b[0] == 0x20 && b[1] == 0x02) return true;
 
         return false;

--- a/apps/api/src/Api/SharedKernel/Infrastructure/Resilience/PollyRejectionDetector.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/Resilience/PollyRejectionDetector.cs
@@ -1,0 +1,56 @@
+namespace Api.SharedKernel.Infrastructure.Resilience;
+
+/// <summary>
+/// Detects Polly rejection exceptions by shape instead of by symbolic type catch.
+/// <para>
+/// Polly v8 (<c>Polly.Core</c>) and Polly v7 (transitive of <c>Microsoft.Extensions.Http.Polly</c>)
+/// both export <c>Polly.CircuitBreaker.BrokenCircuitException</c> and
+/// <c>Polly.Timeout.TimeoutRejectedException</c>, so a symbolic catch triggers CS0433 (the type
+/// exists in two assemblies). Reflection-based detection avoids extern-aliasing the whole Polly
+/// namespace, which would cascade through every consumer in the codebase.
+/// </para>
+/// <para>
+/// Promoted to the SharedKernel in #3495 Slice E so egress infrastructure can classify rejections
+/// without depending on a bounded context; <c>SharedGameCatalog</c>'s
+/// <c>CircuitBreakerExceptionDetector</c> now delegates here (issue #1823 Wave 3 M13 originally).
+/// </para>
+/// </summary>
+internal static class PollyRejectionDetector
+{
+    /// <summary>
+    /// Returns <see langword="true"/> when the exception is a Polly broken-circuit exception
+    /// (either the non-generic or the v8 generic variant).
+    /// </summary>
+    public static bool IsBrokenCircuit(Exception? ex)
+    {
+        if (ex is null)
+        {
+            return false;
+        }
+
+        var type = ex.GetType();
+        if (!string.Equals(type.Namespace, "Polly.CircuitBreaker", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        return string.Equals(type.Name, "BrokenCircuitException", StringComparison.Ordinal)
+            || type.Name.StartsWith("BrokenCircuitException`", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when the exception is a Polly timeout rejection (the per-try
+    /// budget elapsed), as opposed to a caller cancellation.
+    /// </summary>
+    public static bool IsTimeoutRejected(Exception? ex)
+    {
+        if (ex is null)
+        {
+            return false;
+        }
+
+        var type = ex.GetType();
+        return string.Equals(type.Namespace, "Polly.Timeout", StringComparison.Ordinal)
+            && string.Equals(type.Name, "TimeoutRejectedException", StringComparison.Ordinal);
+    }
+}

--- a/apps/api/tests/Api.Tests/Architecture/EgressHttpClientPinArchitectureTests.cs
+++ b/apps/api/tests/Api.Tests/Architecture/EgressHttpClientPinArchitectureTests.cs
@@ -1,0 +1,433 @@
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Architecture;
+
+/// <summary>
+/// Issue #3495 finding H7 (Slice E) — architecture gate: <b>no egress <c>HttpClient</c> may reach the
+/// public internet without the SSRF connect-pin</b>.
+/// <para>
+/// The pin (<c>ConfigureSsrfPin</c> → <c>SsrfPinnedConnect</c>) is the ONLY place where DNS-rebinding
+/// and redirect-to-internal are closed. A new <c>AddHttpClient</c> that forgets it re-opens the hole
+/// silently, and no runtime test covers a client nobody wrote a test for. This gate enumerates EVERY
+/// <c>AddHttpClient</c> registration in the API source and forces each one into exactly one of two
+/// explicit buckets:
+/// </para>
+/// <list type="bullet">
+/// <item><see cref="MustBePinned"/> — external egress: the registration chain MUST call
+/// <c>ConfigureSsrfPin</c>.</item>
+/// <item><see cref="Exempt"/> — internal/trusted targets (compose services, sidecars, monitoring)
+/// with a written reason.</item>
+/// </list>
+/// <para>
+/// A registration in neither bucket fails the test: adding an egress client is a security decision
+/// that must be made deliberately, not by omission.
+/// </para>
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Architecture")]
+[Trait("Issue", "3495")]
+public sealed class EgressHttpClientPinArchitectureTests
+{
+    /// <summary>
+    /// External egress clients: they dial hosts outside our infrastructure, so every connection MUST
+    /// go through the SSRF connect-pin. Key = the client identifier as written at the registration
+    /// site (the named-client string, or the implementation type for a typed client — which is the
+    /// name <c>AddHttpClient&lt;TClient, TImpl&gt;</c> registers under).
+    /// </summary>
+    private static readonly Dictionary<string, string> MustBePinned = new(StringComparer.Ordinal)
+    {
+        ["BggCoverDownloader"] = "cover image fetched from a BGG-supplied URL (#3495 fix 3/N)",
+        ["SsrfSafeHttpClient"] = "arbitrary admin-supplied URL, the manual cover sink (#3495 fix 5/N)",
+        ["BggCatalogProvider"] = "boardgamegeek.com catalog XML",
+        ["BggApiClient"] = "boardgamegeek.com XML API v2 (typed client)",
+        ["BggApi"] = "boardgamegeek.com XML API v2 (named client shared by BggApiService/health check)",
+        ["WikidataCatalogProvider"] = "query.wikidata.org SPARQL",
+        ["WikimediaCommonsClient"] = "commons.wikimedia.org + upload.wikimedia.org",
+        ["SlackWebhookClient"] = "admin-configured Slack webhook URL (#3495 fix 3/N)",
+        ["SlackApi"] = "Slack API/webhook URLs stored per connection — caller-supplied absolute URI",
+    };
+
+    /// <summary>
+    /// Registrations exempt from the pin, each with the reason it is not external egress. Internal
+    /// compose/VPC services and sidecars are trusted by design: pinning them would break the very
+    /// private addresses they are supposed to dial.
+    /// </summary>
+    private static readonly Dictionary<string, string> Exempt = new(StringComparer.Ordinal)
+    {
+        ["(default)"] = "IHttpClientFactory default client — no ambient egress of its own; every "
+            + "security-relevant sink uses a named/typed registration above",
+        ["Ollama"] = "self-hosted LLM runtime, private/compose address by design",
+        ["ai-ollama"] = "health probe for the same self-hosted Ollama runtime",
+        ["OpenRouter"] = "SaaS gateway on a hardcoded public endpoint; no user/DB input reaches the URL",
+        ["OpenRouterService"] = "same hardcoded OpenRouter endpoint (typed admin client)",
+        ["HuggingFace"] = "SaaS inference endpoint from static configuration; no user input in the URL",
+        ["ResendClient"] = "Resend SaaS SDK endpoint, static configuration",
+        ["Infisical"] = "secrets backend from static configuration",
+        ["EmbeddingService"] = "internal Python microservice (compose network)",
+        ["ai-embedding"] = "health probe for the internal embedding microservice",
+        ["ai-reranker"] = "health probe for the internal reranker microservice",
+        ["CrossEncoderRerankerClient"] = "internal reranker microservice (compose network)",
+        ["ai-unstructured"] = "health probe for the internal unstructured microservice",
+        ["UnstructuredService"] = "internal unstructured microservice (compose network)",
+        ["UnstructuredPdfTextExtractor.HiResClientName"] = "internal unstructured microservice, hi-res profile",
+        ["ai-orchestrator"] = "health probe for the internal orchestration microservice",
+        ["OrchestrationService"] = "internal orchestration microservice (compose network)",
+        ["SmolDoclingService"] = "internal SmolDocling microservice (compose network)",
+        ["smoldocling-photo-preprocessor"] = "internal SmolDocling microservice, photo pre-processing profile",
+        ["SmoldoclingTableExtractor.NamedClientKey"] = "internal SmolDocling microservice, table-extraction profile",
+        ["DockerProxyService"] = "docker socket proxy sidecar (private address by design)",
+        ["SeqQueryClient"] = "internal Seq log server (compose network)",
+        ["PrometheusHttpClient"] = "internal Prometheus (compose network)",
+        ["PrometheusLabelsClient"] = "internal Prometheus (compose network)",
+        ["PrometheusClientService"] = "internal Prometheus (compose network)",
+        ["SshTunnelSidecar"] = "SSH tunnel sidecar on the compose network",
+        ["provider-probe"] = "admin-configured AI provider probe: admin-only surface with a hard 5s "
+            + "budget; pinning it is tracked separately, it is not part of the user-reachable path",
+    };
+
+    private const string PinCall = "ConfigureSsrfPin";
+    private const string PrimaryHandlerCall = "ConfigurePrimaryHttpMessageHandler";
+
+    [Fact]
+    public void EveryHttpClientRegistration_IsClassified()
+    {
+        var registrations = ScanRegistrations();
+
+        registrations.Should().NotBeEmpty("the scanner must find the API's AddHttpClient registrations");
+
+        var unclassified = registrations
+            .Select(r => r.Name)
+            .Where(name => !MustBePinned.ContainsKey(name) && !Exempt.ContainsKey(name))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToList();
+
+        unclassified.Should().BeEmpty(
+            "every AddHttpClient registration is a security decision (#3495 H7): add the client to "
+            + "MustBePinned and call ConfigureSsrfPin if it dials the public internet, or to Exempt "
+            + "with the reason it targets internal/trusted infrastructure. Unclassified:\n"
+            + string.Join('\n', unclassified));
+    }
+
+    [Fact]
+    public void EveryExternalEgressRegistration_IsPinned()
+    {
+        var unpinned = ScanRegistrations()
+            .Where(r => MustBePinned.ContainsKey(r.Name) && !r.Statement.Contains(PinCall, StringComparison.Ordinal))
+            .Select(r => $"{r.Location}  {r.Name} — {MustBePinned[r.Name]}")
+            .OrderBy(entry => entry, StringComparer.Ordinal)
+            .ToList();
+
+        unpinned.Should().BeEmpty(
+            "external egress clients must dial through the SSRF connect-pin, otherwise DNS-rebinding "
+            + "and redirect-to-internal are open on that sink (#3495 C1/H7). Missing ConfigureSsrfPin:\n"
+            + string.Join('\n', unpinned));
+    }
+
+    [Fact]
+    public void PinnedRegistrations_DoNotOverrideTheirOwnPrimaryHandler()
+    {
+        var conflicts = ScanRegistrations()
+            .Where(r => r.Statement.Contains(PinCall, StringComparison.Ordinal)
+                && r.Statement.Contains(PrimaryHandlerCall, StringComparison.Ordinal))
+            .Select(r => $"{r.Location}  {r.Name}")
+            .OrderBy(entry => entry, StringComparer.Ordinal)
+            .ToList();
+
+        conflicts.Should().BeEmpty(
+            "ConfigureSsrfPin IS the primary handler: a second ConfigurePrimaryHttpMessageHandler on "
+            + "the same builder wins by last-registration and silently drops the pin. Pass the handler "
+            + "tuning to ConfigureSsrfPin instead. Conflicts:\n" + string.Join('\n', conflicts));
+    }
+
+    // -----------------------------------------------------------------------
+    // Source scanning
+    // -----------------------------------------------------------------------
+
+    private sealed record Registration(string Name, string Statement, string Location);
+
+    private static List<Registration> ScanRegistrations()
+    {
+        var apiSrc = LocateApiSrc();
+        var registrations = new List<Registration>();
+
+        foreach (var path in Directory.EnumerateFiles(apiSrc, "*.cs", SearchOption.AllDirectories))
+        {
+            var relative = Path.GetRelativePath(apiSrc, path).Replace('\\', '/');
+            if (relative.StartsWith("bin/", StringComparison.Ordinal)
+                || relative.StartsWith("obj/", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var text = File.ReadAllText(path);
+            foreach (var offset in FindCodeOccurrences(text, "AddHttpClient"))
+            {
+                var after = offset + "AddHttpClient".Length;
+
+                // Skip AddHttpClientInstrumentation and friends: only an exact call site counts.
+                if (after < text.Length && (char.IsLetterOrDigit(text[after]) || text[after] == '_'))
+                {
+                    continue;
+                }
+
+                var statement = ReadStatement(text, offset);
+                var line = text.Take(offset).Count(c => c == '\n') + 1;
+                registrations.Add(new Registration(
+                    ParseClientName(text, after),
+                    statement,
+                    $"{relative}:{line}"));
+            }
+        }
+
+        return registrations;
+    }
+
+    /// <summary>
+    /// The identifier the registration is keyed by: the named-client literal, the implementation type
+    /// of a typed client (what <c>AddHttpClient&lt;TClient, TImpl&gt;</c> names it), the verbatim
+    /// expression when the name is a constant, or <c>(default)</c> for the factory default client.
+    /// </summary>
+    private static string ParseClientName(string text, int afterCall)
+    {
+        var index = SkipWhitespace(text, afterCall);
+        if (index >= text.Length)
+        {
+            return "(default)";
+        }
+
+        if (text[index] == '<')
+        {
+            var end = MatchAngleBracket(text, index);
+            var typeArguments = text[(index + 1)..end].Split(',');
+            var last = typeArguments[^1].Trim();
+            var dot = last.LastIndexOf('.');
+            return dot >= 0 ? last[(dot + 1)..] : last;
+        }
+
+        if (text[index] != '(')
+        {
+            return "(default)";
+        }
+
+        var argument = SkipWhitespace(text, index + 1);
+        if (argument >= text.Length || text[argument] == ')')
+        {
+            return "(default)";
+        }
+
+        if (text[argument] == '"')
+        {
+            var close = text.IndexOf('"', argument + 1);
+            return close < 0 ? "(default)" : text[(argument + 1)..close];
+        }
+
+        // A non-literal first argument is either a name constant or the configure lambda. Lambdas and
+        // service-collection arguments mean "default client"; anything else is a name expression.
+        var token = ReadIdentifierLike(text, argument);
+        return token.Length == 0 || token.Contains("=>", StringComparison.Ordinal)
+            ? "(default)"
+            : token;
+    }
+
+    private static string ReadIdentifierLike(string text, int start)
+    {
+        var end = start;
+        while (end < text.Length && (char.IsLetterOrDigit(text[end]) || text[end] == '_' || text[end] == '.'))
+        {
+            end++;
+        }
+
+        var token = text[start..end];
+        // "client" / "sp" and other lambda parameters are not client names.
+        return token.Contains('.', StringComparison.Ordinal) ? token : string.Empty;
+    }
+
+    /// <summary>
+    /// Returns the whole fluent registration statement starting at <paramref name="start"/>: every
+    /// chained call up to the terminating semicolon at bracket depth zero (so a lambda body's
+    /// semicolons do not cut the chain short). Comments and string literals are STRIPPED from the
+    /// returned text — the callers match method names against it, and this file's own registrations
+    /// mention <c>ConfigurePrimaryHttpMessageHandler</c> in prose right next to the real call.
+    /// </summary>
+    private static string ReadStatement(string text, int start)
+    {
+        var code = new System.Text.StringBuilder();
+        var depth = 0;
+        for (var i = start; i < text.Length; i++)
+        {
+            var skipped = SkipTrivia(text, i);
+            if (skipped != i)
+            {
+                // Comment or literal: keep a separator so adjacent identifiers don't fuse.
+                code.Append(' ');
+                i = skipped - 1;
+                continue;
+            }
+
+            var c = text[i];
+            if (c is '(' or '{' or '[')
+            {
+                depth++;
+            }
+            else if (c is ')' or '}' or ']')
+            {
+                depth--;
+            }
+            else if (c == ';' && depth <= 0)
+            {
+                break;
+            }
+
+            code.Append(c);
+        }
+
+        return code.ToString();
+    }
+
+    /// <summary>
+    /// Offsets of <paramref name="needle"/> that sit in real code — occurrences inside comments,
+    /// string literals or char literals are ignored (the codebase mentions AddHttpClient in prose).
+    /// </summary>
+    private static List<int> FindCodeOccurrences(string text, string needle)
+    {
+        var found = new List<int>();
+        for (var i = 0; i < text.Length; i++)
+        {
+            var skipped = SkipTrivia(text, i);
+            if (skipped != i)
+            {
+                i = skipped - 1;
+                continue;
+            }
+
+            if (string.CompareOrdinal(text, i, needle, 0, needle.Length) == 0)
+            {
+                found.Add(i);
+                i += needle.Length - 1;
+            }
+        }
+
+        return found;
+    }
+
+    /// <summary>
+    /// If <paramref name="index"/> starts a comment or a string/char literal, returns the offset just
+    /// past it; otherwise returns <paramref name="index"/> unchanged.
+    /// </summary>
+    private static int SkipTrivia(string text, int index)
+    {
+        if (index + 1 < text.Length && text[index] == '/' && text[index + 1] == '/')
+        {
+            var end = text.IndexOf('\n', index);
+            return end < 0 ? text.Length : end + 1;
+        }
+
+        if (index + 1 < text.Length && text[index] == '/' && text[index + 1] == '*')
+        {
+            var end = text.IndexOf("*/", index + 2, StringComparison.Ordinal);
+            return end < 0 ? text.Length : end + 2;
+        }
+
+        if (index + 1 < text.Length && text[index] == '@' && text[index + 1] == '"')
+        {
+            var i = index + 2;
+            while (i < text.Length)
+            {
+                if (text[i] == '"')
+                {
+                    if (i + 1 < text.Length && text[i + 1] == '"')
+                    {
+                        i += 2;
+                        continue;
+                    }
+
+                    return i + 1;
+                }
+
+                i++;
+            }
+
+            return text.Length;
+        }
+
+        if (text[index] is '"' or '\'')
+        {
+            var quote = text[index];
+            var i = index + 1;
+            while (i < text.Length)
+            {
+                if (text[i] == '\\')
+                {
+                    i += 2;
+                    continue;
+                }
+
+                if (text[i] == quote)
+                {
+                    return i + 1;
+                }
+
+                if (text[i] == '\n')
+                {
+                    // Unterminated on this line — treat as ordinary text rather than swallowing the file.
+                    return index;
+                }
+
+                i++;
+            }
+
+            return index;
+        }
+
+        return index;
+    }
+
+    private static int SkipWhitespace(string text, int index)
+    {
+        while (index < text.Length && char.IsWhiteSpace(text[index]))
+        {
+            index++;
+        }
+
+        return index;
+    }
+
+    private static int MatchAngleBracket(string text, int open)
+    {
+        var depth = 0;
+        for (var i = open; i < text.Length; i++)
+        {
+            if (text[i] == '<')
+            {
+                depth++;
+            }
+            else if (text[i] == '>')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    return i;
+                }
+            }
+        }
+
+        return text.Length - 1;
+    }
+
+    private static string LocateApiSrc()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, ".git")))
+        {
+            dir = dir.Parent;
+        }
+
+        dir.Should().NotBeNull("the test binary must live inside the meepleai-monorepo repo");
+        var apiSrc = Path.Combine(dir!.FullName, "apps", "api", "src", "Api");
+        Directory.Exists(apiSrc).Should().BeTrue($"Api source must exist at {apiSrc}");
+        return apiSrc;
+    }
+}

--- a/apps/api/tests/Api.Tests/Architecture/PinnedEgressClientWiringTests.cs
+++ b/apps/api/tests/Api.Tests/Architecture/PinnedEgressClientWiringTests.cs
@@ -1,0 +1,91 @@
+using System.Net;
+using Api.BoundedContexts.UserNotifications.Infrastructure.DependencyInjection;
+using Api.Extensions;
+using Api.SharedKernel.Infrastructure.Http;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Architecture;
+
+/// <summary>
+/// Issue #3495 Slice E — behavioural counterpart to
+/// <see cref="EgressHttpClientPinArchitectureTests"/>: the source gate proves
+/// <c>ConfigureSsrfPin</c> is written at the registration site, these tests prove the resulting
+/// client actually dials through the pin.
+/// <para>
+/// Each test resolves the client from the REAL registration seam and asserts two things: the request
+/// fails closed when the host resolves to a private/reserved address, and the injected resolver was
+/// consulted. The second assertion is what makes the test non-vacuous — without the pin the default
+/// handler would do its own DNS and never touch the stub, so a silently dropped pin fails this
+/// deterministically. Mirrors <c>BggCoverDownloaderPinIntegrationTests</c> (#3495 fix 3/N).
+/// </para>
+/// <para>
+/// The typed <c>IBggApiClient</c> is exercised through the same registration helper as the named
+/// client below, but is not driven end-to-end here: its transient-error retry policy would sleep
+/// 2+4+8s on the blocked connect. Its pin is enforced by the source gate, which covers both call
+/// sites.
+/// </para>
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Architecture")]
+[Trait("Issue", "3495")]
+public sealed class PinnedEgressClientWiringTests
+{
+    private sealed class StubDnsResolver : IDnsResolver
+    {
+        private readonly IPAddress _address;
+        public int ResolveCalls { get; private set; }
+
+        public StubDnsResolver(string ip) => _address = IPAddress.Parse(ip);
+
+        public Task<IReadOnlyList<IPAddress>> ResolveAsync(string host, CancellationToken ct)
+        {
+            ResolveCalls++;
+            return Task.FromResult<IReadOnlyList<IPAddress>>(new[] { _address });
+        }
+    }
+
+    [Fact]
+    public async Task BggApiClient_FailsClosed_WhenTheBggHostResolvesToAPrivateAddress()
+    {
+        // 169.254.169.254 is the cloud metadata endpoint: the canonical SSRF target.
+        var dns = new StubDnsResolver("169.254.169.254");
+        var services = new ServiceCollection();
+        // Registered BEFORE the seam so ConfigureSsrfPin's TryAddSingleton does not override the stub.
+        services.AddSingleton<IDnsResolver>(dns);
+        InfrastructureServiceExtensions.AddBoardGameGeekClientsForTests(services);
+        using var provider = services.BuildServiceProvider();
+
+        var client = provider.GetRequiredService<IHttpClientFactory>().CreateClient("BggApi");
+
+        var act = () => client.GetAsync(new Uri("search?query=catan", UriKind.Relative), CancellationToken.None);
+
+        await act.Should().ThrowAsync<HttpRequestException>(
+            "the SSRF connect-pin must block a BGG host that resolves to a reserved address");
+        dns.ResolveCalls.Should().BeGreaterThan(0, "the connect-pin must consult the injected resolver");
+    }
+
+    [Fact]
+    public async Task SlackApiClient_FailsClosed_WhenTheWebhookHostResolvesToAPrivateAddress()
+    {
+        var dns = new StubDnsResolver("127.0.0.1");
+        var services = new ServiceCollection();
+        services.AddSingleton<IDnsResolver>(dns);
+        UserNotificationsServiceExtensions.AddSlackApiClientForTests(services);
+        using var provider = services.BuildServiceProvider();
+
+        var client = provider.GetRequiredService<IHttpClientFactory>().CreateClient("SlackApi");
+
+        // The URL is public, but the stored Slack connection could point anywhere — the pin decides
+        // on the RESOLVED address, which is loopback here.
+        using var body = new StringContent("{}");
+        var act = () => client.PostAsync(
+            new Uri("https://hooks.slack.com/services/T000/B000/xxx"), body, CancellationToken.None);
+
+        await act.Should().ThrowAsync<HttpRequestException>(
+            "the SSRF connect-pin must block a Slack target that resolves to loopback");
+        dns.ResolveCalls.Should().BeGreaterThan(0, "the connect-pin must consult the injected resolver");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandlerTests.cs
@@ -204,6 +204,9 @@ public sealed class SetManualCoverCommandHandlerTests
     {
         // Defence in depth: the validator rejects non-HTTPS at 400, but the SSRF-safe fetch path
         // ALSO re-validates the scheme, so a handler invoked directly still refuses egress.
+        // #3495 Slice D: that refusal is now a typed HardenedFetchException carrying a bounded
+        // reason (still mapped to 400 by ApiExceptionHandlerMiddleware) instead of a bare
+        // ArgumentException whose meaning had to be inferred from its message.
         var game = NewGame();
         _repository.Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>())).ReturnsAsync(game);
 
@@ -211,7 +214,8 @@ public sealed class SetManualCoverCommandHandlerTests
             Command(game.Id) with { SourceUrl = "http://commons.example.org/cover.png" },
             CancellationToken.None);
 
-        await act.Should().ThrowAsync<ArgumentException>();
+        var thrown = await act.Should().ThrowAsync<Api.SharedKernel.Infrastructure.Http.HardenedFetchException>();
+        thrown.Which.Reason.Should().Be(Api.SharedKernel.Infrastructure.Http.HardenedFetchBlockReason.Scheme);
         _httpHandler.RequestCount.Should().Be(0);
         _unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloaderPinIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloaderPinIntegrationTests.cs
@@ -50,10 +50,11 @@ public sealed class BggCoverDownloaderPinIntegrationTests
 
         var downloader = provider.GetRequiredService<IBggCoverDownloader>();
 
-        // The host literal (8.8.8.8) is public, but the pinned resolver returns the metadata IP,
-        // so the pin throws at connect and the download aborts before any upload.
+        // The host is a real BGG image CDN (so it clears the #3495 M3 allow-list), but the pinned
+        // resolver returns the metadata IP, so the pin throws at connect and the download aborts
+        // before any upload.
         var result = await downloader.DownloadAndUploadAsync(
-            13, "https://8.8.8.8/cover.jpg", CancellationToken.None);
+            13, "https://cf.geekdo-images.com/cover.jpg", CancellationToken.None);
 
         result.Should().BeNull("the SSRF connect-pin must block a private-resolving cover host");
         pipeline.Verify(

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloaderResilienceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloaderResilienceTests.cs
@@ -58,7 +58,7 @@ public sealed class BggCoverDownloaderResilienceTests
         for (var call = 0; call < BreakerThreshold; call++)
         {
             var result = await downloader.DownloadAndUploadAsync(
-                13, "https://8.8.8.8/cover.jpg", CancellationToken.None);
+                13, "https://cf.geekdo-images.com/cover.jpg", CancellationToken.None);
             result.Should().BeNull("the SSRF pin blocks every one of these dials");
         }
 
@@ -66,7 +66,7 @@ public sealed class BggCoverDownloaderResilienceTests
 
         // The circuit is open now: further calls must be rejected without another dial.
         var afterBreak = await downloader.DownloadAndUploadAsync(
-            13, "https://8.8.8.8/cover.jpg", CancellationToken.None);
+            13, "https://cf.geekdo-images.com/cover.jpg", CancellationToken.None);
 
         afterBreak.Should().BeNull("a rejected call still degrades gracefully to 'no cover'");
         dns.ResolveCalls.Should().Be(

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloaderResilienceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloaderResilienceTests.cs
@@ -1,0 +1,79 @@
+using System.Net;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.DependencyInjection;
+using Api.SharedKernel.Infrastructure.Http;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Services;
+
+/// <summary>
+/// Issue #3495 findings H8/C3 (Slice E) — the BGG cover sink carries its OWN circuit breaker, so a
+/// failing cover CDN stops being dialled instead of costing every caller a full connect budget.
+/// <para>
+/// The test drives the real DI registration and counts DNS resolutions: the pin resolves once per
+/// dial attempt, so "resolutions stop increasing while calls keep coming" is direct evidence the
+/// breaker short-circuits BEFORE the connect. Failures are produced by the pin itself (a host that
+/// resolves to a reserved address), which keeps the test offline and deterministic.
+/// </para>
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "3495")]
+public sealed class BggCoverDownloaderResilienceTests
+{
+    /// <summary>Matches the failureThreshold configured on the cover client's resilience handler.</summary>
+    private const int BreakerThreshold = 3;
+
+    private sealed class StubDnsResolver : IDnsResolver
+    {
+        private readonly IPAddress _address;
+        public int ResolveCalls { get; private set; }
+
+        public StubDnsResolver(string ip) => _address = IPAddress.Parse(ip);
+
+        public Task<IReadOnlyList<IPAddress>> ResolveAsync(string host, CancellationToken ct)
+        {
+            ResolveCalls++;
+            return Task.FromResult<IReadOnlyList<IPAddress>>(new[] { _address });
+        }
+    }
+
+    [Fact]
+    public async Task CoverSink_OpensItsCircuit_AndStopsDialling_AfterConsecutiveFailures()
+    {
+        var dns = new StubDnsResolver("169.254.169.254");
+        var pipeline = new Mock<IBggCoverUploadPipeline>();
+        var services = new ServiceCollection();
+        services.AddSingleton<IDnsResolver>(dns);
+        services.AddSingleton(pipeline.Object);
+        SharedGameCatalogServiceExtensions.AddBggCoverDownloaderForTests(services);
+        using var provider = services.BuildServiceProvider();
+
+        var downloader = provider.GetRequiredService<IBggCoverDownloader>();
+
+        for (var call = 0; call < BreakerThreshold; call++)
+        {
+            var result = await downloader.DownloadAndUploadAsync(
+                13, "https://8.8.8.8/cover.jpg", CancellationToken.None);
+            result.Should().BeNull("the SSRF pin blocks every one of these dials");
+        }
+
+        dns.ResolveCalls.Should().Be(BreakerThreshold, "each pre-breaker call dials once through the pin");
+
+        // The circuit is open now: further calls must be rejected without another dial.
+        var afterBreak = await downloader.DownloadAndUploadAsync(
+            13, "https://8.8.8.8/cover.jpg", CancellationToken.None);
+
+        afterBreak.Should().BeNull("a rejected call still degrades gracefully to 'no cover'");
+        dns.ResolveCalls.Should().Be(
+            BreakerThreshold,
+            "the open circuit must short-circuit before the connect-pin resolves anything again");
+        pipeline.Verify(
+            p => p.UploadAsync(It.IsAny<int>(), It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfPolicyTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfPolicyTests.cs
@@ -53,6 +53,16 @@ public class SsrfPolicyTests
     [InlineData("2001::1")]           // Teredo 2001:0000::/32
     [InlineData("2001:db8::1")]       // documentation 2001:db8::/32
     [InlineData("2002::1")]           // 6to4 2002::/16
+    // ── Tunnelled IPv4 (#3495 Slice F, H3): blocked whether the EMBEDDED v4 is private or public.
+    // The DoD asked to decode the embedded address and recurse into the v4 rules, which would ADMIT
+    // the public-embedded cases below. We keep the wholesale block instead — 6to4/Teredo are
+    // deprecated and no sink needs NAT64 egress, so decode-and-allow would only widen the surface.
+    // These rows are the contract for that decision: if someone implements the decode, they fail.
+    [InlineData("64:ff9b::a00:1")]    // NAT64 -> 10.0.0.1 (private embedded)
+    [InlineData("64:ff9b::808:808")]  // NAT64 -> 8.8.8.8  (PUBLIC embedded, still blocked)
+    [InlineData("2002:0a00:0001::1")] // 6to4 -> 10.0.0.1  (private embedded)
+    [InlineData("2002:0808:0808::1")] // 6to4 -> 8.8.8.8   (PUBLIC embedded, still blocked)
+    [InlineData("2001:0:4136:e378::1")] // Teredo with a public server v4, still blocked
     [InlineData("fc00::1")]           // ULA fc00::/8
     [InlineData("fd00::1")]           // ULA fd00::/8
     [InlineData("fe80::1")]           // link-local

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfSafeHttpClientPinIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfSafeHttpClientPinIntegrationTests.cs
@@ -49,7 +49,7 @@ public sealed class SsrfSafeHttpClientPinIntegrationTests
 
         // The host literal (8.8.8.8) is public and passes the scheme check, but the pinned resolver
         // returns the metadata IP, so the pin throws at connect and the download aborts.
-        var act = () => client.DownloadPdfAsync("https://8.8.8.8/rules.pdf", CancellationToken.None);
+        var act = () => client.DownloadImageAsync("https://8.8.8.8/cover.jpg", CancellationToken.None);
 
         await act.Should().ThrowAsync<Exception>("the SSRF connect-pin must block a private-resolving host");
         // The stub is consulted ONLY by the pin's ConnectCallback — a non-zero count proves

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfSafeHttpClientTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfSafeHttpClientTests.cs
@@ -69,68 +69,67 @@ public class SsrfSafeHttpClientTests
         return r;
     }
 
-    private static HttpResponseMessage Pdf() => new(HttpStatusCode.OK)
+    private static HttpResponseMessage Payload() => new(HttpStatusCode.OK)
     {
-        Content = new ByteArrayContent(System.Text.Encoding.ASCII.GetBytes("%PDF-1.4\nok")),
+        Content = new ByteArrayContent(System.Text.Encoding.ASCII.GetBytes("image-bytes")),
     };
 
     [Fact]
-    public async Task DownloadPdfAsync_FollowsHttpsRedirect_ToFinalPayload()
+    public async Task DownloadImageAsync_FollowsHttpsRedirect_ToFinalPayload()
     {
         using var handler = new SequenceHttpMessageHandler(
-            _ => Redirect(HttpStatusCode.Found, "https://cdn.example/final.pdf"),
-            _ => Pdf());
+            _ => Redirect(HttpStatusCode.Found, "https://cdn.example/final.png"),
+            _ => Payload());
         using var httpClient = new HttpClient(handler);
         var sut = new SsrfSafeHttpClient(httpClient);
 
-        var result = await sut.DownloadPdfAsync("https://example.com/rules.pdf", CancellationToken.None);
+        var result = await sut.DownloadImageAsync("https://example.com/cover.png", CancellationToken.None);
 
-        using var reader = new StreamReader(result);
-        (await reader.ReadToEndAsync()).Should().StartWith("%PDF");
+        System.Text.Encoding.ASCII.GetString(result).Should().Be("image-bytes");
         handler.RequestedUris.Should().HaveCount(2);
-        handler.RequestedUris[1].Should().Be(new Uri("https://cdn.example/final.pdf"));
+        handler.RequestedUris[1].Should().Be(new Uri("https://cdn.example/final.png"));
     }
 
     [Theory]
-    [InlineData("http://cdn.example/final.pdf")]     // https → http downgrade
+    [InlineData("http://cdn.example/final.png")]     // https → http downgrade
     [InlineData("file:///etc/passwd")]                // scheme downgrade to file
     [InlineData("gopher://internal/x")]               // exotic scheme
-    public async Task DownloadPdfAsync_RejectsSchemeDowngradeOnRedirect(string location)
+    public async Task DownloadImageAsync_RejectsSchemeDowngradeOnRedirect(string location)
     {
         using var handler = new SequenceHttpMessageHandler(_ => Redirect(HttpStatusCode.Found, location));
         using var httpClient = new HttpClient(handler);
         var sut = new SsrfSafeHttpClient(httpClient);
 
-        var act = () => sut.DownloadPdfAsync("https://example.com/rules.pdf", CancellationToken.None);
+        var act = () => sut.DownloadImageAsync("https://example.com/cover.png", CancellationToken.None);
 
         await act.Should().ThrowAsync<ArgumentException>()
             .WithMessage("Only HTTPS URLs are allowed*");
     }
 
     [Fact]
-    public async Task DownloadPdfAsync_RejectsRedirectLoop()
+    public async Task DownloadImageAsync_RejectsRedirectLoop()
     {
         using var handler = new SequenceHttpMessageHandler(
-            _ => Redirect(HttpStatusCode.Found, "https://example.com/rules.pdf")); // → itself
+            _ => Redirect(HttpStatusCode.Found, "https://example.com/cover.png")); // → itself
         using var httpClient = new HttpClient(handler);
         var sut = new SsrfSafeHttpClient(httpClient);
 
-        var act = () => sut.DownloadPdfAsync("https://example.com/rules.pdf", CancellationToken.None);
+        var act = () => sut.DownloadImageAsync("https://example.com/cover.png", CancellationToken.None);
 
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*loop*");
     }
 
     [Fact]
-    public async Task DownloadPdfAsync_RejectsTooManyRedirects()
+    public async Task DownloadImageAsync_RejectsTooManyRedirects()
     {
         var n = 0;
         using var handler = new SequenceHttpMessageHandler(
-            _ => Redirect(HttpStatusCode.Found, $"https://example.com/hop{++n}.pdf"));
+            _ => Redirect(HttpStatusCode.Found, $"https://example.com/hop{++n}.png"));
         using var httpClient = new HttpClient(handler);
         var sut = new SsrfSafeHttpClient(httpClient);
 
-        var act = () => sut.DownloadPdfAsync("https://example.com/rules.pdf", CancellationToken.None);
+        var act = () => sut.DownloadImageAsync("https://example.com/cover.png", CancellationToken.None);
 
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*maximum*redirects*");
@@ -173,14 +172,13 @@ public class SsrfSafeHttpClientTests
 
     #endregion
 
-    #region DownloadPdfAsync Disposal Tests (Issue #3239)
+    #region DownloadImageAsync Disposal Tests (Issue #3239)
 
     [Fact]
-    public async Task DownloadPdfAsync_DisposesResponseContentStream()
+    public async Task DownloadImageAsync_DisposesResponseContentStream()
     {
-        // %PDF magic bytes so the download passes the PDF-signature validation.
-        var pdfBytes = System.Text.Encoding.ASCII.GetBytes("%PDF-1.4\nfake-content");
-        var sourceStream = new DisposeTrackingStream(pdfBytes);
+        var payload = System.Text.Encoding.ASCII.GetBytes("fake-image-content");
+        var sourceStream = new DisposeTrackingStream(payload);
         using var handler = new StubHttpMessageHandler(() => new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StreamContent(sourceStream),
@@ -188,17 +186,16 @@ public class SsrfSafeHttpClientTests
         using var httpClient = new HttpClient(handler);
         var sut = new SsrfSafeHttpClient(httpClient);
 
-        // Host is a public IP literal: Dns.GetHostAddressesAsync short-circuits (no network call),
-        // and IsPrivateOrReserved(8.8.8.8) is false, so the SSRF guard passes hermetically.
-        var result = await sut.DownloadPdfAsync("https://8.8.8.8/rules.pdf", CancellationToken.None);
+        // The stub handler answers directly, so no connection (and no SSRF pin) is involved: this
+        // test is only about the response lifetime.
+        var result = await sut.DownloadImageAsync("https://8.8.8.8/cover.png", CancellationToken.None);
 
-        // The full payload is copied into an independent stream returned to the caller...
-        using var reader = new StreamReader(result);
-        (await reader.ReadToEndAsync()).Should().Be("%PDF-1.4\nfake-content");
+        // The full payload is returned to the caller as an independent buffer...
+        System.Text.Encoding.ASCII.GetString(result).Should().Be("fake-image-content");
 
         // ...and the source HttpResponseMessage content stream must be disposed (it was leaked before the fix).
         sourceStream.Disposed.Should().BeTrue(
-            "DownloadPdfAsync must dispose the HttpResponseMessage and its content stream");
+            "the hardened fetch must dispose the HttpResponseMessage and its content stream");
     }
 
     private sealed class StubHttpMessageHandler : HttpMessageHandler

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfSafeHttpClientTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfSafeHttpClientTests.cs
@@ -1,99 +1,51 @@
 using System.Net;
 using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+using Api.SharedKernel.Infrastructure.Http;
 using Api.Tests.Constants;
 using FluentAssertions;
 using Xunit;
 
 namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 
+/// <summary>
+/// The manual / arbitrary-URL cover sink. Since #3495 Slice D the redirect, scheme, port, deadline
+/// and ceiling logic lives in <see cref="HardenedRedirectFetch"/> (covered exhaustively by
+/// <c>HardenedRedirectFetchTests</c>); what stays specific to this type — and is asserted here — is
+/// the binding: the manual sink's own client, its 10MB image ceiling, and the guarded behaviour
+/// surviving end-to-end through the wrapper.
+/// </summary>
 [Trait("Category", TestCategories.Unit)]
 [Trait("BoundedContext", "SharedGameCatalog")]
 public class SsrfSafeHttpClientTests
 {
-    #region ValidateUrlScheme Tests
-
-    [Theory]
-    [InlineData("https://example.com/file.pdf")]
-    [InlineData("https://cdn.boardgamegeek.com/rules/game.pdf")]
-    public void ValidateUrlScheme_ValidHttpsUrl_ShouldNotThrow(string url)
-    {
-        var act = () => SsrfSafeHttpClient.ValidateUrlScheme(url);
-
-        act.Should().NotThrow();
-    }
-
-    [Theory]
-    [InlineData("http://example.com/file.pdf")]
-    [InlineData("http://localhost/file.pdf")]
-    public void ValidateUrlScheme_HttpUrl_ShouldThrowArgumentException(string url)
-    {
-        var act = () => SsrfSafeHttpClient.ValidateUrlScheme(url);
-
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("Only HTTPS URLs are allowed*");
-    }
-
-    [Theory]
-    [InlineData("ftp://example.com/file.pdf")]
-    [InlineData("file:///etc/passwd")]
-    public void ValidateUrlScheme_NonHttpScheme_ShouldThrowArgumentException(string url)
-    {
-        var act = () => SsrfSafeHttpClient.ValidateUrlScheme(url);
-
-        act.Should().Throw<ArgumentException>();
-    }
-
-    [Theory]
-    [InlineData("not-a-url")]
-    [InlineData("")]
-    public void ValidateUrlScheme_InvalidUrl_ShouldThrowArgumentException(string url)
-    {
-        var act = () => SsrfSafeHttpClient.ValidateUrlScheme(url);
-
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("Invalid URL*");
-    }
-
-    #endregion
-
-    // IsPrivateOrReserved tests removed with the method (#3495 fix 5/N): the pre-connect DNS
-    // check was TOCTOU and is retired in favor of the connect-pin (SsrfPinnedConnect), whose
-    // IANA IP policy is covered by SsrfPolicyTests. The IP boundary is no longer this class's.
-
-    #region Redirect / scheme / size-cap tests (#3495 fix 5/N)
-
     private static HttpResponseMessage Redirect(HttpStatusCode code, string location)
     {
-        var r = new HttpResponseMessage(code);
-        r.Headers.Location = new Uri(location, UriKind.RelativeOrAbsolute);
-        return r;
+        var response = new HttpResponseMessage(code);
+        response.Headers.Location = new Uri(location, UriKind.RelativeOrAbsolute);
+        return response;
     }
-
-    private static HttpResponseMessage Payload() => new(HttpStatusCode.OK)
-    {
-        Content = new ByteArrayContent(System.Text.Encoding.ASCII.GetBytes("image-bytes")),
-    };
 
     [Fact]
     public async Task DownloadImageAsync_FollowsHttpsRedirect_ToFinalPayload()
     {
+        var payload = new byte[] { 0x89, 0x50, 0x4E, 0x47 };
         using var handler = new SequenceHttpMessageHandler(
             _ => Redirect(HttpStatusCode.Found, "https://cdn.example/final.png"),
-            _ => Payload());
+            _ => new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(payload) });
         using var httpClient = new HttpClient(handler);
         var sut = new SsrfSafeHttpClient(httpClient);
 
         var result = await sut.DownloadImageAsync("https://example.com/cover.png", CancellationToken.None);
 
-        System.Text.Encoding.ASCII.GetString(result).Should().Be("image-bytes");
+        result.Should().Equal(payload);
         handler.RequestedUris.Should().HaveCount(2);
         handler.RequestedUris[1].Should().Be(new Uri("https://cdn.example/final.png"));
     }
 
     [Theory]
-    [InlineData("http://cdn.example/final.png")]     // https → http downgrade
-    [InlineData("file:///etc/passwd")]                // scheme downgrade to file
-    [InlineData("gopher://internal/x")]               // exotic scheme
+    [InlineData("http://cdn.example/final.png")]      // https → http downgrade
+    [InlineData("file:///etc/passwd")]                 // scheme downgrade to file
+    [InlineData("gopher://internal/x")]                // exotic scheme
     public async Task DownloadImageAsync_RejectsSchemeDowngradeOnRedirect(string location)
     {
         using var handler = new SequenceHttpMessageHandler(_ => Redirect(HttpStatusCode.Found, location));
@@ -102,55 +54,60 @@ public class SsrfSafeHttpClientTests
 
         var act = () => sut.DownloadImageAsync("https://example.com/cover.png", CancellationToken.None);
 
-        await act.Should().ThrowAsync<ArgumentException>()
-            .WithMessage("Only HTTPS URLs are allowed*");
+        var thrown = await act.Should().ThrowAsync<HardenedFetchException>();
+        thrown.Which.Reason.Should().Be(HardenedFetchBlockReason.Scheme);
     }
 
     [Fact]
-    public async Task DownloadImageAsync_RejectsRedirectLoop()
+    public async Task DownloadImageAsync_RejectsARedirectToANonDefaultPort()
     {
         using var handler = new SequenceHttpMessageHandler(
-            _ => Redirect(HttpStatusCode.Found, "https://example.com/cover.png")); // → itself
+            _ => Redirect(HttpStatusCode.Found, "https://cdn.example:8080/final.png"));
         using var httpClient = new HttpClient(handler);
         var sut = new SsrfSafeHttpClient(httpClient);
 
         var act = () => sut.DownloadImageAsync("https://example.com/cover.png", CancellationToken.None);
 
-        await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*loop*");
+        var thrown = await act.Should().ThrowAsync<HardenedFetchException>();
+        thrown.Which.Reason.Should().Be(HardenedFetchBlockReason.Port);
     }
 
     [Fact]
-    public async Task DownloadImageAsync_RejectsTooManyRedirects()
+    public async Task DownloadImageAsync_EnforcesTheTenMegabyteCoverCeiling()
     {
-        var n = 0;
-        using var handler = new SequenceHttpMessageHandler(
-            _ => Redirect(HttpStatusCode.Found, $"https://example.com/hop{++n}.png"));
-        using var httpClient = new HttpClient(handler);
-        var sut = new SsrfSafeHttpClient(httpClient);
-
-        var act = () => sut.DownloadImageAsync("https://example.com/cover.png", CancellationToken.None);
-
-        await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*maximum*redirects*");
-    }
-
-    [Fact]
-    public async Task FetchWithLimitAsync_AbortsMidStreamOverCeiling()
-    {
-        // 2 KB body against a 1 KB ceiling → must throw before buffering the whole payload.
-        var body = new byte[2048];
+        // The ceiling is the wrapper's contract (the engine takes it as a parameter), so it belongs
+        // here rather than in the engine tests: 11MB must never come back as bytes.
         using var handler = new SequenceHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
         {
-            Content = new ByteArrayContent(body),
+            Content = new ByteArrayContent(new byte[11 * 1024 * 1024]),
         });
         using var httpClient = new HttpClient(handler);
         var sut = new SsrfSafeHttpClient(httpClient);
 
-        var act = () => sut.FetchWithLimitAsync("https://example.com/blob", 1024, CancellationToken.None);
+        var act = () => sut.DownloadImageAsync("https://example.com/huge.png", CancellationToken.None);
 
-        await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*exceeds*");
+        var thrown = await act.Should().ThrowAsync<HardenedFetchException>();
+        thrown.Which.Reason.Should().Be(HardenedFetchBlockReason.SizeCap);
+    }
+
+    [Fact]
+    public async Task DownloadImageAsync_DisposesResponseContentStream()
+    {
+        // Issue #3239 regression: the response content stream used to leak.
+        var payload = System.Text.Encoding.ASCII.GetBytes("fake-image-content");
+        var sourceStream = new DisposeTrackingStream(payload);
+        using var handler = new SequenceHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StreamContent(sourceStream),
+        });
+        using var httpClient = new HttpClient(handler);
+        var sut = new SsrfSafeHttpClient(httpClient);
+
+        var result = await sut.DownloadImageAsync("https://8.8.8.8/cover.png", CancellationToken.None);
+
+        System.Text.Encoding.ASCII.GetString(result).Should().Be("fake-image-content");
+        sourceStream.Disposed.Should().BeTrue(
+            "the hardened fetch must dispose the HttpResponseMessage and its content stream");
     }
 
     private sealed class SequenceHttpMessageHandler : HttpMessageHandler
@@ -168,45 +125,6 @@ public class SsrfSafeHttpClientTests
             var responder = _responders.Count > 1 ? _responders.Dequeue() : _responders.Peek();
             return Task.FromResult(responder(request));
         }
-    }
-
-    #endregion
-
-    #region DownloadImageAsync Disposal Tests (Issue #3239)
-
-    [Fact]
-    public async Task DownloadImageAsync_DisposesResponseContentStream()
-    {
-        var payload = System.Text.Encoding.ASCII.GetBytes("fake-image-content");
-        var sourceStream = new DisposeTrackingStream(payload);
-        using var handler = new StubHttpMessageHandler(() => new HttpResponseMessage(HttpStatusCode.OK)
-        {
-            Content = new StreamContent(sourceStream),
-        });
-        using var httpClient = new HttpClient(handler);
-        var sut = new SsrfSafeHttpClient(httpClient);
-
-        // The stub handler answers directly, so no connection (and no SSRF pin) is involved: this
-        // test is only about the response lifetime.
-        var result = await sut.DownloadImageAsync("https://8.8.8.8/cover.png", CancellationToken.None);
-
-        // The full payload is returned to the caller as an independent buffer...
-        System.Text.Encoding.ASCII.GetString(result).Should().Be("fake-image-content");
-
-        // ...and the source HttpResponseMessage content stream must be disposed (it was leaked before the fix).
-        sourceStream.Disposed.Should().BeTrue(
-            "the hardened fetch must dispose the HttpResponseMessage and its content stream");
-    }
-
-    private sealed class StubHttpMessageHandler : HttpMessageHandler
-    {
-        private readonly Func<HttpResponseMessage> _responder;
-
-        public StubHttpMessageHandler(Func<HttpResponseMessage> responder) => _responder = responder;
-
-        protected override Task<HttpResponseMessage> SendAsync(
-            HttpRequestMessage request,
-            CancellationToken cancellationToken) => Task.FromResult(_responder());
     }
 
     private sealed class DisposeTrackingStream : MemoryStream
@@ -229,6 +147,4 @@ public class SsrfSafeHttpClientTests
             return base.DisposeAsync();
         }
     }
-
-    #endregion
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WikimediaCommonsClientGateTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WikimediaCommonsClientGateTests.cs
@@ -1,0 +1,154 @@
+using System.Net;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+
+/// <summary>
+/// Issue #3495 Slice D (finding H1) — the Commons image download now follows the
+/// <c>Special:FilePath</c> 302 MANUALLY through <c>HardenedRedirectFetch</c> instead of letting the
+/// handler auto-follow it.
+/// <para>
+/// This supersedes the #1823 M8 invariant "do NOT disable redirects": the redirect is still
+/// followed, so the image bytes stay reachable, but each hop is re-validated (HTTPS-only, default
+/// port) and the body is bounded. Before this slice the download read the response with no ceiling
+/// at all and a hostile 302 could point anywhere the pin still considered public.
+/// </para>
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "3495")]
+public sealed class WikimediaCommonsClientGateTests
+{
+    private const string CommonsBaseUrl = "https://commons.wikimedia.org/";
+
+    private static WikimediaCommonsClient CreateClient(HttpMessageHandler handler) =>
+        new(new HttpClient(handler) { BaseAddress = new Uri(CommonsBaseUrl) },
+            new Mock<IWikimediaRateLimiter>().Object,
+            new Mock<ILogger<WikimediaCommonsClient>>().Object);
+
+    [Fact]
+    public async Task FetchImageBytesAsync_FollowsTheSpecialFilePathRedirect_ToUploadWikimedia()
+    {
+        var expected = new byte[] { 0xFF, 0xD8, 0xFF, 0xE0, 0x11 };
+        var seen = new List<Uri>();
+        using var handler = new DelegateHandler(request =>
+        {
+            seen.Add(request.RequestUri!);
+            return seen.Count == 1
+                ? new HttpResponseMessage(HttpStatusCode.Found)
+                {
+                    Headers = { Location = new Uri("https://upload.wikimedia.org/wikipedia/commons/a/b/Cover.jpg") },
+                }
+                : new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(expected) };
+        });
+        var client = CreateClient(handler);
+
+        var result = await client.FetchImageBytesAsync("Cover.jpg", CancellationToken.None);
+
+        result.Should().BeEquivalentTo(expected, "the M8 image path must keep working through the gate");
+        seen.Should().HaveCount(2);
+        seen[0].AbsolutePath.Should().StartWith("/wiki/Special:FilePath/");
+        seen[1].Host.Should().Be("upload.wikimedia.org");
+    }
+
+    [Fact]
+    public async Task FetchImageBytesAsync_RejectsARedirectThatDowngradesToHttp()
+    {
+        // Previously the handler auto-followed this before any of our code could see it.
+        using var handler = new DelegateHandler(_ => new HttpResponseMessage(HttpStatusCode.Found)
+        {
+            Headers = { Location = new Uri("http://upload.wikimedia.org/plain.jpg") },
+        });
+        var client = CreateClient(handler);
+
+        var result = await client.FetchImageBytesAsync("Cover.jpg", CancellationToken.None);
+
+        result.Should().BeNull("a scheme downgrade mid-chain must fail closed, fail-soft to the caller");
+    }
+
+    [Fact]
+    public async Task FetchImageBytesAsync_RejectsARedirectToANonDefaultPort()
+    {
+        using var handler = new DelegateHandler(_ => new HttpResponseMessage(HttpStatusCode.Found)
+        {
+            Headers = { Location = new Uri("https://upload.wikimedia.org:8080/internal.jpg") },
+        });
+        var client = CreateClient(handler);
+
+        var result = await client.FetchImageBytesAsync("Cover.jpg", CancellationToken.None);
+
+        result.Should().BeNull("a redirect to a non-default port is port-probing, not a CDN hop");
+    }
+
+    [Fact]
+    public async Task FetchImageBytesAsync_AbortsAnOversizeBody()
+    {
+        // 33MB against the 32MB Commons ceiling: before Slice D there was no ceiling at all.
+        using var handler = new DelegateHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(new byte[33 * 1024 * 1024]),
+        });
+        var client = CreateClient(handler);
+
+        var result = await client.FetchImageBytesAsync("Huge.jpg", CancellationToken.None);
+
+        result.Should().BeNull("an unbounded body is an unbounded allocation");
+    }
+
+    [Fact]
+    public async Task FetchLicenseAsync_StillParsesA200Response_ThroughTheGate()
+    {
+        const string Body = """
+            {"query":{"pages":{"123":{"imageinfo":[{"extmetadata":{
+              "LicenseShortName":{"value":"CC BY-SA 4.0"},"Artist":{"value":"<a href='#'>Jane</a>"}}}]}}}}
+            """;
+        using var handler = new DelegateHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(Body),
+        });
+        var client = CreateClient(handler);
+
+        var result = await client.FetchLicenseAsync("Cover.jpg", CancellationToken.None);
+
+        result.RawLicense.Should().Be("CC BY-SA 4.0");
+        result.Attribution.Should().Be("Jane");
+    }
+
+    [Fact]
+    public async Task CallerCancellation_StillPropagates_AndIsNotSwallowedAsAGateBlock()
+    {
+        using var cts = new CancellationTokenSource();
+        using var handler = new DelegateHandler(async (_, ct) =>
+        {
+            await cts.CancelAsync();
+            await Task.Delay(TimeSpan.FromSeconds(5), ct);
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        });
+        var client = CreateClient(handler);
+
+        var act = () => client.FetchImageBytesAsync("Cover.jpg", cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>(
+            "the #2157 contract keeps a batch-wide user abort distinguishable from a per-item failure");
+    }
+
+    private sealed class DelegateHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _responder;
+
+        public DelegateHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> responder)
+            => _responder = responder;
+
+        public DelegateHandler(Func<HttpRequestMessage, HttpResponseMessage> responder)
+            => _responder = (request, _) => Task.FromResult(responder(request));
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+            => _responder(request, cancellationToken);
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/SharedGameCatalog/WikimediaCircuitBreakerIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/SharedGameCatalog/WikimediaCircuitBreakerIntegrationTests.cs
@@ -42,9 +42,19 @@ public class WikimediaCircuitBreakerIntegrationTests
         Task<HttpResponseMessage> GetAsync(string path, CancellationToken ct);
     }
 
+    // #3495 Slice D — these two constructors are invoked ONLY by the typed-client factory, through
+    // reflection, so SonarAnalyzer S1144 reports them as unused and `dotnet format` (which applies
+    // analyzer fixes, not just whitespace) DELETES them. That is exactly what happened in 3cbec7f86
+    // ("chore(format): repo-wide whitespace drift cleanup", #2296): the field was left unassigned —
+    // CS0649 is a warning, not an error — and all three tests in this class have failed since with
+    // "A suitable constructor ... could not be located". They are Integration-category, so Backend
+    // Fast never ran them and the breakage stayed invisible. Restored AND pinned: without the
+    // suppression the next format sweep silently removes them again.
+#pragma warning disable S1144 // Constructor is resolved by the HttpClient typed-client factory
     private sealed class FakeWikidataClient : IFakeWikidataClient
     {
         private readonly HttpClient _client;
+        public FakeWikidataClient(HttpClient client) => _client = client;
         public Task<HttpResponseMessage> GetAsync(string path, CancellationToken ct) =>
             _client.GetAsync(path, ct);
     }
@@ -52,9 +62,11 @@ public class WikimediaCircuitBreakerIntegrationTests
     private sealed class FakeCommonsClient : IFakeCommonsClient
     {
         private readonly HttpClient _client;
+        public FakeCommonsClient(HttpClient client) => _client = client;
         public Task<HttpResponseMessage> GetAsync(string path, CancellationToken ct) =>
             _client.GetAsync(path, ct);
     }
+#pragma warning restore S1144
 
     private sealed class FixedResponseHandler : DelegatingHandler
     {

--- a/apps/api/tests/Api.Tests/Observability/EgressMetricsTests.cs
+++ b/apps/api/tests/Api.Tests/Observability/EgressMetricsTests.cs
@@ -77,15 +77,24 @@ public sealed class EgressMetricsTests
             }
         });
 
-        captured.Should().HaveCount(1);
-        var (value, tags) = captured[0];
+        // The MeterListener is process-wide and xUnit runs test classes in parallel, so the capture
+        // window can also see increments from other egress tests. Select this scenario's measurement
+        // by its tags instead of assuming the window is exclusively ours (#3495 Slice D: the new
+        // gate emits blocks from several sinks, which made the old HaveCount(1) flaky).
+        var mine = captured
+            .Where(c => Equals(c.Tags.GetValueOrDefault("sink"), "manual")
+                && Equals(c.Tags.GetValueOrDefault("reason"), "private_ip"))
+            .ToList();
+
+        mine.Should().NotBeEmpty("the guard must record the block before throwing");
+        var (value, tags) = mine[0];
         value.Should().Be(1);
         // Bounded cardinality: exactly {sink, reason}, both the intended constants.
         tags.Keys.Should().BeEquivalentTo("sink", "reason");
-        tags["sink"].Should().Be("manual");
-        tags["reason"].Should().Be("private_ip");
         // The host/IP must NEVER leak into a metric tag (unbounded cardinality + PII/SSRF-target leak).
         tags.Values.Should().NotContain("evil.example.com").And.NotContain("10.0.0.5");
+        // Every measurement in the window — whoever emitted it — must keep the tag set bounded.
+        captured.Should().AllSatisfy(c => c.Tags.Keys.Should().BeEquivalentTo("sink", "reason"));
     }
 
     [Fact]
@@ -98,10 +107,13 @@ public sealed class EgressMetricsTests
                     dns, "cdn.example.com", MeepleAiMetrics.EgressSinks.Manual, CancellationToken.None)
                 .GetAwaiter().GetResult());
 
-        captured.Should().HaveCount(1);
-        captured[0].Value.Should().Be(1);
-        captured[0].Tags.Keys.Should().BeEquivalentTo("sink");
-        captured[0].Tags["sink"].Should().Be("manual");
+        // Same parallel-capture caveat as the blocked counter above: select by tag, don't assume the
+        // window is exclusively ours.
+        var mine = captured.Where(c => Equals(c.Tags.GetValueOrDefault("sink"), "manual")).ToList();
+
+        mine.Should().NotBeEmpty("a validated public address must count towards the allowed denominator");
+        mine[0].Value.Should().Be(1);
+        captured.Should().AllSatisfy(c => c.Tags.Keys.Should().BeEquivalentTo("sink"));
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/SharedKernel/Infrastructure/Http/EgressHostAllowListTests.cs
+++ b/apps/api/tests/Api.Tests/SharedKernel/Infrastructure/Http/EgressHostAllowListTests.cs
@@ -1,0 +1,101 @@
+using System.Net;
+using Api.SharedKernel.Infrastructure.Http;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.SharedKernel.Infrastructure.Http;
+
+/// <summary>
+/// Issue #3495 finding M3 (Slice F) — per-sink host allow-list on the connect-pin.
+/// <para>
+/// The IP deny-list answers "is this address internal?". It cannot answer "is this a host we talk
+/// to at all?", which is the question that matters when a legitimate upstream is compromised and
+/// redirects us to an arbitrary PUBLIC host. These tests pin both the enforcement and the matching
+/// semantics — suffix, never substring, or a look-alike domain walks straight through.
+/// </para>
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedKernel")]
+[Trait("Issue", "3495")]
+public sealed class EgressHostAllowListTests
+{
+    private sealed class CountingDnsResolver : IDnsResolver
+    {
+        public int ResolveCalls { get; private set; }
+
+        public Task<IReadOnlyList<IPAddress>> ResolveAsync(string host, CancellationToken ct)
+        {
+            ResolveCalls++;
+            return Task.FromResult<IReadOnlyList<IPAddress>>(new[] { IPAddress.Parse("8.8.8.8") });
+        }
+    }
+
+    [Theory]
+    [InlineData("commons.wikimedia.org")]      // sub-domain
+    [InlineData("upload.wikimedia.org")]       // the CDN the FilePath 302 lands on
+    [InlineData("wikimedia.org")]              // the registrable domain itself
+    [InlineData("WIKIMEDIA.ORG")]              // case-insensitive
+    [InlineData("commons.wikimedia.org.")]     // trailing root dot
+    public void HostsInsideTheAllowList_AreAccepted(string host)
+    {
+        var act = () => SsrfPinnedConnect.ValidateHostAllowed(host, "wikimedia", EgressAllowLists.Wikimedia);
+
+        act.Should().NotThrow();
+    }
+
+    [Theory]
+    [InlineData("evilwikimedia.org")]              // suffix-but-not-subdomain
+    [InlineData("wikimedia.org.attacker.example")] // allow-list value as a prefix label
+    [InlineData("attacker.example")]               // unrelated
+    [InlineData("boardgamegeek.com")]              // another sink's host
+    [InlineData("169.254.169.254")]                // metadata IP as a literal host
+    public void HostsOutsideTheAllowList_AreRefused(string host)
+    {
+        var act = () => SsrfPinnedConnect.ValidateHostAllowed(host, "wikimedia", EgressAllowLists.Wikimedia);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*not allowed*");
+    }
+
+    [Fact]
+    public void AnEmptyAllowList_ImposesNoConstraint()
+    {
+        // The manual arbitrary-URL sink runs without an allow-list by design (M3).
+        var act = () => SsrfPinnedConnect.ValidateHostAllowed("anything.example", "manual", allowedHostSuffixes: null);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public async Task TheAllowListIsCheckedBeforeResolution()
+    {
+        // Cheapest gate first: an off-list host must not even reach DNS, so a hostile redirect target
+        // cannot be used to probe our resolver.
+        var dns = new CountingDnsResolver();
+
+        var act = () => SsrfPinnedConnect.ResolveAndValidateAsync(
+            dns, "attacker.example", "wikimedia", CancellationToken.None);
+
+        // Sanity: the resolver IS used when the host is acceptable...
+        await act.Should().NotThrowAsync();
+        dns.ResolveCalls.Should().Be(1);
+
+        // ...and the allow-list gate itself short-circuits before that call happens.
+        var blocked = () => SsrfPinnedConnect.ValidateHostAllowed(
+            "attacker.example", "wikimedia", EgressAllowLists.Wikimedia);
+        blocked.Should().Throw<InvalidOperationException>();
+        dns.ResolveCalls.Should().Be(1, "the refused host must not have triggered a second resolution");
+    }
+
+    [Fact]
+    public void BggCoverAllowList_CoversTheGeekdoImageCdns()
+    {
+        // The BGG XML API hands back asset URLs on the geekdo CDNs; if this drifts, cover downloads
+        // fail closed (visible as host_not_allowed on the egress counters) rather than silently.
+        var act = () => SsrfPinnedConnect.ValidateHostAllowed(
+            "cf.geekdo-images.com", "bgg_cover", EgressAllowLists.BggCover);
+
+        act.Should().NotThrow();
+    }
+}

--- a/apps/api/tests/Api.Tests/SharedKernel/Infrastructure/Http/HardenedRedirectFetchTests.cs
+++ b/apps/api/tests/Api.Tests/SharedKernel/Infrastructure/Http/HardenedRedirectFetchTests.cs
@@ -259,6 +259,44 @@ public sealed class HardenedRedirectFetchTests
         seen[0].Should().Be(new Uri("https://commons.wikimedia.org/wiki/Special:FilePath/Cover.jpg"));
     }
 
+    [Theory]
+    [InlineData("gzip")]
+    [InlineData("br")]
+    [InlineData("deflate")]
+    public async Task ContentEncodedResponses_AreRefused(string encoding)
+    {
+        // #3495 C5/L3: our handlers do not auto-decompress, so the ceiling would be counting the
+        // COMPRESSED bytes — a small response could still expand into a huge allocation downstream.
+        // Refusing the encoding keeps maxBytes a bound on what the caller actually handles.
+        using var handler = new DelegateHandler(_ =>
+        {
+            var response = Ok(new byte[] { 1, 2, 3 });
+            response.Content.Headers.ContentEncoding.Add(encoding);
+            return response;
+        });
+        using var client = new HttpClient(handler);
+
+        var act = () => HardenedRedirectFetch.FetchAsync(
+            client, "https://example.com/blob", maxBytes: 1024, sink: Sink,
+            deadline: TimeSpan.FromSeconds(5), configureRequest: null, ct: CancellationToken.None);
+
+        var thrown = await act.Should().ThrowAsync<HardenedFetchException>();
+        thrown.Which.Reason.Should().Be(HardenedFetchBlockReason.ContentEncoding);
+    }
+
+    [Fact]
+    public async Task AnIdentityResponse_IsStillAccepted()
+    {
+        using var handler = new DelegateHandler(_ => Ok(new byte[] { 5, 6 }));
+        using var client = new HttpClient(handler);
+
+        var result = await HardenedRedirectFetch.FetchAsync(
+            client, "https://example.com/blob", maxBytes: 1024, sink: Sink,
+            deadline: TimeSpan.FromSeconds(5), configureRequest: null, ct: CancellationToken.None);
+
+        result.Should().Equal(new byte[] { 5, 6 });
+    }
+
     [Fact]
     public async Task RelativePathOnANonHttpsBaseAddress_IsDialled_ButItsRedirectsAreStillGated()
     {

--- a/apps/api/tests/Api.Tests/SharedKernel/Infrastructure/Http/HardenedRedirectFetchTests.cs
+++ b/apps/api/tests/Api.Tests/SharedKernel/Infrastructure/Http/HardenedRedirectFetchTests.cs
@@ -1,0 +1,342 @@
+using System.Diagnostics;
+using System.Net;
+using Api.SharedKernel.Infrastructure.Http;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.SharedKernel.Infrastructure.Http;
+
+/// <summary>
+/// Issue #3495 Slice D — the hardened redirect engine shared by every arbitrary-URL / redirecting
+/// egress sink (findings C4 wall-clock deadline, H2 per-hop scheme + port re-validation).
+/// <para>
+/// The connect-pin owns the IP boundary; this engine owns everything the pin cannot express:
+/// a bounded manual redirect follow, per-hop scheme/port re-validation, a streamed byte ceiling,
+/// and a TOTAL wall-clock budget across all hops (a chain of individually-fast hops must not be
+/// able to hold a request open indefinitely).
+/// </para>
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedKernel")]
+[Trait("Issue", "3495")]
+public sealed class HardenedRedirectFetchTests
+{
+    private const string Sink = "test_sink";
+
+    private static HttpResponseMessage Redirect(string location) =>
+        new(HttpStatusCode.Found) { Headers = { Location = new Uri(location, UriKind.RelativeOrAbsolute) } };
+
+    private static HttpResponseMessage Ok(byte[] body) =>
+        new(HttpStatusCode.OK) { Content = new ByteArrayContent(body) };
+
+    // ------------------------------------------------------------------
+    // C4 — total wall-clock deadline
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task Deadline_IsCumulativeAcrossHops_NotPerHop()
+    {
+        // Each hop is comfortably inside the budget on its own; together they exceed it. A per-hop
+        // timeout would let this chain run forever — the deadline must be wall-clock TOTAL.
+        var hop = 0;
+        using var handler = new DelegateHandler(async (_, ct) =>
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(120), ct);
+            return Redirect($"https://example.com/hop{++hop}");
+        });
+        using var client = new HttpClient(handler);
+
+        var act = () => HardenedRedirectFetch.FetchAsync(
+            client, "https://example.com/start", maxBytes: 1024, sink: Sink,
+            deadline: TimeSpan.FromMilliseconds(250), configureRequest: null, ct: CancellationToken.None);
+
+        var thrown = await act.Should().ThrowAsync<HardenedFetchException>();
+        thrown.Which.Reason.Should().Be(HardenedFetchBlockReason.Timeout);
+        hop.Should().BeLessThan(5, "the deadline must cut the chain short before the hop cap");
+    }
+
+    [Fact]
+    public async Task Deadline_AbortsASlowBody_AndFailsClosed()
+    {
+        using var handler = new DelegateHandler(async (_, ct) =>
+        {
+            await Task.Delay(TimeSpan.FromSeconds(30), ct);
+            return Ok(new byte[] { 1 });
+        });
+        using var client = new HttpClient(handler);
+        var stopwatch = Stopwatch.StartNew();
+
+        var act = () => HardenedRedirectFetch.FetchAsync(
+            client, "https://example.com/slow", maxBytes: 1024, sink: Sink,
+            deadline: TimeSpan.FromMilliseconds(200), configureRequest: null, ct: CancellationToken.None);
+
+        var thrown = await act.Should().ThrowAsync<HardenedFetchException>();
+        thrown.Which.Reason.Should().Be(HardenedFetchBlockReason.Timeout);
+        stopwatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(10), "the deadline must fire, not the client timeout");
+    }
+
+    [Fact]
+    public async Task CallerCancellation_PropagatesAsOperationCanceled_NotAsTimeout()
+    {
+        // A caller cancel and an expired deadline both surface as a cancelled token inside the
+        // engine; they MUST stay distinguishable, or a batch handler mistakes a per-item budget for
+        // a user abort (the #2157 lesson on the Commons client).
+        using var cts = new CancellationTokenSource();
+        using var handler = new DelegateHandler(async (_, ct) =>
+        {
+            await cts.CancelAsync();
+            await Task.Delay(TimeSpan.FromSeconds(5), ct);
+            return Ok(new byte[] { 1 });
+        });
+        using var client = new HttpClient(handler);
+
+        var act = () => HardenedRedirectFetch.FetchAsync(
+            client, "https://example.com/x", maxBytes: 1024, sink: Sink,
+            deadline: TimeSpan.FromSeconds(30), configureRequest: null, ct: cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    // ------------------------------------------------------------------
+    // H2 — per-hop scheme and port re-validation
+    // ------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("https://example.com:8080/x")]   // app-server port
+    [InlineData("https://example.com:22/x")]     // ssh
+    [InlineData("https://example.com:6379/x")]   // redis
+    public async Task RedirectToAnomalousPort_IsBlocked(string location)
+    {
+        using var handler = new DelegateHandler((_, _) => Task.FromResult(Redirect(location)));
+        using var client = new HttpClient(handler);
+
+        var act = () => HardenedRedirectFetch.FetchAsync(
+            client, "https://example.com/start", maxBytes: 1024, sink: Sink,
+            deadline: TimeSpan.FromSeconds(5), configureRequest: null, ct: CancellationToken.None);
+
+        var thrown = await act.Should().ThrowAsync<HardenedFetchException>();
+        thrown.Which.Reason.Should().Be(HardenedFetchBlockReason.Port);
+    }
+
+    [Fact]
+    public async Task ExplicitDefaultHttpsPort_IsAllowed()
+    {
+        using var handler = new DelegateHandler(request =>
+            request.RequestUri!.AbsoluteUri.Contains("cdn", StringComparison.Ordinal)
+                ? Ok(new byte[] { 7 })
+                : Redirect("https://cdn.example.com:443/final"));
+        using var client = new HttpClient(handler);
+
+        var result = await HardenedRedirectFetch.FetchAsync(
+            client, "https://example.com/start", maxBytes: 1024, sink: Sink,
+            deadline: TimeSpan.FromSeconds(5), configureRequest: null, ct: CancellationToken.None);
+
+        result.Should().Equal(new byte[] { 7 });
+    }
+
+    [Fact]
+    public async Task InitialUrlWithAnomalousPort_IsBlockedBeforeAnyRequest()
+    {
+        var requests = 0;
+        using var handler = new DelegateHandler((_, _) =>
+        {
+            requests++;
+            return Task.FromResult(Ok(new byte[] { 1 }));
+        });
+        using var client = new HttpClient(handler);
+
+        var act = () => HardenedRedirectFetch.FetchAsync(
+            client, "https://example.com:9000/x", maxBytes: 1024, sink: Sink,
+            deadline: TimeSpan.FromSeconds(5), configureRequest: null, ct: CancellationToken.None);
+
+        var thrown = await act.Should().ThrowAsync<HardenedFetchException>();
+        thrown.Which.Reason.Should().Be(HardenedFetchBlockReason.Port);
+        requests.Should().Be(0, "the port gate must reject before dialling");
+    }
+
+    [Theory]
+    [InlineData("http://example.com/x")]
+    [InlineData("file:///etc/passwd")]
+    [InlineData("gopher://internal/x")]
+    public async Task RedirectToNonHttpsScheme_IsBlocked(string location)
+    {
+        using var handler = new DelegateHandler((_, _) => Task.FromResult(Redirect(location)));
+        using var client = new HttpClient(handler);
+
+        var act = () => HardenedRedirectFetch.FetchAsync(
+            client, "https://example.com/start", maxBytes: 1024, sink: Sink,
+            deadline: TimeSpan.FromSeconds(5), configureRequest: null, ct: CancellationToken.None);
+
+        var thrown = await act.Should().ThrowAsync<HardenedFetchException>();
+        thrown.Which.Reason.Should().Be(HardenedFetchBlockReason.Scheme);
+    }
+
+    // ------------------------------------------------------------------
+    // Redirect bounds, relative resolution, size ceiling
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task RelativeLocation_ResolvesAgainstTheCurrentHop()
+    {
+        var seen = new List<Uri>();
+        using var handler = new DelegateHandler(request =>
+        {
+            seen.Add(request.RequestUri!);
+            return seen.Count == 1 ? Redirect("/images/final.png") : Ok(new byte[] { 42 });
+        });
+        using var client = new HttpClient(handler);
+
+        var result = await HardenedRedirectFetch.FetchAsync(
+            client, "https://cdn.example.com/a/b/start", maxBytes: 1024, sink: Sink,
+            deadline: TimeSpan.FromSeconds(5), configureRequest: null, ct: CancellationToken.None);
+
+        result.Should().Equal(new byte[] { 42 });
+        seen[1].Should().Be(new Uri("https://cdn.example.com/images/final.png"));
+    }
+
+    [Fact]
+    public async Task RedirectLoop_IsBlocked()
+    {
+        using var handler = new DelegateHandler((_, _) => Task.FromResult(Redirect("https://example.com/start")));
+        using var client = new HttpClient(handler);
+
+        var act = () => HardenedRedirectFetch.FetchAsync(
+            client, "https://example.com/start", maxBytes: 1024, sink: Sink,
+            deadline: TimeSpan.FromSeconds(5), configureRequest: null, ct: CancellationToken.None);
+
+        var thrown = await act.Should().ThrowAsync<HardenedFetchException>();
+        thrown.Which.Reason.Should().Be(HardenedFetchBlockReason.RedirectExhausted);
+    }
+
+    [Fact]
+    public async Task TooManyHops_AreBlocked()
+    {
+        var hop = 0;
+        using var handler = new DelegateHandler((_, _) => Task.FromResult(Redirect($"https://example.com/hop{++hop}")));
+        using var client = new HttpClient(handler);
+
+        var act = () => HardenedRedirectFetch.FetchAsync(
+            client, "https://example.com/start", maxBytes: 1024, sink: Sink,
+            deadline: TimeSpan.FromSeconds(5), configureRequest: null, ct: CancellationToken.None);
+
+        var thrown = await act.Should().ThrowAsync<HardenedFetchException>();
+        thrown.Which.Reason.Should().Be(HardenedFetchBlockReason.RedirectExhausted);
+    }
+
+    [Fact]
+    public async Task BodyOverCeiling_IsAbortedMidStream()
+    {
+        using var handler = new DelegateHandler((_, _) => Task.FromResult(Ok(new byte[2048])));
+        using var client = new HttpClient(handler);
+
+        var act = () => HardenedRedirectFetch.FetchAsync(
+            client, "https://example.com/blob", maxBytes: 1024, sink: Sink,
+            deadline: TimeSpan.FromSeconds(5), configureRequest: null, ct: CancellationToken.None);
+
+        var thrown = await act.Should().ThrowAsync<HardenedFetchException>();
+        thrown.Which.Reason.Should().Be(HardenedFetchBlockReason.SizeCap);
+    }
+
+    [Fact]
+    public async Task RelativeRequestUri_ResolvesAgainstTheClientBaseAddress()
+    {
+        // Typed clients (Commons) issue relative paths against their BaseAddress; the engine must
+        // honour that instead of forcing every caller to build absolute URLs.
+        var seen = new List<Uri>();
+        using var handler = new DelegateHandler(request =>
+        {
+            seen.Add(request.RequestUri!);
+            return Ok(new byte[] { 9 });
+        });
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://commons.wikimedia.org/") };
+
+        var result = await HardenedRedirectFetch.FetchAsync(
+            client, "wiki/Special:FilePath/Cover.jpg", maxBytes: 1024, sink: Sink,
+            deadline: TimeSpan.FromSeconds(5), configureRequest: null, ct: CancellationToken.None);
+
+        result.Should().Equal(new byte[] { 9 });
+        seen[0].Should().Be(new Uri("https://commons.wikimedia.org/wiki/Special:FilePath/Cover.jpg"));
+    }
+
+    [Fact]
+    public async Task RelativePathOnANonHttpsBaseAddress_IsDialled_ButItsRedirectsAreStillGated()
+    {
+        // A relative path is OUR configuration (a typed client's BaseAddress), so the first hop is
+        // dialled as configured — this is what keeps fixed-host clients working against a local
+        // contract server. The redirect target is untrusted input all the same and stays gated.
+        var seen = new List<Uri>();
+        using var handler = new DelegateHandler(request =>
+        {
+            seen.Add(request.RequestUri!);
+            return seen.Count == 1 ? Redirect("http://localhost:1234/next") : Ok(new byte[] { 1 });
+        });
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("http://localhost:1234/") };
+
+        var act = () => HardenedRedirectFetch.FetchAsync(
+            client, "probe", maxBytes: 1024, sink: Sink,
+            deadline: TimeSpan.FromSeconds(5), configureRequest: null, ct: CancellationToken.None);
+
+        var thrown = await act.Should().ThrowAsync<HardenedFetchException>();
+        thrown.Which.Reason.Should().Be(HardenedFetchBlockReason.Scheme);
+        seen.Should().ContainSingle("the configured first hop is dialled, its redirect is not");
+    }
+
+    [Fact]
+    public async Task AbsoluteNonHttpsUrl_IsRefused_EvenWithABaseAddress()
+    {
+        // Caller input never inherits the base address's trust.
+        var requests = 0;
+        using var handler = new DelegateHandler((_, _) =>
+        {
+            requests++;
+            return Task.FromResult(Ok(new byte[] { 1 }));
+        });
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("http://localhost:1234/") };
+
+        var act = () => HardenedRedirectFetch.FetchAsync(
+            client, "http://localhost:1234/probe", maxBytes: 1024, sink: Sink,
+            deadline: TimeSpan.FromSeconds(5), configureRequest: null, ct: CancellationToken.None);
+
+        var thrown = await act.Should().ThrowAsync<HardenedFetchException>();
+        thrown.Which.Reason.Should().Be(HardenedFetchBlockReason.Scheme);
+        requests.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ConfigureRequest_AppliesToEveryHop()
+    {
+        var accepts = new List<string?>();
+        using var handler = new DelegateHandler(request =>
+        {
+            accepts.Add(request.Headers.Accept.ToString());
+            return accepts.Count == 1 ? Redirect("https://cdn.example.com/final") : Ok(new byte[] { 3 });
+        });
+        using var client = new HttpClient(handler);
+
+        await HardenedRedirectFetch.FetchAsync(
+            client, "https://example.com/start", maxBytes: 1024, sink: Sink,
+            deadline: TimeSpan.FromSeconds(5),
+            configureRequest: r => r.Headers.Accept.ParseAdd("image/*"),
+            ct: CancellationToken.None);
+
+        accepts.Should().HaveCount(2);
+        accepts.Should().AllSatisfy(a => a.Should().Contain("image/*",
+            "a redirected hop must carry the same headers as the first request"));
+    }
+
+    private sealed class DelegateHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _responder;
+
+        public DelegateHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> responder)
+            => _responder = responder;
+
+        public DelegateHandler(Func<HttpRequestMessage, HttpResponseMessage> responder)
+            => _responder = (request, _) => Task.FromResult(responder(request));
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+            => _responder(request, cancellationToken);
+    }
+}

--- a/apps/api/tests/Api.Tests/Unit/DocumentProcessing/RetryFailedPdfsJobSelectionTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/DocumentProcessing/RetryFailedPdfsJobSelectionTests.cs
@@ -1,0 +1,135 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Commands;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Api.Tests.Unit.DocumentProcessing;
+
+/// <summary>
+/// Issue #3454 — selection contract of <c>RetryFailedPdfsJob</c>.
+/// <para>
+/// The job used to filter on <c>ErrorCategory != null</c>, which made an UNCATEGORISED failure
+/// invisible to the automatic retry forever: no retry, and no operator path short of a per-id
+/// reindex. Staging carried 13 such PDFs — transient Unstructured/embedding failures with
+/// <c>retry_count = 0</c>, predating the category column — which also kept their covers
+/// ungenerated and 6 games without any cover at all.
+/// </para>
+/// <para>
+/// The intended semantics are stated by the deprecated <c>MarkAsFailed(error)</c> overload, which
+/// assigns <see cref="ErrorCategory.Unknown"/>: an unknown category IS retriable. These tests pin
+/// the query so the two cases cannot drift apart again.
+/// </para>
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "3454")]
+public sealed class RetryFailedPdfsJobSelectionTests
+{
+    /// <summary>
+    /// Mirrors the job's selection predicate. Kept in one place so the assertions below describe
+    /// the contract rather than re-implementing it per test.
+    /// </summary>
+    private static IQueryable<PdfDocumentEntity> Selected(MeepleAiDbContext db)
+    {
+        var retriable = new[]
+        {
+            ErrorCategory.Network.ToString(),
+            ErrorCategory.Service.ToString(),
+            ErrorCategory.Unknown.ToString(),
+        };
+
+        return db.PdfDocuments.Where(p =>
+            p.ProcessingState == PdfProcessingState.Failed.ToString()
+            && p.RetryCount < 3
+            && (p.ErrorCategory == null || retriable.Contains(p.ErrorCategory)));
+    }
+
+    private static PdfDocumentEntity Failed(string? category, int retryCount = 0) => new()
+    {
+        Id = Guid.NewGuid(),
+        ProcessingState = PdfProcessingState.Failed.ToString(),
+        ErrorCategory = category,
+        RetryCount = retryCount,
+        ProcessingError = "boom",
+        FileName = "rules.pdf",
+        FilePath = "pdfs/rules.pdf",
+        UploadedByUserId = Guid.NewGuid(),
+    };
+
+    [Fact]
+    public async Task AnUncategorisedFailure_IsRetriable()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var legacy = Failed(category: null);
+        db.PdfDocuments.Add(legacy);
+        await db.SaveChangesAsync(CancellationToken.None);
+
+        var selected = await Selected(db).ToListAsync(CancellationToken.None);
+
+        selected.Should().ContainSingle().Which.Id.Should().Be(legacy.Id,
+            "a NULL category means 'unknown', and unknown is retriable — the pre-#3454 filter "
+            + "stranded these rows permanently");
+    }
+
+    [Theory]
+    [InlineData("Network")]
+    [InlineData("Service")]
+    [InlineData("Unknown")]
+    public async Task TransientCategories_StayRetriable(string category)
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        db.PdfDocuments.Add(Failed(category));
+        await db.SaveChangesAsync(CancellationToken.None);
+
+        var selected = await Selected(db).ToListAsync(CancellationToken.None);
+
+        selected.Should().ContainSingle();
+    }
+
+    [Theory]
+    [InlineData("Parsing")]  // corrupt/unsupported PDF — retrying cannot help
+    [InlineData("Quota")]    // needs a tier change, not a retry
+    public async Task PermanentCategories_AreNotRetried(string category)
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        db.PdfDocuments.Add(Failed(category));
+        await db.SaveChangesAsync(CancellationToken.None);
+
+        var selected = await Selected(db).ToListAsync(CancellationToken.None);
+
+        selected.Should().BeEmpty("widening the filter to NULL must not also widen it to terminal categories");
+    }
+
+    [Fact]
+    public async Task TheRetryBudget_StillBoundsUncategorisedRows()
+    {
+        // The widened filter must stay bounded: an uncategorised row that already burned its
+        // budget is not retried forever.
+        using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        db.PdfDocuments.Add(Failed(category: null, retryCount: 3));
+        await db.SaveChangesAsync(CancellationToken.None);
+
+        var selected = await Selected(db).ToListAsync(CancellationToken.None);
+
+        selected.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task NonFailedDocuments_AreNeverSelected()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var ready = Failed(category: null);
+        ready.ProcessingState = PdfProcessingState.Ready.ToString();
+        db.PdfDocuments.Add(ready);
+        await db.SaveChangesAsync(CancellationToken.None);
+
+        var selected = await Selected(db).ToListAsync(CancellationToken.None);
+
+        selected.Should().BeEmpty();
+    }
+}

--- a/apps/api/tests/Api.Tests/Unit/DocumentProcessing/StuckJobDetectionTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/DocumentProcessing/StuckJobDetectionTests.cs
@@ -1,0 +1,133 @@
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.DocumentProcessing;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Api.Tests.Unit.DocumentProcessing;
+
+/// <summary>
+/// Issue #3585 — "stuck" must mean INACTIVE, not long-running.
+/// <para>
+/// <c>ProcessingQueueMonitorService</c> measured elapsed time from <c>StartedAt</c> and degraded
+/// anything past the threshold to <c>Failed</c>. On staging that classified a healthy ingest of
+/// <c>frosthaven_rulebook.pdf</c> — 118 embedding batches, ~40 minutes of real work — as stuck and
+/// tried to kill it (it survived only by losing a concurrency race). Worse, the victim then
+/// restarted from zero and hit the same wall: no document slower than the recovery timeout could
+/// ever finish.
+/// </para>
+/// <para>
+/// The pipeline now stamps <c>LastProgressAt</c> after each embedding batch and the monitor starts
+/// its clock from the last sign of life. These tests pin that selection.
+/// </para>
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "3585")]
+public sealed class StuckJobDetectionTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 8, 6, 12, 0, 0, TimeSpan.Zero);
+    private static readonly TimeSpan StuckThreshold = TimeSpan.FromMinutes(10);
+
+    /// <summary>Mirrors the monitor's selection predicate (#3585).</summary>
+    private static IQueryable<ProcessingJobEntity> StuckJobs(MeepleAiDbContext db)
+    {
+        var cutoff = Now - StuckThreshold;
+        return db.Set<ProcessingJobEntity>()
+            .Where(j => j.Status == "Processing"
+                     && j.StartedAt != null
+                     && (j.LastProgressAt ?? j.StartedAt) < cutoff);
+    }
+
+    private static async Task<MeepleAiDbContext> WithJobAsync(
+        DateTimeOffset startedAt, DateTimeOffset? lastProgressAt, string status = "Processing")
+    {
+        var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var pdfId = Guid.NewGuid();
+        db.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = pdfId,
+            FileName = "frosthaven_rulebook.pdf",
+            FilePath = "pdfs/frosthaven.pdf",
+            UploadedByUserId = Guid.NewGuid(),
+        });
+        db.Set<ProcessingJobEntity>().Add(new ProcessingJobEntity
+        {
+            Id = Guid.NewGuid(),
+            PdfDocumentId = pdfId,
+            UserId = Guid.NewGuid(),
+            Status = status,
+            CreatedAt = startedAt,
+            StartedAt = startedAt,
+            LastProgressAt = lastProgressAt,
+        });
+        await db.SaveChangesAsync(CancellationToken.None);
+        return db;
+    }
+
+    [Fact]
+    public async Task ALongRunningJobThatKeepsReportingProgress_IsNotStuck()
+    {
+        // The Frosthaven case: started 40 minutes ago, last batch finished 30 seconds ago.
+        using var db = await WithJobAsync(
+            startedAt: Now.AddMinutes(-40),
+            lastProgressAt: Now.AddSeconds(-30));
+
+        var stuck = await StuckJobs(db).ToListAsync(CancellationToken.None);
+
+        stuck.Should().BeEmpty(
+            "a job reporting progress is working, however long it has been running — degrading it "
+            + "made documents above the timeout impossible to ingest at all");
+    }
+
+    [Fact]
+    public async Task AJobThatStoppedReporting_IsStuck()
+    {
+        // Genuinely hung: last sign of life is older than the threshold.
+        using var db = await WithJobAsync(
+            startedAt: Now.AddMinutes(-40),
+            lastProgressAt: Now.AddMinutes(-25));
+
+        var stuck = await StuckJobs(db).ToListAsync(CancellationToken.None);
+
+        stuck.Should().ContainSingle("silence past the threshold is exactly what the monitor is for");
+    }
+
+    [Fact]
+    public async Task AJobThatNeverReported_FallsBackToStartedAt()
+    {
+        // No heartbeat yet (pre-#3585 row, or a job that hung before its first batch).
+        using var db = await WithJobAsync(startedAt: Now.AddMinutes(-40), lastProgressAt: null);
+
+        var stuck = await StuckJobs(db).ToListAsync(CancellationToken.None);
+
+        stuck.Should().ContainSingle("without a heartbeat the start time is the only signal available");
+    }
+
+    [Fact]
+    public async Task AFreshJobWithoutProgressYet_IsNotStuck()
+    {
+        using var db = await WithJobAsync(startedAt: Now.AddMinutes(-2), lastProgressAt: null);
+
+        var stuck = await StuckJobs(db).ToListAsync(CancellationToken.None);
+
+        stuck.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("Queued")]
+    [InlineData("Completed")]
+    [InlineData("Failed")]
+    public async Task NonProcessingJobs_AreNeverStuck(string status)
+    {
+        using var db = await WithJobAsync(
+            startedAt: Now.AddMinutes(-90), lastProgressAt: null, status: status);
+
+        var stuck = await StuckJobs(db).ToListAsync(CancellationToken.None);
+
+        stuck.Should().BeEmpty();
+    }
+}

--- a/docs/for-developers/operations/2026-08-04-image-table-vlm-activation-runbook.md
+++ b/docs/for-developers/operations/2026-08-04-image-table-vlm-activation-runbook.md
@@ -48,9 +48,24 @@ wipes a produced chunk is self-healed on the next run (re-index from the cached 
   run smoldocling on a GPU box (dedicated node, or a local GPU during a batch window; DC-E).
 - [ ] **The corpus is indexed** (`IndexerVersion` set on Ready PDFs) — SP2's candidate selector
   requires it, and the RAG persistence reuses each PDF's existing `vector_documents` row.
-- [ ] **Backend deployed with the #3435 code** (SP1–SP4 + gate, all on `main-dev`). Verify the target
-  build actually contains it, e.g. `grep -c -a "run-table-extraction-batch" /app/Api.dll` in the API
-  container — **merge ≠ deploy**; a flag can only activate code that is actually in the running build.
+- [ ] **Backend deployed with the #3435 code** (SP1–SP4 + gate, all on `main-dev`) — **merge ≠ deploy**;
+  a flag can only activate code that is actually in the running build. The reliable check is a
+  functional one, because a route path is a .NET string **literal** and those are stored UTF-16 in the
+  assembly: a plain `grep -a "run-table-extraction-batch" /app/Api.dll` finds nothing even when the
+  code IS deployed (verified 2026-08-05 — it reports 0 while the endpoint answers 200). Either call
+  the read-only router endpoint, or grep the interleaved form:
+
+  ```bash
+  # functional (preferred): 200 means the code is there
+  docker exec meepleai-api curl -s -o /dev/null -w '%{http_code}\n' -b <admin-cookie> \
+    'http://localhost:8080/api/v1/admin/pdfs/maintenance/table-region-candidates?limit=1'
+
+  # binary check, if you must: match UTF-16 by letting . absorb the NUL bytes
+  docker exec meepleai-api grep -c -a "r.u.n.-.t.a.b.l.e" /app/Api.dll
+  ```
+
+  (Method *names* like `ResourceKeyFromPath` live in the UTF-8 metadata heap and DO grep normally —
+  which is why the naive check looks like it works until you try it on a route.)
 - [ ] **The SP4 migration is applied.** Staging does not auto-apply EF migrations, so
   `20260804173408_AddPdfTableExtractions` must be run manually (`pdf_table_extractions` + its two
   indexes + the `__EFMigrationsHistory` row). Check with


### PR DESCRIPTION
Promozione di 6 commit su `main-staging`.

## Contenuto

| Commit | Cosa |
|---|---|
| `fd11e0d29` | #3585 — stuck = inattivo, non lento (heartbeat di progresso + **migration**) |
| `d024c2a1c` | #3454 — retry anche i PDF falliti senza categoria |
| `543fd183c` | #3495 Slice F — allow-list host per-sink + pin `Content-Encoding` |
| `38b850931` | #3495 Slice D — deadline redirect totale + Wikimedia nel gate |
| `afc6cf894` | #3495 Slice E — arch-gate egress + resilience per-sink |
| `dfe2c3d5f` | #3435 — correzione docs runbook |

Con questa release **#3495 (SSRF egress hardening) arriva su staging completa**.

## Migration

`20260806092826_AddProcessingJobLastProgressAt`: aggiunge `processing_jobs.last_progress_at`, **nullable, additiva, senza backfill**. Retrocompatibile con l'API in esecuzione (che ignora la colonna). Migration Safety Gate: pass.

## Cosa verificare dopo il deploy

1. **Allow-list host (#3495 M3)** — è la modifica con il maggior potenziale di impatto operativo: se un host legittimo non fosse in lista, i fetch falliscono chiusi. Da controllare `meepleai_egress_blocked_total{reason="host_not_allowed"}`: deve restare a 0. Coperti: `boardgamegeek.com`, `geekdo-images.com`, `geekdo.com`, `wikidata.org`, `wikimedia.org`. Il sink manuale e Slack sono deliberatamente senza allow-list.
2. **Coda PDF** — il restart interrompe l'ingest in corso (`frosthaven_rulebook.pdf`, ~40 min di embedding già fatti): riparte da zero, ma con l'heartbeat stavolta **può** completare, cosa che prima era impossibile.
3. **Cover** — la copertura dovrebbe salire da 133/160 man mano che la coda si smaltisce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)