### PR TITLE
fix(docprocessing): degrade stuck job + recovery job orfani (#3588)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/DependencyInjection/DocumentProcessingServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/DependencyInjection/DocumentProcessingServiceExtensions.cs
@@ -217,6 +217,11 @@ internal static class DocumentProcessingServiceExtensions
         // Shared PDF processing pipeline (used by recovery job and future handler consolidation)
         services.AddScoped<IPdfProcessingPipelineService, PdfProcessingPipelineService>();
 
+        // Issue #3588: requeue processing_jobs orphaned by a restart. Registered BEFORE the stale-PDF
+        // recovery and with a shorter startup delay so orphans are back in the queue before that
+        // service starts reprocessing documents.
+        services.AddHostedService<OrphanedProcessingJobRecoveryService>();
+
         // Stale PDF recovery: runs once on startup to reprocess stuck PDFs
         services.AddHostedService<StalePdfRecoveryService>();
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Persistence/ProcessingJobRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Persistence/ProcessingJobRepository.cs
@@ -93,6 +93,37 @@ internal class ProcessingJobRepository : RepositoryBase, IProcessingJobRepositor
             .ConfigureAwait(false))
             .ToHashSet();
 
+        // Same reconciliation problem one level down, for log entries (Issue #3588). Mutations that
+        // append a log to an ALREADY-PERSISTED step — ProcessingJob.Fail() fails the running step,
+        // which calls ProcessingStep.AddLog() — produce a StepLogEntry with a fresh Guid hanging off
+        // a step whose Id is unchanged. The step-level loop below skips such steps, so the new log
+        // row stayed Modified and EF emitted UPDATE step_log_entries WHERE Id = @neverInsertedId →
+        // 0 rows → DbUpdateConcurrencyException. This made DegradeStuckJobCommandHandler fail 100%
+        // of the time against real jobs (which always have a Running step), reported as a bogus
+        // "concurrency conflict" even though processing_jobs declares no concurrency token at all.
+        var existingLogIds = existingStepIds.Count == 0
+            ? new HashSet<Guid>()
+            : (await DbContext.StepLogEntries
+                .AsNoTracking()
+                .Where(l => existingStepIds.Contains(l.ProcessingStepId))
+                .Select(l => l.Id)
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false))
+                .ToHashSet();
+
+        // The domain aggregate has no LastProgressAt (#3585 writes it out-of-band via
+        // ExecuteUpdateAsync from the pipeline heartbeat), so MapToPersistence cannot carry it and a
+        // detached Update would blank the column. Losing it would restart the monitor's idle clock
+        // from StartedAt and re-create the very "healthy ingest degraded as stuck" bug #3585 fixed —
+        // now that degrade actually works, that blanking would no longer be harmless. Round-trip the
+        // persisted value so the UPDATE writes it back unchanged.
+        entity.LastProgressAt = await DbContext.ProcessingJobs
+            .AsNoTracking()
+            .Where(j => j.Id == entity.Id)
+            .Select(j => j.LastProgressAt)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
         var incomingStepIds = entity.Steps.Select(s => s.Id).ToHashSet();
         var removedStepIds = existingStepIds.Where(id => !incomingStepIds.Contains(id)).ToList();
         if (removedStepIds.Count > 0)
@@ -113,12 +144,22 @@ internal class ProcessingJobRepository : RepositoryBase, IProcessingJobRepositor
         // entries) to Added so EF INSERTs them rather than UPDATE-ing rows that do not exist.
         foreach (var stepEntity in entity.Steps)
         {
-            if (existingStepIds.Contains(stepEntity.Id))
+            if (!existingStepIds.Contains(stepEntity.Id))
+            {
+                DbContext.Entry(stepEntity).State = EntityState.Added;
+                foreach (var log in stepEntity.LogEntries)
+                    DbContext.Entry(log).State = EntityState.Added;
                 continue;
+            }
 
-            DbContext.Entry(stepEntity).State = EntityState.Added;
+            // Step already persisted, but it may carry log entries appended in this unit of work
+            // (see the existingLogIds rationale above). Logs are append-only, so anything absent
+            // from the persisted set is new and must be INSERTed. Issue #3588.
             foreach (var log in stepEntity.LogEntries)
-                DbContext.Entry(log).State = EntityState.Added;
+            {
+                if (!existingLogIds.Contains(log.Id))
+                    DbContext.Entry(log).State = EntityState.Added;
+            }
         }
     }
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/OrphanedProcessingJobRecoveryService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/OrphanedProcessingJobRecoveryService.cs
@@ -1,0 +1,144 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.DocumentProcessing;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.DocumentProcessing.Infrastructure.Services;
+
+/// <summary>
+/// One-shot startup recovery for <c>processing_jobs</c> rows orphaned by a restart (Issue #3588).
+///
+/// The queue worker (<c>PdfProcessingQuartzJob</c>) runs in-process: when the container dies
+/// mid-pipeline, its row stays <c>Processing</c> forever. Nothing reclaimed it —
+/// <c>StalePdfRecoveryService</c> only resets <c>pdf_documents</c>, and the monitor's auto-degrade
+/// path was itself broken. Because the worker skips its whole cycle while
+/// <c>Processing &gt;= MaxConcurrentWorkers</c>, a couple of orphans permanently wedge the queue:
+/// on staging a single one blocked ingest for 96 minutes.
+///
+/// Requeue (not degrade to Failed) is the right reaction here: an orphan did not fail, it lost its
+/// worker. This mirrors the manual recovery applied on staging.
+///
+/// <para><b>Assumption — single API instance.</b> At boot no in-process worker can have survived,
+/// so every <c>Processing</c> row is by definition orphaned. Running several API replicas against
+/// one database would break that: a booting replica would requeue jobs another replica is actively
+/// working. That assumption already underpins <c>StalePdfRecoveryService</c>, which reprocesses
+/// every stale PDF at startup. Scaling out means gating both on a worker/lease identity.</para>
+/// </summary>
+internal sealed class OrphanedProcessingJobRecoveryService : BackgroundService
+{
+    /// <summary>
+    /// Short warm-up so migrations and the DB connection are ready. Deliberately shorter than
+    /// <c>StalePdfRecoveryService</c>'s 30s: orphans must be requeued before that service starts
+    /// reprocessing PDFs, so the two do not chase the same documents.
+    /// </summary>
+    private static readonly TimeSpan StartupDelay = TimeSpan.FromSeconds(10);
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<OrphanedProcessingJobRecoveryService> _logger;
+
+    public OrphanedProcessingJobRecoveryService(
+        IServiceScopeFactory scopeFactory,
+        ILogger<OrphanedProcessingJobRecoveryService> logger)
+    {
+        _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            await Task.Delay(StartupDelay, stoppingToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            return;
+        }
+
+        try
+        {
+            var recovered = await RecoverOrphanedJobsAsync(stoppingToken).ConfigureAwait(false);
+
+            if (recovered == 0)
+                _logger.LogInformation("[OrphanedJobRecovery] No orphaned Processing jobs found");
+            else
+                _logger.LogWarning(
+                    "[OrphanedJobRecovery] Requeued {Count} job(s) orphaned by a restart (Issue #3588)",
+                    recovered);
+        }
+#pragma warning disable CA1031 // Startup recovery must never crash the host
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogError(ex, "[OrphanedJobRecovery] Failed to recover orphaned processing jobs");
+        }
+#pragma warning restore CA1031
+    }
+
+    /// <summary>
+    /// Requeues every <c>Processing</c> job and rewinds its PDF so the pipeline can claim it again.
+    /// Exposed as internal for integration testing (InternalsVisibleTo Api.Tests).
+    /// </summary>
+    internal async Task<int> RecoverOrphanedJobsAsync(CancellationToken ct)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var orphans = await db.Set<ProcessingJobEntity>()
+            .AsNoTracking()
+            .Where(j => j.Status == nameof(JobStatus.Processing))
+            .Select(j => new { j.Id, j.PdfDocumentId })
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        if (orphans.Count == 0)
+            return 0;
+
+        var jobIds = orphans.Select(o => o.Id).ToList();
+        var pdfIds = orphans.Select(o => o.PdfDocumentId).Distinct().ToList();
+
+        // Both writes must land together. Requeuing the job while leaving its PDF in a mid-pipeline
+        // state would be worse than doing nothing: the worker would pick the job up, the pipeline's
+        // atomic Pending-claim would refuse a non-Pending document and return silently, and the
+        // worker would then mark the job Completed even though nothing was processed.
+        //
+        // CreateExecutionStrategy() is mandatory: production configures
+        // NpgsqlRetryingExecutionStrategy, which rejects user-opened transactions unless the whole
+        // unit is wrapped so a transient failure can retry it as a block.
+        var strategy = db.Database.CreateExecutionStrategy();
+
+        return await strategy.ExecuteAsync(async () =>
+        {
+            var tx = await db.Database.BeginTransactionAsync(ct).ConfigureAwait(false);
+            await using var _ = tx.ConfigureAwait(false);
+
+            var requeued = await db.Set<ProcessingJobEntity>()
+                .Where(j => jobIds.Contains(j.Id))
+                .ExecuteUpdateAsync(
+                    s => s
+                        .SetProperty(j => j.Status, nameof(JobStatus.Queued))
+                        .SetProperty(j => j.StartedAt, (DateTimeOffset?)null)
+                        .SetProperty(j => j.LastProgressAt, (DateTimeOffset?)null)
+                        .SetProperty(j => j.CurrentStep, (string?)null),
+                    ct)
+                .ConfigureAwait(false);
+
+            // Rewind only non-terminal documents: a PDF that reached Ready or Failed while its job
+            // row was left behind must keep its outcome.
+            await db.Set<PdfDocumentEntity>()
+                .Where(p => pdfIds.Contains(p.Id)
+                         && p.ProcessingState != nameof(PdfProcessingState.Ready)
+                         && p.ProcessingState != nameof(PdfProcessingState.Failed))
+                .ExecuteUpdateAsync(
+                    s => s
+                        .SetProperty(p => p.ProcessingState, nameof(PdfProcessingState.Pending))
+                        .SetProperty(p => p.ProcessingError, (string?)null),
+                    ct)
+                .ConfigureAwait(false);
+
+            await tx.CommitAsync(ct).ConfigureAwait(false);
+
+            return requeued;
+        }).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/Infrastructure/BackgroundServices/StalePdfRecoveryService.cs
+++ b/apps/api/src/Api/Infrastructure/BackgroundServices/StalePdfRecoveryService.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.DocumentProcessing.Application.Services;
 using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.DocumentProcessing;
 using Microsoft.EntityFrameworkCore;
 
 namespace Api.Infrastructure.BackgroundServices;
@@ -194,6 +195,13 @@ internal sealed class StalePdfRecoveryService : BackgroundService
             // seeded in deliberate non-Ready states for the dashboard demo; force-processing them
             // would only fail on the missing blob and flip them to Failed (→ seed_state partial_failed).
             .Where(p => !p.FilePath.StartsWith(PdfDocumentEntity.DemoMockFilePathPrefix))
+            // #3588: leave documents that are already waiting in the queue to the queue worker.
+            // OrphanedProcessingJobRecoveryService requeues restart-orphaned jobs just before this
+            // service runs; without this guard both would drive the same PDF, and this one would
+            // reset it to Pending mid-flight. Only Queued is excluded — a still-Processing row means
+            // that recovery did not run or failed, and this service stays the last line of defence.
+            .Where(p => !db.Set<ProcessingJobEntity>()
+                .Any(j => j.PdfDocumentId == p.Id && j.Status == nameof(JobStatus.Queued)))
             .Where(p =>
                 (p.ProcessingState == pendingState && p.UploadedAt < pendingCutoff) ||
                 ((p.ProcessingState == uploadingState ||

--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/DegradeStuckJobIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/DegradeStuckJobIntegrationTests.cs
@@ -245,4 +245,205 @@ public sealed class DegradeStuckJobIntegrationTests : IAsyncLifetime
         reloadedJob.CompletedAt.Should().NotBeNull(
             "CompletedAt written by job.Fail() via TimeProvider (DateTimeOffset.UtcNow) must persist without ArgumentException");
     }
+
+    /// <summary>
+    /// Regression guard for issue #3588: degrading a job that looks like a REAL one — five
+    /// pipeline steps, a non-null <c>CurrentStep</c>, and that step in <c>Running</c> — must
+    /// still persist Failed state.
+    ///
+    /// The sibling test above deliberately seeds <c>CurrentStep = null</c> and zero steps, so
+    /// <c>ProcessingJob.Fail()</c> skips the step-lookup branch. That is exactly the branch that
+    /// broke in production: failing the running step appends a brand-new <c>StepLogEntry</c>
+    /// (fresh <c>Guid</c>) to an ALREADY-PERSISTED step, and the repository's post-Update
+    /// reconciliation only flipped log entries of BRAND-NEW steps to <c>Added</c>. The new log row
+    /// therefore stayed <c>Modified</c> and EF emitted
+    /// <c>UPDATE step_log_entries … WHERE Id = &lt;never-inserted guid&gt;</c> → 0 rows affected →
+    /// <see cref="DbUpdateConcurrencyException"/>, caught by the handler and reported as a
+    /// "concurrency conflict". Every stuck job in staging hit this, every two minutes, forever.
+    ///
+    /// Note this is NOT an xmin/optimistic-concurrency failure: <c>processing_jobs</c> declares no
+    /// concurrency token at all.
+    /// </summary>
+    [Fact]
+    [Trait("Issue", "3588")]
+    public async Task Degrade_StuckJobWithRunningStep_PersistsFailedState_AndAppendsErrorLog()
+    {
+        // ── Arrange ──────────────────────────────────────────────────────────────
+        var pdfId = Guid.NewGuid();
+        var jobId = Guid.NewGuid();
+        var runningStepId = Guid.NewGuid();
+
+        _dbContext!.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = pdfId,
+            FileName = "stuck-with-steps.pdf",
+            FilePath = $"/test/stuck-steps-{pdfId:N}.pdf",
+            FileSizeBytes = 2_048,
+            ContentType = "application/pdf",
+            UploadedByUserId = TestUserId,
+            SharedGameId = TestGameId,
+            ProcessingState = nameof(PdfProcessingState.Embedding),
+            UploadedAt = DateTime.UtcNow.AddHours(-2),
+        });
+
+        // A realistic job: Processing, stalled mid-Embed, with all five steps persisted.
+        _dbContext.ProcessingJobs.Add(new ProcessingJobEntity
+        {
+            Id = jobId,
+            PdfDocumentId = pdfId,
+            UserId = TestUserId,
+            Status = "Processing",
+            Priority = 0,
+            CurrentStep = nameof(ProcessingStepType.Embed),
+            CreatedAt = DateTimeOffset.UtcNow.AddHours(-2),
+            StartedAt = DateTimeOffset.UtcNow.AddMinutes(-90),
+            MaxRetries = 3,
+        });
+
+        var stepOrder = new[]
+        {
+            ProcessingStepType.Upload,
+            ProcessingStepType.Extract,
+            ProcessingStepType.Chunk,
+            ProcessingStepType.Embed,
+            ProcessingStepType.Index,
+        };
+
+        foreach (var stepType in stepOrder)
+        {
+            var isRunning = stepType == ProcessingStepType.Embed;
+            var isDone = stepType < ProcessingStepType.Embed;
+
+            _dbContext.ProcessingSteps.Add(new ProcessingStepEntity
+            {
+                Id = isRunning ? runningStepId : Guid.NewGuid(),
+                ProcessingJobId = jobId,
+                StepName = stepType.ToString(),
+                Status = isRunning
+                    ? nameof(StepStatus.Running)
+                    : isDone ? nameof(StepStatus.Completed) : nameof(StepStatus.Pending),
+                StartedAt = isRunning || isDone ? DateTimeOffset.UtcNow.AddMinutes(-90) : null,
+                CompletedAt = isDone ? DateTimeOffset.UtcNow.AddMinutes(-89) : null,
+            });
+        }
+
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+
+        // ── Act ───────────────────────────────────────────────────────────────────
+        using var scope = _serviceProvider!.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+        var result = await mediator.Send(
+            new DegradeStuckJobCommand(jobId, 90.0),
+            TestCancellationToken);
+
+        // ── Assert ────────────────────────────────────────────────────────────────
+        result.Degraded.Should().BeTrue(
+            "a job with a Running step must degrade — appending the step's error log must be an "
+            + "INSERT, not an UPDATE against a row that was never inserted (#3588)");
+
+        var reloadedJob = await _dbContext.ProcessingJobs.AsNoTracking()
+            .FirstAsync(j => j.Id == jobId, TestCancellationToken);
+        reloadedJob.Status.Should().Be("Failed", "the stuck job must reach a terminal state");
+
+        var reloadedStep = await _dbContext.ProcessingSteps.AsNoTracking()
+            .FirstAsync(s => s.Id == runningStepId, TestCancellationToken);
+        reloadedStep.Status.Should().Be(nameof(StepStatus.Failed),
+            "the step that was Running when the job stalled must be marked Failed");
+
+        var logEntries = await _dbContext.StepLogEntries.AsNoTracking()
+            .Where(l => l.ProcessingStepId == runningStepId)
+            .ToListAsync(TestCancellationToken);
+        logEntries.Should().ContainSingle(
+            "ProcessingStep.Fail() appends exactly one error log entry, which must be INSERTed")
+            .Which.Level.Should().Be(nameof(StepLogLevel.Error));
+
+        // The step count must be unchanged: reconciliation must not delete or duplicate steps.
+        var stepCount = await _dbContext.ProcessingSteps.AsNoTracking()
+            .CountAsync(s => s.ProcessingJobId == jobId, TestCancellationToken);
+        stepCount.Should().Be(5, "degrading a job must not add or remove pipeline steps");
+    }
+
+    /// <summary>
+    /// Guard for the round-trip loss that #3588 exposed: <c>last_progress_at</c> (#3585) is written
+    /// out-of-band by the pipeline heartbeat via <c>ExecuteUpdateAsync</c> and has no counterpart on
+    /// the <c>ProcessingJob</c> aggregate, so a detached <c>MapToPersistence</c> → <c>Update</c>
+    /// round-trip would silently blank it. Blanking it restarts the monitor's idle clock from
+    /// <c>StartedAt</c>, which is exactly the false-positive "stuck" classification #3585 removed.
+    /// </summary>
+    [Fact]
+    [Trait("Issue", "3588")]
+    public async Task Update_AfterHeartbeat_PreservesLastProgressAt()
+    {
+        // ── Arrange ──────────────────────────────────────────────────────────────
+        var pdfId = Guid.NewGuid();
+        var jobId = Guid.NewGuid();
+        var heartbeat = new DateTimeOffset(2026, 8, 6, 11, 30, 0, TimeSpan.Zero);
+
+        _dbContext!.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = pdfId,
+            FileName = "heartbeat.pdf",
+            FilePath = $"/test/heartbeat-{pdfId:N}.pdf",
+            FileSizeBytes = 512,
+            ContentType = "application/pdf",
+            UploadedByUserId = TestUserId,
+            SharedGameId = TestGameId,
+            ProcessingState = nameof(PdfProcessingState.Embedding),
+            UploadedAt = DateTime.UtcNow.AddHours(-1),
+        });
+
+        _dbContext.ProcessingJobs.Add(new ProcessingJobEntity
+        {
+            Id = jobId,
+            PdfDocumentId = pdfId,
+            UserId = TestUserId,
+            Status = "Processing",
+            Priority = 0,
+            CurrentStep = nameof(ProcessingStepType.Embed),
+            CreatedAt = DateTimeOffset.UtcNow.AddHours(-2),
+            StartedAt = DateTimeOffset.UtcNow.AddMinutes(-90),
+            LastProgressAt = heartbeat, // written by the pipeline heartbeat (#3585)
+            MaxRetries = 3,
+        });
+
+        var embedStepId = Guid.NewGuid();
+        _dbContext.ProcessingSteps.Add(new ProcessingStepEntity
+        {
+            Id = embedStepId,
+            ProcessingJobId = jobId,
+            StepName = nameof(ProcessingStepType.Embed),
+            Status = nameof(StepStatus.Running),
+            StartedAt = DateTimeOffset.UtcNow.AddMinutes(-90),
+        });
+
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+
+        // ── Act ───────────────────────────────────────────────────────────────────
+        // Load through the real repository and write it back — the detached round-trip that every
+        // ProcessingJob mutation goes through. AddStepLog is used because it leaves the job in
+        // Processing, which is the only state in which blanking the heartbeat can do damage.
+        using var scope = _serviceProvider!.CreateScope();
+        var jobRepository = scope.ServiceProvider.GetRequiredService<IProcessingJobRepository>();
+        var unitOfWork = scope.ServiceProvider
+            .GetRequiredService<Api.SharedKernel.Infrastructure.Persistence.IUnitOfWork>();
+
+        var job = await jobRepository.GetByIdAsync(jobId, TestCancellationToken);
+        job.Should().NotBeNull();
+        job!.AddStepLog(ProcessingStepType.Embed, StepLogLevel.Info, "batch 42/118 embedded");
+        await jobRepository.UpdateAsync(job, TestCancellationToken);
+        await unitOfWork.SaveChangesAsync(TestCancellationToken);
+
+        // ── Assert ────────────────────────────────────────────────────────────────
+        var reloaded = await _dbContext.ProcessingJobs.AsNoTracking()
+            .FirstAsync(j => j.Id == jobId, TestCancellationToken);
+
+        var persistedLogs = await _dbContext.StepLogEntries.AsNoTracking()
+            .CountAsync(l => l.ProcessingStepId == embedStepId, TestCancellationToken);
+        persistedLogs.Should().Be(1, "the mutation under test must actually have been persisted");
+
+        reloaded.Status.Should().Be("Processing", "the job must still be in flight");
+        reloaded.LastProgressAt.Should().Be(heartbeat,
+            "an unrelated job mutation must not blank the progress heartbeat the monitor reads");
+    }
 }

--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/OrphanedProcessingJobRecoveryIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/OrphanedProcessingJobRecoveryIntegrationTests.cs
@@ -1,0 +1,232 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Services;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.DocumentProcessing;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Api.Tests.Integration.DocumentProcessing;
+
+/// <summary>
+/// Regression guard for issue #3588 (second defect): a <c>processing_jobs</c> row left
+/// <c>Processing</c> by a container restart is orphaned forever. The queue worker skips its entire
+/// cycle while <c>Processing &gt;= MaxConcurrentWorkers</c>, so a handful of orphans permanently
+/// wedge ingest — on staging one of them blocked it for 96 minutes.
+///
+/// Recovery must requeue (not fail) the job AND rewind its PDF, because the pipeline's atomic claim
+/// only accepts a <c>Pending</c> document: requeuing the job alone would have the worker pick it up,
+/// silently skip on the refused claim, and then mark the job <c>Completed</c> without doing any work.
+/// </summary>
+[Collection("Integration-GroupA")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "3588")]
+public sealed class OrphanedProcessingJobRecoveryIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _isolatedDbConnectionString = string.Empty;
+    private string _databaseName = string.Empty;
+    private MeepleAiDbContext? _dbContext;
+    private ServiceProvider? _serviceProvider;
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    private static readonly Guid TestUserId = new("A0000000-0000-0000-0000-000003588001");
+    private static readonly Guid TestGameId = new("B0000000-0000-0000-0000-000003588001");
+
+    public OrphanedProcessingJobRecoveryIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_orphan_jobs_{Guid.NewGuid():N}";
+        _isolatedDbConnectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(_isolatedDbConnectionString);
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        await _dbContext.Database.MigrateAsync(TestCancellationToken);
+        await SeedBaseDataAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_dbContext is not null)
+            await _dbContext.DisposeAsync();
+
+        if (_serviceProvider is not null)
+            await _serviceProvider.DisposeAsync();
+
+        if (!string.IsNullOrEmpty(_databaseName))
+        {
+            try
+            {
+                await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+            }
+            catch
+            {
+                // Best-effort cleanup — test isolation already achieved by isolated DB.
+            }
+        }
+    }
+
+    private async Task SeedBaseDataAsync()
+    {
+        _dbContext!.Users.Add(new UserEntity
+        {
+            Id = TestUserId,
+            Email = "orphan-job-test@meepleai.test",
+            DisplayName = "Orphan Job Test User",
+            Role = "user",
+            CreatedAt = DateTime.UtcNow,
+        });
+        _dbContext.SharedGames.Add(new SharedGameEntity
+        {
+            Id = TestGameId,
+            Title = "Orphan Job Test Game",
+            BggId = Guid.NewGuid().GetHashCode() & 0x7FFFFFFF,
+            YearPublished = 2024,
+            MinPlayers = 2,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 60,
+            CreatedAt = DateTime.UtcNow,
+        });
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+    }
+
+    private Guid SeedJob(string jobStatus, string pdfState, DateTimeOffset? startedAt)
+    {
+        var pdfId = Guid.NewGuid();
+        var jobId = Guid.NewGuid();
+
+        _dbContext!.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = pdfId,
+            FileName = $"orphan-{jobId:N}.pdf",
+            FilePath = $"/test/orphan-{jobId:N}.pdf",
+            FileSizeBytes = 1_024,
+            ContentType = "application/pdf",
+            UploadedByUserId = TestUserId,
+            SharedGameId = TestGameId,
+            ProcessingState = pdfState,
+            ProcessingError = "worker died mid-pipeline",
+            UploadedAt = DateTime.UtcNow.AddHours(-1),
+        });
+
+        _dbContext.ProcessingJobs.Add(new ProcessingJobEntity
+        {
+            Id = jobId,
+            PdfDocumentId = pdfId,
+            UserId = TestUserId,
+            Status = jobStatus,
+            Priority = 0,
+            CurrentStep = startedAt is null ? null : nameof(ProcessingStepType.Embed),
+            CreatedAt = DateTimeOffset.UtcNow.AddHours(-2),
+            StartedAt = startedAt,
+            LastProgressAt = startedAt,
+            MaxRetries = 3,
+        });
+
+        return jobId;
+    }
+
+    private OrphanedProcessingJobRecoveryService CreateService() =>
+        new(_serviceProvider!.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<OrphanedProcessingJobRecoveryService>.Instance);
+
+    [Fact]
+    public async Task Recover_OrphanedProcessingJob_RequeuesJobAndRewindsPdf()
+    {
+        // ── Arrange ──────────────────────────────────────────────────────────────
+        var orphanId = SeedJob("Processing", nameof(PdfProcessingState.Embedding),
+            DateTimeOffset.UtcNow.AddMinutes(-90));
+        await _dbContext!.SaveChangesAsync(TestCancellationToken);
+
+        // ── Act ───────────────────────────────────────────────────────────────────
+        var recovered = await CreateService().RecoverOrphanedJobsAsync(TestCancellationToken);
+
+        // ── Assert ────────────────────────────────────────────────────────────────
+        recovered.Should().Be(1);
+
+        var job = await _dbContext.ProcessingJobs.AsNoTracking()
+            .FirstAsync(j => j.Id == orphanId, TestCancellationToken);
+
+        job.Status.Should().Be(nameof(JobStatus.Queued),
+            "an orphan did not fail — it lost its worker, so it goes back in the queue");
+        job.StartedAt.Should().BeNull("the requeued job has not started yet");
+        job.LastProgressAt.Should().BeNull("the idle clock must restart with the new attempt");
+        job.CurrentStep.Should().BeNull("the pipeline restarts from the first step");
+
+        var pdf = await _dbContext.PdfDocuments.AsNoTracking()
+            .FirstAsync(p => p.Id == job.PdfDocumentId, TestCancellationToken);
+
+        pdf.ProcessingState.Should().Be(nameof(PdfProcessingState.Pending),
+            "the pipeline's atomic claim only accepts a Pending document; leaving it mid-pipeline "
+            + "would make the worker skip and then falsely mark the job Completed");
+        pdf.ProcessingError.Should().BeNull("the stale error from the killed worker must be cleared");
+    }
+
+    [Fact]
+    public async Task Recover_LeavesQueuedAndTerminalJobsUntouched()
+    {
+        // ── Arrange ──────────────────────────────────────────────────────────────
+        var queuedId = SeedJob("Queued", nameof(PdfProcessingState.Pending), startedAt: null);
+        var completedId = SeedJob("Completed", nameof(PdfProcessingState.Ready),
+            DateTimeOffset.UtcNow.AddHours(-1));
+        var failedId = SeedJob("Failed", nameof(PdfProcessingState.Failed),
+            DateTimeOffset.UtcNow.AddHours(-1));
+        await _dbContext!.SaveChangesAsync(TestCancellationToken);
+
+        // ── Act ───────────────────────────────────────────────────────────────────
+        var recovered = await CreateService().RecoverOrphanedJobsAsync(TestCancellationToken);
+
+        // ── Assert ────────────────────────────────────────────────────────────────
+        recovered.Should().Be(0, "only Processing rows can be orphaned by a restart");
+
+        var jobs = await _dbContext.ProcessingJobs.AsNoTracking()
+            .Where(j => j.Id == queuedId || j.Id == completedId || j.Id == failedId)
+            .ToDictionaryAsync(j => j.Id, TestCancellationToken);
+
+        jobs[queuedId].Status.Should().Be("Queued");
+        jobs[completedId].Status.Should().Be("Completed");
+        jobs[failedId].Status.Should().Be("Failed");
+
+        var readyPdf = await _dbContext.PdfDocuments.AsNoTracking()
+            .FirstAsync(p => p.Id == jobs[completedId].PdfDocumentId, TestCancellationToken);
+        readyPdf.ProcessingState.Should().Be(nameof(PdfProcessingState.Ready),
+            "a document that reached a terminal state must keep its outcome");
+    }
+
+    [Fact]
+    public async Task Recover_OrphanWhosePdfAlreadyReady_RequeuesJobButKeepsPdfReady()
+    {
+        // The worker died after the pipeline had persisted Ready but before it wrote the job row.
+        // Rewinding such a document would discard a completed, indexed ingest.
+        var orphanId = SeedJob("Processing", nameof(PdfProcessingState.Ready),
+            DateTimeOffset.UtcNow.AddMinutes(-45));
+        await _dbContext!.SaveChangesAsync(TestCancellationToken);
+
+        var recovered = await CreateService().RecoverOrphanedJobsAsync(TestCancellationToken);
+
+        recovered.Should().Be(1);
+
+        var job = await _dbContext.ProcessingJobs.AsNoTracking()
+            .FirstAsync(j => j.Id == orphanId, TestCancellationToken);
+        job.Status.Should().Be(nameof(JobStatus.Queued), "the job row must stop consuming a slot");
+
+        var pdf = await _dbContext.PdfDocuments.AsNoTracking()
+            .FirstAsync(p => p.Id == job.PdfDocumentId, TestCancellationToken);
+        pdf.ProcessingState.Should().Be(nameof(PdfProcessingState.Ready),
+            "a Ready document must not be rewound — its ingest already succeeded");
+    }
+}


### PR DESCRIPTION
Closes #3588.

## La diagnosi nell'issue era sbagliata, e cambiava il fix

L'issue ipotizzava la firma NoTracking/xmin (`AsTracking()` nel percorso di degrade). **`processing_jobs` non dichiara alcun concurrency token** — `ProcessingJobEntityConfiguration` non configura né `xmin` né `IsRowVersion`, quindi `AsTracking()` non avrebbe cambiato nulla.

La catena reale è deterministica, non una race:

1. `ProcessingJob.Fail()` fallisce lo step corrente → `ProcessingStep.Fail()` → `AddLog(...)` → nasce uno `StepLogEntry` con `Id = Guid.NewGuid()`.
2. `ProcessingJobRepository.UpdateAsync` fa `Update(entity)`, che marca **tutto il grafo** `Modified`, log nuovo incluso.
3. La riconciliazione del fix #2903 flippava ad `Added` solo i log degli step **nuovi** (`if (existingStepIds.Contains(...)) continue;`). Un log fresco appeso a uno step **già persistito** restava `Modified`.
4. EF emetteva `UPDATE step_log_entries … WHERE Id = <mai inserito>` → **0 righe** → `DbUpdateConcurrencyException`.

Ecco perché falliva su una riga che nessuno toccava, sempre, per 90+ minuti.

## Perché il test esistente passava

`DegradeStuckJobIntegrationTests` seeda `CurrentStep = null` e zero step, con il commento «so job.Fail() skips the step-lookup branch». Quel ramo saltato è esattamente quello che rompe in produzione: un job reale ha sempre 5 step e un `CurrentStep` valorizzato. Il nuovo test seeda un job realistico (5 step, quello corrente `Running`) ed **è stato verificato rosso prima del fix**, con l'esatto sintomo dell'issue (`Degraded == false`).

## Difetto 2 — job orfani dal restart

Il worker (`PdfProcessingQuartzJob`) salta l'intero ciclo finché `Processing >= MaxConcurrentWorkers`: pochi orfani wedgiano la coda in modo permanente, e nulla li recuperava (`StalePdfRecoveryService` tocca solo `pdf_documents`).

`OrphanedProcessingJobRecoveryService` (one-shot al boot) li rimette in **`Queued`**, non in `Failed`: un orfano non ha fallito, ha perso il worker — è il recupero già applicato a mano su staging, e rispetta il vincolo degrade-only del revert #2686 per il percorso a runtime.

Rimette in `Pending` **anche il PDF**, e nella stessa transazione: il claim atomico del pipeline accetta solo documenti `Pending`, quindi requeuare il solo job avrebbe fatto sì che il worker lo riprendesse, saltasse silenziosamente sul claim rifiutato e poi lo marcasse `Completed` senza aver processato nulla. I documenti già `Ready`/`Failed` non vengono riavvolti.

## Due correlati inclusi, perché attivati da questi fix

- **`MapToPersistence` non copiava `LastProgressAt`**: ogni round-trip detached azzerava l'heartbeat di #3585, riportando l'orologio del monitor a `StartedAt`. Finché il degrade era rotto era innocuo; ora non più. Il guard è verificato significativo (disattivando il fix, il test fallisce).
- **`StalePdfRecoveryService` salta i PDF con un job già `Queued`**: senza, i due recuperi guiderebbero lo stesso documento e questo lo resetterebbe a `Pending` a metà volo. Escluso solo `Queued` — un `Processing` residuo significa che il recovery non è girato, e questo servizio resta l'ultima linea di difesa.

## Verifica

- 3 test in `DegradeStuckJobIntegrationTests` (di cui 2 nuovi) — Postgres reale via Testcontainers.
- 3 test in `OrphanedProcessingJobRecoveryIntegrationTests` (nuovi): requeue + rewind, stati non-`Processing` intatti, PDF `Ready` non riavvolto.
- 74 test verdi sui percorsi toccati (`StalePdfRecovery`, `ProcessingJobRepository`, `ProcessingQueueMonitor`, `DegradeStuckJob`, `RetryJob`, `BulkReindex`, `QueueBackpressure`, `PdfProcessingQuartz`).

Il terzo test ha colto un errore che sarebbe esploso solo in produzione: `NpgsqlRetryingExecutionStrategy` rifiuta le transazioni user-initiated, ora avvolte in `CreateExecutionStrategy()`.

## Assunzione dichiarata

Il recovery al boot presume **una sola istanza API**: al boot nessun worker in-process può essere sopravvissuto, quindi ogni riga `Processing` è per definizione orfana. La stessa assunzione regge già `StalePdfRecoveryService`. Con più repliche sullo stesso DB andrebbero entrambi gated su un'identità di worker/lease — annotato nell'XML doc del servizio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)