### PR TITLE
fix(docprocessing): StalePdfRecovery non tocca i PDF con un job attivo (#3588 follow-up)

### DIFF
--- a/apps/api/src/Api/Infrastructure/BackgroundServices/StalePdfRecoveryService.cs
+++ b/apps/api/src/Api/Infrastructure/BackgroundServices/StalePdfRecoveryService.cs
@@ -195,13 +195,21 @@ internal sealed class StalePdfRecoveryService : BackgroundService
             // seeded in deliberate non-Ready states for the dashboard demo; force-processing them
             // would only fail on the missing blob and flip them to Failed (→ seed_state partial_failed).
             .Where(p => !p.FilePath.StartsWith(PdfDocumentEntity.DemoMockFilePathPrefix))
-            // #3588: leave documents that are already waiting in the queue to the queue worker.
-            // OrphanedProcessingJobRecoveryService requeues restart-orphaned jobs just before this
-            // service runs; without this guard both would drive the same PDF, and this one would
-            // reset it to Pending mid-flight. Only Queued is excluded — a still-Processing row means
-            // that recovery did not run or failed, and this service stays the last line of defence.
+            // #3588: a document with an ACTIVE job row belongs to the queue worker, not to this
+            // service. Driving it here calls ResetToPendingAsync on it, which rewinds a document
+            // mid-flight — and that reset runs BEFORE the pipeline's atomic Pending-claim can refuse
+            // it, so the claim is not a sufficient defence on its own.
+            //
+            // Excluding only Queued was not enough (observed on staging 2026-08-07): a job requeued
+            // by OrphanedProcessingJobRecoveryService is picked up by the worker within seconds, so
+            // by the time this service runs it has already moved Queued → Processing. Both queue
+            // states mean "owned", so both are excluded.
+            //
+            // Terminal jobs (Completed/Failed/Cancelled) and documents with no job row have no owner
+            // and stay in scope — that is the case this service exists for.
             .Where(p => !db.Set<ProcessingJobEntity>()
-                .Any(j => j.PdfDocumentId == p.Id && j.Status == nameof(JobStatus.Queued)))
+                .Any(j => j.PdfDocumentId == p.Id
+                       && (j.Status == nameof(JobStatus.Queued) || j.Status == nameof(JobStatus.Processing))))
             .Where(p =>
                 (p.ProcessingState == pendingState && p.UploadedAt < pendingCutoff) ||
                 ((p.ProcessingState == uploadingState ||

--- a/apps/api/tests/Api.Tests/Infrastructure/BackgroundServices/StalePdfRecoveryServiceTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/BackgroundServices/StalePdfRecoveryServiceTests.cs
@@ -3,6 +3,7 @@ using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.Infrastructure;
 using Api.Infrastructure.BackgroundServices;
 using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.DocumentProcessing;
 using Api.Tests.Constants;
 using Api.Tests.TestHelpers;
 using Microsoft.Extensions.DependencyInjection;
@@ -45,6 +46,23 @@ public sealed class StalePdfRecoveryServiceTests
             UploadedByUserId = userId ?? Guid.NewGuid(),
             UploadedAt = uploadedAt,
             ProcessingState = processingState,
+        };
+    }
+
+    /// <summary>
+    /// Builds a <see cref="ProcessingJobEntity"/> in the given status for a PDF, so tests can
+    /// express "this document is owned by the queue" vs "nothing owns it". Issue #3588 follow-up.
+    /// </summary>
+    private static ProcessingJobEntity BuildJobFor(Guid pdfDocumentId, string status)
+    {
+        return new ProcessingJobEntity
+        {
+            Id = Guid.NewGuid(),
+            PdfDocumentId = pdfDocumentId,
+            UserId = Guid.NewGuid(),
+            Status = status,
+            Priority = 0,
+            CreatedAt = DateTimeOffset.UtcNow.AddHours(-1),
         };
     }
 
@@ -456,6 +474,105 @@ public sealed class StalePdfRecoveryServiceTests
         var updated = await db.PdfDocuments.FindAsync(entity.Id);
         Assert.NotNull(updated);
         Assert.Equal(nameof(PdfProcessingState.Ready), updated.ProcessingState);
+    }
+
+    // ── FindStalePdfsAsync: ownership guard vs the queue worker (#3588 follow-up) ──
+
+    /// <summary>
+    /// A PDF whose job is <c>Queued</c> belongs to the queue worker, not to this service.
+    /// Driving it here would reset it to Pending under the worker's feet.
+    /// </summary>
+    [Fact]
+    [Trait("Issue", "3588")]
+    public async Task FindStalePdfsAsync_PdfWithQueuedJob_IsExcluded()
+    {
+        var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var pdf = BuildPdfEntity(
+            nameof(PdfProcessingState.Chunking),
+            DateTime.UtcNow - TimeSpan.FromMinutes(40));
+        db.PdfDocuments.Add(pdf);
+        db.ProcessingJobs.Add(BuildJobFor(pdf.Id, nameof(JobStatus.Queued)));
+        await db.SaveChangesAsync();
+
+        var (scopeFactory, _) = BuildScopeFactory(db, new Mock<IPdfProcessingPipelineService>());
+
+        var stalePdfs = await InvokeFindStalePdfsAsync(CreateService(scopeFactory));
+
+        Assert.Empty(stalePdfs);
+    }
+
+    /// <summary>
+    /// Regression guard for the gap observed on staging on 2026-08-07: a job requeued by
+    /// <c>OrphanedProcessingJobRecoveryService</c> is picked up by the worker within seconds, so it
+    /// leaves <c>Queued</c> for <c>Processing</c>. The original guard only excluded <c>Queued</c>,
+    /// so this service then tried to "recover" a document the worker was actively processing —
+    /// calling <c>ResetToPendingAsync</c> on it BEFORE the pipeline's atomic claim could refuse it.
+    /// No corruption resulted (the claim held), but the protection rested entirely on that claim.
+    ///
+    /// An active job means an owner: both queue states must be excluded.
+    /// </summary>
+    [Fact]
+    [Trait("Issue", "3588")]
+    public async Task FindStalePdfsAsync_PdfWithProcessingJob_IsExcluded()
+    {
+        var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var pdf = BuildPdfEntity(
+            nameof(PdfProcessingState.Chunking),
+            DateTime.UtcNow - TimeSpan.FromMinutes(40));
+        db.PdfDocuments.Add(pdf);
+        db.ProcessingJobs.Add(BuildJobFor(pdf.Id, nameof(JobStatus.Processing)));
+        await db.SaveChangesAsync();
+
+        var stalePdfs = await InvokeFindStalePdfsAsync(
+            CreateService(BuildScopeFactory(db, new Mock<IPdfProcessingPipelineService>()).scopeFactory));
+
+        Assert.Empty(stalePdfs);
+    }
+
+    /// <summary>
+    /// The guard must stay narrow: a job in a TERMINAL state has no owner, so a document left
+    /// mid-pipeline behind it is genuinely stale and must still be recovered. Without this, the
+    /// ownership guard would silently disable the service for every document that ever had a job.
+    /// </summary>
+    [Theory]
+    [Trait("Issue", "3588")]
+    [InlineData("Completed")]
+    [InlineData("Failed")]
+    [InlineData("Cancelled")]
+    public async Task FindStalePdfsAsync_PdfWithTerminalJob_IsStillRecovered(string terminalStatus)
+    {
+        var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var pdf = BuildPdfEntity(
+            nameof(PdfProcessingState.Chunking),
+            DateTime.UtcNow - TimeSpan.FromMinutes(40));
+        db.PdfDocuments.Add(pdf);
+        db.ProcessingJobs.Add(BuildJobFor(pdf.Id, terminalStatus));
+        await db.SaveChangesAsync();
+
+        var stalePdfs = await InvokeFindStalePdfsAsync(
+            CreateService(BuildScopeFactory(db, new Mock<IPdfProcessingPipelineService>()).scopeFactory));
+
+        Assert.Single(stalePdfs);
+        Assert.Equal(pdf.Id, stalePdfs[0].Id);
+    }
+
+    /// <summary>A document with no job row at all is the classic stale case — always recovered.</summary>
+    [Fact]
+    [Trait("Issue", "3588")]
+    public async Task FindStalePdfsAsync_PdfWithNoJobAtAll_IsStillRecovered()
+    {
+        var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var pdf = BuildPdfEntity(
+            nameof(PdfProcessingState.Embedding),
+            DateTime.UtcNow - TimeSpan.FromMinutes(40));
+        db.PdfDocuments.Add(pdf);
+        await db.SaveChangesAsync();
+
+        var stalePdfs = await InvokeFindStalePdfsAsync(
+            CreateService(BuildScopeFactory(db, new Mock<IPdfProcessingPipelineService>()).scopeFactory));
+
+        Assert.Single(stalePdfs);
+        Assert.Equal(pdf.Id, stalePdfs[0].Id);
     }
 
     // ── Constructor: null guards ─────────────────────────────────────────────


### PR DESCRIPTION
Follow-up di #3591, osservato **sui log di staging** subito dopo il suo deploy.

## Il difetto

Il guard introdotto con #3591 escludeva solo i PDF con job `Queued`. Ma il deploy stesso ha mostrato la sequenza reale:

```
06:47:11 [OrphanedJobRecovery] Requeued 1 job(s) orphaned by a restart (#3588)
06:47:15 Processing job 3e7a7cb0… for PDF 3b3c0823…        ← worker: Queued → Processing
06:47:31 [StalePdfRecovery] Recovering PDF 3b3c0823 (was Chunking…)  ← guard non applicato
06:47:31 [StalePdfRecovery] PDF 3b3c0823 did NOT progress; recovery ineffective
06:50:50 Job 3e7a7cb0… completed successfully in 214.6s
```

Un job rimesso in coda dal recovery degli orfani viene preso dal worker in **4 secondi**, quindi lascia `Queued` per `Processing` prima che `StalePdfRecovery` giri. Il guard smetteva di applicarsi proprio nella finestra che doveva coprire.

**Nessun danno concreto**: il claim atomico ha rifiutato il documento non-`Pending` (`ProcessAsync` è rientrato in 83 ms) e il job è arrivato a completamento. Ma la protezione restava appesa al solo claim, mentre `ResetToPendingAsync` viene eseguito **prima** del claim e può riavvolgere un documento in volo.

## Il fix

La premessa che avevo scritto nel commento originale — «un job ancora `Processing` significa che il recovery non è girato» — era **incompleta**: può anche significare che il worker ha legittimamente preso in carico il job appena rimesso in coda.

Regola corretta: **un job attivo = un proprietario**. `Queued` e `Processing` vengono entrambi esclusi.

Il guard resta volutamente stretto: job terminali (`Completed`/`Failed`/`Cancelled`) e documenti **senza** job non hanno proprietario e restano in scope — è il caso per cui questo servizio esiste. Copertura per stato:

| Situazione | Chi se ne occupa |
|---|---|
| Orfani da restart | `OrphanedProcessingJobRecoveryService` (requeue al boot) |
| Job bloccato a runtime | `ProcessingQueueMonitor` → degrade a `Failed` → `RetryFailedPdfsJob` |
| Documento stale senza job attivo | `StalePdfRecoveryService` |

## Test

4 nuovi test su `FindStalePdfsAsync`, verificati **rossi prima del fix** (falliva esattamente il caso `Processing`, 1 rosso su 27):

- `PdfWithQueuedJob_IsExcluded` — copre anche il guard originale, che era senza test
- `PdfWithProcessingJob_IsExcluded` — il caso osservato in staging
- `PdfWithTerminalJob_IsStillRecovered` — `Theory` sui tre stati terminali, impedisce al guard di allargarsi fino a disabilitare il servizio
- `PdfWithNoJobAtAll_IsStillRecovered` — il caso classico

46 test verdi sui percorsi correlati (`StalePdf`, `OrphanedProcessingJob`, `ProcessingQueueMonitor`, `DegradeStuckJob`).

Correlato: #3592 (stessa famiglia — il worker marca `Completed` quando il claim rifiuta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)