### PR TITLE
test(docprocessing): guard di integrazione per l'heartbeat (#3585)

### DIFF
--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/ProgressHeartbeatIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/ProgressHeartbeatIntegrationTests.cs
@@ -1,0 +1,171 @@
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.DocumentProcessing;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.DocumentProcessing;
+
+/// <summary>
+/// Issue #3585 — proves the progress heartbeat actually WRITES on real Postgres.
+/// <para>
+/// The heartbeat is deliberately best-effort (wrapped in a catch so a failed beat never aborts an
+/// ingest), which means a broken write is INVISIBLE at runtime: on staging the column stayed NULL
+/// while jobs were embedding, with nothing in the logs above Debug. A unit test cannot catch that —
+/// the InMemory provider does not even support <c>ExecuteUpdate</c>. This test runs the exact
+/// statement the pipeline runs, against a real database, so a translation or type failure surfaces
+/// in CI instead of silently disabling the stuck-job protection.
+/// </para>
+/// </summary>
+[Collection("Integration-GroupA")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "3585")]
+public sealed class ProgressHeartbeatIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _isolatedDbConnectionString = string.Empty;
+    private string _databaseName = string.Empty;
+    private MeepleAiDbContext? _dbContext;
+    private ServiceProvider? _serviceProvider;
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    private static readonly Guid TestUserId = new("A0000000-0000-0000-0000-000003585001");
+
+    public ProgressHeartbeatIntegrationTests(SharedTestcontainersFixture fixture) => _fixture = fixture;
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_heartbeat_{Guid.NewGuid():N}";
+        _isolatedDbConnectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(_isolatedDbConnectionString);
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
+        await _dbContext.Database.MigrateAsync(TestCancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_dbContext is not null)
+        {
+            await _dbContext.DisposeAsync();
+        }
+
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+        }
+
+        if (!string.IsNullOrEmpty(_databaseName))
+        {
+            try
+            {
+                await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+            }
+            catch
+            {
+                // Best-effort cleanup — test isolation already achieved by isolated DB.
+            }
+        }
+    }
+
+    private async Task<(Guid PdfId, Guid JobId)> SeedProcessingJobAsync()
+    {
+        var db = _dbContext!;
+
+        db.Users.Add(new UserEntity
+        {
+            Id = TestUserId,
+            Email = $"heartbeat-{Guid.NewGuid():N}@test.local",
+            DisplayName = "Heartbeat Test",
+            PasswordHash = "x",
+            Role = "user",
+        });
+
+        var pdfId = Guid.NewGuid();
+        db.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = pdfId,
+            FileName = "big_rulebook.pdf",
+            FilePath = "pdfs/big_rulebook.pdf",
+            UploadedByUserId = TestUserId,
+            ProcessingState = "Embedding",
+        });
+
+        var jobId = Guid.NewGuid();
+        db.Set<ProcessingJobEntity>().Add(new ProcessingJobEntity
+        {
+            Id = jobId,
+            PdfDocumentId = pdfId,
+            UserId = TestUserId,
+            Status = "Processing",
+            CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-40),
+            StartedAt = DateTimeOffset.UtcNow.AddMinutes(-40),
+            LastProgressAt = null,
+        });
+
+        await db.SaveChangesAsync(TestCancellationToken);
+        db.ChangeTracker.Clear();
+        return (pdfId, jobId);
+    }
+
+    [Fact]
+    public async Task TheHeartbeatStatement_WritesLastProgressAt_OnRealPostgres()
+    {
+        var (pdfId, jobId) = await SeedProcessingJobAsync();
+        var db = _dbContext!;
+        var now = DateTimeOffset.UtcNow;
+
+        // EXACTLY the statement PdfProcessingPipelineService.ReportProgressAsync runs.
+        var affected = await db.Set<ProcessingJobEntity>()
+            .Where(j => j.PdfDocumentId == pdfId && j.Status == "Processing")
+            .ExecuteUpdateAsync(s => s.SetProperty(j => j.LastProgressAt, now), TestCancellationToken);
+
+        affected.Should().Be(1, "the heartbeat must update the active job for this PDF");
+
+        db.ChangeTracker.Clear();
+        var stored = await db.Set<ProcessingJobEntity>()
+            .AsNoTracking()
+            .FirstAsync(j => j.Id == jobId, TestCancellationToken);
+
+        stored.LastProgressAt.Should().NotBeNull("a NULL here means the stuck-job guard is disabled");
+        stored.LastProgressAt!.Value.Should().BeCloseTo(now, TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task TheHeartbeat_DoesNotTouchJobsInOtherStates()
+    {
+        var (pdfId, _) = await SeedProcessingJobAsync();
+        var db = _dbContext!;
+
+        var queuedJobId = Guid.NewGuid();
+        db.Set<ProcessingJobEntity>().Add(new ProcessingJobEntity
+        {
+            Id = queuedJobId,
+            PdfDocumentId = pdfId,
+            UserId = TestUserId,
+            Status = "Queued",
+            CreatedAt = DateTimeOffset.UtcNow,
+        });
+        await db.SaveChangesAsync(TestCancellationToken);
+        db.ChangeTracker.Clear();
+
+        var now = DateTimeOffset.UtcNow;
+        await db.Set<ProcessingJobEntity>()
+            .Where(j => j.PdfDocumentId == pdfId && j.Status == "Processing")
+            .ExecuteUpdateAsync(s => s.SetProperty(j => j.LastProgressAt, now), TestCancellationToken);
+
+        db.ChangeTracker.Clear();
+        var queued = await db.Set<ProcessingJobEntity>()
+            .AsNoTracking()
+            .FirstAsync(j => j.Id == queuedJobId, TestCancellationToken);
+
+        queued.LastProgressAt.Should().BeNull("only the in-flight job reports progress");
+    }
+}


### PR DESCRIPTION
Copertura postuma per #3585 (già chiusa e in produzione). Il test era stato scritto durante quel lavoro ma è rimasto **non committato**, quindi finora non girava in CI.

## Perché serve un test di integrazione, non uno unit

L'heartbeat è best-effort per scelta — avvolto in un `catch` così un beat fallito non aborta mai un ingest. Il rovescio è che una scrittura rotta è **invisibile a runtime**: su staging la colonna restava `NULL` mentre i job embeddavano, senza nulla nei log sopra `Debug`. Un unit test non può coglierlo: il provider InMemory non supporta nemmeno `ExecuteUpdate`.

Il test esegue **esattamente** lo statement di `PdfProcessingPipelineService.ReportProgressAsync` su Postgres reale, così un fallimento di traduzione o di tipo emerge in CI invece di disabilitare in silenzio la protezione sui job stuck. Il secondo caso copre il filtro di stato: solo il job in volo riporta progresso, un `Queued` sullo stesso PDF resta intatto.

## Modifiche rispetto al file trovato nel working tree

Aggiunto il drop del database isolato nel `DisposeAsync`, per coerenza con le altre classi di integrazione della suite (le altre lo fanno già; senza, i DB di test si accumulano nel container condiviso).

## Verifica

2/2 verdi in locale (Testcontainers, Postgres reale). Il test non dipende da #3591: usa `ExecuteUpdateAsync` diretto, non il repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)