### PR TITLE
test(kb): margine robusto per T3-AC-2 (#3601)

### DIFF
--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentPerChunkTimeoutTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentPerChunkTimeoutTests.cs
@@ -119,11 +119,29 @@ public sealed class ChatWithSessionAgentPerChunkTimeoutTests
     [Fact(DisplayName = "T3-AC-2: slow-but-steady stream delivers full response even when total exceeds one chunk deadline")]
     public async Task Handle_SlowButSteadyStream_DeliversFullResponseWhenEachChunkArrrivesWithinDeadline()
     {
-        // per-chunk timeout = 200 ms; each chunk takes 80 ms.
-        // 3 chunks × 80 ms = 240 ms total > one 200 ms chunk-timeout.
-        // The disarm-between-chunks logic must reset the deadline after each received chunk.
-        const double perChunkTimeoutSeconds = 0.2; // 200 ms
-        const int chunkDelayMs = 80;               // each chunk arrives in 80 ms
+        // The invariant under test: TOTAL duration exceeds one chunk deadline, while EVERY
+        // individual chunk arrives within it — so the disarm-between-chunks logic must re-arm the
+        // deadline after each received chunk. Two constraints, both preserved below:
+        //   chunkCount × chunkDelay > perChunkTimeout   (total trips one deadline's worth)
+        //   chunkDelay              < perChunkTimeout   (no single chunk trips it)
+        //
+        // #3601: this is the only test in the class whose margin shrinks under CI load. The other
+        // two run the safe way round — they WANT a deadline to fire, and a loaded runner only makes
+        // the stall longer. Here load works against us: the original 200 ms deadline vs 80 ms chunks
+        // left just 120 ms of headroom, and a single GC pause or thread-pool scheduling delay was
+        // enough to trip a deadline that should never have fired (observed on PR #3591).
+        //
+        // Stalls of that kind cost roughly a fixed amount of wall-clock, not a proportional one, so
+        // the defence is a bigger ABSOLUTE margin rather than a bigger ratio: 975 ms of headroom per
+        // chunk instead of 120 ms (40× the deadline instead of 2.5×), for ~1.1 s of test time.
+        //
+        // Honest limit: this makes a spurious failure far less likely, it does not make it
+        // impossible — the deadline is still real wall-clock. Eliminating it outright means driving
+        // the handler's CancelAfter through an injected TimeProvider (see #3601), which is a
+        // refactor of a reliability-critical streaming path and is deliberately not done here.
+        const double perChunkTimeoutSeconds = 1.0; // 1000 ms
+        const int chunkDelayMs = 25;               // 975 ms of headroom per chunk
+        const int chunkCount = 45;                 // 45 × 25 ms = 1125 ms total > 1000 ms deadline
         const string expectedToken = "hello";
 
         var llmService = new Mock<ILlmService>();
@@ -131,7 +149,7 @@ public sealed class ChatWithSessionAgentPerChunkTimeoutTests
             .Setup(l => l.GenerateCompletionStreamAsync(
                 It.IsAny<string>(), It.IsAny<string>(),
                 It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()))
-            .Returns(SlowButSteadyStream(delayPerChunkMs: chunkDelayMs, content: expectedToken, chunkCount: 3));
+            .Returns(SlowButSteadyStream(delayPerChunkMs: chunkDelayMs, content: expectedToken, chunkCount: chunkCount));
 
         var handler = BuildHandler(llmService.Object, perChunkTimeoutSeconds);
         var command = BuildCommand();


### PR DESCRIPTION
Closes #3601.

## Diagnosi affinata

Dei tre test della classe, **solo T3-AC-2 è fragile**. Gli altri due girano dal verso sicuro: *vogliono* che una deadline scatti, e un runner carico allunga lo stallo — quindi il carico li aiuta.

| Test | Deadline | Evento | Il carico… |
|---|---|---|---|
| T3-AC-1 | 50 ms | stallo 500 ms | …allunga lo stallo → **aiuta** |
| T3-AC-3 | 5 s | disconnect a 100 ms | …ha 5 s di margine → **irrilevante** |
| **T3-AC-2** | 200 ms | chunk da 80 ms | …ritarda i chunk → **gioca contro** |

Solo T3-AC-2 richiede che qualcosa arrivi *più in fretta* della deadline, ed è l'unico che sia mai fallito (PR #3591: 1 rosso su 21.365, in un'area estranea a quella PR).

## Il fix

Margine **assoluto** più grande, non rapporto più grande: gli stalli da GC o da scheduling costano wall-clock grossomodo *fisso*, non proporzionale.

|  | Prima | Dopo |
|---|---|---|
| Deadline per chunk | 200 ms | 1000 ms |
| Ritardo per chunk | 80 ms | 25 ms |
| Numero di chunk | 3 | 45 |
| **Margine per chunk** | **120 ms** (2.5×) | **975 ms** (40×) |
| Durata test | ~240 ms | ~1.1 s |

Entrambi i vincoli dell'invariante restano intatti:

```
chunkCount × chunkDelay > perChunkTimeout    45 × 25 = 1125 ms > 1000 ms  ✓
chunkDelay              < perChunkTimeout    25 ms  <<  1000 ms           ✓
```

## Verifica che il test non sia diventato vacuo

Allargare i numeri di un test a tempo rischia di renderlo inerte, quindi l'ho controllato con una mutazione sul codice di produzione: **deadline armata una sola volta fuori dal loop e disarm rimosso** — cioè una deadline *totale* invece che per-chunk, esattamente la regressione che questo test esiste per cogliere.

- Con la mutazione → **rosso** ✓
- Codice integro → **5 run consecutivi verdi**

Un primo tentativo di mutazione (solo l'arm spostato fuori dal loop) passava: il disarm interno lo neutralizzava — e sarebbe successo anche coi numeri originali, quindi non diceva nulla sul cambio. L'ho rifatto correttamente. Codice di produzione ripristinato e verificato pulito (nessun residuo).

## Limite dichiarato

Questo rende un fallimento spurio **molto meno probabile, non impossibile**: la deadline resta wall-clock reale. Eliminarlo del tutto significa pilotare `CancelAfter` con un `TimeProvider` iniettato — `FakeTimeProvider` è già disponibile nel progetto — ma è un refactor di un percorso di streaming critico per l'affidabilità (il handler ha già 17 parametri di costruttore, e la discriminazione timeout/disconnect andrebbe ristrutturata). Deliberatamente non fatto qui.

Nessuna modifica al codice di produzione: solo il test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)