### PR TITLE
fix(docprocessing): esito esplicito del pipeline (#3592)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/PdfProcessingQuartzJob.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/PdfProcessingQuartzJob.cs
@@ -176,8 +176,30 @@ public sealed class PdfProcessingQuartzJob : IJob
             var pipelineService = _serviceProvider.GetRequiredService<IPdfProcessingPipelineService>();
 
             // Delegate to pipeline service: validate -> extract -> chunk -> embed -> index -> ready
-            await pipelineService.ProcessAsync(
+            var outcome = await pipelineService.ProcessAsync(
                 pdfDoc.Id, pdfDoc.FilePath, jobEntity.UserId, ct).ConfigureAwait(false);
+
+            // Issue #3592: only Processed means work was actually done. ProcessAsync returns
+            // normally on several no-op paths — a refused claim (the document is owned by another
+            // worker or already terminal), a vanished row, a concurrency abort. Treating that
+            // silence as success stamped Completed on the job AND all five steps, a terminal state
+            // no retry reclaims, and fed step metrics/ETA with durations for work never performed.
+            if (outcome != PdfPipelineOutcome.Processed)
+            {
+                _logger.LogWarning(
+                    "Job {JobId} did not process PDF {PdfId} (outcome: {Outcome}); not marking Completed",
+                    jobEntity.Id, pdfDoc.Id, outcome);
+
+                // Fail the job row rather than leaving it Processing: it did no work, and an
+                // abandoned Processing row holds a worker slot until the stuck-job monitor degrades
+                // it. FailJobAsync touches only the job — the document keeps whatever state its real
+                // owner (or the pipeline's own failure handling) already persisted.
+                await FailJobAsync(
+                    jobEntity,
+                    $"Pipeline did not process the document (outcome: {outcome}).",
+                    ct).ConfigureAwait(false);
+                return;
+            }
 
             // Fix: reload from DB to detect external cancellation during pipeline execution.
             // CancelJobCommand changes status to Cancelled in DB without stopping the worker,

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/IPdfProcessingPipelineService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/IPdfProcessingPipelineService.cs
@@ -16,5 +16,9 @@ internal interface IPdfProcessingPipelineService
     /// <param name="filePath">Path to the PDF file on disk.</param>
     /// <param name="uploadedByUserId">The user who uploaded the PDF.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    Task ProcessAsync(Guid pdfDocumentId, string filePath, Guid uploadedByUserId, CancellationToken cancellationToken);
+    /// <returns>
+    /// What actually happened. Callers MUST NOT infer success from a normal return: several exits
+    /// (refused claim, concurrency abort, missing document) do no work at all. Issue #3592.
+    /// </returns>
+    Task<PdfPipelineOutcome> ProcessAsync(Guid pdfDocumentId, string filePath, Guid uploadedByUserId, CancellationToken cancellationToken);
 }

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfPipelineOutcome.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfPipelineOutcome.cs
@@ -1,0 +1,39 @@
+namespace Api.BoundedContexts.DocumentProcessing.Application.Services;
+
+/// <summary>
+/// Explicit outcome of <see cref="IPdfProcessingPipelineService.ProcessAsync"/> (Issue #3592).
+///
+/// <para>The pipeline used to return a bare <c>Task</c>, so every early exit — a refused claim, a
+/// concurrency abort, a document that vanished — was indistinguishable from a full success. The
+/// queue worker inferred success from that silence and marked the job (and all five steps)
+/// <c>Completed</c> without anything having been processed: a terminal state no retry reclaims,
+/// plus step metrics and ETA fed with invented durations.</para>
+///
+/// <para>Only <see cref="Processed"/> means the document was actually taken through the pipeline.</para>
+/// </summary>
+internal enum PdfPipelineOutcome
+{
+    /// <summary>The full pipeline ran to the end: text extracted, chunked, embedded, indexed.</summary>
+    Processed,
+
+    /// <summary>
+    /// The atomic Pending-claim refused the document: it is already claimed by another worker or
+    /// sits in a terminal state. This job did no work — someone else owns the outcome.
+    /// </summary>
+    SkippedNotClaimed,
+
+    /// <summary>The row disappeared between the claim and the reload (deleted concurrently).</summary>
+    DocumentMissing,
+
+    /// <summary>
+    /// The pipeline marked the document Failed itself (no usable chunks, extraction error,
+    /// unhandled exception). The failure is already persisted on the document.
+    /// </summary>
+    Failed,
+
+    /// <summary>
+    /// A concurrency conflict aborted the run mid-flight — an admin mutation won the race. The
+    /// document keeps its intermediate state deliberately, for the next tick to re-read.
+    /// </summary>
+    AbortedConcurrency,
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
@@ -128,7 +128,7 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
         _extractionStrategySelector = extractionStrategySelector;
     }
 
-    public async Task ProcessAsync(
+    public async Task<PdfPipelineOutcome> ProcessAsync(
         Guid pdfDocumentId,
         string filePath,
         Guid uploadedByUserId,
@@ -151,7 +151,7 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
                 _logger.LogInformation(
                     "[PdfPipeline] PDF {PdfId} not in Pending state (already claimed or terminal), skipping",
                     pdfId);
-                return;
+                return PdfPipelineOutcome.SkippedNotClaimed;
             }
 
             // Re-load with tracked entity for the rest of the pipeline.
@@ -162,7 +162,7 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
             if (pdfDoc == null)
             {
                 _logger.LogError("[PdfPipeline] PDF document {PdfId} disappeared after claim", pdfId);
-                return;
+                return PdfPipelineOutcome.DocumentMissing;
             }
             // Refresh tracked entity to reflect the UPDATE we just executed.
             await _db.Entry(pdfDoc).ReloadAsync(cancellationToken).ConfigureAwait(false);
@@ -201,7 +201,9 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
                 _logger.LogWarning(ex,
                     "Concurrency conflict on PdfDocument {PdfId} in {Handler} (Category B) — admin mutation wins, pipeline will re-read on next tick",
                     pdfId, nameof(PdfProcessingPipelineService));
-                return; // CRITICAL: do not throw — Quartz must see job as successful
+                // CRITICAL: do not throw — Quartz must not treat this as a crash. It is NOT a
+                // success either: nothing was indexed, so the outcome says so explicitly (#3592).
+                return PdfPipelineOutcome.AbortedConcurrency;
             }
 
             // Step 3: Chunk text
@@ -217,7 +219,7 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
             {
                 _logger.LogWarning("[PdfPipeline] No chunks produced for {PdfId}, marking as failed", pdfId);
                 await MarkFailedAsync(pdfDoc, "Text extraction produced no usable chunks").ConfigureAwait(false);
-                return;
+                return PdfPipelineOutcome.Failed;
             }
 
             // Dual-language indexing: translate non-English chunks to English
@@ -411,7 +413,9 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
                 _logger.LogWarning(ex,
                     "Concurrency conflict on PdfDocument {PdfId} in {Handler} (Category B) — admin mutation wins, pipeline will re-read on next tick",
                     pdfId, nameof(PdfProcessingPipelineService));
-                return; // CRITICAL: do not throw — Quartz must see job as successful
+                // CRITICAL: do not throw — Quartz must not treat this as a crash. It is NOT a
+                // success either: nothing was indexed, so the outcome says so explicitly (#3592).
+                return PdfPipelineOutcome.AbortedConcurrency;
             }
 
             // Step 4a: Generate embeddings (for all chunks: original + translated)
@@ -433,7 +437,9 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
                 _logger.LogWarning(ex,
                     "Concurrency conflict on PdfDocument {PdfId} in {Handler} (Category B) — admin mutation wins, pipeline will re-read on next tick",
                     pdfId, nameof(PdfProcessingPipelineService));
-                return; // CRITICAL: do not throw — Quartz must see job as successful
+                // CRITICAL: do not throw — Quartz must not treat this as a crash. It is NOT a
+                // success either: nothing was indexed, so the outcome says so explicitly (#3592).
+                return PdfPipelineOutcome.AbortedConcurrency;
             }
 
             // Step 4b: Index in pgvector.
@@ -470,11 +476,15 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
                 _logger.LogWarning(ex,
                     "Concurrency conflict on PdfDocument {PdfId} in {Handler} (Category B) — admin mutation wins, pipeline will re-read on next tick",
                     pdfId, nameof(PdfProcessingPipelineService));
-                return; // CRITICAL: do not throw — Quartz must see job as successful
+                // CRITICAL: do not throw — Quartz must not treat this as a crash. It is NOT a
+                // success either: nothing was indexed, so the outcome says so explicitly (#3592).
+                return PdfPipelineOutcome.AbortedConcurrency;
             }
 
             _logger.LogInformation("[PdfPipeline] Successfully processed PDF {PdfId}: {Pages} pages, {Chunks} chunks (incl. translations)",
                 pdfId, pdfDoc.PageCount ?? 0, translatedChunks.Count);
+
+            return PdfPipelineOutcome.Processed;
         }
 #pragma warning disable CA1031 // Background pipeline must catch all to mark status
         catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested)
@@ -495,11 +505,13 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
                 pdfId, ex.IsPermanentFailure);
             var category = ex.IsPermanentFailure ? ErrorCategory.PayloadTooLarge : (ErrorCategory?)null;
             await TryMarkFailedAsync(pdfDocumentId, ex.Message, category).ConfigureAwait(false);
+            return PdfPipelineOutcome.Failed;
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "[PdfPipeline] Processing FAILED for PDF {PdfId}", pdfId);
             await TryMarkFailedAsync(pdfDocumentId, ex.Message).ConfigureAwait(false);
+            return PdfPipelineOutcome.Failed;
         }
 #pragma warning restore CA1031
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Commands/ProcessPendingPdfs/ProcessPendingPdfsCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Commands/ProcessPendingPdfs/ProcessPendingPdfsCommandHandlerTests.cs
@@ -36,7 +36,7 @@ public sealed class ProcessPendingPdfsCommandHandlerTests : IAsyncLifetime
         _pipeline = new Mock<IPdfProcessingPipelineService>();
         _pipeline
             .Setup(p => p.ProcessAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
+            .ReturnsAsync(PdfPipelineOutcome.Processed);
         _handler = new ProcessPendingPdfsCommandHandler(
             _db, _pipeline.Object, NullLogger<ProcessPendingPdfsCommandHandler>.Instance);
         return ValueTask.CompletedTask;

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Jobs/PdfProcessingQuartzJobTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Jobs/PdfProcessingQuartzJobTests.cs
@@ -93,6 +93,7 @@ public sealed class PdfProcessingQuartzJobTests
                     .FirstAsync(d => d.Id == id, innerCt);
                 doc.PageCount = PersistedPageCount;
                 await pipelineContext.SaveChangesAsync(innerCt);
+                return PdfPipelineOutcome.Processed;
             });
 
         var metrics = new Mock<IProcessingMetricsService>();
@@ -137,5 +138,112 @@ public sealed class PdfProcessingQuartzJobTests
                 It.IsAny<Guid?>(),
                 It.IsAny<CancellationToken>()),
             Times.Never);
+    }
+
+    // ── Issue #3592: the job must not infer success from a bare return ────────
+
+    /// <summary>
+    /// Seeds one Queued job + its PDF and runs the worker against a pipeline that reports
+    /// <paramref name="outcome"/>. Returns the persisted job row afterwards.
+    /// </summary>
+    private static async Task<ProcessingJobEntity> RunJobWithOutcomeAsync(PdfPipelineOutcome outcome)
+    {
+        var dbName = $"issue-3592-{Guid.NewGuid()}";
+        using var jobContext = TestDbContextFactory.CreateInMemoryDbContext(dbName);
+
+        var pdfId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var jobId = Guid.NewGuid();
+
+        jobContext.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = pdfId,
+            FileName = "rules.pdf",
+            FilePath = "/tmp/rules.pdf",
+            FileSizeBytes = 2048,
+            UploadedByUserId = userId,
+            // Deliberately NOT Ready: the pipeline did no work, so the document is untouched.
+            ProcessingState = nameof(PdfProcessingState.Pending),
+            PageCount = 10,
+        });
+        jobContext.ProcessingJobs.Add(new ProcessingJobEntity
+        {
+            Id = jobId,
+            PdfDocumentId = pdfId,
+            UserId = userId,
+            Status = nameof(JobStatus.Queued),
+            Priority = 0,
+            CreatedAt = DateTimeOffset.UtcNow,
+        });
+        foreach (var stepName in StepNames)
+        {
+            jobContext.ProcessingSteps.Add(new ProcessingStepEntity
+            {
+                Id = Guid.NewGuid(),
+                ProcessingJobId = jobId,
+                StepName = stepName,
+                Status = nameof(StepStatus.Pending),
+            });
+        }
+        await jobContext.SaveChangesAsync();
+
+        var pipeline = new Mock<IPdfProcessingPipelineService>();
+        pipeline
+            .Setup(p => p.ProcessAsync(pdfId, It.IsAny<string>(), userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(outcome);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(pipeline.Object);
+        services.AddSingleton(new Mock<IProcessingMetricsService>().Object);
+        services.AddSingleton(new Mock<IQueueStreamService>().Object);
+        using var serviceProvider = services.BuildServiceProvider();
+
+        var job = new PdfProcessingQuartzJob(
+            jobContext,
+            serviceProvider,
+            NullLogger<PdfProcessingQuartzJob>.Instance,
+            TimeProvider.System);
+
+        var executionContext = new Mock<IJobExecutionContext>();
+        executionContext.SetupGet(c => c.CancellationToken).Returns(CancellationToken.None);
+
+        await job.Execute(executionContext.Object);
+
+        using var readContext = TestDbContextFactory.CreateInMemoryDbContext(dbName);
+        return await readContext.ProcessingJobs.AsNoTracking().FirstAsync(j => j.Id == jobId);
+    }
+
+    /// <summary>
+    /// Regression guard for #3592. <c>ProcessAsync</c> returns without doing any work when the
+    /// atomic claim refuses the document, when it vanishes, when a concurrency conflict aborts the
+    /// run, or when the pipeline marked it Failed. The worker used to read that bare return as
+    /// success and stamp <c>Completed</c> on the job and all five steps — a terminal state no retry
+    /// reclaims, with step metrics fed by durations for work never performed.
+    /// </summary>
+    [Theory]
+    [Trait("Issue", "3592")]
+    [InlineData(PdfPipelineOutcome.SkippedNotClaimed)]
+    [InlineData(PdfPipelineOutcome.DocumentMissing)]
+    [InlineData(PdfPipelineOutcome.AbortedConcurrency)]
+    [InlineData(PdfPipelineOutcome.Failed)]
+    internal async Task Execute_PipelineDidNotProcess_JobIsNotMarkedCompleted(PdfPipelineOutcome outcome)
+    {
+        var job = await RunJobWithOutcomeAsync(outcome);
+
+        Assert.NotEqual(nameof(JobStatus.Completed), job.Status);
+    }
+
+    /// <summary>
+    /// The guard must stay narrow: a genuinely processed document still completes normally.
+    /// Without this, "never mark Completed" would trivially satisfy the test above.
+    /// </summary>
+    [Fact]
+    [Trait("Issue", "3592")]
+    public async Task Execute_PipelineProcessed_JobIsMarkedCompleted()
+    {
+        var job = await RunJobWithOutcomeAsync(PdfPipelineOutcome.Processed);
+
+        Assert.Equal(nameof(JobStatus.Completed), job.Status);
+        Assert.NotNull(job.CompletedAt);
     }
 }

--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/ProcessPendingPdfsRecoveryIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/ProcessPendingPdfsRecoveryIntegrationTests.cs
@@ -65,7 +65,7 @@ public sealed class ProcessPendingPdfsRecoveryIntegrationTests : IAsyncLifetime
 
         _pipeline
             .Setup(p => p.ProcessAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
+            .ReturnsAsync(PdfPipelineOutcome.Processed);
         // Registered last so it wins over any real pipeline registration from CreateBase.
         services.AddScoped(_ => _pipeline.Object);
 

--- a/apps/api/tests/Api.Tests/Unit/DocumentProcessing/StalePdfRecoveryServiceTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/DocumentProcessing/StalePdfRecoveryServiceTests.cs
@@ -77,7 +77,7 @@ public sealed class StalePdfRecoveryServiceTests
         pipelineMock
             .Setup(p => p.ProcessAsync(
                 It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
+            .ReturnsAsync(PdfPipelineOutcome.Processed);
 
         var scopeFactory = BuildScopeFactory(dbName, pipelineMock.Object);
         var sut = new StalePdfRecoveryService(
@@ -119,6 +119,7 @@ public sealed class StalePdfRecoveryServiceTests
                     entity.ProcessingState = "Ready";
                     await db.SaveChangesAsync(ct);
                 }
+                return PdfPipelineOutcome.Processed;
             });
 
         var scopeFactory = BuildScopeFactory(dbName, pipelineMock.Object);
@@ -160,6 +161,7 @@ public sealed class StalePdfRecoveryServiceTests
                     entity.ProcessingState = "Failed";
                     await db.SaveChangesAsync(ct);
                 }
+                return PdfPipelineOutcome.Failed;
             });
 
         var scopeFactory = BuildScopeFactory(dbName, pipelineMock.Object);


### PR DESCRIPTION
Closes #3592.

## Il difetto

`ProcessAsync` restituiva un `Task` nudo, quindi ogni uscita anticipata era **indistinguibile da un successo pieno**:

```csharp
var claimed = await _pdfClaimService.TryClaimPendingAsync(pdfDocumentId, ct);
if (!claimed) { _logger.LogInformation("…skipping"); return; }   // ← identico a "fatto tutto"
```

Il worker Quartz leggeva quel silenzio come successo e marcava `Completed` il job **e tutti e cinque gli step** senza che nulla fosse stato processato. Conseguenze:

- `Completed` è terminale: nessun retry lo riprende.
- Metriche step ed ETA storici alimentati con durate inventate (`totalMs / 5` su lavoro mai svolto).
- Un documento non indicizzato risulta processato in dashboard e nei conteggi KB.

## Il fix

Nuovo enum `PdfPipelineOutcome` con i cinque esiti reali; **tutti e 10 i punti di uscita** di `ProcessAsync` ora dichiarano il proprio:

| Esito | Significato |
|---|---|
| `Processed` | pipeline completo: estratto, chunked, embedded, indicizzato |
| `SkippedNotClaimed` | claim rifiutato — il documento è di un altro worker o già terminale |
| `DocumentMissing` | la riga è sparita tra claim e reload |
| `Failed` | il pipeline ha marcato Failed da sé (no chunk, errore estrazione, eccezione) |
| `AbortedConcurrency` | conflitto di concorrenza, stato intermedio lasciato al tick successivo |

Il worker marca `Completed` **solo** su `Processed`. Sugli altri esiti **fallisce la riga di job** invece di lasciarla `Processing`: non ha fatto lavoro, e una riga `Processing` abbandonata occupa uno slot del worker finché il monitor non la degrada (30 min). `FailJobAsync` tocca solo il job — il documento conserva lo stato che il suo vero proprietario, o la gestione errori del pipeline, ha già persistito.

## Perché l'esito esplicito e non il guard su `Ready`

L'issue proponeva anche un guard minimale («marca `Completed` solo se `pdfDoc.ProcessingState == Ready`»). Scartato: sposterebbe l'inferenza su un'altra colonna anziché eliminarla — il worker continuerebbe a **dedurre** cosa è successo invece di **saperlo**.

## Test

5 test nuovi, verificati **rossi prima del fix** (4 rossi su 6):

- `Execute_PipelineDidNotProcess_JobIsNotMarkedCompleted` — `Theory` sui quattro esiti non-`Processed`
- `Execute_PipelineProcessed_JobIsMarkedCompleted` — impedisce al fix di degenerare in «non completare mai», che soddisferebbe banalmente il test sopra

54 test verdi sui percorsi correlati (`StalePdfRecovery`, `ProcessPendingPdfs`, `PdfProcessingQuartz`, `OrphanedProcessingJob`, `PdfProcessingPipeline`).

Nota: i test double esistenti usavano `.Returns(Task.CompletedTask)`, che con Moq **compila ma esplode a runtime** su un metodo `Task<T>` — aggiornati a `.ReturnsAsync(...)`.

Chiude la famiglia di difetti aperta con #3588 e #3604.

🤖 Generated with [Claude Code](https://claude.com/claude-code)