### PR TITLE
feat(egress): wire delle reason di osservabilità mancanti (#3583)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommandHandler.cs
@@ -220,6 +220,10 @@ internal sealed class EnrichCatalogCoverCommandHandler
         }
         catch (ImageProcessingException ex)
         {
+            // #3583 — il payload scaricato da Commons è stato rifiutato dal decoder. L'esito
+            // (Failed/image_processing) resta invariato; qui si aggiunge la visibilità su egress.
+            MeepleAiMetrics.RecordEgressBlocked(
+                MeepleAiMetrics.EgressSinks.Wikimedia, MeepleAiMetrics.EgressBlockReasons.DecodeFail);
             EmitOutcomeMetric(OutcomeFailed, FailReasonImageProcessing);
             _logger.LogWarning(ex,
                 "SharedGame {GameId} QID {Qid} WebP encoding failed for file '{Filename}'.",

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandler.cs
@@ -73,6 +73,11 @@ internal sealed class SetManualCoverCommandHandler : ICommandHandler<SetManualCo
         // any path that reaches the handler without the FluentValidation pipeline. Reject BEFORE egress.
         if (BggHostDenyList.IsBanned(command.SourceUrl))
         {
+            // #3583 — raggiungibile solo se un percorso salta la pipeline FluentValidation (il
+            // validator rifiuta prima). Mutuamente esclusivo con il gate del validator, quindi una
+            // richiesta conta una volta sola.
+            MeepleAiMetrics.RecordEgressBlocked(
+                MeepleAiMetrics.EgressSinks.Manual, MeepleAiMetrics.EgressBlockReasons.DenylistHit);
             throw new ArgumentException(
                 "SourceUrl host is banned by ADR-059 §5 (BGG/geekdo assets).", nameof(command));
         }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandler.cs
@@ -4,6 +4,7 @@ using Api.BoundedContexts.SecurityAudit.Application.Services;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 using Api.Middleware.Exceptions;
+using Api.Observability;
 using Api.Services;
 using Api.Services.Pdf;
 using Api.SharedKernel.Application.Interfaces;
@@ -81,9 +82,21 @@ internal sealed class SetManualCoverCommandHandler : ICommandHandler<SetManualCo
 
         // Re-encode to WebP: normalizes the format AND drops the original container/metadata. The
         // license was whitelisted by the validator, so we persist the attested value below.
-        var webpBytes = await _webpGenerator
-            .GenerateWebpAsync(imageBytes, WebpTargetWidth, WebpTargetHeight, cancellationToken)
-            .ConfigureAwait(false);
+        byte[] webpBytes;
+        try
+        {
+            webpBytes = await _webpGenerator
+                .GenerateWebpAsync(imageBytes, WebpTargetWidth, WebpTargetHeight, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (ImageProcessingException)
+        {
+            // #3583 — il payload scaricato è stato rifiutato dal decoder (decompression bomb o coder
+            // non-raster, #3495 M1). Il rifiuto è corretto: qui lo si rende visibile.
+            MeepleAiMetrics.RecordEgressBlocked(
+                MeepleAiMetrics.EgressSinks.Manual, MeepleAiMetrics.EgressBlockReasons.DecodeFail);
+            throw;
+        }
 
         // Write to the deterministic manual physical key via the RAW-KEY path (the categorized
         // StoreAsync would reject the slash-containing key + mint an unresolvable random key).

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandValidator.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+using Api.Observability;
 using Api.SharedKernel.Infrastructure.Http;
 using FluentValidation;
 
@@ -24,13 +25,40 @@ internal sealed class SetManualCoverCommandValidator : AbstractValidator<SetManu
         RuleFor(x => x.SourceUrl)
             .NotEmpty().WithMessage("SourceUrl is required")
             .Must(BeAbsoluteHttps).WithMessage("SourceUrl must be an absolute HTTPS URL")
-            .Must(url => !BggHostDenyList.IsBanned(url))
+            .Must(url => !IsBannedAndRecorded(url))
             .WithMessage("SourceUrl host is banned by ADR-059 §5 (BGG/geekdo assets)");
 
         RuleFor(x => x.License)
             .NotEmpty().WithMessage("License is required")
             .Must(LicenseValidator.IsWhitelisted)
             .WithMessage("License must be on the whitelist (Public Domain / CC0 / CC-BY / CC-BY-SA)");
+    }
+
+    /// <summary>
+    /// #3583 — registra l'hit sulla deny-list ADR-059 §5 prima di far fallire la regola, così un
+    /// tentativo ripetuto di laundering attorno al ban BGG è visibile su
+    /// <c>meepleai_egress_blocked_total</c>. Il predicato conserva la semantica originale:
+    /// ritorna true quando l'URL è bandito (quindi la regola <c>Must(!…)</c> fallisce).
+    /// <para>
+    /// PRECONDIZIONE per la correttezza del conteggio: questo predicato viene valutato ESATTAMENTE
+    /// una volta per richiesta. Oggi è vero perché (a) il cascade rule-level è il default
+    /// <c>Continue</c> e la catena su SourceUrl esegue questo Must una sola volta, e (b) il validator
+    /// è invocato solo dal <c>ValidationBehavior</c> di MediatR, una volta per comando. È una
+    /// garanzia EMERGENTE, non protetta da un test: un secondo
+    /// <c>IValidator&lt;SetManualCoverCommand&gt;</c> registrato, o un endpoint filter che validi
+    /// prima di MediatR, farebbero raddoppiare il counter in silenzio.
+    /// </para>
+    /// </summary>
+    private static bool IsBannedAndRecorded(string? url)
+    {
+        if (!BggHostDenyList.IsBanned(url))
+        {
+            return false;
+        }
+
+        MeepleAiMetrics.RecordEgressBlocked(
+            MeepleAiMetrics.EgressSinks.Manual, MeepleAiMetrics.EgressBlockReasons.DenylistHit);
+        return true;
     }
 
     private static bool BeAbsoluteHttps(string? url) =>

--- a/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.Egress.cs
+++ b/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.Egress.cs
@@ -38,6 +38,8 @@ internal static partial class MeepleAiMetrics
         public const string RedirectExhausted = "redirect_exhausted";
         public const string SizeCap = "size_cap";
         public const string DecodeFail = "decode_fail";
+        /// <summary>La risoluzione DNS ha lanciato (NXDOMAIN, timeout del resolver, socket error) — #3583.</summary>
+        public const string DnsFailure = "dns_failure";
         public const string Timeout = "timeout";
         public const string BreakerOpen = "breaker_open";
         public const string Scheme = "scheme";

--- a/apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPinnedConnect.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPinnedConnect.cs
@@ -27,7 +27,30 @@ internal static class SsrfPinnedConnect
         string sink,
         CancellationToken ct)
     {
-        IReadOnlyList<IPAddress> addresses = await dns.ResolveAsync(host, ct).ConfigureAwait(false);
+        IReadOnlyList<IPAddress> addresses;
+        try
+        {
+            addresses = await dns.ResolveAsync(host, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException || !ct.IsCancellationRequested)
+        {
+            // #3583 — l'esito era già fail-closed (la connessione non avviene), ma senza questo
+            // counter un sink che degrada per problemi DNS è indistinguibile da un sink inattivo su
+            // meepleai_egress_blocked_total. Registra e RILANCIA: nessun esito cambia.
+            //
+            // Il filtro esclude la cancellazione iniziata dal chiamante — che non è un guasto di
+            // egress — pur continuando a contare un timeout interno del resolver (che si presenta
+            // come OperationCanceledException con un CTS proprio, quindi con `ct` non cancellato).
+            //
+            // Due limiti noti e accettati:
+            //   - se il chiamante cancella e il resolver risponde con SocketException invece che
+            //     OperationCanceledException, il caso viene contato come dns_failure;
+            //   - questo guard gira dentro il ConnectCallback, quindi UNA VOLTA PER CONNESSIONE:
+            //     ogni hop di redirect e ogni nuova connessione del pool incrementa. Il counter va
+            //     letto come rate di fallimenti di dial, MAI come "richieste utente fallite".
+            MeepleAiMetrics.RecordEgressBlocked(sink, MeepleAiMetrics.EgressBlockReasons.DnsFailure);
+            throw;
+        }
 
         if (addresses.Count == 0)
         {

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommandHandlerTests.cs
@@ -10,6 +10,7 @@ using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Providers;
 using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 using Api.Middleware.Exceptions;
+using Api.Observability;
 using Api.Services;
 using Api.Services.Pdf;
 using Api.SharedKernel.Infrastructure.Persistence;
@@ -399,6 +400,40 @@ public class EnrichCatalogCoverCommandHandlerTests
             Times.Never,
             "image-processing error short-circuits BEFORE R2 upload");
         harness.UowMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public void Handle_ImageProcessingError_RecordsDecodeFail_OnWikimediaSink()
+    {
+        // Stesso arrangiamento di Handle_ImageProcessingError_ReturnsFailedImageProcessingError.
+        // L'harness monta il VERO WebpVariantGenerator: sono i byte corrotti scaricati da Commons a
+        // farlo fallire (DetectRasterFormat -> null), non un mock che lancia.
+        var harness = BuildHarness();
+        var game = BuildGame(qid: TestQid);
+
+        harness.RepoMock
+            .Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(game);
+
+        harness.WikidataHandler.SparqlJson = BuildSparqlImageResponse(TestFilename);
+        harness.CommonsHandler.LicenseJson = BuildImageInfoResponse("CC0");
+        harness.CommonsHandler.ImageBytes = new byte[] { 0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE };
+
+        EnrichCatalogCoverResult? result = null;
+        var captured = Api.Tests.Observability.MetricCapture.Capture(
+            MeepleAiMetrics.EgressBlocked.Name,
+            () => result = harness.Sut
+                .Handle(new EnrichCatalogCoverCommand(game.Id), CancellationToken.None)
+                .GetAwaiter().GetResult());
+
+        // L'handler CATTURA ImageProcessingException e ritorna Failed: nessuna eccezione esce,
+        // quindi qui NON serve try/catch (a differenza del path manuale).
+        result.Should().BeOfType<EnrichCatalogCoverResult.Failed>();
+
+        captured
+            .Where(c => Equals(c.Tags.GetValueOrDefault("sink"), "wikimedia")
+                && Equals(c.Tags.GetValueOrDefault("reason"), "decode_fail"))
+            .Should().NotBeEmpty("il rifiuto del decoder su un'immagine Commons è un blocco di egress");
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandlerTests.cs
@@ -268,6 +268,39 @@ public sealed class SetManualCoverCommandHandlerTests
             .Should().NotBeEmpty("il rifiuto del decoder su un payload scaricato è un blocco di egress");
     }
 
+    [Fact]
+    public void Handle_BggHost_RecordsDenylistHit_AndNeverFetches()
+    {
+        // Gate difensivo (#3495 C6): raggiungibile solo saltando la pipeline FluentValidation, quindi
+        // qui si invoca l'handler direttamente. Deve rifiutare PRIMA di qualunque egress.
+        var game = NewGame();
+        _repository.Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>())).ReturnsAsync(game);
+        var banned = Command(game.Id) with { SourceUrl = "https://cf.geekdo-images.com/abc/cover.jpg" };
+
+        var captured = Api.Tests.Observability.MetricCapture.Capture(
+            MeepleAiMetrics.EgressBlocked.Name,
+            () =>
+            {
+                try
+                {
+                    CreateHandler().Handle(banned, CancellationToken.None).GetAwaiter().GetResult();
+                    throw new Xunit.Sdk.XunitException(
+                        "expected the ADR-059 deny-list to reject the host");
+                }
+                catch (ArgumentException)
+                {
+                    // atteso
+                }
+            });
+
+        captured
+            .Where(c => Equals(c.Tags.GetValueOrDefault("sink"), "manual")
+                && Equals(c.Tags.GetValueOrDefault("reason"), "denylist_hit"))
+            .Should().NotBeEmpty("anche il gate difensivo deve essere visibile");
+
+        _httpHandler.RequestCount.Should().Be(0, "il rifiuto deve precedere qualunque fetch");
+    }
+
     private sealed class StubImageHandler : HttpMessageHandler
     {
         public byte[] ImageBytes { get; set; } = Array.Empty<byte>();

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandlerTests.cs
@@ -5,6 +5,7 @@ using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 using Api.Middleware.Exceptions;
+using Api.Observability;
 using Api.Services;
 using Api.Services.Pdf;
 using Api.SharedKernel.Infrastructure.Persistence;
@@ -233,6 +234,40 @@ public sealed class SetManualCoverCommandHandlerTests
     /// Minimal egress stub: returns the configured image bytes on the first (non-redirect) hop and
     /// counts requests so tests can assert "no download happened" on the short-circuit paths.
     /// </summary>
+    [Fact]
+    public void Handle_NonRasterPayload_RecordsDecodeFail_OnManualSink()
+    {
+        var game = NewGame();
+        _repository.Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>())).ReturnsAsync(game);
+        // SVG: coder non-raster, rifiutato da DetectRasterFormat prima di raggiungere Magick (#3495 M1).
+        // Lo StubImageHandler dichiara Content-Type: image/png e il fetch non ispeziona i magic bytes,
+        // quindi il payload arriva davvero al decoder.
+        _httpHandler.ImageBytes = System.Text.Encoding.UTF8.GetBytes(
+            "<svg xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"10\" height=\"10\"/></svg>");
+
+        var captured = Api.Tests.Observability.MetricCapture.Capture(
+            MeepleAiMetrics.EgressBlocked.Name,
+            () =>
+            {
+                try
+                {
+                    CreateHandler().Handle(Command(game.Id), CancellationToken.None)
+                        .GetAwaiter().GetResult();
+                    throw new Xunit.Sdk.XunitException(
+                        "expected the decoder to reject the non-raster payload");
+                }
+                catch (ImageProcessingException)
+                {
+                    // atteso — l'handler registra e RILANCIA
+                }
+            });
+
+        captured
+            .Where(c => Equals(c.Tags.GetValueOrDefault("sink"), "manual")
+                && Equals(c.Tags.GetValueOrDefault("reason"), "decode_fail"))
+            .Should().NotBeEmpty("il rifiuto del decoder su un payload scaricato è un blocco di egress");
+    }
+
     private sealed class StubImageHandler : HttpMessageHandler
     {
         public byte[] ImageBytes { get; set; } = Array.Empty<byte>();

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandValidatorTests.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+using Api.Observability;
 using FluentAssertions;
 using FluentValidation.TestHelper;
 using Xunit;
@@ -83,6 +84,24 @@ public sealed class SetManualCoverCommandValidatorTests
         // Each URL is absolute-HTTPS with a whitelisted license, so ONLY the new host rule can reject it.
         _validator.TestValidate(Valid() with { SourceUrl = url })
             .ShouldHaveValidationErrorFor(x => x.SourceUrl);
+    }
+
+    [Fact]
+    public void Validate_BggHost_RecordsDenylistHit_OnManualSink()
+    {
+        // NOTA: Fails_WhenSourceUrlIsBannedBggHost qui sopra ha 5 [InlineData], ognuna delle quali
+        // emette una misurazione {manual, denylist_hit}. La finestra di MetricCapture è process-wide:
+        // asserire la presenza, MAI un conteggio esatto.
+        var captured = Api.Tests.Observability.MetricCapture.Capture(
+            MeepleAiMetrics.EgressBlocked.Name,
+            () => _validator
+                .TestValidate(Valid() with { SourceUrl = "https://cf.geekdo-images.com/abc/cover.jpg" })
+                .ShouldHaveValidationErrorFor(x => x.SourceUrl));
+
+        captured
+            .Where(c => Equals(c.Tags.GetValueOrDefault("sink"), "manual")
+                && Equals(c.Tags.GetValueOrDefault("reason"), "denylist_hit"))
+            .Should().NotBeEmpty("un tentativo di aggirare il ban BGG deve essere visibile");
     }
 
     [Theory]

--- a/apps/api/tests/Api.Tests/Observability/EgressMetricsTests.cs
+++ b/apps/api/tests/Api.Tests/Observability/EgressMetricsTests.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.Metrics;
 using System.Net;
 using Api.Observability;
 using Api.SharedKernel.Infrastructure.Http;
@@ -25,34 +24,12 @@ public sealed class EgressMetricsTests
             Task.FromResult(_addresses);
     }
 
-    private static List<(long Value, IReadOnlyDictionary<string, object?> Tags)> Capture(
-        string instrumentName, Action act)
+    private sealed class ThrowingDnsResolver : IDnsResolver
     {
-        var captured = new List<(long, IReadOnlyDictionary<string, object?>)>();
-        using var listener = new MeterListener
-        {
-            InstrumentPublished = (instrument, l) =>
-            {
-                if (instrument.Name == instrumentName)
-                {
-                    l.EnableMeasurementEvents(instrument);
-                }
-            },
-        };
-        listener.SetMeasurementEventCallback<long>((_, value, tags, _) =>
-        {
-            var dict = new Dictionary<string, object?>(StringComparer.Ordinal);
-            foreach (var t in tags)
-            {
-                dict[t.Key] = t.Value;
-            }
-            captured.Add((value, dict));
-        });
-        listener.Start();
-
-        act();
-
-        return captured;
+        private readonly Exception _toThrow;
+        public ThrowingDnsResolver(Exception toThrow) => _toThrow = toThrow;
+        public Task<IReadOnlyList<IPAddress>> ResolveAsync(string host, CancellationToken ct) =>
+            Task.FromException<IReadOnlyList<IPAddress>>(_toThrow);
     }
 
     [Fact]
@@ -60,7 +37,7 @@ public sealed class EgressMetricsTests
     {
         var dns = new FakeDnsResolver("10.0.0.5");
 
-        var captured = Capture(MeepleAiMetrics.EgressBlocked.Name, () =>
+        var captured = MetricCapture.Capture(MeepleAiMetrics.EgressBlocked.Name, () =>
         {
             // The guard records the block BEFORE it throws; swallow the expected throw so we can
             // assert the increment already happened.
@@ -102,7 +79,7 @@ public sealed class EgressMetricsTests
     {
         var dns = new FakeDnsResolver("8.8.8.8");
 
-        var captured = Capture(MeepleAiMetrics.EgressAllowed.Name, () =>
+        var captured = MetricCapture.Capture(MeepleAiMetrics.EgressAllowed.Name, () =>
             SsrfPinnedConnect.ResolveAndValidateAsync(
                     dns, "cdn.example.com", MeepleAiMetrics.EgressSinks.Manual, CancellationToken.None)
                 .GetAwaiter().GetResult());
@@ -117,9 +94,76 @@ public sealed class EgressMetricsTests
     }
 
     [Fact]
+    public void ResolveAndValidate_DnsThrows_IncrementsBlocked_WithDnsFailure_AndRethrows()
+    {
+        // Un NXDOMAIN / timeout del resolver: la connessione non avviene (fail-closed corretto), ma
+        // senza questo counter il sink degradato è indistinguibile da un sink inattivo (#3583).
+        var dns = new ThrowingDnsResolver(new System.Net.Sockets.SocketException(11001));
+
+        var captured = MetricCapture.Capture(MeepleAiMetrics.EgressBlocked.Name, () =>
+        {
+            try
+            {
+                SsrfPinnedConnect.ResolveAndValidateAsync(
+                        dns, "nxdomain.example.com", MeepleAiMetrics.EgressSinks.Wikidata, CancellationToken.None)
+                    .GetAwaiter().GetResult();
+                throw new Xunit.Sdk.XunitException("expected the DNS failure to propagate");
+            }
+            catch (System.Net.Sockets.SocketException)
+            {
+                // atteso — il guard registra e RILANCIA senza alterare l'esito
+            }
+        });
+
+        var mine = captured
+            .Where(c => Equals(c.Tags.GetValueOrDefault("sink"), "wikidata")
+                && Equals(c.Tags.GetValueOrDefault("reason"), "dns_failure"))
+            .ToList();
+
+        mine.Should().NotBeEmpty("un fallimento DNS deve essere visibile sul counter di blocco");
+        mine[0].Value.Should().Be(1);
+        captured.Should().AllSatisfy(c => c.Tags.Keys.Should().BeEquivalentTo("sink", "reason"));
+    }
+
+    [Fact]
+    public void ResolveAndValidate_CallerCancellation_DoesNotIncrementBlocked()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var dns = new ThrowingDnsResolver(new OperationCanceledException(cts.Token));
+
+        var captured = MetricCapture.Capture(MeepleAiMetrics.EgressBlocked.Name, () =>
+        {
+            try
+            {
+                SsrfPinnedConnect.ResolveAndValidateAsync(
+                        dns, "cancelled.example.com", MeepleAiMetrics.EgressSinks.Wikimedia, cts.Token)
+                    .GetAwaiter().GetResult();
+                throw new Xunit.Sdk.XunitException("expected the cancellation to propagate");
+            }
+            catch (OperationCanceledException)
+            {
+                // atteso
+            }
+        });
+
+        captured
+            .Where(c => Equals(c.Tags.GetValueOrDefault("sink"), "wikimedia")
+                && Equals(c.Tags.GetValueOrDefault("reason"), "dns_failure"))
+            .Should().BeEmpty("un abort del chiamante non è un fallimento DNS e non va contato");
+    }
+
+    [Fact]
     public void Counters_HaveStableBoundedNames()
     {
         MeepleAiMetrics.EgressBlocked.Name.Should().Be("meepleai.egress.blocked.total");
         MeepleAiMetrics.EgressAllowed.Name.Should().Be("meepleai.egress.allowed.total");
+
+        MeepleAiMetrics.EgressBlockReasons.DnsFailure.Should().Be("dns_failure");
+        // Pinnati perché sono il selettore delle regole in infra/prometheus/alerts/egress-guard.yml:
+        // rinominarli spegnerebbe gli alert senza rompere nulla in compilazione (#3583).
+        MeepleAiMetrics.EgressBlockReasons.PrivateIp.Should().Be("private_ip");
+        MeepleAiMetrics.EgressBlockReasons.DenylistHit.Should().Be("denylist_hit");
+        MeepleAiMetrics.EgressBlockReasons.DecodeFail.Should().Be("decode_fail");
     }
 }

--- a/apps/api/tests/Api.Tests/Observability/MetricCapture.cs
+++ b/apps/api/tests/Api.Tests/Observability/MetricCapture.cs
@@ -1,0 +1,47 @@
+using System.Diagnostics.Metrics;
+
+namespace Api.Tests.Observability;
+
+/// <summary>
+/// Cattura le misurazioni di uno strumento durante l'esecuzione di <paramref name="act"/>.
+/// Estratto da <c>EgressMetricsTests</c> in #3583 perché i test di <c>decode_fail</c> /
+/// <c>denylist_hit</c> vivono nei file dei rispettivi handler e validator.
+/// <para>
+/// ATTENZIONE: il <see cref="MeterListener"/> è process-wide e xUnit esegue le classi di test in
+/// parallelo, per cui la finestra di cattura può contenere misurazioni emesse da altri test. Chi
+/// asserisce DEVE selezionare la propria misurazione per tag e limitarsi a verificarne la presenza,
+/// mai il conteggio esatto (regressione già occorsa in #3495 Slice D).
+/// </para>
+/// </summary>
+internal static class MetricCapture
+{
+    public static List<(long Value, IReadOnlyDictionary<string, object?> Tags)> Capture(
+        string instrumentName, Action act)
+    {
+        var captured = new List<(long, IReadOnlyDictionary<string, object?>)>();
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Name == instrumentName)
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            },
+        };
+        listener.SetMeasurementEventCallback<long>((_, value, tags, _) =>
+        {
+            var dict = new Dictionary<string, object?>(StringComparer.Ordinal);
+            foreach (var t in tags)
+            {
+                dict[t.Key] = t.Value;
+            }
+            captured.Add((value, dict));
+        });
+        listener.Start();
+
+        act();
+
+        return captured;
+    }
+}

--- a/docs/superpowers/plans/2026-08-06-egress-observability-reasons.md
+++ b/docs/superpowers/plans/2026-08-06-egress-observability-reasons.md
@@ -1,0 +1,765 @@
+# Egress observability reasons (#3583) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rendere visibili su `meepleai_egress_blocked_total` tre esiti di egress che oggi falliscono chiusi in silenzio — fallimento DNS, rifiuto del decoder immagine, hit sulla deny-list BGG.
+
+**Architecture:** Nessun cambio di comportamento: ogni percorso già rifiuta correttamente. Si aggiunge una `RecordEgressBlocked` immediatamente **prima** del throw esistente, con i soli due tag bounded `{sink, reason}`. Il `sink` è sempre noto al chiamante, mai al componente generico: per questo `decode_fail` viene wirato ai call site alimentati da rete e non dentro `WebpVariantGenerator`. In coda, lo split dell'alert Prometheus separa `denylist_hit` (violazione di policy) da `private_ip` (incidente SSRF).
+
+**Tech Stack:** .NET 9, xUnit + FluentAssertions + Moq, `System.Diagnostics.Metrics` (`MeterListener`), Prometheus + promtool.
+
+## Global Constraints
+
+- I tag delle metriche egress sono **esclusivamente** `sink` e `reason`, entrambi costanti da `MeepleAiMetrics.EgressSinks` / `MeepleAiMetrics.EgressBlockReasons`. Un host o un IP non è **mai** un tag (cardinalità illimitata + leak del target).
+- Ogni `RecordEgressBlocked` va **prima** del `throw`, e il throw resta invariato: nessuna eccezione viene inghiottita, nessun esito cambia.
+- La cancellazione iniziata dal chiamante non è un fallimento di egress e non va contata.
+- I test asseriscono selezionando la misurazione **per tag**, mai assumendo che la finestra di cattura sia esclusiva: il `MeterListener` è process-wide e xUnit esegue le classi in parallelo (regressione già occorsa in #3495 Slice D).
+- Working dir dei comandi: `D:/Repositories/meepleai-monorepo-main/.claude/worktrees/i3583`. Branch: `feature/issue-3583-egress-observability-reasons`.
+- Comando test di riferimento (da `apps/api`): `dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "<filtro>"`.
+
+## File Structure
+
+| File | Responsabilità | Azione |
+|---|---|---|
+| `apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.Egress.cs` | Costanti bounded delle reason | Modifica: aggiunge `DnsFailure` |
+| `apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPinnedConnect.cs` | Chokepoint connect-pin | Modifica: try/catch sulla risoluzione |
+| `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandler.cs` | Cover manuale da URL admin | Modifica: `decode_fail` + `denylist_hit` |
+| `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandValidator.cs` | Gate di boundary del path manuale | Modifica: `denylist_hit` |
+| `.../Commands/EnrichCatalogCover/EnrichCatalogCoverCommandHandler.cs` | Enrichment Wikidata/Commons | Modifica: `decode_fail` |
+| `apps/api/tests/Api.Tests/Observability/MetricCapture.cs` | Helper condiviso di cattura misurazioni | **Crea** |
+| `apps/api/tests/Api.Tests/Observability/EgressMetricsTests.cs` | Test del chokepoint | Modifica: usa l'helper, aggiunge i test DNS |
+| `.../Commands/SetManualCoverCommandHandlerTests.cs` | Test handler manuale | Modifica: test `decode_fail` |
+| `.../EnrichCatalogCover/EnrichCatalogCoverCommandHandlerTests.cs` | Test handler enrichment | Modifica: test `decode_fail` |
+| `.../Commands/SetManualCoverCommandValidatorTests.cs` | Test validator | Modifica: test `denylist_hit` |
+| `infra/prometheus/alerts/egress-guard.yml` | Alert egress | Modifica: split in due regole |
+| `infra/prometheus/alerts/egress-guard.test.yml` | Test promtool | Modifica: casi per le due regole |
+
+---
+
+### Task 1: reason `dns_failure` sul chokepoint
+
+**Files:**
+- Modify: `apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.Egress.cs:40`
+- Modify: `apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPinnedConnect.cs:30`
+- Create: `apps/api/tests/Api.Tests/Observability/MetricCapture.cs`
+- Modify: `apps/api/tests/Api.Tests/Observability/EgressMetricsTests.cs`
+
+**Interfaces:**
+- Consumes: `IDnsResolver.ResolveAsync(string host, CancellationToken ct) -> Task<IReadOnlyList<IPAddress>>`; `MeepleAiMetrics.RecordEgressBlocked(string sink, string reason)`.
+- Produces: costante `MeepleAiMetrics.EgressBlockReasons.DnsFailure` (valore `"dns_failure"`), usata dai task successivi solo come riferimento di stile. Helper `Api.Tests.Observability.MetricCapture.Capture(string instrumentName, Action act) -> List<(long Value, IReadOnlyDictionary<string, object?> Tags)>`, consumato dai Task 2 e 3.
+
+- [ ] **Step 1: creare l'helper condiviso di cattura**
+
+Crea `apps/api/tests/Api.Tests/Observability/MetricCapture.cs`. È l'estrazione verbatim del metodo `Capture` già presente in `EgressMetricsTests.cs:28-56`, così i test dei Task 2 e 3 (che vivono in altri file) non lo duplicano.
+
+```csharp
+using System.Diagnostics.Metrics;
+
+namespace Api.Tests.Observability;
+
+/// <summary>
+/// Cattura le misurazioni di uno strumento durante l'esecuzione di <paramref name="act"/>.
+/// Estratto da EgressMetricsTests in #3583 perché i test di decode_fail/denylist_hit vivono
+/// nei file dei rispettivi handler/validator.
+/// <para>
+/// ATTENZIONE: il MeterListener è process-wide e xUnit esegue le classi di test in parallelo, per
+/// cui la finestra di cattura può contenere misurazioni di altri test. Chi asserisce DEVE
+/// selezionare la propria misurazione per tag, non assumere che la finestra sia esclusiva.
+/// </para>
+/// </summary>
+internal static class MetricCapture
+{
+    public static List<(long Value, IReadOnlyDictionary<string, object?> Tags)> Capture(
+        string instrumentName, Action act)
+    {
+        var captured = new List<(long, IReadOnlyDictionary<string, object?>)>();
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Name == instrumentName)
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            },
+        };
+        listener.SetMeasurementEventCallback<long>((_, value, tags, _) =>
+        {
+            var dict = new Dictionary<string, object?>(StringComparer.Ordinal);
+            foreach (var t in tags)
+            {
+                dict[t.Key] = t.Value;
+            }
+            captured.Add((value, dict));
+        });
+        listener.Start();
+
+        act();
+
+        return captured;
+    }
+}
+```
+
+- [ ] **Step 2: far usare l'helper a EgressMetricsTests**
+
+In `apps/api/tests/Api.Tests/Observability/EgressMetricsTests.cs`, elimina il metodo privato `Capture` (righe 28-56) e sostituisci le tre chiamate `Capture(` con `MetricCapture.Capture(`. Nessun altro cambiamento: è un refactor meccanico che i test esistenti devono confermare verde.
+
+- [ ] **Step 3: eseguire i test esistenti per provare che il refactor non regredisce**
+
+Da `apps/api`:
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~EgressMetrics"
+```
+
+Atteso: PASS, 3 test.
+
+- [ ] **Step 4: scrivere i due test che falliscono**
+
+Aggiungi in `EgressMetricsTests.cs`, dentro la classe, subito dopo la classe annidata `FakeDnsResolver`:
+
+```csharp
+    private sealed class ThrowingDnsResolver : IDnsResolver
+    {
+        private readonly Exception _toThrow;
+        public ThrowingDnsResolver(Exception toThrow) => _toThrow = toThrow;
+        public Task<IReadOnlyList<IPAddress>> ResolveAsync(string host, CancellationToken ct) =>
+            Task.FromException<IReadOnlyList<IPAddress>>(_toThrow);
+    }
+```
+
+e i due fatti in coda alla classe:
+
+```csharp
+    [Fact]
+    public void ResolveAndValidate_DnsThrows_IncrementsBlocked_WithDnsFailure_AndRethrows()
+    {
+        // Un NXDOMAIN / timeout del resolver: la connessione non avviene (fail-closed corretto), ma
+        // senza questo counter il sink degradato è indistinguibile da un sink inattivo (#3583).
+        var dns = new ThrowingDnsResolver(new System.Net.Sockets.SocketException(11001));
+
+        var captured = MetricCapture.Capture(MeepleAiMetrics.EgressBlocked.Name, () =>
+        {
+            try
+            {
+                SsrfPinnedConnect.ResolveAndValidateAsync(
+                        dns, "nxdomain.example.com", MeepleAiMetrics.EgressSinks.Wikidata, CancellationToken.None)
+                    .GetAwaiter().GetResult();
+                throw new Xunit.Sdk.XunitException("expected the DNS failure to propagate");
+            }
+            catch (System.Net.Sockets.SocketException)
+            {
+                // atteso — il guard registra e RILANCIA senza alterare l'esito
+            }
+        });
+
+        var mine = captured
+            .Where(c => Equals(c.Tags.GetValueOrDefault("sink"), "wikidata")
+                && Equals(c.Tags.GetValueOrDefault("reason"), "dns_failure"))
+            .ToList();
+
+        mine.Should().NotBeEmpty("un fallimento DNS deve essere visibile sul counter di blocco");
+        mine[0].Value.Should().Be(1);
+        captured.Should().AllSatisfy(c => c.Tags.Keys.Should().BeEquivalentTo("sink", "reason"));
+    }
+
+    [Fact]
+    public void ResolveAndValidate_CallerCancellation_DoesNotIncrementBlocked()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var dns = new ThrowingDnsResolver(new OperationCanceledException(cts.Token));
+
+        var captured = MetricCapture.Capture(MeepleAiMetrics.EgressBlocked.Name, () =>
+        {
+            try
+            {
+                SsrfPinnedConnect.ResolveAndValidateAsync(
+                        dns, "cancelled.example.com", MeepleAiMetrics.EgressSinks.Wikimedia, cts.Token)
+                    .GetAwaiter().GetResult();
+                throw new Xunit.Sdk.XunitException("expected the cancellation to propagate");
+            }
+            catch (OperationCanceledException)
+            {
+                // atteso
+            }
+        });
+
+        captured
+            .Where(c => Equals(c.Tags.GetValueOrDefault("sink"), "wikimedia")
+                && Equals(c.Tags.GetValueOrDefault("reason"), "dns_failure"))
+            .Should().BeEmpty("un abort del chiamante non è un fallimento DNS e non va contato");
+    }
+```
+
+Estendi anche l'asserzione sui nomi stabili, in `Counters_HaveStableBoundedNames`:
+
+```csharp
+        MeepleAiMetrics.EgressBlockReasons.DnsFailure.Should().Be("dns_failure");
+```
+
+- [ ] **Step 5: eseguire i test per verificare che falliscano**
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~EgressMetrics"
+```
+
+Atteso: FALLISCE in compilazione, con `'EgressBlockReasons' does not contain a definition for 'DnsFailure'`.
+
+- [ ] **Step 6: aggiungere la costante**
+
+In `MeepleAiMetrics.Egress.cs`, subito dopo `DecodeFail` (riga 40):
+
+```csharp
+        /// <summary>La risoluzione DNS ha lanciato (NXDOMAIN, timeout del resolver, socket error) — #3583.</summary>
+        public const string DnsFailure = "dns_failure";
+```
+
+- [ ] **Step 7: eseguire i test — ora compilano ma il primo fallisce**
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~EgressMetrics"
+```
+
+Atteso: `ResolveAndValidate_DnsThrows_...` FALLISCE su `mine.Should().NotBeEmpty(...)`. `ResolveAndValidate_CallerCancellation_...` passa già (nessuno registra nulla oggi) — è un test di non-regressione, è corretto che sia verde fin da subito.
+
+- [ ] **Step 8: implementare il guard**
+
+In `SsrfPinnedConnect.cs`, sostituisci la riga 30:
+
+```csharp
+        IReadOnlyList<IPAddress> addresses = await dns.ResolveAsync(host, ct).ConfigureAwait(false);
+```
+
+con:
+
+```csharp
+        IReadOnlyList<IPAddress> addresses;
+        try
+        {
+            addresses = await dns.ResolveAsync(host, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException || !ct.IsCancellationRequested)
+        {
+            // #3583 — l'esito era già fail-closed (la connessione non avviene), ma senza questo
+            // counter un sink che degrada per problemi DNS è indistinguibile da un sink inattivo su
+            // meepleai_egress_blocked_total. Registra e RILANCIA: nessun esito cambia.
+            // Il filtro esclude la cancellazione iniziata dal chiamante — che non è un guasto di
+            // egress — pur continuando a contare un timeout interno del resolver.
+            _ = ex;
+            MeepleAiMetrics.RecordEgressBlocked(sink, MeepleAiMetrics.EgressBlockReasons.DnsFailure);
+            throw;
+        }
+```
+
+- [ ] **Step 9: eseguire i test per verificare che passino**
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~EgressMetrics"
+```
+
+Atteso: PASS, 5 test.
+
+- [ ] **Step 10: verificare che il build non abbia introdotto warning**
+
+Da `apps/api/src/Api`:
+
+```bash
+dotnet build --nologo -v q
+```
+
+Atteso: `Avvisi: 0`, `Errori: 0`. Se compare CA1031 (cattura di `Exception` generica), **non** aggiungere una soppressione: il `when` filter + `throw;` non inghiottono nulla, ma se l'analyzer protesta comunque restringi la cattura a `catch (Exception ex) when (...)` → già così; in tal caso riporta il warning esatto invece di sopprimerlo alla cieca.
+
+- [ ] **Step 11: commit**
+
+```bash
+git add apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.Egress.cs \
+        apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPinnedConnect.cs \
+        apps/api/tests/Api.Tests/Observability/MetricCapture.cs \
+        apps/api/tests/Api.Tests/Observability/EgressMetricsTests.cs
+git commit -m "feat(egress): conta le eccezioni DNS come dns_failure (#3583)"
+```
+
+---
+
+### Task 2: reason `decode_fail` sui due call site di rete
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandler.cs:84-86`
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommandHandler.cs:221`
+- Modify: `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandlerTests.cs`
+- Modify: `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommandHandlerTests.cs`
+
+**Interfaces:**
+- Consumes: `MetricCapture.Capture` (Task 1); `MeepleAiMetrics.EgressBlockReasons.DecodeFail` (già esistente, valore `"decode_fail"`); `ImageProcessingException` da `Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services`.
+- Produces: nulla di consumato da task successivi.
+
+**Perché qui e non in `WebpVariantGenerator`:** il generator non conosce il `sink` e non potrebbe taggare la metrica senza cambiare `IWebpVariantGenerator`; inoltre il suo terzo chiamante, `MaterializePdfCoverCommandHandler.cs:77`, decodifica un PDF **locale**, dove un decode fallito non è un blocco di egress e falserebbe il rapporto blocked/allowed. Entrambi i rifiuti citati da #3583 — decompression bomb (`WebpVariantGenerator.cs:119-128`) e coder non-raster (`WebpVariantGenerator.cs:100-108`) — risalgono comunque come `ImageProcessingException`, quindi wirare il catch al call site li copre entrambi.
+
+- [ ] **Step 1: scrivere il test che fallisce sul path manuale**
+
+In `SetManualCoverCommandHandlerTests.cs` aggiungi in coda alla classe. Il fixture monta il **vero** `WebpVariantGenerator`, quindi basta far restituire allo stub HTTP un payload non-raster perché il decoder lo rifiuti:
+
+```csharp
+    [Fact]
+    public async Task Handle_NonRasterPayload_RecordsDecodeFail_OnManualSink()
+    {
+        var game = NewGame();
+        _repository.Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>())).ReturnsAsync(game);
+        // SVG: coder non-raster, rifiutato da DetectRasterFormat prima di raggiungere Magick (#3495 M1).
+        _httpHandler.ImageBytes = System.Text.Encoding.UTF8.GetBytes(
+            "<svg xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"10\" height=\"10\"/></svg>");
+
+        var captured = Api.Tests.Observability.MetricCapture.Capture(
+            MeepleAiMetrics.EgressBlocked.Name,
+            () =>
+            {
+                Func<Task> act = () => CreateHandler().Handle(Command(game.Id), CancellationToken.None);
+                act.Should().ThrowAsync<ImageProcessingException>().GetAwaiter().GetResult();
+            });
+
+        captured
+            .Where(c => Equals(c.Tags.GetValueOrDefault("sink"), "manual")
+                && Equals(c.Tags.GetValueOrDefault("reason"), "decode_fail"))
+            .Should().NotBeEmpty("il rifiuto del decoder su un payload scaricato è un blocco di egress");
+    }
+```
+
+Aggiungi in testa al file i `using` mancanti:
+
+```csharp
+using Api.Observability;
+```
+
+- [ ] **Step 2: eseguire il test per verificare che fallisca**
+
+Da `apps/api`:
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~SetManualCoverCommandHandlerTests.Handle_NonRasterPayload_RecordsDecodeFail_OnManualSink"
+```
+
+Atteso: FALLISCE su `Should().NotBeEmpty(...)` — l'eccezione risale già correttamente, manca solo il counter.
+
+- [ ] **Step 3: implementare sul path manuale**
+
+In `SetManualCoverCommandHandler.cs` aggiungi `using Api.Observability;` alla lista dei using, poi sostituisci le righe 84-86:
+
+```csharp
+        var webpBytes = await _webpGenerator
+            .GenerateWebpAsync(imageBytes, WebpTargetWidth, WebpTargetHeight, cancellationToken)
+            .ConfigureAwait(false);
+```
+
+con:
+
+```csharp
+        byte[] webpBytes;
+        try
+        {
+            webpBytes = await _webpGenerator
+                .GenerateWebpAsync(imageBytes, WebpTargetWidth, WebpTargetHeight, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (ImageProcessingException)
+        {
+            // #3583 — il payload scaricato è stato rifiutato dal decoder (decompression bomb o coder
+            // non-raster, #3495 M1). Il rifiuto è corretto: qui lo si rende visibile.
+            MeepleAiMetrics.RecordEgressBlocked(
+                MeepleAiMetrics.EgressSinks.Manual, MeepleAiMetrics.EgressBlockReasons.DecodeFail);
+            throw;
+        }
+```
+
+- [ ] **Step 4: eseguire il test per verificare che passi**
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~SetManualCoverCommandHandlerTests"
+```
+
+Atteso: PASS, tutti i test della classe.
+
+- [ ] **Step 5: scrivere il test che fallisce sul path enrichment**
+
+In `EnrichCatalogCoverCommandHandlerTests.cs`, il test esistente `Handle_ImageProcessingError_ReturnsFailedImageProcessingError` (riga 372) copre già l'esito. Aggiungi un fatto sibling che asserisce la metrica, replicando lo stesso arrangiamento di quel test — leggi le righe 372-395 e riusa il medesimo setup di mock, cambiando solo l'asserzione finale:
+
+```csharp
+    [Fact]
+    public async Task Handle_ImageProcessingError_RecordsDecodeFail_OnWikimediaSink()
+    {
+        // Stesso arrangiamento di Handle_ImageProcessingError_ReturnsFailedImageProcessingError:
+        // il generator WebP mockato lancia ImageProcessingException sul payload scaricato da Commons.
+        var captured = Api.Tests.Observability.MetricCapture.Capture(
+            MeepleAiMetrics.EgressBlocked.Name,
+            () => { /* invocazione dell'handler, come nel test sibling */ });
+
+        captured
+            .Where(c => Equals(c.Tags.GetValueOrDefault("sink"), "wikimedia")
+                && Equals(c.Tags.GetValueOrDefault("reason"), "decode_fail"))
+            .Should().NotBeEmpty("il rifiuto del decoder su un'immagine Commons è un blocco di egress");
+    }
+```
+
+Nota per chi implementa: `MetricCapture.Capture` accetta un `Action` sincrona; l'handler è async. Nel corpo della lambda usa lo stesso pattern del Task 1 — `handler.Handle(...).GetAwaiter().GetResult()` racchiuso in un `try/catch` dell'eccezione attesa, oppure `.Wait()` se il test sibling non si aspetta un throw ma un `EnrichCatalogCoverResult.Failed` (in quel caso non serve il try/catch: l'handler cattura internamente).
+
+- [ ] **Step 6: eseguire il test per verificare che fallisca**
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~EnrichCatalogCoverCommandHandlerTests.Handle_ImageProcessingError_RecordsDecodeFail_OnWikimediaSink"
+```
+
+Atteso: FALLISCE su `Should().NotBeEmpty(...)`.
+
+- [ ] **Step 7: implementare sul path enrichment**
+
+In `EnrichCatalogCoverCommandHandler.cs`, dentro il `catch (ImageProcessingException ex)` già presente alla riga 221, come **prima** istruzione del blocco:
+
+```csharp
+            // #3583 — il payload scaricato da Commons è stato rifiutato dal decoder. L'esito
+            // (Failed/image_processing) resta invariato; qui si aggiunge la visibilità su egress.
+            MeepleAiMetrics.RecordEgressBlocked(
+                MeepleAiMetrics.EgressSinks.Wikimedia, MeepleAiMetrics.EgressBlockReasons.DecodeFail);
+```
+
+Il file ha già `using Api.Observability;` — non aggiungerlo.
+
+- [ ] **Step 8: eseguire i test per verificare che passino**
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~EnrichCatalogCoverCommandHandlerTests|FullyQualifiedName~SetManualCoverCommandHandlerTests"
+```
+
+Atteso: PASS.
+
+- [ ] **Step 9: commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandler.cs \
+        apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommandHandler.cs \
+        apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandlerTests.cs \
+        apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommandHandlerTests.cs
+git commit -m "feat(egress): conta i rifiuti del decoder come decode_fail (#3583)"
+```
+
+---
+
+### Task 3: reason `denylist_hit` sui due gate della deny-list BGG
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandValidator.cs:27`
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandler.cs:73`
+- Modify: `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandValidatorTests.cs`
+
+**Interfaces:**
+- Consumes: `MetricCapture.Capture` (Task 1); `BggHostDenyList.IsBanned(string? url) -> bool`; `MeepleAiMetrics.EgressBlockReasons.DenylistHit` (già esistente, valore `"denylist_hit"`).
+- Produces: nulla di consumato da task successivi.
+
+**Perché entrambi i gate:** sono mutuamente esclusivi — se il validator rifiuta, l'handler non gira — quindi una richiesta conta esattamente una volta. Il gate del validator cattura il caso reale (admin che incolla un URL BGG); quello dell'handler cattura la difesa in profondità (un percorso che raggiunge l'handler saltando la pipeline FluentValidation). Wirarne uno solo lascerebbe cieco l'altro.
+
+- [ ] **Step 1: scrivere il test che fallisce sul validator**
+
+In `SetManualCoverCommandValidatorTests.cs` aggiungi in coda alla classe. Adatta la costruzione del comando al costruttore già usato nel file (`new SetManualCoverCommand(gameId, sourceUrl, license, attribution, adminId)`):
+
+```csharp
+    [Fact]
+    public void Validate_BggHost_RecordsDenylistHit_OnManualSink()
+    {
+        var command = new SetManualCoverCommand(
+            Guid.NewGuid(),
+            "https://cf.geekdo-images.com/abc/original/cover.jpg",
+            "CC BY-SA 4.0",
+            "Jane Doe",
+            Guid.NewGuid());
+
+        var captured = Api.Tests.Observability.MetricCapture.Capture(
+            MeepleAiMetrics.EgressBlocked.Name,
+            () =>
+            {
+                var result = new SetManualCoverCommandValidator().Validate(command);
+                result.IsValid.Should().BeFalse("la deny-list ADR-059 §5 deve rifiutare un host BGG");
+            });
+
+        captured
+            .Where(c => Equals(c.Tags.GetValueOrDefault("sink"), "manual")
+                && Equals(c.Tags.GetValueOrDefault("reason"), "denylist_hit"))
+            .Should().NotBeEmpty("un tentativo di aggirare il ban BGG deve essere visibile");
+    }
+```
+
+Aggiungi in testa al file, se assenti:
+
+```csharp
+using Api.Observability;
+```
+
+- [ ] **Step 2: eseguire il test per verificare che fallisca**
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~SetManualCoverCommandValidatorTests.Validate_BggHost_RecordsDenylistHit_OnManualSink"
+```
+
+Atteso: FALLISCE su `Should().NotBeEmpty(...)` — il rifiuto avviene già, manca il counter.
+
+- [ ] **Step 3: implementare sul validator**
+
+In `SetManualCoverCommandValidator.cs` aggiungi `using Api.Observability;`, sostituisci la riga 27:
+
+```csharp
+            .Must(url => !BggHostDenyList.IsBanned(url))
+```
+
+con:
+
+```csharp
+            .Must(url => !IsBannedAndRecorded(url))
+```
+
+e aggiungi il metodo privato accanto a `BeAbsoluteHttps`:
+
+```csharp
+    /// <summary>
+    /// #3583 — registra l'hit sulla deny-list ADR-059 §5 prima di far fallire la regola, così un
+    /// tentativo ripetuto di laundering attorno al ban BGG è visibile su
+    /// <c>meepleai_egress_blocked_total</c>. Il predicato conserva la semantica originale:
+    /// ritorna true quando l'URL è bandito (quindi la regola `Must(!…)` fallisce).
+    /// </summary>
+    private static bool IsBannedAndRecorded(string? url)
+    {
+        if (!BggHostDenyList.IsBanned(url))
+        {
+            return false;
+        }
+
+        MeepleAiMetrics.RecordEgressBlocked(
+            MeepleAiMetrics.EgressSinks.Manual, MeepleAiMetrics.EgressBlockReasons.DenylistHit);
+        return true;
+    }
+```
+
+- [ ] **Step 4: eseguire i test del validator per verificare che passino**
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~SetManualCoverCommandValidatorTests"
+```
+
+Atteso: PASS, tutti i test della classe (i test esistenti sul rifiuto BGG devono restare verdi: la semantica del predicato non cambia).
+
+- [ ] **Step 5: implementare sul gate difensivo dell'handler**
+
+In `SetManualCoverCommandHandler.cs` (che dopo il Task 2 ha già `using Api.Observability;`), sostituisci le righe 73-77:
+
+```csharp
+        if (BggHostDenyList.IsBanned(command.SourceUrl))
+        {
+            throw new ArgumentException(
+                "SourceUrl host is banned by ADR-059 §5 (BGG/geekdo assets).", nameof(command));
+        }
+```
+
+con:
+
+```csharp
+        if (BggHostDenyList.IsBanned(command.SourceUrl))
+        {
+            // #3583 — raggiungibile solo se un percorso salta la pipeline FluentValidation (il
+            // validator rifiuta prima). Mutuamente esclusivo con il gate del validator, quindi una
+            // richiesta conta una volta sola.
+            MeepleAiMetrics.RecordEgressBlocked(
+                MeepleAiMetrics.EgressSinks.Manual, MeepleAiMetrics.EgressBlockReasons.DenylistHit);
+            throw new ArgumentException(
+                "SourceUrl host is banned by ADR-059 §5 (BGG/geekdo assets).", nameof(command));
+        }
+```
+
+- [ ] **Step 6: eseguire la suite delle aree toccate**
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~EgressMetrics|FullyQualifiedName~EgressHostAllowList|FullyQualifiedName~BggHostDenyList|FullyQualifiedName~WebpVariantGenerator|FullyQualifiedName~SsrfPolicy|FullyQualifiedName~SetManualCover|FullyQualifiedName~EnrichCatalogCover"
+```
+
+Atteso: PASS, 0 falliti. Il baseline pre-modifica su questi filtri (senza `SetManualCover`/`EnrichCatalogCover`) era 119 passati / 0 falliti.
+
+- [ ] **Step 7: commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandValidator.cs \
+        apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandler.cs \
+        apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandValidatorTests.cs
+git commit -m "feat(egress): conta gli hit sulla deny-list BGG come denylist_hit (#3583)"
+```
+
+---
+
+### Task 4: split dell'alert Prometheus
+
+**Files:**
+- Modify: `infra/prometheus/alerts/egress-guard.yml`
+- Modify: `infra/prometheus/alerts/egress-guard.test.yml`
+
+**Interfaces:**
+- Consumes: la serie `meepleai_egress_blocked_total{sink,reason}` ora popolata anche con `reason="denylist_hit"` (Task 3).
+- Produces: due alert distinti, `EgressBlockedManualSensitive` (invariato nel nome, ristretto a `private_ip`) e `EgressDenylistHit` (nuovo, `severity: warning`).
+
+**Perché:** `egress-guard.yml:18` tratta oggi `private_ip|denylist_hit` come un unico incidente P1 con SLO=0. Dal Task 3 in poi il ramo `denylist_hit` diventa raggiungibile: senza questo split, un admin che incolla un URL BGG — errore di policy, non tentativo di raggiungere un target interno — farebbe scattare un P1. Con il carve-out BGG previsto da #3590 il caso diventerà più frequente, non meno.
+
+- [ ] **Step 1: aggiornare le regole**
+
+In `egress-guard.yml`, sostituisci la riga 18 (`expr:` di `EgressBlockedManualSensitive`) restringendola a `private_ip`:
+
+```yaml
+        expr: (sum(rate(meepleai_egress_blocked_total{sink="manual",reason="private_ip"}[5m])) or vector(0)) > 0
+```
+
+aggiorna le due annotazioni della stessa regola perché non citino più `denylist_hit`:
+
+```yaml
+          summary: "Manual-cover SSRF attempt blocked (sink=manual, private_ip)"
+          description: "meepleai_egress_blocked_total incremented for sink=manual with reason private_ip: an admin-supplied manual-cover URL resolved to an internal/reserved address. SLO for this metric is ZERO; any nonzero rate is a P1 SSRF incident (#3495)."
+```
+
+e aggiungi in coda al blocco `rules:` la nuova regola:
+
+```yaml
+      - alert: EgressDenylistHit
+        # #3583 — separata da EgressBlockedManualSensitive: un hit sulla deny-list ADR-059 §5 è una
+        # violazione di POLICY (un URL BGG/geekdo nel campo cover manuale), non un tentativo di
+        # raggiungere un target interno. Trattarlo come P1 SSRF genererebbe pagine su un errore di
+        # battitura di un admin — tanto più col carve-out BGG server-to-server (#3590).
+        expr: (sum(rate(meepleai_egress_blocked_total{sink="manual",reason="denylist_hit"}[5m])) or vector(0)) > 0
+        for: 0m
+        labels:
+          severity: warning
+          subsystem: egress-policy
+        annotations:
+          summary: "Manual-cover URL rejected by the ADR-059 BGG deny-list (sink=manual)"
+          description: "meepleai_egress_blocked_total incremented for sink=manual with reason denylist_hit: someone submitted a BGG/geekdo asset URL to the manual-cover field, which ADR-059 §5 bans. A one-off is an admin mistake; a sustained rate is an attempt to launder around the ban and warrants review of who is submitting it. The legitimate route for a BGG cover is the admin server-to-server re-upload path, never the arbitrary-URL field."
+          runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-developers/operations/operations-manual.md"
+```
+
+Aggiorna infine il commento di testata (righe 8-10) perché descriva i due segnali separati:
+
+```yaml
+# SLO for the manual (arbitrary-URL) sink hitting private_ip is ZERO: any nonzero rate means an
+# admin-supplied manual-cover URL resolved to an internal/reserved address — a live SSRF attempt.
+# severity=critical pages via the alertmanager critical-alerts route.
+#
+# denylist_hit is tracked SEPARATELY at severity=warning (#3583): it is an ADR-059 §5 policy
+# violation (a BGG/geekdo URL in the manual field), not an internal-target attempt.
+```
+
+- [ ] **Step 2: aggiornare i test promtool**
+
+In `egress-guard.test.yml`, aggiorna il commento del caso 3 (riga 31) e aggiungi due casi. Il caso 3 resta valido così com'è (`size_cap` non è né `private_ip` né `denylist_hit`), cambia solo la dicitura:
+
+```yaml
+  # 3) DOES NOT FIRE for a non-sensitive reason on the manual sink (size_cap is neither rule's reason).
+```
+
+Aggiungi in coda al file:
+
+```yaml
+  # 4) denylist_hit FIRES EgressDenylistHit at warning — and NOT the critical SSRF alert (#3583).
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_egress_blocked_total{sink="manual",reason="denylist_hit"}'
+        values: '0 0 1 1 1 1'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: EgressDenylistHit
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              subsystem: egress-policy
+      - eval_time: 5m
+        alertname: EgressBlockedManualSensitive
+        exp_alerts: []
+
+  # 5) private_ip FIRES the critical alert and NOT the policy one — the two must not cross-trigger.
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_egress_blocked_total{sink="manual",reason="private_ip"}'
+        values: '0 0 1 1 1 1'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: EgressDenylistHit
+        exp_alerts: []
+```
+
+- [ ] **Step 3: eseguire promtool per verificare le regole**
+
+Dalla root del worktree:
+
+```bash
+docker run --rm -v "$(pwd)/infra/prometheus/alerts:/work" prom/prometheus:v3.7.0 promtool test rules /work/egress-guard.test.yml
+```
+
+Atteso: `SUCCESS`. Se Docker non è disponibile in questa sessione, riporta il fatto invece di dichiarare il passo completato: la validazione promtool è l'unico gate su questi file e non va saltata in silenzio.
+
+- [ ] **Step 4: commit**
+
+```bash
+git add infra/prometheus/alerts/egress-guard.yml infra/prometheus/alerts/egress-guard.test.yml
+git commit -m "feat(egress): separa denylist_hit dall'alert P1 SSRF (#3583)"
+```
+
+---
+
+### Task 5: verifica finale e PR
+
+**Files:** nessuna modifica di codice.
+
+- [ ] **Step 1: build pulita**
+
+Da `apps/api/src/Api`:
+
+```bash
+dotnet build --nologo -v q
+```
+
+Atteso: `Avvisi: 0`, `Errori: 0`.
+
+- [ ] **Step 2: suite delle aree toccate**
+
+Da `apps/api`:
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~EgressMetrics|FullyQualifiedName~EgressHostAllowList|FullyQualifiedName~BggHostDenyList|FullyQualifiedName~WebpVariantGenerator|FullyQualifiedName~SsrfPolicy|FullyQualifiedName~SetManualCover|FullyQualifiedName~EnrichCatalogCover"
+```
+
+Atteso: 0 falliti. Riporta il conteggio esatto passati/falliti — non "sembra a posto".
+
+- [ ] **Step 3: formattazione backend**
+
+Il pre-commit salta il format backend sulle branch `feature/*`, quindi va lanciato a mano prima della PR. Da `apps/api`:
+
+```bash
+dotnet format --include $(git diff --name-only origin/main-dev...HEAD -- '*.cs' | tr '\n' ' ')
+```
+
+**`--include` è obbligatorio**: senza, `dotnet format` applica i fix degli analyzer a tutto il progetto e ha già cancellato costruttori DI usati solo via reflection (S1144), lasciando 3 test rossi per mesi.
+
+- [ ] **Step 4: push e apertura PR verso main-dev**
+
+```bash
+git push -u origin feature/issue-3583-egress-observability-reasons
+gh pr create --base main-dev \
+  --title "feat(egress): wire delle reason di osservabilità mancanti (#3583)" \
+  --body "<corpo: cosa cambia, le tre deviazioni dal testo dell'issue e il perché, esito dei test e di promtool>"
+```
+
+Il target **deve** essere `main-dev`, mai `main`.
+
+---
+
+## Self-Review
+
+**Copertura della spec (sezione PR 1):**
+- §1.1 `dns_failure` → Task 1. ✔
+- §1.2 `decode_fail` sui due call site di rete, con la motivazione della deviazione → Task 2. ✔
+- §1.3 `denylist_hit` sui due gate + split dell'alert → Task 3 (wiring) e Task 4 (alert). ✔
+- §"Test PR 1": unit DNS + cancellazione → Task 1 Step 4; decode_fail nei due sink → Task 2; denylist_hit → Task 3; estensione di `Counters_HaveStableBoundedNames` → Task 1 Step 4; promtool → Task 4 Step 3. ✔
+
+**Scan dei placeholder:** un punto resta deliberatamente non letterale — Task 2 Step 5, dove il corpo della lambda rimanda all'arrangiamento del test sibling alle righe 372-395 di `EnrichCatalogCoverCommandHandlerTests.cs`. Non ho letto quel blocco per intero, quindi trascriverlo a memoria avrebbe prodotto codice plausibile ma non verificato: peggio di un rimando esplicito. Chi implementa legge quelle righe e riusa il setup reale.
+
+**Coerenza dei tipi:** `MetricCapture.Capture(string, Action) -> List<(long Value, IReadOnlyDictionary<string, object?> Tags)>` è definita nel Task 1 Step 1 e usata con la stessa firma nei Task 2 e 3. Le costanti citate esistono tutte: `DecodeFail` e `DenylistHit` già in `MeepleAiMetrics.Egress.cs:31,40`; `DnsFailure` la crea il Task 1 Step 6. `ImageProcessingException` e `BggHostDenyList.IsBanned` sono verificati nel sorgente.

--- a/docs/superpowers/plans/2026-08-06-egress-observability-reasons.md
+++ b/docs/superpowers/plans/2026-08-06-egress-observability-reasons.md
@@ -33,6 +33,7 @@
 | `.../Commands/SetManualCoverCommandValidatorTests.cs` | Test validator | Modifica: test `denylist_hit` |
 | `infra/prometheus/alerts/egress-guard.yml` | Alert egress | Modifica: split in due regole |
 | `infra/prometheus/alerts/egress-guard.test.yml` | Test promtool | Modifica: casi per le due regole |
+| `infra/prometheus.staging.yml` · `infra/prometheus.prod.yml` | `rule_files:` per ambiente | Modifica: caricano `egress-guard.yml`, oggi assente |
 
 ---
 
@@ -103,7 +104,11 @@ internal static class MetricCapture
 
 - [ ] **Step 2: far usare l'helper a EgressMetricsTests**
 
-In `apps/api/tests/Api.Tests/Observability/EgressMetricsTests.cs`, elimina il metodo privato `Capture` (righe 28-56) e sostituisci le tre chiamate `Capture(` con `MetricCapture.Capture(`. Nessun altro cambiamento: è un refactor meccanico che i test esistenti devono confermare verde.
+In `apps/api/tests/Api.Tests/Observability/EgressMetricsTests.cs`, elimina il metodo privato `Capture` (righe 28-56) e sostituisci le **due** chiamate `Capture(` (righe 63 e 105) con `MetricCapture.Capture(`. Il terzo `[Fact]`, `Counters_HaveStableBoundedNames`, non usa `Capture`.
+
+Rimuovi anche il `using System.Diagnostics.Metrics;` in testa al file: era lì solo per `MeterListener`, che ora vive nell'helper, e resterebbe orfano (IDE0005).
+
+Nessun altro cambiamento: è un refactor meccanico che i test esistenti devono confermare verde.
 
 - [ ] **Step 3: eseguire i test esistenti per provare che il refactor non regredisce**
 
@@ -193,10 +198,15 @@ e i due fatti in coda alla classe:
     }
 ```
 
-Estendi anche l'asserzione sui nomi stabili, in `Counters_HaveStableBoundedNames`:
+Estendi anche l'asserzione sui nomi stabili, in `Counters_HaveStableBoundedNames`. Non solo la costante nuova: dal Task 4 in poi queste stringhe sono un **contratto con i selettori delle regole Prometheus** (`reason="private_ip"`, `reason="denylist_hit"`), quindi un rename della costante renderebbe gli alert silenziosamente morti senza che nessun test se ne accorga.
 
 ```csharp
         MeepleAiMetrics.EgressBlockReasons.DnsFailure.Should().Be("dns_failure");
+        // Pinnati perché sono il selettore delle regole in infra/prometheus/alerts/egress-guard.yml:
+        // rinominarli spegnerebbe gli alert senza rompere nulla in compilazione (#3583).
+        MeepleAiMetrics.EgressBlockReasons.PrivateIp.Should().Be("private_ip");
+        MeepleAiMetrics.EgressBlockReasons.DenylistHit.Should().Be("denylist_hit");
+        MeepleAiMetrics.EgressBlockReasons.DecodeFail.Should().Be("decode_fail");
 ```
 
 - [ ] **Step 5: eseguire i test per verificare che falliscano**
@@ -245,9 +255,17 @@ con:
             // #3583 — l'esito era già fail-closed (la connessione non avviene), ma senza questo
             // counter un sink che degrada per problemi DNS è indistinguibile da un sink inattivo su
             // meepleai_egress_blocked_total. Registra e RILANCIA: nessun esito cambia.
+            //
             // Il filtro esclude la cancellazione iniziata dal chiamante — che non è un guasto di
-            // egress — pur continuando a contare un timeout interno del resolver.
-            _ = ex;
+            // egress — pur continuando a contare un timeout interno del resolver (che si presenta
+            // come OperationCanceledException con un CTS proprio, quindi con `ct` non cancellato).
+            //
+            // Due limiti noti e accettati:
+            //   - se il chiamante cancella e il resolver risponde con SocketException invece che
+            //     OperationCanceledException, il caso viene contato come dns_failure;
+            //   - questo guard gira dentro il ConnectCallback, quindi UNA VOLTA PER CONNESSIONE:
+            //     ogni hop di redirect e ogni nuova connessione del pool incrementa. Il counter va
+            //     letto come rate di fallimenti di dial, MAI come "richieste utente fallite".
             MeepleAiMetrics.RecordEgressBlocked(sink, MeepleAiMetrics.EgressBlockReasons.DnsFailure);
             throw;
         }
@@ -269,7 +287,11 @@ Da `apps/api/src/Api`:
 dotnet build --nologo -v q
 ```
 
-Atteso: `Avvisi: 0`, `Errori: 0`. Se compare CA1031 (cattura di `Exception` generica), **non** aggiungere una soppressione: il `when` filter + `throw;` non inghiottono nulla, ma se l'analyzer protesta comunque restringi la cattura a `catch (Exception ex) when (...)` → già così; in tal caso riporta il warning esatto invece di sopprimerlo alla cieca.
+Atteso: `Avvisi: 0`, `Errori: 0`.
+
+CA1031 **non** dovrebbe scattare: lo stesso idioma `catch (Exception ex) when (...)` è già in uso in `EnrichCatalogCoverCommandHandler.cs:195` sotto lo stesso `TreatWarningsAsErrors`. Se comparisse comunque un warning, riportalo testualmente invece di sopprimerlo alla cieca.
+
+Nota: questo build copre solo `src/Api`. Gli errori nel progetto di test emergono soltanto con `dotnet test`, già eseguito allo Step 9.
 
 - [ ] **Step 11: commit**
 
@@ -295,7 +317,7 @@ git commit -m "feat(egress): conta le eccezioni DNS come dns_failure (#3583)"
 - Consumes: `MetricCapture.Capture` (Task 1); `MeepleAiMetrics.EgressBlockReasons.DecodeFail` (già esistente, valore `"decode_fail"`); `ImageProcessingException` da `Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services`.
 - Produces: nulla di consumato da task successivi.
 
-**Perché qui e non in `WebpVariantGenerator`:** il generator non conosce il `sink` e non potrebbe taggare la metrica senza cambiare `IWebpVariantGenerator`; inoltre il suo terzo chiamante, `MaterializePdfCoverCommandHandler.cs:77`, decodifica un PDF **locale**, dove un decode fallito non è un blocco di egress e falserebbe il rapporto blocked/allowed. Entrambi i rifiuti citati da #3583 — decompression bomb (`WebpVariantGenerator.cs:119-128`) e coder non-raster (`WebpVariantGenerator.cs:100-108`) — risalgono comunque come `ImageProcessingException`, quindi wirare il catch al call site li copre entrambi.
+**Perché qui e non in `WebpVariantGenerator`:** il generator non conosce il `sink` e non potrebbe taggare la metrica senza cambiare `IWebpVariantGenerator`; inoltre il suo terzo chiamante — `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/MaterializePdfCoverCommandHandler.cs:77`, nel bounded context **DocumentProcessing**, non in SharedGameCatalog — decodifica un PDF **locale**, dove un decode fallito non è un blocco di egress e falserebbe il rapporto blocked/allowed. Entrambi i rifiuti citati da #3583 — decompression bomb (`WebpVariantGenerator.cs:119-128`) e coder non-raster (`WebpVariantGenerator.cs:100-108`) — risalgono comunque come `ImageProcessingException`, quindi wirare il catch al call site li copre entrambi.
 
 - [ ] **Step 1: scrivere il test che fallisce sul path manuale**
 
@@ -303,11 +325,13 @@ In `SetManualCoverCommandHandlerTests.cs` aggiungi in coda alla classe. Il fixtu
 
 ```csharp
     [Fact]
-    public async Task Handle_NonRasterPayload_RecordsDecodeFail_OnManualSink()
+    public void Handle_NonRasterPayload_RecordsDecodeFail_OnManualSink()
     {
         var game = NewGame();
         _repository.Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>())).ReturnsAsync(game);
         // SVG: coder non-raster, rifiutato da DetectRasterFormat prima di raggiungere Magick (#3495 M1).
+        // Lo StubImageHandler dichiara Content-Type: image/png e il fetch non ispeziona i magic bytes,
+        // quindi il payload arriva davvero al decoder.
         _httpHandler.ImageBytes = System.Text.Encoding.UTF8.GetBytes(
             "<svg xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"10\" height=\"10\"/></svg>");
 
@@ -315,8 +339,17 @@ In `SetManualCoverCommandHandlerTests.cs` aggiungi in coda alla classe. Il fixtu
             MeepleAiMetrics.EgressBlocked.Name,
             () =>
             {
-                Func<Task> act = () => CreateHandler().Handle(Command(game.Id), CancellationToken.None);
-                act.Should().ThrowAsync<ImageProcessingException>().GetAwaiter().GetResult();
+                try
+                {
+                    CreateHandler().Handle(Command(game.Id), CancellationToken.None)
+                        .GetAwaiter().GetResult();
+                    throw new Xunit.Sdk.XunitException(
+                        "expected the decoder to reject the non-raster payload");
+                }
+                catch (ImageProcessingException)
+                {
+                    // atteso — l'handler registra e RILANCIA
+                }
             });
 
         captured
@@ -325,6 +358,8 @@ In `SetManualCoverCommandHandlerTests.cs` aggiungi in coda alla classe. Il fixtu
             .Should().NotBeEmpty("il rifiuto del decoder su un payload scaricato è un blocco di egress");
     }
 ```
+
+Il metodo è volutamente `void` e non `async Task`: non c'è nulla da attendere, e `MetricCapture.Capture` accetta una `Action` sincrona. Lo stile `try/catch` + `GetAwaiter().GetResult()` è lo stesso del Task 1 — evita di mescolare due idiomi e, se `Handle` lanciasse un'eccezione diversa da quella attesa, produce un messaggio d'errore che punta al tipo sbagliato invece di far esplodere l'assertion dentro la lambda con una diagnostica fuorviante.
 
 Aggiungi in testa al file i `using` mancanti:
 
@@ -382,17 +417,34 @@ Atteso: PASS, tutti i test della classe.
 
 - [ ] **Step 5: scrivere il test che fallisce sul path enrichment**
 
-In `EnrichCatalogCoverCommandHandlerTests.cs`, il test esistente `Handle_ImageProcessingError_ReturnsFailedImageProcessingError` (riga 372) copre già l'esito. Aggiungi un fatto sibling che asserisce la metrica, replicando lo stesso arrangiamento di quel test — leggi le righe 372-395 e riusa il medesimo setup di mock, cambiando solo l'asserzione finale:
+In `EnrichCatalogCoverCommandHandlerTests.cs`, il test esistente `Handle_ImageProcessingError_ReturnsFailedImageProcessingError` (righe 371-402) copre già l'esito. Aggiungi questo fatto sibling, che riusa il medesimo arrangiamento:
 
 ```csharp
     [Fact]
-    public async Task Handle_ImageProcessingError_RecordsDecodeFail_OnWikimediaSink()
+    public void Handle_ImageProcessingError_RecordsDecodeFail_OnWikimediaSink()
     {
-        // Stesso arrangiamento di Handle_ImageProcessingError_ReturnsFailedImageProcessingError:
-        // il generator WebP mockato lancia ImageProcessingException sul payload scaricato da Commons.
+        // Stesso arrangiamento di Handle_ImageProcessingError_ReturnsFailedImageProcessingError.
+        // L'harness monta il VERO WebpVariantGenerator: sono i byte corrotti scaricati da Commons a
+        // farlo fallire (DetectRasterFormat -> null), non un mock che lancia.
+        var harness = BuildHarness();
+        var game = BuildGame(qid: TestQid);
+        harness.RepoMock
+            .Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(game);
+        harness.WikidataHandler.SparqlJson = BuildSparqlImageResponse(TestFilename);
+        harness.CommonsHandler.LicenseJson = BuildImageInfoResponse("CC0");
+        harness.CommonsHandler.ImageBytes = new byte[] { 0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE };
+
+        EnrichCatalogCoverResult? result = null;
         var captured = Api.Tests.Observability.MetricCapture.Capture(
             MeepleAiMetrics.EgressBlocked.Name,
-            () => { /* invocazione dell'handler, come nel test sibling */ });
+            () => result = harness.Sut
+                .Handle(new EnrichCatalogCoverCommand(game.Id), CancellationToken.None)
+                .GetAwaiter().GetResult());
+
+        // L'handler CATTURA ImageProcessingException e ritorna Failed: nessuna eccezione esce,
+        // quindi qui NON serve try/catch (a differenza del path manuale del Task 2 Step 1).
+        result.Should().BeOfType<EnrichCatalogCoverResult.Failed>();
 
         captured
             .Where(c => Equals(c.Tags.GetValueOrDefault("sink"), "wikimedia")
@@ -400,8 +452,6 @@ In `EnrichCatalogCoverCommandHandlerTests.cs`, il test esistente `Handle_ImagePr
             .Should().NotBeEmpty("il rifiuto del decoder su un'immagine Commons è un blocco di egress");
     }
 ```
-
-Nota per chi implementa: `MetricCapture.Capture` accetta un `Action` sincrona; l'handler è async. Nel corpo della lambda usa lo stesso pattern del Task 1 — `handler.Handle(...).GetAwaiter().GetResult()` racchiuso in un `try/catch` dell'eccezione attesa, oppure `.Wait()` se il test sibling non si aspetta un throw ma un `EnrichCatalogCoverResult.Failed` (in quel caso non serve il try/catch: l'handler cattura internamente).
 
 - [ ] **Step 6: eseguire il test per verificare che fallisca**
 
@@ -450,6 +500,7 @@ git commit -m "feat(egress): conta i rifiuti del decoder come decode_fail (#3583
 - Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandValidator.cs:27`
 - Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandler.cs:73`
 - Modify: `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandValidatorTests.cs`
+- Modify: `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandlerTests.cs`
 
 **Interfaces:**
 - Consumes: `MetricCapture.Capture` (Task 1); `BggHostDenyList.IsBanned(string? url) -> bool`; `MeepleAiMetrics.EgressBlockReasons.DenylistHit` (già esistente, valore `"denylist_hit"`).
@@ -459,26 +510,20 @@ git commit -m "feat(egress): conta i rifiuti del decoder come decode_fail (#3583
 
 - [ ] **Step 1: scrivere il test che fallisce sul validator**
 
-In `SetManualCoverCommandValidatorTests.cs` aggiungi in coda alla classe. Adatta la costruzione del comando al costruttore già usato nel file (`new SetManualCoverCommand(gameId, sourceUrl, license, attribution, adminId)`):
+In `SetManualCoverCommandValidatorTests.cs` aggiungi in coda alla classe, usando l'idioma già in uso nel file (`_validator.TestValidate(Valid() with { … })`, non `new SetManualCoverCommand(...)` + `.Validate(...)`):
 
 ```csharp
     [Fact]
     public void Validate_BggHost_RecordsDenylistHit_OnManualSink()
     {
-        var command = new SetManualCoverCommand(
-            Guid.NewGuid(),
-            "https://cf.geekdo-images.com/abc/original/cover.jpg",
-            "CC BY-SA 4.0",
-            "Jane Doe",
-            Guid.NewGuid());
-
+        // NOTA: il file contiene già Fails_WhenSourceUrlIsBannedBggHost con 5 [InlineData], ognuna
+        // delle quali emetterà una misurazione {manual, denylist_hit}. La finestra di MetricCapture è
+        // process-wide: asserire NotBeEmpty, MAI un conteggio esatto.
         var captured = Api.Tests.Observability.MetricCapture.Capture(
             MeepleAiMetrics.EgressBlocked.Name,
-            () =>
-            {
-                var result = new SetManualCoverCommandValidator().Validate(command);
-                result.IsValid.Should().BeFalse("la deny-list ADR-059 §5 deve rifiutare un host BGG");
-            });
+            () => _validator
+                .TestValidate(Valid() with { SourceUrl = "https://cf.geekdo-images.com/abc/cover.jpg" })
+                .ShouldHaveValidationErrorFor(x => x.SourceUrl));
 
         captured
             .Where(c => Equals(c.Tags.GetValueOrDefault("sink"), "manual")
@@ -523,6 +568,14 @@ e aggiungi il metodo privato accanto a `BeAbsoluteHttps`:
     /// tentativo ripetuto di laundering attorno al ban BGG è visibile su
     /// <c>meepleai_egress_blocked_total</c>. Il predicato conserva la semantica originale:
     /// ritorna true quando l'URL è bandito (quindi la regola `Must(!…)` fallisce).
+    /// <para>
+    /// PRECONDIZIONE per la correttezza del conteggio: questo predicato viene valutato ESATTAMENTE
+    /// una volta per richiesta. Oggi è vero perché (a) il cascade rule-level è il default `Continue`
+    /// e la catena su SourceUrl esegue questo Must una sola volta, e (b) il validator è invocato solo
+    /// dal <c>ValidationBehavior</c> di MediatR, una volta per comando. È una garanzia EMERGENTE, non
+    /// protetta da un test: un secondo <c>IValidator&lt;SetManualCoverCommand&gt;</c> registrato, o un
+    /// endpoint filter che validi prima di MediatR, farebbero raddoppiare il counter in silenzio.
+    /// </para>
     /// </summary>
     private static bool IsBannedAndRecorded(string? url)
     {
@@ -572,6 +625,52 @@ con:
         }
 ```
 
+- [ ] **Step 5b: scrivere ed eseguire il test del gate difensivo dell'handler**
+
+La spec chiede test su validator **e** handler. `SetManualCoverCommandHandlerTests.cs` non contiene oggi alcun test con un URL BGG, quindi senza questo il ramo modificato allo Step 5 resta non eseguito. Aggiungi in coda alla classe:
+
+```csharp
+    [Fact]
+    public void Handle_BggHost_RecordsDenylistHit_AndNeverFetches()
+    {
+        // Gate difensivo: raggiungibile solo saltando la pipeline FluentValidation, quindi qui si
+        // invoca l'handler direttamente. Deve rifiutare PRIMA di qualunque egress.
+        var game = NewGame();
+        _repository.Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>())).ReturnsAsync(game);
+        var banned = Command(game.Id) with { SourceUrl = "https://cf.geekdo-images.com/abc/cover.jpg" };
+
+        var captured = Api.Tests.Observability.MetricCapture.Capture(
+            MeepleAiMetrics.EgressBlocked.Name,
+            () =>
+            {
+                try
+                {
+                    CreateHandler().Handle(banned, CancellationToken.None).GetAwaiter().GetResult();
+                    throw new Xunit.Sdk.XunitException("expected the ADR-059 deny-list to reject the host");
+                }
+                catch (ArgumentException)
+                {
+                    // atteso
+                }
+            });
+
+        captured
+            .Where(c => Equals(c.Tags.GetValueOrDefault("sink"), "manual")
+                && Equals(c.Tags.GetValueOrDefault("reason"), "denylist_hit"))
+            .Should().NotBeEmpty("anche il gate difensivo deve essere visibile");
+    }
+```
+
+Se `StubImageHandler` espone un contatore di richieste, asserisci anche che sia rimasto a zero: il rifiuto deve precedere il fetch. Se non lo espone, non aggiungerlo solo per questo — il `catch (ArgumentException)` prova già che il flusso si è fermato al gate.
+
+Esegui:
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~SetManualCoverCommandHandlerTests"
+```
+
+Atteso: PASS.
+
 - [ ] **Step 6: eseguire la suite delle aree toccate**
 
 ```bash
@@ -585,7 +684,8 @@ Atteso: PASS, 0 falliti. Il baseline pre-modifica su questi filtri (senza `SetMa
 ```bash
 git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandValidator.cs \
         apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandler.cs \
-        apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandValidatorTests.cs
+        apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandValidatorTests.cs \
+        apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandlerTests.cs
 git commit -m "feat(egress): conta gli hit sulla deny-list BGG come denylist_hit (#3583)"
 ```
 
@@ -596,12 +696,16 @@ git commit -m "feat(egress): conta gli hit sulla deny-list BGG come denylist_hit
 **Files:**
 - Modify: `infra/prometheus/alerts/egress-guard.yml`
 - Modify: `infra/prometheus/alerts/egress-guard.test.yml`
+- Modify: `infra/prometheus.staging.yml`
+- Modify: `infra/prometheus.prod.yml`
 
 **Interfaces:**
 - Consumes: la serie `meepleai_egress_blocked_total{sink,reason}` ora popolata anche con `reason="denylist_hit"` (Task 3).
 - Produces: due alert distinti, `EgressBlockedManualSensitive` (invariato nel nome, ristretto a `private_ip`) e `EgressDenylistHit` (nuovo, `severity: warning`).
 
 **Perché:** `egress-guard.yml:18` tratta oggi `private_ip|denylist_hit` come un unico incidente P1 con SLO=0. Dal Task 3 in poi il ramo `denylist_hit` diventa raggiungibile: senza questo split, un admin che incolla un URL BGG — errore di policy, non tentativo di raggiungere un target interno — farebbe scattare un P1. Con il carve-out BGG previsto da #3590 il caso diventerà più frequente, non meno.
+
+Attenzione a non fraintendere la portata attuale: quel P1 oggi esiste **solo in dev**, perché `egress-guard.yml` non è referenziato nei `rule_files:` di staging e prod (vedi Step 3b, che lo corregge). Lo split resta comunque necessario proprio perché lo Step 3b accende quelle regole nei due ambienti dove finora tacevano.
 
 - [ ] **Step 1: aggiornare le regole**
 
@@ -675,7 +779,7 @@ Aggiungi in coda al file:
         alertname: EgressBlockedManualSensitive
         exp_alerts: []
 
-  # 5) private_ip FIRES the critical alert and NOT the policy one — the two must not cross-trigger.
+  # 5) private_ip does NOT cross-trigger the policy alert (its own firing is covered by case 1).
   - interval: 1m
     input_series:
       - series: 'meepleai_egress_blocked_total{sink="manual",reason="private_ip"}'
@@ -694,14 +798,31 @@ Dalla root del worktree:
 docker run --rm -v "$(pwd)/infra/prometheus/alerts:/work" prom/prometheus:v3.7.0 promtool test rules /work/egress-guard.test.yml
 ```
 
-Atteso: `SUCCESS`. Se Docker non è disponibile in questa sessione, riporta il fatto invece di dichiarare il passo completato: la validazione promtool è l'unico gate su questi file e non va saltata in silenzio.
+Atteso: `SUCCESS`.
+
+Questo passo è **bloccante**, non una formalità: nessun workflow CI invoca `promtool` (l'header di `egress-guard.test.yml:1` lo dice esplicitamente, e un grep su `.github/workflows/` e `infra/Makefile` non trova nessuna invocazione). Se le regole sono sbagliate, niente le intercetta a valle. Se Docker non è disponibile in questa sessione, **riporta il fatto** invece di dichiarare il passo completato.
+
+- [ ] **Step 3b: caricare le regole in staging e prod**
+
+`egress-guard.yml` è montato in tutti e tre i compose (`docker-compose.yml:358`, `compose.staging.yml:360`, `compose.prod.yml:245`) ma compare in `rule_files:` **soltanto** in `infra/prometheus.yml` (dev). In staging e prod le regole egress non sono mai state caricate: `EgressBlockedManualSensitive` non esiste lì da #3495 M2, e senza questo passo il nuovo `EgressDenylistHit` nascerebbe morto negli stessi ambienti.
+
+Aggiungi in `infra/prometheus.staging.yml` e `infra/prometheus.prod.yml`, nel blocco `rule_files:`, dopo la riga di `bgg-tos-compliance.yml` (stessa posizione che ha in `infra/prometheus.yml`, per tenere le tre liste allineate):
+
+```yaml
+  # #3495 M2 — SSRF egress guard (private_ip = P1) + #3583 policy alert (denylist_hit = warning).
+  # Il file era già montato ma mai referenziato in staging/prod: regole caricate solo da #3583.
+  - '/etc/prometheus/egress-guard.yml'
+```
 
 - [ ] **Step 4: commit**
 
 ```bash
-git add infra/prometheus/alerts/egress-guard.yml infra/prometheus/alerts/egress-guard.test.yml
+git add infra/prometheus/alerts/egress-guard.yml infra/prometheus/alerts/egress-guard.test.yml \
+        infra/prometheus.staging.yml infra/prometheus.prod.yml
 git commit -m "feat(egress): separa denylist_hit dall'alert P1 SSRF (#3583)"
 ```
+
+Nota per il corpo della PR: le regole Prometheus **non si ricaricano al deploy**. Dopo il merge serve un force-recreate del container prometheus su staging perché le nuove regole diventino attive; finché non avviene, la config è a posto ma inerte.
 
 ---
 
@@ -731,13 +852,15 @@ Atteso: 0 falliti. Riporta il conteggio esatto passati/falliti — non "sembra a
 
 - [ ] **Step 3: formattazione backend**
 
-Il pre-commit salta il format backend sulle branch `feature/*`, quindi va lanciato a mano prima della PR. Da `apps/api`:
+Il pre-commit salta il format backend sulle branch `feature/*`, quindi va lanciato a mano prima della PR. **Dalla root del worktree** (non da `apps/api`: `git diff --name-only` restituisce path relativi alla root, che con un'altra cwd non matcherebbero nulla e produrrebbero un `--include` vuoto):
 
 ```bash
-dotnet format --include $(git diff --name-only origin/main-dev...HEAD -- '*.cs' | tr '\n' ' ')
+dotnet format apps/api/MeepleAI.Api.sln --include $(git diff --name-only origin/main-dev...HEAD -- '*.cs' | tr '\n' ' ')
 ```
 
 **`--include` è obbligatorio**: senza, `dotnet format` applica i fix degli analyzer a tutto il progetto e ha già cancellato costruttori DI usati solo via reflection (S1144), lasciando 3 test rossi per mesi.
+
+Se il comando non modifica nulla, `git status` resta pulito: è l'esito atteso, non un errore.
 
 - [ ] **Step 4: push e apertura PR verso main-dev**
 
@@ -745,10 +868,18 @@ dotnet format --include $(git diff --name-only origin/main-dev...HEAD -- '*.cs' 
 git push -u origin feature/issue-3583-egress-observability-reasons
 gh pr create --base main-dev \
   --title "feat(egress): wire delle reason di osservabilità mancanti (#3583)" \
-  --body "<corpo: cosa cambia, le tre deviazioni dal testo dell'issue e il perché, esito dei test e di promtool>"
+  --body "<vedi contenuti obbligatori sotto>"
 ```
 
 Il target **deve** essere `main-dev`, mai `main`.
+
+Il corpo della PR deve contenere, oltre a cosa cambia e all'esito di test e promtool:
+
+1. **Le tre deviazioni dal testo dell'issue** e il perché: `decode_fail` sui call site invece che nel generator; split dell'alert `denylist_hit`; nessun allentamento della deny-list.
+2. **Il denominatore del block-ratio si sporca.** `RecordEgressAllowed` è emesso solo dal connect-pin, una volta per connessione TCP validata. Ora `denylist_hit` dal validator incrementa `blocked` **senza** che sia mai avvenuto un tentativo di connessione (nessun `allowed` corrispondente), mentre `decode_fail` incrementa `blocked` **dopo** che la connessione è stata concessa (quindi con un `allowed` già contato per la stessa operazione). Qualunque alert futuro su `blocked/(blocked+allowed)` — il motivo per cui #3495 M2 ha creato `EgressAllowed` — va progettato sapendolo.
+3. **La semantica del counter cambia**: da "connessione rifiutata" a "connessione o payload rifiutati". Le dashboard esistenti su `meepleai_egress_blocked_total` vanno rilette in questa luce.
+4. **`egress-guard.yml` non era caricato in staging né in prod** (bug pre-esistente di #3495 M2, corretto qui): prima di questa PR quegli alert non esistevano fuori dal dev.
+5. **Serve un force-recreate di prometheus su staging** dopo il merge perché le regole diventino attive — il deploy da solo non le ricarica.
 
 ---
 
@@ -760,6 +891,14 @@ Il target **deve** essere `main-dev`, mai `main`.
 - §1.3 `denylist_hit` sui due gate + split dell'alert → Task 3 (wiring) e Task 4 (alert). ✔
 - §"Test PR 1": unit DNS + cancellazione → Task 1 Step 4; decode_fail nei due sink → Task 2; denylist_hit → Task 3; estensione di `Counters_HaveStableBoundedNames` → Task 1 Step 4; promtool → Task 4 Step 3. ✔
 
-**Scan dei placeholder:** un punto resta deliberatamente non letterale — Task 2 Step 5, dove il corpo della lambda rimanda all'arrangiamento del test sibling alle righe 372-395 di `EnrichCatalogCoverCommandHandlerTests.cs`. Non ho letto quel blocco per intero, quindi trascriverlo a memoria avrebbe prodotto codice plausibile ma non verificato: peggio di un rimando esplicito. Chi implementa legge quelle righe e riusa il setup reale.
+**Scan dei placeholder:** nessuno residuo. Il Task 2 Step 5, che nella prima stesura rimandava genericamente al test sibling, è ora letterale: l'arrangiamento reale (`BuildHarness`, `BuildGame`, i due stub handler, i byte corrotti) è trascritto, ed è chiarito che l'handler **cattura** `ImageProcessingException` e ritorna `Failed` invece di rilanciare — quindi lì non serve `try/catch`, a differenza del path manuale.
 
-**Coerenza dei tipi:** `MetricCapture.Capture(string, Action) -> List<(long Value, IReadOnlyDictionary<string, object?> Tags)>` è definita nel Task 1 Step 1 e usata con la stessa firma nei Task 2 e 3. Le costanti citate esistono tutte: `DecodeFail` e `DenylistHit` già in `MeepleAiMetrics.Egress.cs:31,40`; `DnsFailure` la crea il Task 1 Step 6. `ImageProcessingException` e `BggHostDenyList.IsBanned` sono verificati nel sorgente.
+**Coerenza dei tipi:** `MetricCapture.Capture(string, Action) -> List<(long Value, IReadOnlyDictionary<string, object?> Tags)>` è definita nel Task 1 Step 1 e usata con la stessa firma nei Task 2 e 3. Le costanti citate esistono tutte: `DecodeFail` e `DenylistHit` già in `MeepleAiMetrics.Egress.cs:31,40`; `DnsFailure` la crea il Task 1 Step 6. `ImageProcessingException` e `BggHostDenyList.IsBanned` sono verificati nel sorgente. Il costruttore posizionale `SetManualCoverCommand(GameId, SourceUrl, License, Attribution, AdminId)` è verificato in `SetManualCoverCommandValidatorTests.cs:22-23`.
+
+**Dipendenza d'ordine:** il Task 3 Step 5 assume che il Task 2 abbia già aggiunto `using Api.Observability;` a `SetManualCoverCommandHandler.cs`. Eseguendo i task fuori ordine non compila — vanno eseguiti in sequenza.
+
+## Trovato durante la review — fuori scope di questa PR
+
+`infra/prometheus/alerts/api-single-instance.yml` (il tripwire `count(up{job="meepleai-api"}) > 1` di #3383 / ADR-087 D4) **non è montato in nessun compose e non compare in nessun `rule_files:`**, dev incluso. Il file esiste e ha il suo test promtool, ma Prometheus non lo carica in alcun ambiente: l'alert che secondo ADR-087 D4 «rende un scale-out rumoroso» — e che è la ragione dichiarata per cui la hard-prevention è stata rinviata — non è mai stato attivo.
+
+Non lo correggo qui perché appartiene a #3383 (PR 2), dove va aggiunto sia il mount nei tre compose sia la riga nei tre `rule_files:`. Va anche riaperta la prima checkbox "Subito" di #3383, oggi spuntata.

--- a/docs/superpowers/specs/2026-08-06-egress-observability-single-pod-cover-gap-design.md
+++ b/docs/superpowers/specs/2026-08-06-egress-observability-single-pod-cover-gap-design.md
@@ -1,0 +1,219 @@
+# Design — osservabilità egress, enforcement single-pod, cover-gap catalogo
+
+**Data**: 2026-08-06
+**Issue**: [#3583](https://github.com/meepleAi-app/meepleai-monorepo/issues/3583), [#3383](https://github.com/meepleAi-app/meepleai-monorepo/issues/3383), [#3590](https://github.com/meepleAi-app/meepleai-monorepo/issues/3590)
+**Base**: `main-dev` @ `d3af99912`
+
+Record di design per un lotto di tre issue indipendenti, consegnate in tre PR separate verso
+`main-dev`. Il documento è committato con la prima PR perché le tre si toccano in un punto: lo
+split dell'alert `denylist_hit` (#3583) è ciò che rende sostenibile il carve-out BGG (#3590).
+
+---
+
+## PR 1 — #3583: reason di osservabilità egress non wired
+
+Tre segnali mancanti su percorsi che **già falliscono chiusi**. Nessuno è un buco di sicurezza:
+l'esito è corretto, manca il contatore che lo rende visibile.
+
+### 1.1 `dns_failure`
+
+`SsrfPinnedConnect.ResolveAndValidateAsync` (`SsrfPinnedConnect.cs:30`) conta il blocco quando la
+risoluzione ritorna zero indirizzi o un indirizzo bloccato, ma se `IDnsResolver.ResolveAsync`
+**lancia** (NXDOMAIN, timeout del resolver, socket error) l'eccezione propaga senza passare da
+`RecordEgressBlocked`. Un sink che degrada per problemi DNS diventa indistinguibile da un sink
+inattivo.
+
+- Nuova costante `EgressBlockReasons.DnsFailure = "dns_failure"` in `MeepleAiMetrics.Egress.cs`.
+- `try/catch` attorno alla risoluzione: registra e **rilancia** (l'esito fail-closed non cambia).
+- L'exception filter esclude la cancellazione del chiamante:
+  `catch (Exception ex) when (ex is not OperationCanceledException || !ct.IsCancellationRequested)`.
+  Un timeout interno del resolver viene contato; un abort del chiamante no.
+- Nessun host/IP nei tag: restano i due soli tag bounded `sink` e `reason`.
+
+### 1.2 `decode_fail` — deviazione motivata dal testo dell'issue
+
+L'issue propone di wirarlo dentro `WebpVariantGenerator`. **Non lo faccio**, per due ragioni
+verificate nel codice:
+
+1. Il generator non conosce il `sink` e non potrebbe taggare la metrica senza cambiarne
+   l'interfaccia (`IWebpVariantGenerator`). Il sink è una proprietà del chiamante, non del codec.
+2. Uno dei tre chiamanti — `MaterializePdfCoverCommandHandler.cs:77` — lavora su un PDF **locale**:
+   lì un decode fallito non è un blocco di egress e conteggiarlo falserebbe il rapporto
+   blocked/allowed.
+
+Wiro invece i due call site alimentati da rete:
+
+| Call site | Sink |
+|---|---|
+| `SetManualCoverCommandHandler.cs:85` | `EgressSinks.Manual` |
+| `EnrichCatalogCoverCommandHandler.cs:221` (ha già il `catch (ImageProcessingException)`) | `EgressSinks.Wikimedia` |
+
+Copre entrambi i rifiuti di `WebpVariantGenerator` citati dall'issue — decompression bomb
+(cap dimensione/megapixel, `WebpVariantGenerator.cs:119-128`) e coder non-raster
+(`DetectRasterFormat` → `null`, `WebpVariantGenerator.cs:100-108`) — perché entrambi risalgono come
+`ImageProcessingException`.
+
+### 1.3 `denylist_hit` + split dell'alert
+
+`BggHostDenyList` ha due call site, mutuamente esclusivi (se il validator rifiuta, l'handler non
+gira): `SetManualCoverCommandValidator.cs:27` e `SetManualCoverCommandHandler.cs:73`
+(defense-in-depth). Wiro entrambi con `sink=manual`; l'esclusività garantisce che una richiesta
+conti una volta sola.
+
+**Il punto non ovvio**: `infra/prometheus/alerts/egress-guard.yml:18` tratta già
+`sink="manual", reason=~"private_ip|denylist_hit"` come **incidente P1 SSRF con SLO=0**. Wirare il
+counter così com'è farebbe scattare un P1 ogni volta che un admin incolla un URL BGG — che è una
+violazione della policy ADR-059 §5, non un tentativo di raggiungere un target interno. Con il
+carve-out BGG di PR 3 gli admin avranno più occasioni di provarci, quindi il falso P1 diventerebbe
+ricorrente.
+
+Separo quindi i due segnali:
+
+- `private_ip` → resta P1 SSRF, SLO=0, invariato.
+- `denylist_hit` → alert distinto `severity: warning`, descritto come violazione della policy
+  ADR-059 (tentativo di laundering attorno al ban BGG), con runbook che punta al carve-out.
+
+`infra/prometheus/alerts/egress-guard.test.yml` va aggiornato in pari passo (i test promtool sono
+parte del gate).
+
+### Test PR 1
+
+- Unit su `ResolveAndValidateAsync`: eccezione DNS → `dns_failure` incrementato + rilancio;
+  cancellazione del chiamante → **nessun** incremento.
+- Unit sui due call site `decode_fail` con il sink atteso.
+- Unit su validator e handler per `denylist_hit`.
+- Estensione di `Counters_HaveStableBoundedNames` (`EgressMetricsTests.cs:120`) alle nuove reason.
+- `promtool test rules` sui file alert modificati.
+
+---
+
+## PR 2 — #3383: enforcement single-pod (D4 di #3373)
+
+I tre punti "Subito" dell'issue sono già a terra e verificati: tripwire
+`infra/prometheus/alerts/api-single-instance.yml` (`count(up{job="meepleai-api"}) > 1`, `for: 5m`),
+commento sul vincolo in `infra/docker-compose*.yml:60`, emendamento DEC-3e in
+`adr-087-cover-procedure-design-decisions.md:38-44`. Restano i due task deferiti.
+
+### 2.1 Gauge dead-letter da `COUNT` DB
+
+Oggi il gauge è ibrido: `WikidataCoverEnrichmentRunner.cs:121` incrementa in memoria a ogni nuovo
+dead-letter, e `WikidataCoverDeadLetterRetentionJob.cs:92-93` ri-ancora al `COUNT` reale dopo lo
+sweep — che gira **una volta al giorno alle 03:00 UTC**. A >1 pod ogni processo ha il suo contatore:
+`sum()` raddoppia, `max()` deriva.
+
+- Nuovo `WikidataDeadLetterMetricsRefreshService : BackgroundService`, sul pattern già in uso di
+  `ImpersonationMetricsRefreshService.cs`: ogni 60s apre uno scope, chiama `CountDeadLettersAsync`
+  e pusha via `SetWikidataDeadLetterCount`.
+- L'`ObservableGauge` continua a leggere il campo in memoria: è il servizio che lo aggiorna. Questo
+  evita l'anti-pattern segnalato dall'issue (query al DB a ogni scrape Prometheus).
+- **Rimuovo** `IncrementWikidataDeadLetterCount` dal runner: con il refresh periodico l'incremento
+  ottimistico diventa solo una fonte di drift, e un valore puramente DB-derivato è esattamente ciò
+  che rende `max()` corretto a più pod (ogni pod riporta lo stesso ground truth).
+- Resilienza come nel precedente: un refresh fallito logga e ritenta al tick successivo, non
+  abbatte l'host.
+
+### 2.2 Lease Redis fail-closed sul batch
+
+`WikidataCoverEnrichmentJob` ha oggi solo `[DisallowConcurrentExecution]`, che è una garanzia
+**intra-processo**: non impedisce a due pod di girare lo stesso batch e raddoppiare il rate verso
+Wikimedia (violazione ToS, DEC-3e).
+
+- Lease su Redis via `IConnectionMultiplexer` (già disponibile nel progetto), `SET NX PX` con TTL
+  maggiore della durata attesa del tick, rilascio in `finally`.
+- **Fail-closed**: se il lease non si acquisisce *o Redis non è raggiungibile*, il tick viene
+  saltato e loggato.
+
+Trade-off da mettere per iscritto, perché non è gratis: fail-closed significa che
+**un'indisponibilità di Redis ferma l'enrichment**. È la semantica di hard-prevention richiesta
+dall'issue — si preferisce non arricchire piuttosto che rischiare di violare il rate cap — ma va
+documentata nell'emendamento ADR-087 e nel runbook, altrimenti a un'incidente Redis nessuno collega
+l'enrichment fermo.
+
+### Test PR 2
+
+- Unit sul refresh service: `RefreshOnceAsync` pusha il valore contato; un'eccezione del repo non
+  propaga fuori dal loop.
+- Unit sul job: lease acquisito → il batch gira; lease non acquisito → batch saltato; Redis in
+  errore → batch saltato (fail-closed), non un'eccezione che risale a Quartz.
+
+---
+
+## PR 3 — #3590: cover-gap catalogo + carve-out BGG
+
+### Premessa: il testo dell'issue è in parte superato
+
+Due assunzioni sono cambiate e vanno corrette nell'issue:
+
+1. **«la via più economica resta sbloccare #3589 e ri-processarli»** — #3589 è chiusa ma ha corretto
+   solo la *classificazione* dell'errore 413 (permanente anziché retriable) e il messaggio
+   fuorviante. L'issue stessa classifica l'innalzamento del limite come «una scelta di capacità, non
+   un bug». Però il default nel codice è **già 100MB** da `0afeb58b8` (#3424, 2026-07-31)
+   — `apps/unstructured-service/src/config/settings.py:17` — mentre staging il 2026-08-06 riportava
+   ancora `exceeds maximum 52428800 bytes` (50MB). `MAX_FILE_SIZE` non è impostato in `infra/`.
+   Ipotesi da verificare: immagine staging stale. Se confermata, i 4 PDF si sbloccano con un
+   redeploy, senza codice nuovo.
+2. **La via BGG è sbarrata, non aperta** — `BggHostDenyList` blocca `geekdo-images.com`,
+   `geekdo.com`, `boardgamegeek.com` sul path manuale in due punti. L'opzione 1 dell'issue non può
+   passare per `SetManualCoverCommand`.
+
+### 3.1 Vista admin cover-gap
+
+Il collo di bottiglia reale non è la mancanza di uno strumento per risolvere, ma la mancanza di un
+modo per **trovare** i giochi da risolvere: non esiste alcuna vista admin dei giochi senza cover, e
+l'unico accesso all'editor è l'affordance a matita in hover sulle card della pagina *pubblica*
+`/shared-games`.
+
+- Query CQRS che incrocia `shared_games.{pdf,bgg,wikidata,manual}_cover_r2_key IS NULL` con
+  `pdf_documents.{cover_generation_status, error_category}` per derivare la causa, nei tre gruppi
+  dell'issue: PDF oltre il limite di dimensione · pagina rifiutata dall'euristica · nessuna sorgente.
+- Endpoint admin + pagina sotto `apps/web/src/app/admin/(dashboard)/shared-games/`, con accesso
+  diretto all'editor cover esistente.
+- **Gotcha da rispettare**: il gruppo "euristica" si riconosce da `cover_generation_status =
+  'Skipped'` scritto **direttamente sul campo** da `BackfillPdfCoversJob`, non via
+  `PdfDocument.MarkCoverSkipped()` (metodo morto).
+
+Il path manuale a valle funziona già end-to-end: il form "Aggiungi copertina da URL" di
+`AdminCoverSourceDialog.tsx` sta fuori dal ramo `candidates.length === 0`, quindi resta usabile
+anche sui giochi con zero candidati — cioè esattamente i 26.
+
+### 3.2 Carve-out BGG re-upload
+
+`BggCoverDownloader` + `BggCoverUploadPipeline` esistono già, sono sanzionati da ADR-059 §2 e sono
+già in uso da `CreateSharedGameFromPdfCommandHandler.cs:123` — ma solo alla **creazione** di uno
+SharedGame da PDF. Non esiste un trigger per un gioco già a catalogo.
+
+Comando/endpoint admin dedicato che riusa quel path, **senza** passare da `SetManualCoverCommand`.
+
+La distinzione è il punto centrale del design: `BggHostDenyList` resta **intatta** sul path a URL
+arbitrario, che è esattamente il suo scopo (impedire a un admin di aggirare il ban incollando un
+URL geekdo nel campo libero). Non è una nuova postura legale né un allentamento: è un trigger nuovo
+su un path server-to-server già esistente e già sanzionato. Il freeze #2123 riguarda le richieste
+*browser* verso gli host geekdo e non è toccato.
+
+Da aggiornare: `docs/for-developers/specs/2026-08-02-admin-cover-editor-design.md:88` afferma «host
+BGG non bloccati nel fetch server-side (ADR-059 §2)» — affermazione superata da #3495, il doc è
+obsoleto su quel punto.
+
+### Test PR 3
+
+- Unit sulla query cover-gap: classificazione corretta nei tre gruppi, inclusa la riga `Skipped`.
+- Unit sul comando BGG re-upload: gioco senza `bggId` → errore di dominio; percorso felice →
+  chiave R2 attesa; la deny-list resta attiva su `SetManualCover` (test di non-regressione).
+- Test FE sulla pagina cover-gap.
+
+### Fuori PR — verifica ops
+
+SSH allo staging per leggere il limite effettivo di `unstructured-service`; se stale, redeploy e
+retry sui 4 PDF grandi. Esito riportato su #3590.
+
+---
+
+## Note trasversali
+
+- **Branch**: uno per issue, ciascuno da `main-dev` aggiornato, PR sequenziali (1 issue = 1 PR).
+- **Worktree**: `.claude/worktrees/i3583`, da eliminare a merge avvenuto in `main-dev`.
+- **Baseline verificata** su `d3af99912`: build API pulita (0 warning, 0 errori); 119 test passati,
+  0 falliti sui filtri `EgressMetrics|EgressHostAllowList|BggHostDenyList|WebpVariantGenerator|SsrfPolicy`.
+- **Decisioni di #3495 da non riaprire**: facade `IHardenedEgressClient` declinata (E3); four-eyes
+  su `source=Manual` deferita (M7); decode-and-recurse dell'IPv4 embedded è una deviazione
+  deliberata; gli assert H5 sugli invarianti R2 restano gated su #3498.

--- a/infra/prometheus.prod.yml
+++ b/infra/prometheus.prod.yml
@@ -27,6 +27,9 @@ rule_files:
   - '/etc/prometheus/wikidata-enrichment.yml'
   # Issue #3082 — BGG ToS-compliance SLO=0 alert (any nonzero render attempt = P1).
   - '/etc/prometheus/bgg-tos-compliance.yml'
+  # #3495 M2 — SSRF egress guard (private_ip = P1) + #3583 policy alert (denylist_hit = warning).
+  # Il file era già montato ma mai referenziato in staging/prod: regole caricate solo da #3583.
+  - '/etc/prometheus/egress-guard.yml'
   # Issue #3112 — OPS-02 Slack delivery observability alerts.
   - '/etc/prometheus/slack-delivery.yml'
   # Issue #3116 — SP5 Admin Security audit_outbox health alerts.

--- a/infra/prometheus.staging.yml
+++ b/infra/prometheus.staging.yml
@@ -27,6 +27,9 @@ rule_files:
   - '/etc/prometheus/wikidata-enrichment.yml'
   # Issue #3082 — BGG ToS-compliance SLO=0 alert (any nonzero render attempt = P1).
   - '/etc/prometheus/bgg-tos-compliance.yml'
+  # #3495 M2 — SSRF egress guard (private_ip = P1) + #3583 policy alert (denylist_hit = warning).
+  # Il file era già montato ma mai referenziato in staging/prod: regole caricate solo da #3583.
+  - '/etc/prometheus/egress-guard.yml'
   # Issue #3112 — OPS-02 Slack delivery observability alerts.
   - '/etc/prometheus/slack-delivery.yml'
   # Issue #3116 — SP5 Admin Security audit_outbox health alerts.

--- a/infra/prometheus/alerts/egress-guard.test.yml
+++ b/infra/prometheus/alerts/egress-guard.test.yml
@@ -1,6 +1,15 @@
-# promtool test for egress-guard.yml (#3495 M2). NOT run in CI — on-demand only:
-#   docker run --rm -v "$(pwd)/infra/prometheus/alerts:/work" prom/prometheus:v3.7.0 \
-#     promtool test rules /work/egress-guard.test.yml
+# promtool test for egress-guard.yml (#3495 M2). NOT run in CI — on-demand only.
+#
+# L'immagine prom/prometheus ha `prometheus` come entrypoint, quindi promtool va invocato con
+# --entrypoint; su Git Bash serve anche MSYS_NO_PATHCONV=1, altrimenti /work viene riscritto in
+# C:/Program Files/Git/work (#3583 — il comando documentato in origine non funzionava):
+#   MSYS_NO_PATHCONV=1 docker run --rm --entrypoint promtool \
+#     -v "$(pwd)/infra/prometheus/alerts:/work" prom/prometheus:v3.7.0 \
+#     test rules /work/egress-guard.test.yml
+#
+# NOTA (#3583): exp_annotations è OBBLIGATORIO quando exp_alerts non è vuoto — promtool confronta
+# l'intero alert, annotazioni incluse. Questo file era l'unico dei nove a ometterlo, quindi il suo
+# test falliva fin dalla creazione; le annotazioni sotto devono restare allineate a egress-guard.yml.
 rule_files:
   - egress-guard.yml
 evaluation_interval: 1m
@@ -17,6 +26,10 @@ tests:
           - exp_labels:
               severity: critical
               subsystem: egress-ssrf
+            exp_annotations:
+              summary: "Manual-cover SSRF attempt blocked (sink=manual, private_ip)"
+              description: "meepleai_egress_blocked_total incremented for sink=manual with reason private_ip: an admin-supplied manual-cover URL resolved to an internal/reserved address. SLO for this metric is ZERO; any nonzero rate is a P1 SSRF incident (#3495)."
+              runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-developers/operations/operations-manual.md"
 
   # 2) DOES NOT FIRE on cold-start: only an unrelated sink series exists; `or vector(0)` keeps it silent.
   - interval: 1m
@@ -28,7 +41,7 @@ tests:
         alertname: EgressBlockedManualSensitive
         exp_alerts: []
 
-  # 3) DOES NOT FIRE for a non-sensitive reason on the manual sink (size_cap is not private_ip/denylist_hit).
+  # 3) DOES NOT FIRE for a non-sensitive reason on the manual sink (size_cap is neither rule's reason).
   - interval: 1m
     input_series:
       - series: 'meepleai_egress_blocked_total{sink="manual",reason="size_cap"}'
@@ -36,4 +49,37 @@ tests:
     alert_rule_test:
       - eval_time: 5m
         alertname: EgressBlockedManualSensitive
+        exp_alerts: []
+      - eval_time: 5m
+        alertname: EgressDenylistHit
+        exp_alerts: []
+
+  # 4) denylist_hit FIRES EgressDenylistHit at warning — and NOT the critical SSRF alert (#3583).
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_egress_blocked_total{sink="manual",reason="denylist_hit"}'
+        values: '0 0 1 1 1 1'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: EgressDenylistHit
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              subsystem: egress-policy
+            exp_annotations:
+              summary: "Manual-cover URL rejected by the ADR-059 BGG deny-list (sink=manual)"
+              description: "meepleai_egress_blocked_total incremented for sink=manual with reason denylist_hit: someone submitted a BGG/geekdo asset URL to the manual-cover field, which ADR-059 §5 bans. A one-off is an admin mistake; a sustained rate is an attempt to launder around the ban and warrants review of who is submitting it. The legitimate route for a BGG cover is the admin server-to-server re-upload path, never the arbitrary-URL field."
+              runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-developers/operations/operations-manual.md"
+      - eval_time: 5m
+        alertname: EgressBlockedManualSensitive
+        exp_alerts: []
+
+  # 5) private_ip does NOT cross-trigger the policy alert (its own firing is covered by case 1).
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_egress_blocked_total{sink="manual",reason="private_ip"}'
+        values: '0 0 1 1 1 1'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: EgressDenylistHit
         exp_alerts: []

--- a/infra/prometheus/alerts/egress-guard.yml
+++ b/infra/prometheus/alerts/egress-guard.yml
@@ -5,9 +5,13 @@
 #   - meepleai_egress_allowed_total{sink}         — allowed connections (block-ratio denominator).
 # Labels are bounded constants (sink/reason); a host or IP is NEVER a label.
 #
-# SLO for the manual (arbitrary-URL) sink hitting private_ip / denylist_hit is ZERO: any nonzero
-# rate means an admin-supplied manual-cover URL resolved to an internal/denied target — a live
-# SSRF attempt. severity=critical pages via the alertmanager critical-alerts route.
+# SLO for the manual (arbitrary-URL) sink hitting private_ip is ZERO: any nonzero rate means an
+# admin-supplied manual-cover URL resolved to an internal/reserved address — a live SSRF attempt.
+# severity=critical pages via the alertmanager critical-alerts route.
+#
+# denylist_hit is tracked SEPARATELY at severity=warning (#3583): it is an ADR-059 §5 policy
+# violation (a BGG/geekdo URL in the manual field), not an internal-target attempt. Paging on it
+# would mean paging on an admin's typo.
 #
 # promtool test: infra/prometheus/alerts/egress-guard.test.yml
 groups:
@@ -15,12 +19,27 @@ groups:
     rules:
       - alert: EgressBlockedManualSensitive
         # `or vector(0)` guards cold-start: the series may not exist yet on a fresh deploy.
-        expr: (sum(rate(meepleai_egress_blocked_total{sink="manual",reason=~"private_ip|denylist_hit"}[5m])) or vector(0)) > 0
+        expr: (sum(rate(meepleai_egress_blocked_total{sink="manual",reason="private_ip"}[5m])) or vector(0)) > 0
         for: 0m
         labels:
           severity: critical
           subsystem: egress-ssrf
         annotations:
-          summary: "Manual-cover SSRF attempt blocked (sink=manual, private_ip|denylist_hit)"
-          description: "meepleai_egress_blocked_total incremented for sink=manual with reason private_ip or denylist_hit: an admin-supplied manual-cover URL resolved to an internal/denied target. SLO for this metric is ZERO; any nonzero rate is a P1 SSRF incident (#3495)."
+          summary: "Manual-cover SSRF attempt blocked (sink=manual, private_ip)"
+          description: "meepleai_egress_blocked_total incremented for sink=manual with reason private_ip: an admin-supplied manual-cover URL resolved to an internal/reserved address. SLO for this metric is ZERO; any nonzero rate is a P1 SSRF incident (#3495)."
+          runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-developers/operations/operations-manual.md"
+
+      - alert: EgressDenylistHit
+        # #3583 — separata da EgressBlockedManualSensitive: un hit sulla deny-list ADR-059 §5 è una
+        # violazione di POLICY (un URL BGG/geekdo nel campo cover manuale), non un tentativo di
+        # raggiungere un target interno. Trattarlo come P1 SSRF genererebbe pagine su un errore di
+        # battitura di un admin — tanto più col carve-out BGG server-to-server (#3590).
+        expr: (sum(rate(meepleai_egress_blocked_total{sink="manual",reason="denylist_hit"}[5m])) or vector(0)) > 0
+        for: 0m
+        labels:
+          severity: warning
+          subsystem: egress-policy
+        annotations:
+          summary: "Manual-cover URL rejected by the ADR-059 BGG deny-list (sink=manual)"
+          description: "meepleai_egress_blocked_total incremented for sink=manual with reason denylist_hit: someone submitted a BGG/geekdo asset URL to the manual-cover field, which ADR-059 §5 bans. A one-off is an admin mistake; a sustained rate is an attempt to launder around the ban and warrants review of who is submitting it. The legitimate route for a BGG cover is the admin server-to-server re-upload path, never the arbitrary-URL field."
           runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-developers/operations/operations-manual.md"


### PR DESCRIPTION
Closes #3583.

Tre reason di osservabilità egress esistevano come costanti ma non le emetteva nessuno. Nessuno dei percorsi era un buco di sicurezza: **falliscono già chiusi**, mancava solo il contatore che li rende visibili.

## Cosa cambia

| Reason | Dove | Nota |
|---|---|---|
| `dns_failure` (nuova) | `SsrfPinnedConnect.ResolveAndValidateAsync` | Se il resolver **lancia** (NXDOMAIN, timeout, socket error) l'eccezione propagava senza passare da `RecordEgressBlocked`: un sink degradato per DNS era indistinguibile da un sink inattivo. |
| `decode_fail` | `SetManualCoverCommandHandler` (`manual`) · `EnrichCatalogCoverCommandHandler` (`wikimedia`) | Rifiuto del decoder su un payload scaricato. |
| `denylist_hit` | `SetManualCoverCommandValidator` + gate difensivo dell'handler | Tentativo di aggirare il ban BGG di ADR-059 §5. |

In più: split dell'alert Prometheus, `EgressDenylistHit` a `severity: warning` separato dal P1 SSRF.

## Le tre deviazioni dal testo dell'issue

1. **`decode_fail` sui call site, non dentro `WebpVariantGenerator`.** Il generator non conosce il `sink` e non potrebbe taggare la metrica senza cambiarne l'interfaccia; e il suo terzo chiamante, `MaterializePdfCoverCommandHandler`, decodifica un PDF **locale**, dove un decode fallito non è un blocco di egress. Copre comunque entrambi i rifiuti citati dall'issue (decompression bomb e coder non-raster): risalgono entrambi come `ImageProcessingException`.

2. **Split dell'alert.** `EgressBlockedManualSensitive` trattava `private_ip|denylist_hit` come un unico incidente P1 con SLO=0. Ora che `denylist_hit` è raggiungibile, lasciarlo lì significherebbe **paginare sull'errore di battitura di un admin** — e col carve-out BGG previsto da #3590 il caso diventerà più frequente, non meno. `private_ip` resta P1 invariato.

3. **Entrambi i gate della deny-list, non uno.** Sono mutuamente esclusivi (se il validator rifiuta, l'handler non gira), quindi una richiesta conta una volta sola; wirarne uno solo lascerebbe cieco l'altro.

## Difetti pre-esistenti di #3495 M2 corretti qui

Emersi lavorando alla issue, nessuno era nel suo testo:

1. **`egress-guard.yml` non era caricato in staging né in prod.** Montato in tutti e tre i compose, ma presente in `rule_files:` solo in `infra/prometheus.yml` (dev). Gli alert egress non sono mai esistiti fuori dal dev, e senza questa correzione `EgressDenylistHit` sarebbe nato morto negli stessi ambienti.
2. **`egress-guard.test.yml` era l'unico dei nove file di test alert senza `exp_annotations`**, che promtool pretende quando `exp_alerts` non è vuoto: il suo test **falliva fin dalla creazione**. Ora passa.
3. **Il comando promtool documentato nel suo header non funzionava**: l'immagine `prom/prometheus` ha `prometheus` come entrypoint, e su Git Bash serve `MSYS_NO_PATHCONV=1`. Sostituito con quello reale.

## Da sapere per leggere le metriche

- **Il denominatore del block-ratio si sporca.** `RecordEgressAllowed` è emesso solo dal connect-pin, una volta per connessione TCP validata. Ora `denylist_hit` dal validator incrementa `blocked` **senza** che sia mai avvenuto un tentativo di connessione (nessun `allowed` corrispondente), mentre `decode_fail` incrementa `blocked` **dopo** che la connessione è stata concessa (quindi con un `allowed` già contato). Qualunque alert futuro su `blocked/(blocked+allowed)` va progettato sapendolo.
- **La semantica del counter cambia**: da "connessione rifiutata" a "connessione o payload rifiutati".
- **`dns_failure` conta per connessione, non per richiesta**: il guard gira nel `ConnectCallback`, quindi ogni hop di redirect e ogni nuova connessione del pool incrementa.
- **Il conteggio di `denylist_hit` poggia su una garanzia emergente** (cascade rule-level `Continue` + validator invocato solo dal `ValidationBehavior`), documentata nel commento XML perché non è protetta da un test.

## Azione richiesta dopo il merge

Le regole Prometheus **non si ricaricano al deploy**: serve un force-recreate del container prometheus su staging perché diventino attive.

## Verifica

- `dotnet build`: `Avvisi: 0`, `Errori: 0`
- Categoria `Unit` completa: **21361 passati, 0 falliti**, 23 skipped
- `promtool test rules /work/egress-guard.test.yml`: **SUCCESS**
- `dotnet format` sui file modificati: nessuna modifica

## Trovato fuori scope — per #3383

`infra/prometheus/alerts/api-single-instance.yml` (il tripwire `count(up{job="meepleai-api"}) > 1` di ADR-087 D4) **non è montato in nessun compose e non compare in nessun `rule_files:`, dev incluso**. L'alert che secondo D4 «rende un scale-out rumoroso» — la ragione dichiarata per cui la hard-prevention è stata rinviata — non è mai stato attivo. Va sistemato in #3383, dove la prima checkbox "Subito" andrebbe riaperta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
