### PR TITLE
fix(docprocessing): 413 non e' un errore di rete e non va ritentato (#3589)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/DTOs/PdfDocumentDto.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/DTOs/PdfDocumentDto.cs
@@ -22,7 +22,7 @@ internal record PdfDocumentDto(
     int RetryCount = 0, // Issue #5186: number of retries attempted
     int MaxRetries = 3, // Issue #5186: always 3 per domain model
     bool CanRetry = false,           // Issue #5186: true if state=Failed && retryCount < maxRetries
-    string? ErrorCategory = null,    // Issue #5186: "Network"|"Parsing"|"Quota"|"Service"|"Unknown"
+    string? ErrorCategory = null,    // Issue #5186: "Network"|"Parsing"|"Quota"|"Service"|"PayloadTooLarge"|"Unknown"
     string? ProcessingError = null,  // Issue #5186: human-readable error message
     string DocumentCategory = "Rulebook", // Issue #5443: pipeline routing category
     Guid? BaseDocumentId = null, // Issue #5444: linked base rulebook for expansion/errata

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/EnhancedPdfProcessingOrchestrator.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/EnhancedPdfProcessingOrchestrator.cs
@@ -373,7 +373,9 @@ internal class EnhancedPdfProcessingOrchestrator
     }
 
     /// <summary>
-    /// Creates paged validation failure result
+    /// Creates paged validation failure result. Only caller is the pre-flight file-size
+    /// check, which is permanent by construction (#3589 follow-up — see the non-paged
+    /// CreateFailure for the same reasoning).
     /// </summary>
     private static EnhancedPagedExtractionResult CreatePagedValidationFailureResult(string errorMessage, TimeSpan duration)
     {
@@ -386,7 +388,8 @@ internal class EnhancedPdfProcessingOrchestrator
             StageUsed: 0,
             StageName: "Validation",
             TotalDurationMs: (int)duration.TotalMilliseconds,
-            ErrorMessage: errorMessage);
+            ErrorMessage: errorMessage,
+            IsPermanentFailure: true);
     }
 
     /// <summary>
@@ -459,7 +462,8 @@ internal class EnhancedPdfProcessingOrchestrator
             StageUsed: stageUsed,
             StageName: stageName,
             TotalDurationMs: (int)totalDuration.TotalMilliseconds,
-            ErrorMessage: extractionResult.ErrorMessage);
+            ErrorMessage: extractionResult.ErrorMessage,
+            IsPermanentFailure: extractionResult.IsPermanentFailure);
     }
     /// <summary>
     /// Extracts text page-by-page using 3-stage fallback pipeline
@@ -687,7 +691,8 @@ internal class EnhancedPdfProcessingOrchestrator
             StageName: stageName,
             TotalDurationMs: (int)totalDuration.TotalMilliseconds,
             ErrorMessage: pagedResult.ErrorMessage,
-            StructuredElements: pagedResult.StructuredElements);
+            StructuredElements: pagedResult.StructuredElements,
+            IsPermanentFailure: pagedResult.IsPermanentFailure);
     }
 
     /// <summary>
@@ -829,7 +834,12 @@ internal record EnhancedExtractionResult(
     int StageUsed,
     string StageName,
     int TotalDurationMs,
-    string? ErrorMessage = null)
+    string? ErrorMessage = null,
+    // #3589 follow-up: mirrors ErrorMessage's existing convention — only the FINAL surfaced
+    // stage's flag survives (not an aggregate of all 3 stages). Without this, a permanent
+    // Stage-1 413 that falls through to a (deterministically non-permanent) Stage-3 Docnet
+    // failure would silently lose the signal downstream callers rely on for retry decisions.
+    bool IsPermanentFailure = false)
 {
     /// <summary>
     /// Creates success result from stage extraction
@@ -850,11 +860,14 @@ internal record EnhancedExtractionResult(
             StageUsed: stageUsed,
             StageName: stageName,
             TotalDurationMs: totalDurationMs,
-            ErrorMessage: result.ErrorMessage);
+            ErrorMessage: result.ErrorMessage,
+            IsPermanentFailure: result.IsPermanentFailure);
     }
 
     /// <summary>
-    /// Creates failure result with error message (defense in depth validation)
+    /// Creates failure result with error message (defense in depth validation). Only caller
+    /// is the pre-flight file-size check, which is permanent by construction — a file that
+    /// exceeds PdfProcessing:MaxFileSizeBytes won't shrink on retry (#3589 follow-up).
     /// </summary>
     public static EnhancedExtractionResult CreateFailure(string errorMessage)
     {
@@ -868,7 +881,8 @@ internal record EnhancedExtractionResult(
             StageUsed: 0,
             StageName: "None",
             TotalDurationMs: 0,
-            ErrorMessage: errorMessage);
+            ErrorMessage: errorMessage,
+            IsPermanentFailure: true);
     }
 }
 
@@ -885,7 +899,9 @@ internal record EnhancedPagedExtractionResult(
     string StageName,
     int TotalDurationMs,
     string? ErrorMessage = null,
-    IReadOnlyList<ExtractedElement>? StructuredElements = null)
+    IReadOnlyList<ExtractedElement>? StructuredElements = null,
+    // #3589 follow-up: see EnhancedExtractionResult.IsPermanentFailure.
+    bool IsPermanentFailure = false)
 {
     /// <summary>
     /// Creates success result from stage extraction
@@ -906,7 +922,8 @@ internal record EnhancedPagedExtractionResult(
             StageName: stageName,
             TotalDurationMs: totalDurationMs,
             ErrorMessage: result.ErrorMessage,
-            StructuredElements: result.StructuredElements);
+            StructuredElements: result.StructuredElements,
+            IsPermanentFailure: result.IsPermanentFailure);
     }
 }
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfExtractionFailedException.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfExtractionFailedException.cs
@@ -1,0 +1,18 @@
+namespace Api.BoundedContexts.DocumentProcessing.Application.Services;
+
+/// <summary>
+/// Thrown by <see cref="PdfProcessingPipelineService"/> when text extraction fails, carrying
+/// whether the failure is permanent (file will never succeed on retry — e.g. Unstructured 413)
+/// so the pipeline's catch-all can classify PdfDocument.ErrorCategory correctly instead of
+/// leaving it unset (silently treated as retriable by RetryFailedPdfsJob). Issue #3589.
+/// </summary>
+internal sealed class PdfExtractionFailedException : InvalidOperationException
+{
+    public bool IsPermanentFailure { get; }
+
+    public PdfExtractionFailedException(string message, bool isPermanentFailure)
+        : base(message)
+    {
+        IsPermanentFailure = isPermanentFailure;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
@@ -482,6 +482,20 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
             _logger.LogWarning(ex, "[PdfPipeline] Processing cancelled for PDF {PdfId}", pdfId);
             throw; // Let caller handle cancellation
         }
+        catch (PdfExtractionFailedException ex)
+        {
+            // #3589: this is the path RetryFailedPdfsJob and manual retry drive (via
+            // EnqueuePdfCommand → PdfProcessingQuartzJob → ProcessAsync). Before this fix
+            // ErrorCategory was left NULL here regardless of cause, which RetryFailedPdfsJob
+            // treats as retriable — a permanent 413 burned 3 full automatic retries on a file
+            // that will never shrink. Only permanent failures get a non-retryable category;
+            // transient ones keep the pre-existing NULL/retriable behavior.
+            _logger.LogError(ex,
+                "[PdfPipeline] Text extraction failed for PDF {PdfId} (permanent={IsPermanentFailure})",
+                pdfId, ex.IsPermanentFailure);
+            var category = ex.IsPermanentFailure ? ErrorCategory.PayloadTooLarge : (ErrorCategory?)null;
+            await TryMarkFailedAsync(pdfDocumentId, ex.Message, category).ConfigureAwait(false);
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "[PdfPipeline] Processing FAILED for PDF {PdfId}", pdfId);
@@ -543,8 +557,12 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
 
             if (!extractResult.Success)
             {
-                throw new InvalidOperationException(
-                    $"Text extraction failed: {extractResult.ErrorMessage}");
+                // #3589: PdfExtractionFailedException carries IsPermanentFailure so the
+                // catch-all in ProcessAsync can set the correct ErrorCategory (see that
+                // catch block for why a plain InvalidOperationException lost this signal).
+                throw new PdfExtractionFailedException(
+                    $"Text extraction failed: {extractResult.ErrorMessage}",
+                    extractResult.IsPermanentFailure);
             }
 
             var fullText = string.Join("\n\n", extractResult.PageChunks
@@ -1179,7 +1197,14 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
     /// Best-effort attempt to mark a PDF as failed. Used in catch blocks where
     /// the original DbContext may be in a bad state.
     /// </summary>
-    private async Task TryMarkFailedAsync(Guid pdfDocumentId, string errorMessage)
+    /// <param name="pdfDocumentId">The PDF document to mark as failed.</param>
+    /// <param name="errorMessage">Persisted (truncated to 500 chars) as ProcessingError.</param>
+    /// <param name="category">
+    /// #3589: when provided, persisted as PdfDocument.ErrorCategory so RetryFailedPdfsJob can
+    /// exclude permanent failures from automatic retry. Omitted (null) preserves the
+    /// pre-#3589 behavior of leaving ErrorCategory untouched (NULL — treated as retriable).
+    /// </param>
+    private async Task TryMarkFailedAsync(Guid pdfDocumentId, string errorMessage, ErrorCategory? category = null)
     {
         try
         {
@@ -1196,6 +1221,10 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
                     ? errorMessage[..500]
                     : errorMessage;
                 pdfDoc.ProcessedAt = _timeProvider.GetUtcNow().UtcDateTime;
+                if (category.HasValue)
+                {
+                    pdfDoc.ErrorCategory = category.Value.ToString();
+                }
                 await _db.SaveChangesAsync(CancellationToken.None).ConfigureAwait(false);
             }
         }

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Enums/ErrorCategory.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Enums/ErrorCategory.cs
@@ -31,6 +31,14 @@ public enum ErrorCategory
     Service = 4,
 
     /// <summary>
+    /// File exceeds the extraction service's size limit (e.g. HTTP 413).
+    /// Retry strategy: Never — permanent, the file will not shrink. Requires a capacity
+    /// decision (raise the service limit, split/compress the PDF) or operator action.
+    /// Issue #3589.
+    /// </summary>
+    PayloadTooLarge = 5,
+
+    /// <summary>
     /// Unclassified error: unexpected exception, unknown failure mode.
     /// Retry strategy: Treat as transient, allow retry with caution.
     /// </summary>

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/External/IPdfTextExtractor.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/External/IPdfTextExtractor.cs
@@ -44,7 +44,11 @@ internal record TextExtractionResult(
     int CharacterCount,
     bool OcrTriggered,
     ExtractionQuality Quality,
-    string? ErrorMessage = null)
+    string? ErrorMessage = null,
+    // #3589: true when the failure is permanent (e.g. Unstructured 413 — the file will
+    // never shrink on retry) so callers can classify it as non-retryable instead of
+    // leaving it eligible for RetryFailedPdfsJob's automatic backoff retries.
+    bool IsPermanentFailure = false)
 {
     public static TextExtractionResult CreateSuccess(
         string extractedText,
@@ -63,7 +67,7 @@ internal record TextExtractionResult(
             ErrorMessage: null);
     }
 
-    public static TextExtractionResult CreateFailure(string errorMessage)
+    public static TextExtractionResult CreateFailure(string errorMessage, bool isPermanentFailure = false)
     {
         return new TextExtractionResult(
             Success: false,
@@ -72,7 +76,8 @@ internal record TextExtractionResult(
             CharacterCount: 0,
             OcrTriggered: false,
             Quality: ExtractionQuality.VeryLow,
-            ErrorMessage: errorMessage);
+            ErrorMessage: errorMessage,
+            IsPermanentFailure: isPermanentFailure);
     }
 }
 
@@ -86,7 +91,9 @@ internal record PagedTextExtractionResult(
     int TotalCharacters,
     bool OcrTriggered,
     string? ErrorMessage = null,
-    IReadOnlyList<ExtractedElement>? StructuredElements = null)
+    IReadOnlyList<ExtractedElement>? StructuredElements = null,
+    // #3589: see TextExtractionResult.IsPermanentFailure.
+    bool IsPermanentFailure = false)
 {
     public static PagedTextExtractionResult CreateSuccess(
         IList<PageTextChunk> pageChunks,
@@ -105,7 +112,7 @@ internal record PagedTextExtractionResult(
             StructuredElements: structuredElements);
     }
 
-    public static PagedTextExtractionResult CreateFailure(string errorMessage)
+    public static PagedTextExtractionResult CreateFailure(string errorMessage, bool isPermanentFailure = false)
     {
         return new PagedTextExtractionResult(
             Success: false,
@@ -113,7 +120,8 @@ internal record PagedTextExtractionResult(
             TotalPages: 0,
             TotalCharacters: 0,
             OcrTriggered: false,
-            ErrorMessage: errorMessage);
+            ErrorMessage: errorMessage,
+            IsPermanentFailure: isPermanentFailure);
     }
 }
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/External/OrchestratedPdfTextExtractor.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/External/OrchestratedPdfTextExtractor.cs
@@ -40,7 +40,8 @@ internal class OrchestratedPdfTextExtractor : IPdfTextExtractor
             CharacterCount: enhancedResult.CharacterCount,
             OcrTriggered: enhancedResult.OcrTriggered,
             Quality: enhancedResult.Quality,
-            ErrorMessage: enhancedResult.ErrorMessage);
+            ErrorMessage: enhancedResult.ErrorMessage,
+            IsPermanentFailure: enhancedResult.IsPermanentFailure);
     }
 
     /// <summary>
@@ -61,7 +62,8 @@ internal class OrchestratedPdfTextExtractor : IPdfTextExtractor
             TotalCharacters: enhancedResult.TotalCharacters,
             OcrTriggered: enhancedResult.OcrTriggered,
             ErrorMessage: enhancedResult.ErrorMessage,
-            StructuredElements: enhancedResult.StructuredElements);
+            StructuredElements: enhancedResult.StructuredElements,
+            IsPermanentFailure: enhancedResult.IsPermanentFailure);
     }
 }
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/External/UnstructuredPdfTextExtractor.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/External/UnstructuredPdfTextExtractor.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -89,6 +90,19 @@ internal class UnstructuredPdfTextExtractor : IPdfTextExtractor, IRawHiResExtrac
         }
         catch (HttpRequestException ex)
         {
+            if (ex.StatusCode.HasValue)
+            {
+                // #3589: the connection succeeded and the service responded with an error
+                // status (e.g. 413 payload too large) — ex.Message already carries the
+                // status + body, no "Failed to connect" wrapping needed.
+                _logger.LogError(ex,
+                    "Unstructured service returned an error response. RequestId: {RequestId}, StatusCode: {StatusCode}",
+                    requestId, ex.StatusCode);
+                return TextExtractionResult.CreateFailure(
+                    ex.Message,
+                    isPermanentFailure: ex.StatusCode == HttpStatusCode.RequestEntityTooLarge);
+            }
+
             _logger.LogError(ex,
                 "HTTP request to Unstructured service failed. RequestId: {RequestId}",
                 requestId);
@@ -180,8 +194,15 @@ internal class UnstructuredPdfTextExtractor : IPdfTextExtractor, IRawHiResExtrac
                 response.StatusCode,
                 errorContent);
 
+            // #3589: carry the actual status code on the exception so callers can tell "the
+            // service answered with an error" (StatusCode set) apart from "the connection
+            // never succeeded" (StatusCode null, thrown by the HTTP stack itself) — collapsing
+            // both into the same "Failed to connect" message sent staging diagnosis toward
+            // network/DNS causes for what was actually a 413 response.
             throw new HttpRequestException(
-                $"Unstructured extraction failed with status {response.StatusCode}: {errorContent}");
+                $"Unstructured extraction failed with status {response.StatusCode}: {errorContent}",
+                inner: null,
+                statusCode: response.StatusCode);
         }
 
         return response;
@@ -282,6 +303,17 @@ internal class UnstructuredPdfTextExtractor : IPdfTextExtractor, IRawHiResExtrac
         }
         catch (HttpRequestException ex)
         {
+            if (ex.StatusCode.HasValue)
+            {
+                // #3589: see ExtractTextAsync's mirrored catch block.
+                _logger.LogError(ex,
+                    "Unstructured service (paged) returned an error response. RequestId: {RequestId}, StatusCode: {StatusCode}",
+                    requestId, ex.StatusCode);
+                return PagedTextExtractionResult.CreateFailure(
+                    ex.Message,
+                    isPermanentFailure: ex.StatusCode == HttpStatusCode.RequestEntityTooLarge);
+            }
+
             _logger.LogError(ex, "HTTP request to Unstructured service (paged) failed. RequestId: {RequestId}", requestId);
             return PagedTextExtractionResult.CreateFailure($"Failed to connect to Unstructured service: {ex.Message}");
         }

--- a/apps/api/src/Api/Infrastructure/Entities/DocumentProcessing/PdfDocumentEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/DocumentProcessing/PdfDocumentEntity.cs
@@ -47,7 +47,7 @@ public class PdfDocumentEntity
 
     // Issue #4216: Retry mechanism tracking
     public int RetryCount { get; set; }
-    public string? ErrorCategory { get; set; } // ErrorCategory enum: Network, Parsing, Quota, Service, Unknown
+    public string? ErrorCategory { get; set; } // ErrorCategory enum: Network, Parsing, Quota, Service, PayloadTooLarge, Unknown
     public string? FailedAtState { get; set; } // PdfProcessingState where failure occurred
 
     // PDF-03: Structured data extraction fields

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/EnhancedPdfProcessingOrchestratorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/EnhancedPdfProcessingOrchestratorTests.cs
@@ -179,6 +179,50 @@ public class EnhancedPdfProcessingOrchestratorTests
         stage3.CallCount.Should().Be(1);
     }
 
+    /// <summary>
+    /// #3589 follow-up: a review of the original fix flagged that IsPermanentFailure was
+    /// silently dropped by EnhancedExtractionResult/EnhancedPagedExtractionResult, which have
+    /// no such field. Mirrors ErrorMessage's existing behavior (only the FINAL surfaced
+    /// stage's message survives, not an aggregate of all 3 stages) — same convention, now
+    /// applied to IsPermanentFailure.
+    /// </summary>
+    [Fact]
+    public async Task AllStagesFail_Stage3Permanent_PropagatesIsPermanentFailure()
+    {
+        var stage1 = new FakeExtractor(success: false, quality: ExtractionQuality.VeryLow, text: "", errorMsg: "Stage1 error");
+        var stage2 = new FakeExtractor(success: false, quality: ExtractionQuality.VeryLow, text: "", errorMsg: "Stage2 error");
+        var stage3 = new FakeExtractor(success: false, quality: ExtractionQuality.VeryLow, text: "", errorMsg: "Stage3 error", isPermanentFailure: true);
+
+        var orchestrator = new EnhancedPdfProcessingOrchestrator(
+            stage1, stage2, stage3, _logger, _configuration, _options, _chunkingService);
+
+        await using var pdfStream = CreateDummyPdfStream();
+
+        var result = await orchestrator.ExtractTextWithFallbackAsync(pdfStream, cancellationToken: TestCancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.IsPermanentFailure.Should().BeTrue();
+    }
+
+    /// <summary>Paged counterpart of <see cref="AllStagesFail_Stage3Permanent_PropagatesIsPermanentFailure"/>.</summary>
+    [Fact]
+    public async Task AllStagesFailPaged_Stage3Permanent_PropagatesIsPermanentFailure()
+    {
+        var stage1 = new FakeExtractor(success: false, quality: ExtractionQuality.VeryLow, text: "", errorMsg: "Stage1 error");
+        var stage2 = new FakeExtractor(success: false, quality: ExtractionQuality.VeryLow, text: "", errorMsg: "Stage2 error");
+        var stage3 = new FakeExtractor(success: false, quality: ExtractionQuality.VeryLow, text: "", errorMsg: "Stage3 error", isPermanentFailure: true);
+
+        var orchestrator = new EnhancedPdfProcessingOrchestrator(
+            stage1, stage2, stage3, _logger, _configuration, _options, _chunkingService);
+
+        await using var pdfStream = CreateDummyPdfStream();
+
+        var result = await orchestrator.ExtractPagedTextWithFallbackAsync(pdfStream, cancellationToken: TestCancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.IsPermanentFailure.Should().BeTrue();
+    }
+
     [Fact]
     public async Task Stage1Exception_CatchesAndFallsBackToStage2()
     {
@@ -527,6 +571,7 @@ public class EnhancedPdfProcessingOrchestratorTests
         private readonly bool _throwException;
         private readonly int _pageCount;
         private readonly int _charsPerPage;
+        private readonly bool _isPermanentFailure;
 
         public int CallCount { get; private set; }
         public int PagedCallCount { get; private set; }
@@ -538,7 +583,8 @@ public class EnhancedPdfProcessingOrchestratorTests
             string? errorMsg = null,
             bool throwException = false,
             int pageCount = 10,
-            int charsPerPage = 100)
+            int charsPerPage = 100,
+            bool isPermanentFailure = false)
         {
             _success = success;
             _quality = quality;
@@ -547,6 +593,7 @@ public class EnhancedPdfProcessingOrchestratorTests
             _throwException = throwException;
             _pageCount = pageCount;
             _charsPerPage = charsPerPage;
+            _isPermanentFailure = isPermanentFailure;
         }
 
         public Task<TextExtractionResult> ExtractTextAsync(
@@ -571,7 +618,7 @@ public class EnhancedPdfProcessingOrchestratorTests
                     quality: _quality));
             }
 
-            return Task.FromResult(TextExtractionResult.CreateFailure(_errorMsg ?? "Fake extraction failed"));
+            return Task.FromResult(TextExtractionResult.CreateFailure(_errorMsg ?? "Fake extraction failed", _isPermanentFailure));
         }
 
         public Task<PagedTextExtractionResult> ExtractPagedTextAsync(
@@ -604,7 +651,7 @@ public class EnhancedPdfProcessingOrchestratorTests
                     ocrTriggered: false));
             }
 
-            return Task.FromResult(PagedTextExtractionResult.CreateFailure(_errorMsg ?? "Fake paged extraction failed"));
+            return Task.FromResult(PagedTextExtractionResult.CreateFailure(_errorMsg ?? "Fake paged extraction failed", _isPermanentFailure));
         }
     }
     private static MemoryStream CreateDummyPdfStream()

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineServiceExtractTextTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineServiceExtractTextTests.cs
@@ -1,0 +1,141 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
+using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Services;
+using Api.Services.Pdf;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Application.Services;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Services;
+
+/// <summary>
+/// #3589: staging burned 3 automatic retries on PDFs the Unstructured service permanently
+/// rejects with 413 (file too large). Root cause: this pipeline's extraction-failure path
+/// (used by RetryFailedPdfsJob and manual retry, via <see cref="ProcessAsync"/>) marked the
+/// PdfDocument Failed via direct EF mutation without ever setting ErrorCategory — leaving it
+/// NULL, which RetryFailedPdfsJob treats as retriable (see #3584). These tests pin that a
+/// permanent extraction failure now lands on ErrorCategory.PayloadTooLarge (excluded from
+/// RetryFailedPdfsJob's RetriableCategories), while a transient extraction failure keeps the
+/// pre-existing NULL/retriable behavior unchanged.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "3589")]
+public sealed class PdfProcessingPipelineServiceExtractTextTests : IDisposable
+{
+    private readonly MeepleAiDbContext _db;
+    private readonly Mock<IBlobStorageService> _blob = new();
+    private readonly Mock<IPdfClaimService> _claimService = new();
+    private readonly Mock<IPdfTextExtractor> _textExtractor = new();
+
+    public PdfProcessingPipelineServiceExtractTextTests()
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase($"PdfPipelineExtractText_{Guid.NewGuid()}")
+            .Options;
+        _db = new MeepleAiDbContext(options, new Mock<IMediator>().Object, new Mock<IDomainEventCollector>().Object);
+
+        _blob.Setup(b => b.RetrieveAsync(It.IsAny<string>(), BlobCategory.Pdf, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+             .ReturnsAsync(() => new MemoryStream(new byte[] { 0x25, 0x50, 0x44, 0x46 }));
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private async Task<PdfDocumentEntity> SeedPendingPdfAsync()
+    {
+        var pdf = new PdfDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            FileName = "big-rulebook.pdf",
+            FilePath = "/tmp/big-rulebook.pdf",
+            FileSizeBytes = 65_824_691,
+            ContentType = "application/pdf",
+            UploadedByUserId = Guid.NewGuid(),
+            UploadedAt = DateTime.UtcNow,
+            ProcessingState = "Pending",
+        };
+        _db.PdfDocuments.Add(pdf);
+        await _db.SaveChangesAsync();
+        return pdf;
+    }
+
+    private PdfProcessingPipelineService CreateSut()
+    {
+        return new PdfProcessingPipelineService(
+            db: _db,
+            pdfClaimService: _claimService.Object,
+            pdfTextExtractor: _textExtractor.Object,
+            tableExtractor: Mock.Of<IPdfTableExtractor>(),
+            chunkingService: Mock.Of<ITextChunkingService>(),
+            embeddingService: Mock.Of<IEmbeddingService>(),
+            blobStorageService: _blob.Object,
+            timeProvider: TimeProvider.System,
+            logger: NullLogger<PdfProcessingPipelineService>.Instance,
+            languageDetector: Mock.Of<ILanguageDetector>(),
+            chunkTranslationService: Mock.Of<IChunkTranslationService>(),
+            indexingPipeline: Mock.Of<IPdfIndexingPipeline>(),
+            raptorIndexer: null,
+            entityExtractor: null,
+            vectorStore: null,
+            featureFlagService: null,
+            roleClassifier: null,
+            pdfCoverExtractor: null,
+            eventCollector: Mock.Of<IDomainEventCollector>(),
+            pdfCoverUploadPipeline: null);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_PermanentExtractionFailure_MarksFailedWithPayloadTooLargeCategory()
+    {
+        var pdf = await SeedPendingPdfAsync();
+        _claimService.Setup(c => c.TryClaimPendingAsync(pdf.Id, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _textExtractor
+            .Setup(e => e.ExtractPagedTextAsync(It.IsAny<Stream>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PagedTextExtractionResult.CreateFailure(
+                "Unstructured extraction failed with status RequestEntityTooLarge: {\"detail\":{\"error\":{\"code\":\"FILE_TOO_LARGE\"}}}",
+                isPermanentFailure: true));
+
+        var sut = CreateSut();
+
+        await sut.ProcessAsync(pdf.Id, pdf.FilePath, pdf.UploadedByUserId, CancellationToken.None);
+
+        var reloaded = await _db.PdfDocuments.AsNoTracking().FirstAsync(p => p.Id == pdf.Id);
+        reloaded.ProcessingState.Should().Be("Failed");
+        reloaded.ErrorCategory.Should().Be(nameof(ErrorCategory.PayloadTooLarge));
+    }
+
+    /// <summary>
+    /// Regression pin: a transient extraction failure (e.g. Unstructured 500/timeout) must
+    /// keep the pre-#3589 behavior — ErrorCategory left NULL, which RetryFailedPdfsJob treats
+    /// as retriable (#3584). This fix targets ONLY the permanent case; it must not make
+    /// ordinary transient failures newly non-retryable.
+    /// </summary>
+    [Fact]
+    public async Task ProcessAsync_TransientExtractionFailure_LeavesErrorCategoryNull()
+    {
+        var pdf = await SeedPendingPdfAsync();
+        _claimService.Setup(c => c.TryClaimPendingAsync(pdf.Id, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _textExtractor
+            .Setup(e => e.ExtractPagedTextAsync(It.IsAny<Stream>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PagedTextExtractionResult.CreateFailure(
+                "Unstructured extraction failed with status InternalServerError: {}",
+                isPermanentFailure: false));
+
+        var sut = CreateSut();
+
+        await sut.ProcessAsync(pdf.Id, pdf.FilePath, pdf.UploadedByUserId, CancellationToken.None);
+
+        var reloaded = await _db.PdfDocuments.AsNoTracking().FirstAsync(p => p.Id == pdf.Id);
+        reloaded.ProcessingState.Should().Be("Failed");
+        reloaded.ErrorCategory.Should().BeNull();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/External/OrchestratedPdfTextExtractorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/External/OrchestratedPdfTextExtractorTests.cs
@@ -34,6 +34,16 @@ public class OrchestratedPdfTextExtractorTests
                 totalPages: 1, totalCharacters: 800, ocrTriggered: false, structuredElements: _elements));
     }
 
+    /// <summary>#3589 follow-up: every stage fails, the final (Stage 3) failure is permanent.</summary>
+    private sealed class AlwaysPermanentlyFailingExtractor : IPdfTextExtractor
+    {
+        public Task<TextExtractionResult> ExtractTextAsync(Stream s, bool ocr = true, CancellationToken ct = default) =>
+            Task.FromResult(TextExtractionResult.CreateFailure("permanent", isPermanentFailure: true));
+
+        public Task<PagedTextExtractionResult> ExtractPagedTextAsync(Stream s, bool ocr = true, CancellationToken ct = default) =>
+            Task.FromResult(PagedTextExtractionResult.CreateFailure("permanent", isPermanentFailure: true));
+    }
+
     private static Stream DummyPdf() =>
         new MemoryStream(System.Text.Encoding.ASCII.GetBytes("%PDF-1.4\ntest\n%%EOF"));
 
@@ -57,5 +67,52 @@ public class OrchestratedPdfTextExtractorTests
         result.Success.Should().BeTrue();
         result.StructuredElements.Should().NotBeNull();
         result.StructuredElements!.Single().Text.Should().Be("Preparazione");
+    }
+
+    /// <summary>
+    /// #3589 follow-up: IsPermanentFailure must survive the full Orchestrator round-trip
+    /// (IPdfTextExtractor → EnhancedPdfProcessingOrchestrator → OrchestratedPdfTextExtractor)
+    /// so a downstream PdfProcessingPipelineService.ExtractTextAsync sees the same signal it
+    /// gets from the direct (non-orchestrated) UnstructuredPdfTextExtractor.
+    /// </summary>
+    [Fact]
+    public async Task ExtractTextAsync_AllStagesPermanentlyFail_PropagatesIsPermanentFailure()
+    {
+        var orchestrator = new EnhancedPdfProcessingOrchestrator(
+            new AlwaysPermanentlyFailingExtractor(),
+            new AlwaysPermanentlyFailingExtractor(),
+            new AlwaysPermanentlyFailingExtractor(),
+            Mock.Of<ILogger<EnhancedPdfProcessingOrchestrator>>(),
+            new ConfigurationBuilder().Build(),
+            Options.Create(new PdfProcessingOptions { LargePdfThresholdBytes = 52428800, UseTempFileForLargePdfs = true }),
+            Mock.Of<ITextChunkingService>());
+        var adapter = new OrchestratedPdfTextExtractor(orchestrator);
+
+        await using var pdf = DummyPdf();
+        var result = await adapter.ExtractTextAsync(pdf, cancellationToken: TestCancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.IsPermanentFailure.Should().BeTrue();
+    }
+
+    /// <summary>Paged counterpart of <see cref="ExtractTextAsync_AllStagesPermanentlyFail_PropagatesIsPermanentFailure"/>.</summary>
+    [Fact]
+    public async Task ExtractPagedTextAsync_AllStagesPermanentlyFail_PropagatesIsPermanentFailure()
+    {
+        var orchestrator = new EnhancedPdfProcessingOrchestrator(
+            new AlwaysPermanentlyFailingExtractor(),
+            new AlwaysPermanentlyFailingExtractor(),
+            new AlwaysPermanentlyFailingExtractor(),
+            Mock.Of<ILogger<EnhancedPdfProcessingOrchestrator>>(),
+            new ConfigurationBuilder().Build(),
+            Options.Create(new PdfProcessingOptions { LargePdfThresholdBytes = 52428800, UseTempFileForLargePdfs = true }),
+            Mock.Of<ITextChunkingService>());
+        var adapter = new OrchestratedPdfTextExtractor(orchestrator);
+
+        await using var pdf = DummyPdf();
+        var result = await adapter.ExtractPagedTextAsync(pdf, cancellationToken: TestCancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.IsPermanentFailure.Should().BeTrue();
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/External/UnstructuredPdfTextExtractorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/External/UnstructuredPdfTextExtractorTests.cs
@@ -405,6 +405,10 @@ public class UnstructuredPdfTextExtractorTests
         // Assert
         result.Success.Should().BeFalse();
         result.ErrorMessage.Should().Contain("Failed to connect");
+        // #3589: a genuine transport failure (no HTTP status was ever received) has no
+        // StatusCode on the exception, so this really is a connection failure, not a
+        // masked service response — must not be flagged permanent.
+        result.IsPermanentFailure.Should().BeFalse();
     }
 
     [Fact]
@@ -457,10 +461,20 @@ public class UnstructuredPdfTextExtractorTests
         // Assert
         result.Success.Should().BeFalse();
         result.ErrorMessage.Should().NotBeNull();
+        // #3589: the service answered (with a 4xx), so the message must not claim a
+        // connection failure — and a 400 is not the specific permanent condition (413).
+        result.ErrorMessage.Should().NotContain("Failed to connect");
+        result.IsPermanentFailure.Should().BeFalse();
     }
 
+    /// <summary>
+    /// #3589: reproduces the staging incident where Unstructured rejects an oversized
+    /// PDF with 413 and the extractor (a) blamed a connection failure that never
+    /// happened and (b) gave the pipeline no way to know the failure is permanent —
+    /// RetryFailedPdfsJob burned 3 full retries on a file that will never shrink.
+    /// </summary>
     [Fact]
-    public async Task ExtractTextAsync_FileTooLarge_ReturnsFailureResult()
+    public async Task ExtractTextAsync_FileTooLarge_IsPermanentFailure_AndDoesNotClaimConnectionFailure()
     {
         // Arrange
         var extractor = CreateExtractor();
@@ -475,7 +489,8 @@ public class UnstructuredPdfTextExtractorTests
             .ReturnsAsync(new HttpResponseMessage
             {
                 StatusCode = HttpStatusCode.RequestEntityTooLarge,
-                Content = new StringContent("{}")
+                Content = new StringContent(
+                    "{\"detail\":{\"error\":{\"code\":\"FILE_TOO_LARGE\",\"message\":\"File size 65824691 bytes exceeds maximum 52428800 bytes\"}}}")
             });
 
         // Act
@@ -483,6 +498,9 @@ public class UnstructuredPdfTextExtractorTests
 
         // Assert
         result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().NotContain("Failed to connect");
+        result.ErrorMessage.Should().Contain("RequestEntityTooLarge");
+        result.IsPermanentFailure.Should().BeTrue();
     }
 
     [Fact]
@@ -703,6 +721,65 @@ public class UnstructuredPdfTextExtractorTests
         // Assert
         result.Success.Should().BeFalse();
         result.ErrorMessage.Should().NotBeNull();
+        result.ErrorMessage.Should().NotContain("Failed to connect");
+        result.IsPermanentFailure.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// #3589: same fix as <c>ExtractTextAsync_FileTooLarge_IsPermanentFailure_...</c> but
+    /// on the paged extraction path — <c>ExtractPagedTextAsync</c> has its own catch block.
+    /// </summary>
+    [Fact]
+    public async Task ExtractPagedTextAsync_FileTooLarge_IsPermanentFailure_AndDoesNotClaimConnectionFailure()
+    {
+        // Arrange
+        var extractor = CreateExtractor();
+        var pdfStream = CreateTestPdfStream();
+
+        _mockHttpMessageHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.RequestEntityTooLarge,
+                Content = new StringContent("{\"detail\":{\"error\":{\"code\":\"FILE_TOO_LARGE\"}}}")
+            });
+
+        // Act
+        var result = await extractor.ExtractPagedTextAsync(pdfStream, cancellationToken: TestCancellationToken);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().NotContain("Failed to connect");
+        result.IsPermanentFailure.Should().BeTrue();
+    }
+
+    /// <summary>#3589: genuine transport failure on the paged path must stay non-permanent.</summary>
+    [Fact]
+    public async Task ExtractPagedTextAsync_ConnectionFailure_IsNotPermanent()
+    {
+        // Arrange
+        var extractor = CreateExtractor();
+        var pdfStream = CreateTestPdfStream();
+
+        _mockHttpMessageHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("Connection refused"));
+
+        // Act
+        var result = await extractor.ExtractPagedTextAsync(pdfStream, cancellationToken: TestCancellationToken);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Failed to connect");
+        result.IsPermanentFailure.Should().BeFalse();
     }
 
     [Fact]


### PR DESCRIPTION
## Cosa risolve

Chiude #3589: quando Unstructured rifiuta un PDF con **413** (file troppo grande), succedevano due cose sbagliate:

1. **Messaggio fuorviante**: `UnstructuredPdfTextExtractor` avvolgeva ogni `HttpRequestException` — comprese quelle sollevate a mano per uno status non-2xx — nel messaggio `"Failed to connect to Unstructured service: ..."`. La connessione era riuscita, il servizio aveva risposto 413: la diagnosi finiva per puntare a rete/DNS invece che al reale errore applicativo.
2. **Ritentato inutilmente**: sul path di retry (`RetryFailedPdfsJob` / retry manuale, via `PdfProcessingPipelineService.ProcessAsync`) il fallimento veniva marcato `Failed` con `ErrorCategory` sempre `NULL` (mutazione EF diretta, mai passata dal dominio) — che `RetryFailedPdfsJob` tratta come retriable (comportamento voluto post-#3584 per le righe storiche non categorizzate). Un 413 permanente bruciava così 3 retry automatici con backoff su un file che non diventerà mai più piccolo.

## Fix

- `HttpRequestException` ora porta lo `StatusCode` reale (nuovo overload a 3 argomenti). I catch in `ExtractTextAsync`/`ExtractPagedTextAsync` distinguono: `StatusCode` presente → il servizio ha risposto, niente più wrapping "Failed to connect"; `StatusCode` assente → fallimento di trasporto genuino, messaggio invariato.
- `TextExtractionResult`/`PagedTextExtractionResult` espongono `IsPermanentFailure` (true per HTTP 413).
- Nuovo `ErrorCategory.PayloadTooLarge`, esclusa da `RetryFailedPdfsJob.RetriableCategories` → non più retriable automaticamente.
- `PdfProcessingPipelineService.ProcessAsync` classifica un'estrazione fallita in modo permanente con la nuova categoria (nuova `PdfExtractionFailedException` + catch dedicato); i fallimenti transitori mantengono il comportamento pre-esistente (NULL/retriable) — nessuna regressione sul resto della classificazione.
- **Follow-up da self-review**: il path `Orchestrator` (`EnhancedPdfProcessingOrchestrator` → `OrchestratedPdfTextExtractor`, non attivo in nessun deployment attuale — default `Docnet`, staging usa `Unstructured` diretto) perdeva silenziosamente `IsPermanentFailure` non avendo il campo sui suoi result record. Corretto per coerenza del contratto `IPdfTextExtractor`, stessa convenzione già usata per `ErrorMessage` (solo l'ultimo stadio tentato sopravvive, non un aggregato dei 3). Anche il controllo pre-flight sulla dimensione file è ora marcato permanente.

## Fuori scope (deliberato)

- `UploadPdfCommandHandler.Processing.cs` (path del primo upload) classifica già come `ErrorCategory.Parsing`, già non-retryable — non toccato perché non è la causa dei retry osservati (quelli passano dalla coda/retry pipeline).
- Retry manuale (bottone UI, `RetryPdfProcessingCommandHandler` via `PdfDocument.CanRetry()`) e bulk reindex (`BulkReindexFailedCommandHandler`) non consultano `ErrorCategory` — un PDF `PayloadTooLarge` resta comunque ritentabile da un umano tramite quei path. È una decisione di prodotto/UX (bloccare il bottone vs. solo segnalare) non richiesta dall'issue; da aprire come follow-up separato se si vuole.
- Fail-fast lato client sulla dimensione e la scelta capacitiva (alzare il limite del servizio / split PDF) — esplicitamente indicati come "decisione di prodotto" nell'issue stessa.

## Testing

TDD: ogni test aggiunto è stato verificato RED (fallisce per il motivo atteso — errore di compilazione per il nuovo campo, o assert su valore sbagliato) prima del fix, poi GREEN dopo.

- `UnstructuredPdfTextExtractorTests`: 413 → `IsPermanentFailure=true` + niente "Failed to connect"; connessione realmente fallita → `IsPermanentFailure=false` + messaggio invariato; 400/500 → non permanenti, messaggio non fuorviante. Copre sia `ExtractTextAsync` che `ExtractPagedTextAsync`.
- `PdfProcessingPipelineServiceExtractTextTests` (nuovo): guida il vero `ProcessAsync` pubblico (DB InMemory, mock su claim/extractor/blob) — fallimento permanente → `ErrorCategory="PayloadTooLarge"`; fallimento transitorio → `ErrorCategory=null` (pin di non-regressione).
- `EnhancedPdfProcessingOrchestratorTests` / `OrchestratedPdfTextExtractorTests`: propagazione end-to-end attraverso il path Orchestrator.

Suite `DocumentProcessing` (Unit): **669/669** verdi. Build `Api` pulita (0 warning, 0 errori). `dotnet format` sui soli file toccati: nessun diff.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>