### PR TITLE
feat(catalog): vista admin cover-gap + unstructured nel deploy (#3590 Slice A)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -198,6 +198,8 @@ jobs:
               - 'apps/reranker-service/**'
             orchestration:
               - 'apps/orchestration-service/**'
+            unstructured:
+              - 'apps/unstructured-service/**'
 
       - name: Determine what to deploy
         id: decision
@@ -239,22 +241,34 @@ jobs:
           EMB="${{ steps.changes.outputs.embedding }}"
           RRK="${{ steps.changes.outputs.reranker }}"
           ORC="${{ steps.changes.outputs.orchestration }}"
+          # #3590 — unstructured-service NON era in alcuna pipeline: non qui e non in un workflow
+          # di build/publish GHCR. Si ricostruiva solo a mano sul VPS, quindi andava alla deriva in
+          # silenzio: il 2026-08-07 staging girava un'immagine costruita un'ora PRIMA che il commit
+          # del limite 50->100MB atterrasse, e le mancavano anche i due commit di region-seeding RAG.
+          # Il servizio è build-from-source nel compose (nessuna immagine GHCR da pullare), quindi
+          # sotto viene ricostruito sul VPS invece che pullato.
+          UNS="${{ steps.changes.outputs.unstructured }}"
           if [ "$EVENT" = "workflow_dispatch" ] \
             || [ "$FORCE" = "true" ] \
             || [ "$BEFORE" = "$ZEROS" ] \
             || [ -z "$BEFORE" ]; then
-            EMB=true; RRK=true; ORC=true
+            EMB=true; RRK=true; ORC=true; UNS=true
           fi
           # paths-filter outputs are empty when the changes step is skipped
           # (workflow_dispatch). Normalize empties to false.
-          EMB="${EMB:-false}"; RRK="${RRK:-false}"; ORC="${ORC:-false}"
-          echo "ai_changed={\"embedding\":$EMB,\"reranker\":$RRK,\"orchestration\":$ORC}" >> $GITHUB_OUTPUT
+          EMB="${EMB:-false}"; RRK="${RRK:-false}"; ORC="${ORC:-false}"; UNS="${UNS:-false}"
+          echo "ai_changed={\"embedding\":$EMB,\"reranker\":$RRK,\"orchestration\":$ORC,\"unstructured\":$UNS}" >> $GITHUB_OUTPUT
+          # NOTA: `unstructured` è deliberatamente ESCLUSO da ai_any. ai_any gate il job di
+          # build+push su GHCR, la cui matrice è [embedding, reranker, orchestration];
+          # unstructured-service non ha un'immagine GHCR (è build-from-source nel compose) e viene
+          # ricostruito direttamente sul VPS nello step di deploy. Includerlo qui farebbe girare
+          # a vuoto il job GHCR.
           if [ "$EMB" = "true" ] || [ "$RRK" = "true" ] || [ "$ORC" = "true" ]; then
             echo "ai_any=true" >> $GITHUB_OUTPUT
           else
             echo "ai_any=false" >> $GITHUB_OUTPUT
           fi
-          echo "🤖 AI changed: embedding=$EMB reranker=$RRK orchestration=$ORC"
+          echo "🤖 AI changed: embedding=$EMB reranker=$RRK orchestration=$ORC unstructured=$UNS"
 
   # Lightweight pre-deploy validation (full CI already ran on main-dev PR)
   # Rationale: Code reaching main-staging has already passed the full ci.yml
@@ -1051,6 +1065,7 @@ jobs:
             EMB_CHANGED="${{ fromJSON(needs.detect-changes.outputs.ai_changed).embedding }}"
             RRK_CHANGED="${{ fromJSON(needs.detect-changes.outputs.ai_changed).reranker }}"
             ORC_CHANGED="${{ fromJSON(needs.detect-changes.outputs.ai_changed).orchestration }}"
+            UNS_CHANGED="${{ fromJSON(needs.detect-changes.outputs.ai_changed).unstructured }}"
 
             # Issue #1578 follow-up — free OLD AI images BEFORE the disk gate (disk-safe order).
             # The old image stays referenced by the running container while the new one is pulled
@@ -1122,6 +1137,34 @@ jobs:
             if [ "$ORC_CHANGED" = "true" ]; then
               docker pull "$ORCHESTRATION_IMAGE" || echo "⚠️ orchestration pull failed (non-blocking; not active in staging)"
               echo "📦 orchestration-service image cached (not started in staging)"
+            fi
+
+            # #3590 — unstructured-service è build-from-source nel compose (nessuna immagine GHCR
+            # da pullare), quindi si ricostruisce QUI sul VPS. Prima di #3590 non era in alcuna
+            # pipeline: si aggiornava solo a mano e andava alla deriva in silenzio.
+            #
+            # ORDINE OBBLIGATORIO — prune PRIMA del build, non dopo. L'immagine pesa ~10GB e il
+            # 2026-08-07 un rebuild manuale ha portato il disco dal 74% al 99% (873MB liberi).
+            # `docker builder prune` recupera ~6.5GB di cache: farlo dopo è troppo tardi.
+            if [ "$UNS_CHANGED" = "true" ]; then
+              echo "🧹 Pre-prune before unstructured-service rebuild (image is ~10GB)..."
+              docker builder prune -f || true
+              docker image prune -f || true
+
+              FREE_GB=$(df -BG / | awk 'NR==2 {gsub(/G/,"",$4); print $4}')
+              echo "💽 VPS disk before unstructured build: ${FREE_GB} GB free — gate ${AI_PULL_GATE_GB} GB"
+              if [ "$FREE_GB" -lt "$AI_PULL_GATE_GB" ]; then
+                echo "::error::Insufficient disk to rebuild unstructured-service: ${FREE_GB} GB free < ${AI_PULL_GATE_GB} GB"
+                echo "🚫 Aborting (fail-safe). Manual cleanup on the VPS:"
+                echo "  docker image prune -af && docker builder prune -af"
+                exit 1
+              fi
+
+              echo "🔨 Rebuilding unstructured-service from source on the VPS..."
+              docker compose -f docker-compose.yml -f compose.staging.yml --profile ai \
+                build unstructured-service
+              SERVICES="$SERVICES unstructured-service"
+              echo "📦 unstructured-service rebuilt"
             fi
 
             if [ -z "$SERVICES" ]; then

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetCoverGap/GetCoverGapQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetCoverGap/GetCoverGapQuery.cs
@@ -1,0 +1,61 @@
+using Api.Models;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetCoverGap;
+
+/// <summary>
+/// #3590 — elenca i giochi del catalogo SENZA alcuna cover (tutte e quattro le chiavi nulle), con
+/// la CAUSA per cui la pipeline cover-da-PDF non li copre.
+/// <para>
+/// Il collo di bottiglia non era risolvere questi casi — il picker manuale da URL esiste da #3545 —
+/// ma TROVARLI: non esisteva alcuna vista dei giochi senza cover, e l'unico accesso all'editor era
+/// l'affordance a matita in hover sulla griglia pubblica.
+/// </para>
+/// </summary>
+/// <param name="PageNumber">Pagina richiesta, 1-based.</param>
+/// <param name="PageSize">Dimensione pagina (1-100).</param>
+/// <param name="Cause">Filtro opzionale su una delle cause note. Null = tutte.</param>
+internal record GetCoverGapQuery(
+    int PageNumber = 1,
+    int PageSize = 20,
+    string? Cause = null) : IQuery<PagedResult<CoverGapGameDto>>;
+
+/// <summary>Un gioco senza cover, con la causa derivata dallo stato dei suoi PDF collegati.</summary>
+/// <param name="GameId">Id del gioco a catalogo.</param>
+/// <param name="Title">Titolo del gioco.</param>
+/// <param name="BggId">Id BoardGameGeek, quando noto.</param>
+/// <param name="Cause">Una delle costanti di <see cref="CoverGapCauses"/>.</param>
+/// <param name="PdfFileName">Nome del PDF più rilevante collegato, se esiste.</param>
+/// <param name="PdfSizeBytes">Dimensione di quel PDF in byte, se esiste.</param>
+/// <param name="ErrorCategory">Categoria d'errore di quel PDF, se valorizzata.</param>
+internal record CoverGapGameDto(
+    Guid GameId,
+    string Title,
+    int? BggId,
+    string Cause,
+    string? PdfFileName,
+    long? PdfSizeBytes,
+    string? ErrorCategory);
+
+/// <summary>
+/// Cause bounded. Sono un contratto con il front-end (enum Zod in
+/// <c>admin-cover.schemas.ts</c>) e con il filtro <see cref="GetCoverGapQuery.Cause"/>:
+/// cambiarle qui richiede di cambiarle anche lì.
+/// </summary>
+internal static class CoverGapCauses
+{
+    /// <summary>Il PDF eccede il limite di dimensione del servizio di estrazione.</summary>
+    public const string PdfTooLarge = "pdf_too_large";
+
+    /// <summary>Nessuna pagina del rulebook è una cover accettabile — esito CORRETTO, non un guasto.</summary>
+    public const string HeuristicRejected = "heuristic_rejected";
+
+    /// <summary>Nessun PDF collegato: non esiste una sorgente da cui generare.</summary>
+    public const string NoSource = "no_source";
+
+    /// <summary>Tutto il resto: PDF ancora in lavorazione o fallimenti non classificati.</summary>
+    public const string Other = "other";
+
+    public static readonly IReadOnlyList<string> All =
+        new[] { PdfTooLarge, HeuristicRejected, NoSource, Other };
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetCoverGap/GetCoverGapQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetCoverGap/GetCoverGapQueryHandler.cs
@@ -1,0 +1,150 @@
+using Api.Infrastructure;
+using Api.Models;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetCoverGap;
+
+/// <summary>
+/// Handler di <see cref="GetCoverGapQuery"/>. Parte dai giochi con tutte e quattro le chiavi cover
+/// nulle, porta i PDF collegati e deriva una causa per gioco.
+/// </summary>
+internal sealed class GetCoverGapQueryHandler
+    : IQueryHandler<GetCoverGapQuery, PagedResult<CoverGapGameDto>>
+{
+    /// <summary>
+    /// Soglia oltre la quale un fallimento di estrazione si spiega con la dimensione. Allineata al
+    /// limite storico del servizio Unstructured (50MB): i fallimenti precedenti al fix #3589 hanno
+    /// <c>ErrorCategory = "Service"</c> con un messaggio fuorviante ("Failed to connect to
+    /// Unstructured service"), quindi la sola categoria non basta a riconoscerli.
+    /// </summary>
+    private const long LargePdfThresholdBytes = 52_428_800;
+
+    private readonly MeepleAiDbContext _context;
+    private readonly ILogger<GetCoverGapQueryHandler> _logger;
+
+    public GetCoverGapQueryHandler(
+        MeepleAiDbContext context,
+        ILogger<GetCoverGapQueryHandler> logger)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<PagedResult<CoverGapGameDto>> Handle(
+        GetCoverGapQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // Il filtro soft-delete è GLOBALE (SharedGameEntityConfiguration.HasQueryFilter):
+        // riaggiungerlo qui sarebbe ridondante.
+        var gapGames = _context.SharedGames
+            .AsNoTracking()
+            .Where(g => string.IsNullOrWhiteSpace(g.PdfCoverR2Key)
+                     && string.IsNullOrWhiteSpace(g.BggCoverR2Key)
+                     && string.IsNullOrWhiteSpace(g.WikidataCoverR2Key)
+                     && string.IsNullOrWhiteSpace(g.ManualCoverR2Key));
+
+        // I PDF si collegano via la tabella ponte shared_game_documents: è la relazione canonica.
+        // PdfDocumentEntity.SharedGameId è nullable e popolata solo su alcuni percorsi, quindi non
+        // è affidabile come join primario.
+        var rows = await (
+            from g in gapGames
+            join sgd in _context.SharedGameDocuments on g.Id equals sgd.SharedGameId into links
+            from sgd in links.DefaultIfEmpty()
+            join p in _context.PdfDocuments on sgd.PdfDocumentId equals p.Id into pdfs
+            from p in pdfs.DefaultIfEmpty()
+            select new
+            {
+                g.Id,
+                g.Title,
+                g.BggId,
+                PdfFileName = p != null ? p.FileName : null,
+                PdfSize = p != null ? (long?)p.FileSizeBytes : null,
+                CoverStatus = p != null ? p.CoverGenerationStatus : null,
+                ErrorCategory = p != null ? p.ErrorCategory : null,
+                ProcessingState = p != null ? p.ProcessingState : null,
+            })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        // La classificazione gira in memoria dopo la proiezione: i rami non si traducono bene in
+        // SQL e l'insieme è di decine di righe (160 giochi in staging, 24 senza cover).
+        var classified = rows
+            .GroupBy(r => new { r.Id, r.Title, r.BggId })
+            .Select(grp =>
+            {
+                // Un gioco può avere più PDF: tieni la riga con la causa più azionabile.
+                var best = grp
+                    .OrderByDescending(r => Rank(
+                        Classify(r.CoverStatus, r.ErrorCategory, r.ProcessingState, r.PdfSize)))
+                    .First();
+
+                var cause = Classify(best.CoverStatus, best.ErrorCategory, best.ProcessingState, best.PdfSize);
+
+                return new CoverGapGameDto(
+                    grp.Key.Id,
+                    grp.Key.Title,
+                    grp.Key.BggId,
+                    cause,
+                    best.PdfFileName,
+                    best.PdfSize,
+                    best.ErrorCategory);
+            })
+            .Where(d => request.Cause is null || string.Equals(d.Cause, request.Cause, StringComparison.Ordinal))
+            .OrderBy(d => d.Cause, StringComparer.Ordinal)
+            .ThenBy(d => d.Title, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var total = classified.Count;
+        var items = classified
+            .Skip((request.PageNumber - 1) * request.PageSize)
+            .Take(request.PageSize)
+            .ToList();
+
+        _logger.LogDebug(
+            "GetCoverGap: {Total} giochi senza cover (filtro causa: {Cause}).",
+            total, request.Cause ?? "(nessuno)");
+
+        return new PagedResult<CoverGapGameDto>(items, total, request.PageNumber, request.PageSize);
+    }
+
+    /// <summary>Deriva la causa dallo stato del PDF collegato (null su tutto = nessun PDF).</summary>
+    private static string Classify(
+        string? coverStatus,
+        string? errorCategory,
+        string? processingState,
+        long? sizeBytes)
+    {
+        if (coverStatus is null && processingState is null)
+        {
+            return CoverGapCauses.NoSource;
+        }
+
+        if (string.Equals(errorCategory, "PayloadTooLarge", StringComparison.Ordinal)
+            || (string.Equals(processingState, "Failed", StringComparison.Ordinal)
+                && sizeBytes > LargePdfThresholdBytes))
+        {
+            return CoverGapCauses.PdfTooLarge;
+        }
+
+        // 'Skipped' è scritto direttamente sul campo da BackfillPdfCoversJob, non via
+        // PdfDocument.MarkCoverSkipped() (metodo morto).
+        if (string.Equals(coverStatus, "Skipped", StringComparison.Ordinal))
+        {
+            return CoverGapCauses.HeuristicRejected;
+        }
+
+        return CoverGapCauses.Other;
+    }
+
+    /// <summary>Precedenza quando un gioco ha più PDF: la causa più azionabile vince.</summary>
+    private static int Rank(string cause) => cause switch
+    {
+        CoverGapCauses.PdfTooLarge => 3,
+        CoverGapCauses.HeuristicRejected => 2,
+        CoverGapCauses.Other => 1,
+        _ => 0,
+    };
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetCoverGap/GetCoverGapQueryValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetCoverGap/GetCoverGapQueryValidator.cs
@@ -1,0 +1,23 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetCoverGap;
+
+/// <summary>
+/// Boundary validation per <see cref="GetCoverGapQuery"/> — un 422 via la pipeline
+/// FluentValidation, non un 500, su input fuori range o causa sconosciuta.
+/// </summary>
+internal sealed class GetCoverGapQueryValidator : AbstractValidator<GetCoverGapQuery>
+{
+    public GetCoverGapQueryValidator()
+    {
+        RuleFor(x => x.PageNumber)
+            .GreaterThanOrEqualTo(1).WithMessage("PageNumber must be >= 1");
+
+        RuleFor(x => x.PageSize)
+            .InclusiveBetween(1, 100).WithMessage("PageSize must be between 1 and 100");
+
+        RuleFor(x => x.Cause)
+            .Must(c => c is null || CoverGapCauses.All.Contains(c, StringComparer.Ordinal))
+            .WithMessage($"Cause must be one of: {string.Join(", ", CoverGapCauses.All)}");
+    }
+}

--- a/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogAdminEndpoints.cs
+++ b/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogAdminEndpoints.cs
@@ -5,6 +5,7 @@ using Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCo
 using Api.BoundedContexts.SharedGameCatalog.Application.Commands.RemoveRagFromSharedGame;
 using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries;
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetCoverGap;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetGameRagReadiness;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries.ExportSharedGamesTracking;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetSeedingStatus;
@@ -445,6 +446,15 @@ internal static class SharedGameCatalogAdminEndpoints
             .WithName("GetSeedingStatus")
             .WithSummary("Get seeding/enrichment status for all games (Admin/Editor)")
             .Produces<List<SeedingGameDto>>();
+
+        // #3590 — i giochi senza alcuna cover, con la causa per cui la pipeline cover-da-PDF non
+        // li copre. La route costante non confligge con {id:guid}: il constraint disambigua.
+        group.MapGet("/admin/shared-games/cover-gap", HandleGetCoverGap)
+            .RequireAuthorization("AdminOrEditorPolicy")
+            .WithName("GetCoverGap")
+            .WithSummary("Get catalog games with no cover, grouped by cause (Admin/Editor)")
+            .WithDescription("Cause: pdf_too_large, heuristic_rejected, no_source, other.")
+            .Produces<PagedResult<CoverGapGameDto>>();
 
         // Export tracking spreadsheet (all shared games with progress status)
         group.MapGet("/admin/shared-games/tracking-export", HandleTrackingExport)
@@ -1561,6 +1571,20 @@ internal static class SharedGameCatalogAdminEndpoints
     {
         var result = await mediator.Send(
             new GetSeedingStatusQuery(),
+            cancellationToken).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    /// <summary>#3590 — i giochi senza cover, con la causa. Solo IMediator: regola CQRS.</summary>
+    private static async Task<IResult> HandleGetCoverGap(
+        IMediator mediator,
+        [FromQuery] string? cause = null,
+        [FromQuery] int pageNumber = 1,
+        [FromQuery] int pageSize = 20,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await mediator.Send(
+            new GetCoverGapQuery(pageNumber, pageSize, cause),
             cancellationToken).ConfigureAwait(false);
         return Results.Ok(result);
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetCoverGap/GetCoverGapQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetCoverGap/GetCoverGapQueryHandlerTests.cs
@@ -1,0 +1,195 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetCoverGap;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Queries.GetCoverGap;
+
+/// <summary>
+/// #3590 — la vista cover-gap elenca i giochi SENZA alcuna cover, con la causa per cui la pipeline
+/// cover-da-PDF non li copre. Il collo di bottiglia non era risolverli (il picker manuale esiste da
+/// #3545) ma TROVARLI: non esisteva alcuna vista dei giochi senza cover.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class GetCoverGapQueryHandlerTests
+{
+    private static GetCoverGapQueryHandler Sut(MeepleAiDbContext db) =>
+        new(db, NullLogger<GetCoverGapQueryHandler>.Instance);
+
+    private static SharedGameEntity NewGame(string title, Action<SharedGameEntity>? tweak = null)
+    {
+        var game = new SharedGameEntity
+        {
+            Id = Guid.NewGuid(),
+            Title = title,
+            Description = "desc",
+            Status = 2, // Published
+            CreatedBy = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow,
+            ImageUrl = string.Empty,
+            ThumbnailUrl = string.Empty,
+        };
+        tweak?.Invoke(game);
+        return game;
+    }
+
+    private static PdfDocumentEntity NewPdf(Action<PdfDocumentEntity>? tweak = null)
+    {
+        var pdf = new PdfDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            FileName = "rulebook.pdf",
+            FilePath = "/tmp/rulebook.pdf",
+            FileSizeBytes = 1024,
+            UploadedByUserId = Guid.NewGuid(),
+        };
+        tweak?.Invoke(pdf);
+        return pdf;
+    }
+
+    private static SharedGameDocumentEntity Link(Guid gameId, Guid pdfId) => new()
+    {
+        Id = Guid.NewGuid(),
+        SharedGameId = gameId,
+        PdfDocumentId = pdfId,
+        DocumentType = 0,
+        IsActive = true,
+        CreatedAt = DateTime.UtcNow,
+        CreatedBy = Guid.NewGuid(),
+    };
+
+    [Fact]
+    public async Task Handle_GameWithNoCoverAndNoPdf_ClassifiedAsNoSource()
+    {
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var game = NewGame("Senza Sorgente");
+        db.SharedGames.Add(game);
+        await db.SaveChangesAsync();
+
+        var result = await Sut(db).Handle(new GetCoverGapQuery(), CancellationToken.None);
+
+        result.Items.Should().ContainSingle();
+        result.Items[0].GameId.Should().Be(game.Id);
+        result.Items[0].Cause.Should().Be(CoverGapCauses.NoSource);
+        result.Total.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Handle_GameWithSkippedCover_ClassifiedAsHeuristicRejected()
+    {
+        // Gotcha: 'Skipped' è scritto direttamente sul campo da BackfillPdfCoversJob,
+        // non via PdfDocument.MarkCoverSkipped() (metodo morto).
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var game = NewGame("Euristica Rifiuta");
+        var pdf = NewPdf(p =>
+        {
+            p.ProcessingState = "Ready";
+            p.CoverGenerationStatus = "Skipped";
+        });
+        db.SharedGames.Add(game);
+        db.PdfDocuments.Add(pdf);
+        db.SharedGameDocuments.Add(Link(game.Id, pdf.Id));
+        await db.SaveChangesAsync();
+
+        var result = await Sut(db).Handle(new GetCoverGapQuery(), CancellationToken.None);
+
+        result.Items.Should().ContainSingle();
+        result.Items[0].Cause.Should().Be(CoverGapCauses.HeuristicRejected);
+        result.Items[0].PdfFileName.Should().Be("rulebook.pdf");
+    }
+
+    [Fact]
+    public async Task Handle_GameWithPayloadTooLargePdf_ClassifiedAsPdfTooLarge()
+    {
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var game = NewGame("PDF Enorme");
+        var pdf = NewPdf(p =>
+        {
+            p.ProcessingState = "Failed";
+            p.ErrorCategory = "PayloadTooLarge";
+            p.FileSizeBytes = 65_000_000;
+        });
+        db.SharedGames.Add(game);
+        db.PdfDocuments.Add(pdf);
+        db.SharedGameDocuments.Add(Link(game.Id, pdf.Id));
+        await db.SaveChangesAsync();
+
+        var result = await Sut(db).Handle(new GetCoverGapQuery(), CancellationToken.None);
+
+        result.Items.Should().ContainSingle();
+        result.Items[0].Cause.Should().Be(CoverGapCauses.PdfTooLarge);
+        result.Items[0].PdfSizeBytes.Should().Be(65_000_000);
+    }
+
+    [Fact]
+    public async Task Handle_LegacyLargeFailureWithoutCategory_ClassifiedAsPdfTooLarge()
+    {
+        // I fallimenti precedenti al fix #3589 hanno ErrorCategory "Service" e un messaggio
+        // fuorviante ("Failed to connect"): la sola categoria non basta, serve la dimensione.
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var game = NewGame("Legacy 413");
+        var pdf = NewPdf(p =>
+        {
+            p.ProcessingState = "Failed";
+            p.ErrorCategory = "Service";
+            p.FileSizeBytes = 62_000_000;
+        });
+        db.SharedGames.Add(game);
+        db.PdfDocuments.Add(pdf);
+        db.SharedGameDocuments.Add(Link(game.Id, pdf.Id));
+        await db.SaveChangesAsync();
+
+        var result = await Sut(db).Handle(new GetCoverGapQuery(), CancellationToken.None);
+
+        result.Items.Should().ContainSingle();
+        result.Items[0].Cause.Should().Be(CoverGapCauses.PdfTooLarge);
+    }
+
+    [Fact]
+    public async Task Handle_GameWithAnyCoverKey_IsExcluded()
+    {
+        // Contratto centrale: la vista elenca SOLO chi non ha NESSUNA delle quattro chiavi.
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        db.SharedGames.AddRange(
+            NewGame("Con PDF", g => g.PdfCoverR2Key = "covers/pdf/x"),
+            NewGame("Con BGG", g => g.BggCoverR2Key = "bgg-covers/1/cover"),
+            NewGame("Con Wikidata", g => g.WikidataCoverR2Key = "covers/y"),
+            NewGame("Con Manuale", g => g.ManualCoverR2Key = "covers/manual/z/cover"));
+        await db.SaveChangesAsync();
+
+        var result = await Sut(db).Handle(new GetCoverGapQuery(), CancellationToken.None);
+
+        result.Items.Should().BeEmpty("avere una qualsiasi cover esclude dal gap");
+        result.Total.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_FiltersByCause_WhenCauseProvided()
+    {
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var senzaSorgente = NewGame("Senza Sorgente");
+        var euristica = NewGame("Euristica");
+        var pdf = NewPdf(p =>
+        {
+            p.ProcessingState = "Ready";
+            p.CoverGenerationStatus = "Skipped";
+        });
+        db.SharedGames.AddRange(senzaSorgente, euristica);
+        db.PdfDocuments.Add(pdf);
+        db.SharedGameDocuments.Add(Link(euristica.Id, pdf.Id));
+        await db.SaveChangesAsync();
+
+        var result = await Sut(db)
+            .Handle(new GetCoverGapQuery(Cause: CoverGapCauses.NoSource), CancellationToken.None);
+
+        result.Items.Should().ContainSingle();
+        result.Items[0].GameId.Should().Be(senzaSorgente.Id);
+        result.Total.Should().Be(1);
+    }
+}

--- a/apps/web/src/app/admin/(dashboard)/shared-games/cover-gap/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/shared-games/cover-gap/page.tsx
@@ -1,0 +1,157 @@
+/**
+ * Admin — Cover gap (#3590).
+ *
+ * Elenca i giochi del catalogo **senza alcuna cover**, raggruppati per la causa che impedisce
+ * alla pipeline cover-da-PDF di coprirli.
+ *
+ * Perché esiste: risolvere questi casi era già possibile (il picker manuale da URL c'è da #3545),
+ * ma non c'era modo di TROVARLI — l'unico accesso all'editor era l'affordance a matita in hover
+ * sulla griglia pubblica, quindi bisognava scorrerla a occhio. Questa pagina chiude quel buco.
+ *
+ * Fuori scope: l'editing della cover. Ogni riga porta al gioco su /shared-games, dove vive
+ * l'editor esistente (`AdminCoverEditAffordance`) — non duplicarlo qui.
+ */
+
+'use client';
+
+import { useState } from 'react';
+
+import { useCoverGap } from '@/hooks/admin/useCoverGap';
+import type { CoverGapCause } from '@/lib/api/schemas/admin/admin-cover.schemas';
+
+const CAUSE_FILTERS: { value: CoverGapCause | ''; label: string }[] = [
+  { value: '', label: 'Tutte le cause' },
+  { value: 'no_source', label: 'Nessuna sorgente' },
+  { value: 'heuristic_rejected', label: 'Euristica ha rifiutato' },
+  { value: 'pdf_too_large', label: 'PDF troppo grande' },
+  { value: 'other', label: 'Altro' },
+];
+
+const CAUSE_LABELS: Record<CoverGapCause, string> = {
+  no_source: 'Nessuna sorgente',
+  heuristic_rejected: 'Euristica ha rifiutato',
+  pdf_too_large: 'PDF troppo grande',
+  other: 'Altro',
+};
+
+/** Spiegazione operativa: cosa può fare l'admin per ciascun gruppo. */
+const CAUSE_HINTS: Record<CoverGapCause, string> = {
+  no_source: 'Nessun PDF collegato e nessuna immagine libera: serve una cover manuale da URL.',
+  heuristic_rejected:
+    'Esito corretto — nessuna pagina del rulebook è una cover accettabile. Serve una cover manuale.',
+  pdf_too_large:
+    "Il PDF eccede il limite del servizio di estrazione. Verificare che l'immagine di unstructured-service sia aggiornata prima di intervenire a mano.",
+  other: 'PDF ancora in lavorazione o fallimento non classificato: ricontrollare più tardi.',
+};
+
+function formatMb(bytes: number | null): string {
+  if (bytes === null) return '—';
+  return `${Math.round(bytes / 1_048_576)} MB`;
+}
+
+export default function CoverGapPage() {
+  const [cause, setCause] = useState<CoverGapCause | ''>('');
+  const { data, isLoading, isError, error } = useCoverGap(cause || undefined);
+
+  const items = data?.items ?? [];
+
+  return (
+    <div className="space-y-6 p-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold text-foreground">Giochi senza cover</h1>
+        <p className="text-sm text-muted-foreground">
+          Giochi del catalogo privi di qualunque cover (PDF, BGG, Wikidata, manuale), con la causa
+          per cui la pipeline cover-da-PDF non li copre. Per risolvere, apri il gioco e usa
+          l&apos;editor cover.
+        </p>
+      </header>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <label htmlFor="cause-filter" className="text-sm text-muted-foreground">
+          Causa
+        </label>
+        <select
+          id="cause-filter"
+          value={cause}
+          onChange={e => setCause(e.target.value as CoverGapCause | '')}
+          className="rounded-md border border-border bg-card px-3 py-1.5 text-sm text-foreground"
+        >
+          {CAUSE_FILTERS.map(f => (
+            <option key={f.value || 'all'} value={f.value}>
+              {f.label}
+            </option>
+          ))}
+        </select>
+
+        {data && (
+          <span className="text-sm text-muted-foreground">
+            {data.total} {data.total === 1 ? 'gioco' : 'giochi'} senza cover
+          </span>
+        )}
+      </div>
+
+      {isLoading && <p className="text-sm text-muted-foreground">Caricamento…</p>}
+
+      {isError && (
+        <p role="alert" className="text-sm text-destructive">
+          Impossibile caricare l&apos;elenco: {error?.message ?? 'errore sconosciuto'}
+        </p>
+      )}
+
+      {!isLoading && !isError && items.length === 0 && (
+        <p className="text-sm text-muted-foreground">
+          Nessun gioco senza cover per il filtro selezionato.
+        </p>
+      )}
+
+      {items.length > 0 && (
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[720px] border-collapse text-sm">
+            <thead>
+              <tr className="border-b border-border text-left text-muted-foreground">
+                <th scope="col" className="py-2 pr-4 font-medium">
+                  Gioco
+                </th>
+                <th scope="col" className="py-2 pr-4 font-medium">
+                  Causa
+                </th>
+                <th scope="col" className="py-2 pr-4 font-medium">
+                  PDF
+                </th>
+                <th scope="col" className="py-2 pr-4 font-medium">
+                  Dimensione
+                </th>
+                <th scope="col" className="py-2 font-medium">
+                  Azione
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map(game => (
+                <tr key={game.gameId} className="border-b border-border">
+                  <td className="py-2 pr-4 text-foreground">{game.title}</td>
+                  <td className="py-2 pr-4">
+                    <span className="text-foreground">{CAUSE_LABELS[game.cause]}</span>
+                    <span className="block text-xs text-muted-foreground">
+                      {CAUSE_HINTS[game.cause]}
+                    </span>
+                  </td>
+                  <td className="py-2 pr-4 text-muted-foreground">{game.pdfFileName ?? '—'}</td>
+                  <td className="py-2 pr-4 text-muted-foreground">{formatMb(game.pdfSizeBytes)}</td>
+                  <td className="py-2">
+                    <a
+                      href={`/shared-games?highlight=${encodeURIComponent(game.gameId)}`}
+                      className="text-primary underline underline-offset-2"
+                    >
+                      Apri nel catalogo
+                    </a>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/hooks/admin/coverEditorKeys.ts
+++ b/apps/web/src/hooks/admin/coverEditorKeys.ts
@@ -6,4 +6,6 @@
 export const coverEditorKeys = {
   all: ['admin', 'cover-editor'] as const,
   candidates: (gameId: string) => ['admin', 'cover-editor', 'candidates', gameId] as const,
+  /** #3590 — elenco dei giochi senza cover, opzionalmente filtrato per causa. */
+  gap: (cause?: string) => ['admin', 'cover-editor', 'gap', cause ?? 'all'] as const,
 } as const;

--- a/apps/web/src/hooks/admin/useCoverGap.ts
+++ b/apps/web/src/hooks/admin/useCoverGap.ts
@@ -1,0 +1,22 @@
+/**
+ * Admin cover-gap (#3590).
+ *
+ * Query hook: i giochi del catalogo senza alcuna cover, con la causa per cui la pipeline
+ * cover-da-PDF non li copre. Wrappa `api.admin.getCoverGap()`.
+ */
+
+'use client';
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { api } from '@/lib/api';
+import type { CoverGapCause, CoverGapPage } from '@/lib/api/schemas/admin/admin-cover.schemas';
+
+import { coverEditorKeys } from './coverEditorKeys';
+
+export function useCoverGap(cause?: CoverGapCause): UseQueryResult<CoverGapPage | null, Error> {
+  return useQuery({
+    queryKey: coverEditorKeys.gap(cause),
+    queryFn: () => api.admin.getCoverGap({ cause, pageSize: 100 }),
+  });
+}

--- a/apps/web/src/lib/api/clients/admin/adminCoverClient.ts
+++ b/apps/web/src/lib/api/clients/admin/adminCoverClient.ts
@@ -10,6 +10,9 @@ import {
   CoverCandidatesSchema,
   CoverAssignmentSchema,
   ManualCoverResultSchema,
+  CoverGapPageSchema,
+  type CoverGapCause,
+  type CoverGapPage,
   type CoverCandidates,
   type CoverAssignment,
   type CoverContext,
@@ -68,6 +71,30 @@ export function createAdminCoverClient(http: HttpClient) {
         `/api/v1/admin/shared-games/${encodeURIComponent(gameId)}/manual-cover`,
         body,
         ManualCoverResultSchema
+      );
+    },
+
+    /**
+     * GET the catalog games that have NO cover at all, each with the cause the cover-from-PDF
+     * pipeline cannot cover it (#3590). Optional `cause` filters to one bounded value.
+     * Returns null on 401.
+     */
+    async getCoverGap(
+      params: {
+        cause?: CoverGapCause;
+        pageNumber?: number;
+        pageSize?: number;
+      } = {}
+    ): Promise<CoverGapPage | null> {
+      const search = new URLSearchParams();
+      if (params.cause) search.set('cause', params.cause);
+      if (params.pageNumber) search.set('pageNumber', String(params.pageNumber));
+      if (params.pageSize) search.set('pageSize', String(params.pageSize));
+      const qs = search.toString();
+
+      return http.get(
+        `/api/v1/admin/shared-games/cover-gap${qs ? `?${qs}` : ''}`,
+        CoverGapPageSchema
       );
     },
   };

--- a/apps/web/src/lib/api/schemas/admin/admin-cover.schemas.ts
+++ b/apps/web/src/lib/api/schemas/admin/admin-cover.schemas.ts
@@ -100,3 +100,45 @@ export const ManualCoverResultSchema = z.object({
   presignedUrl: z.string(),
 });
 export type ManualCoverResult = z.infer<typeof ManualCoverResultSchema>;
+
+/**
+ * #3590 — cover-gap: la causa per cui un gioco è privo di cover. Enum bounded, speculare a
+ * `CoverGapCauses` lato backend (`GetCoverGapQuery.cs`): cambiarne uno richiede di cambiare
+ * anche l'altro.
+ *
+ * - `pdf_too_large`      — il PDF eccede il limite del servizio di estrazione
+ * - `heuristic_rejected` — nessuna pagina è una cover accettabile (esito CORRETTO, non un guasto)
+ * - `no_source`          — nessun PDF collegato: non c'è nulla da cui generare
+ * - `other`              — PDF ancora in lavorazione o fallimenti non classificati
+ */
+export const CoverGapCauseSchema = z.enum([
+  'pdf_too_large',
+  'heuristic_rejected',
+  'no_source',
+  'other',
+]);
+export type CoverGapCause = z.infer<typeof CoverGapCauseSchema>;
+
+/**
+ * Un gioco senza alcuna cover. I campi PDF sono nullable perché il gruppo `no_source` non ha
+ * alcun documento collegato — non stringerli a required senza cambiare il DTO C#.
+ */
+export const CoverGapGameSchema = z.object({
+  gameId: z.string().uuid(),
+  title: z.string(),
+  bggId: z.number().nullable(),
+  cause: CoverGapCauseSchema,
+  pdfFileName: z.string().nullable(),
+  pdfSizeBytes: z.number().nullable(),
+  errorCategory: z.string().nullable(),
+});
+export type CoverGapGame = z.infer<typeof CoverGapGameSchema>;
+
+/** Pagina di risultati cover-gap (PagedResult&lt;CoverGapGameDto&gt; lato backend). */
+export const CoverGapPageSchema = z.object({
+  items: z.array(CoverGapGameSchema),
+  total: z.number(),
+  page: z.number(),
+  pageSize: z.number(),
+});
+export type CoverGapPage = z.infer<typeof CoverGapPageSchema>;

--- a/docs/superpowers/plans/2026-08-07-cover-gap-view.md
+++ b/docs/superpowers/plans/2026-08-07-cover-gap-view.md
@@ -1,0 +1,577 @@
+# Vista cover-gap admin (#3590 Slice A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Dare agli admin un modo per **trovare** i giochi senza cover, raggruppati per causa, e chiudere la deriva di deploy che li ha resi non recuperabili.
+
+**Architecture:** Una query CQRS di sola lettura incrocia `shared_games` (le 4 chiavi cover tutte nulle) con i PDF collegati via la tabella ponte `shared_game_documents`, e deriva una causa per gioco da `cover_generation_status` + `error_category`. Un endpoint admin la espone; una pagina admin la consuma e porta all'editor cover già esistente. In coda, `unstructured-service` entra nella pipeline di deploy.
+
+**Tech Stack:** .NET 9 + MediatR + EF Core, xUnit/FluentAssertions/Moq, Next.js 16 + React Query + Vitest, GitHub Actions.
+
+## Global Constraints
+
+- **Branch impilata** su `feature/issue-3383-single-pod-enforcement` (PR #3597). La PR va aperta con `--base feature/issue-3383-single-pod-enforcement`. Se le PR sotto mergiano prima, ribasare su `main-dev` e correggere la base.
+- **CQRS**: gli endpoint usano SOLO `IMediator.Send()`. Mai iniettare un servizio in un endpoint.
+- `SharedGameEntityConfiguration` ha `HasQueryFilter(e => !e.IsDeleted)`: il filtro soft-delete è **globale**, non riaggiungerlo.
+- `PagedResult<T>` è quello di **`Api.Models`** (`Contracts.cs:586`). Ne esiste un secondo omonimo in `UserLibrary/.../GetUserGamesQuery.cs:69` — non usare quello.
+- `cover_generation_status` e `error_category` sono persistiti come **stringa**, non come enum: confronta con `nameof(...)` o letterali.
+- Policy degli endpoint admin di lettura: `AdminOrEditorPolicy`.
+- MediatR e FluentValidation si auto-registrano per assembly scan (`Program.cs:344-361`): **nessuna registrazione manuale**.
+- Working dir: `D:/Repositories/meepleai-monorepo-main/.claude/worktrees/i3583`. Branch: `feature/issue-3590-cover-gap-and-bgg-carveout`.
+
+## Contesto verificato su staging (2026-08-07)
+
+Numeri reali contro cui validare, dalla verifica documentata in [#3590](https://github.com/meepleAi-app/meepleai-monorepo/issues/3590#issuecomment-5214497502): **160 giochi, 136 con cover, 24 senza**. Il gruppo "PDF oltre il limite" è stato risolto (rebuild dell'immagine `unstructured` stale) e vale 2, non 4, perché due di quei giochi avevano già una cover Wikidata.
+
+## File Structure
+
+| File | Responsabilità | Azione |
+|---|---|---|
+| `.../SharedGameCatalog/Application/Queries/GetCoverGap/GetCoverGapQuery.cs` | Query + DTO monouso | **Crea** |
+| `.../Queries/GetCoverGap/GetCoverGapQueryHandler.cs` | Join + classificazione causa | **Crea** |
+| `.../Queries/GetCoverGap/GetCoverGapQueryValidator.cs` | Bound su paginazione | **Crea** |
+| `apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogAdminEndpoints.cs` | Endpoint admin | Modifica: `GET /admin/shared-games/cover-gap` |
+| `apps/api/tests/.../Queries/GetCoverGap/GetCoverGapQueryHandlerTests.cs` | Test classificazione | **Crea** |
+| `apps/web/src/lib/api/clients/admin/adminCoverClient.ts` | Client admin cover | Modifica: `getCoverGap` |
+| `apps/web/src/lib/api/schemas/admin/admin-cover.schemas.ts` | Schemi Zod | Modifica: schema cover-gap |
+| `apps/web/src/hooks/admin/useCoverGap.ts` | Hook React Query | **Crea** |
+| `apps/web/src/app/admin/(dashboard)/shared-games/cover-gap/page.tsx` | Pagina admin | **Crea** |
+| `.github/workflows/deploy-staging.yml` | Pipeline deploy | Modifica: include `unstructured-service` |
+
+---
+
+### Task 1: query cover-gap con classificazione della causa
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetCoverGap/GetCoverGapQuery.cs`
+- Create: `.../GetCoverGap/GetCoverGapQueryHandler.cs`
+- Create: `.../GetCoverGap/GetCoverGapQueryValidator.cs`
+- Create: `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetCoverGap/GetCoverGapQueryHandlerTests.cs`
+
+**Interfaces:**
+- Consumes: `MeepleAiDbContext.SharedGames` (`DbSet<SharedGameEntity>`), `.SharedGameDocuments` (`DbSet<SharedGameDocumentEntity>`), `.PdfDocuments` (`DbSet<PdfDocumentEntity>`); `Api.Models.PagedResult<T>`; `IQuery<T>` / `IQueryHandler<,>` da `Api.SharedKernel.Application.Interfaces`.
+- Produces: `GetCoverGapQuery(int PageNumber = 1, int PageSize = 20, string? Cause = null) : IQuery<PagedResult<CoverGapGameDto>>` e `CoverGapGameDto(Guid GameId, string Title, int? BggId, string Cause, string? PdfFileName, long? PdfSizeBytes, string? ErrorCategory)`. Consumati dal Task 2 (endpoint) e dal Task 3 (FE).
+
+**Le quattro cause** (stringhe stabili, sono un contratto con il FE e con il filtro `Cause`):
+
+| Valore | Significato | Come si riconosce |
+|---|---|---|
+| `pdf_too_large` | Il PDF eccede il limite del servizio di estrazione | PDF collegato con `ErrorCategory == "PayloadTooLarge"` **oppure** `ProcessingState == "Failed"` con `FileSizeBytes` sopra soglia |
+| `heuristic_rejected` | Nessuna pagina del rulebook è una cover accettabile — **esito corretto** | PDF collegato con `CoverGenerationStatus == "Skipped"` |
+| `no_source` | Nessun PDF collegato e nessuna immagine libera | nessun PDF collegato |
+| `other` | Tutto il resto (PDF in lavorazione, fallimenti non classificati) | fallback |
+
+**Gotcha da rispettare** (verificati):
+- Il gruppo "euristica" si riconosce da `CoverGenerationStatus == "Skipped"` scritto **direttamente sul campo** da `BackfillPdfCoversJob`, non via `PdfDocument.MarkCoverSkipped()` (metodo morto).
+- La relazione PDF→gioco affidabile è la tabella ponte `SharedGameDocuments` (`SharedGameId` + `PdfDocumentId`). `PdfDocumentEntity.SharedGameId` è nullable e popolata solo su alcuni percorsi: **non** usarla come join primario.
+- `ErrorCategory` è `"PayloadTooLarge"` solo dal fix #3589 in poi; i fallimenti precedenti hanno `"Service"` con un messaggio fuorviante. Per questo la causa `pdf_too_large` guarda **anche** la dimensione, non solo la categoria.
+
+- [ ] **Step 1: scrivere il test che fallisce**
+
+Crea il file di test. Usa una `DbContextOptionsBuilder` InMemory come fanno gli altri handler test del contesto (controlla `GetFilteredSharedGamesQueryHandlerTests.cs` per il fixture esatto e riusalo).
+
+```csharp
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class GetCoverGapQueryHandlerTests
+{
+    [Fact]
+    public async Task Handle_GameWithNoCoverAndNoPdf_ClassifiedAsNoSource()
+    {
+        // Arrange: un gioco con tutte e 4 le chiavi cover null e nessun documento collegato.
+        // Assert: Items contiene il gioco con Cause == "no_source".
+    }
+
+    [Fact]
+    public async Task Handle_GameWithSkippedCover_ClassifiedAsHeuristicRejected()
+    {
+        // PDF collegato via SharedGameDocuments con CoverGenerationStatus = "Skipped".
+        // Assert: Cause == "heuristic_rejected".
+    }
+
+    [Fact]
+    public async Task Handle_GameWithPayloadTooLargePdf_ClassifiedAsPdfTooLarge()
+    {
+        // PDF collegato con ErrorCategory = "PayloadTooLarge".
+        // Assert: Cause == "pdf_too_large".
+    }
+
+    [Fact]
+    public async Task Handle_GameWithAnyCoverKey_IsExcluded()
+    {
+        // Quattro giochi, ciascuno con UNA sola chiave valorizzata (pdf/bgg/wikidata/manual).
+        // Assert: Items vuoto — avere una qualsiasi cover esclude dal gap.
+        // Questo test protegge il contratto centrale: la vista elenca SOLO chi non ha NULLA.
+    }
+
+    [Fact]
+    public async Task Handle_FiltersByCause_WhenCauseProvided()
+    {
+        // Due giochi con cause diverse; query con Cause = "no_source".
+        // Assert: torna solo quello.
+    }
+}
+```
+
+Scrivi i corpi per intero seguendo il fixture reale del file di riferimento — non lasciare i commenti come segnaposto.
+
+- [ ] **Step 2: eseguire i test per verificare che falliscano**
+
+```bash
+cd apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~GetCoverGapQueryHandlerTests"
+```
+
+Atteso: FALLISCE in compilazione (i tipi non esistono).
+
+- [ ] **Step 3: creare query, DTO e validator**
+
+`GetCoverGapQuery.cs` — DTO monouso nello stesso file (pattern recente del contesto, es. `GetSeedingStatus`):
+
+```csharp
+using Api.Models;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetCoverGap;
+
+/// <summary>
+/// #3590 — elenca i giochi del catalogo SENZA alcuna cover (tutte e quattro le chiavi nulle),
+/// con la CAUSA per cui la pipeline cover-da-PDF non li copre. Il collo di bottiglia non era
+/// risolvere questi casi — il picker manuale esiste da #3545 — ma TROVARLI: non esisteva alcuna
+/// vista dei giochi senza cover.
+/// </summary>
+/// <param name="Cause">Filtro opzionale su una delle cause note. Null = tutte.</param>
+internal record GetCoverGapQuery(
+    int PageNumber = 1,
+    int PageSize = 20,
+    string? Cause = null) : IQuery<PagedResult<CoverGapGameDto>>;
+
+/// <summary>Un gioco senza cover, con la causa derivata dallo stato dei suoi PDF.</summary>
+internal record CoverGapGameDto(
+    Guid GameId,
+    string Title,
+    int? BggId,
+    string Cause,
+    string? PdfFileName,
+    long? PdfSizeBytes,
+    string? ErrorCategory);
+
+/// <summary>Cause bounded — contratto con il front-end e con il filtro della query.</summary>
+internal static class CoverGapCauses
+{
+    public const string PdfTooLarge = "pdf_too_large";
+    public const string HeuristicRejected = "heuristic_rejected";
+    public const string NoSource = "no_source";
+    public const string Other = "other";
+
+    public static readonly IReadOnlyList<string> All =
+        new[] { PdfTooLarge, HeuristicRejected, NoSource, Other };
+}
+```
+
+`GetCoverGapQueryValidator.cs`:
+
+```csharp
+using FluentValidation;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetCoverGap;
+
+internal sealed class GetCoverGapQueryValidator : AbstractValidator<GetCoverGapQuery>
+{
+    public GetCoverGapQueryValidator()
+    {
+        RuleFor(x => x.PageNumber).GreaterThanOrEqualTo(1);
+        RuleFor(x => x.PageSize).InclusiveBetween(1, 100);
+        RuleFor(x => x.Cause)
+            .Must(c => c is null || CoverGapCauses.All.Contains(c))
+            .WithMessage($"Cause must be one of: {string.Join(", ", CoverGapCauses.All)}");
+    }
+}
+```
+
+- [ ] **Step 4: implementare l'handler**
+
+`GetCoverGapQueryHandler.cs`. Struttura: parti dai giochi con tutte e 4 le chiavi nulle, porta i PDF collegati via la tabella ponte, classifica in memoria dopo la proiezione (la classificazione ha rami che EF non traduce bene, ed è su un insieme piccolo — decine di righe, non migliaia).
+
+```csharp
+public async Task<PagedResult<CoverGapGameDto>> Handle(GetCoverGapQuery request, CancellationToken ct)
+{
+    // Il filtro soft-delete è globale (HasQueryFilter): non va riaggiunto qui.
+    var gapGames = _context.SharedGames
+        .AsNoTracking()
+        .Where(g => string.IsNullOrWhiteSpace(g.PdfCoverR2Key)
+                 && string.IsNullOrWhiteSpace(g.BggCoverR2Key)
+                 && string.IsNullOrWhiteSpace(g.WikidataCoverR2Key)
+                 && string.IsNullOrWhiteSpace(g.ManualCoverR2Key));
+
+    // PDF collegati via la tabella ponte (relazione canonica; PdfDocumentEntity.SharedGameId è
+    // nullable e popolata solo su alcuni percorsi, quindi non è affidabile come join primario).
+    var rows = await (
+        from g in gapGames
+        join sgd in _context.SharedGameDocuments on g.Id equals sgd.SharedGameId into docs
+        from sgd in docs.DefaultIfEmpty()
+        join p in _context.PdfDocuments on sgd.PdfDocumentId equals p.Id into pdfs
+        from p in pdfs.DefaultIfEmpty()
+        select new
+        {
+            g.Id,
+            g.Title,
+            g.BggId,
+            PdfFileName = p != null ? p.FileName : null,
+            PdfSize = p != null ? (long?)p.FileSizeBytes : null,
+            CoverStatus = p != null ? p.CoverGenerationStatus : null,
+            ErrorCategory = p != null ? p.ErrorCategory : null,
+            ProcessingState = p != null ? p.ProcessingState : null,
+        })
+        .ToListAsync(ct)
+        .ConfigureAwait(false);
+
+    // Un gioco può avere più PDF: tieni la riga più informativa per gioco.
+    var classified = rows
+        .GroupBy(r => new { r.Id, r.Title, r.BggId })
+        .Select(grp =>
+        {
+            var best = grp
+                .OrderByDescending(r => Rank(Classify(r.CoverStatus, r.ErrorCategory, r.ProcessingState, r.PdfSize)))
+                .First();
+            var cause = Classify(best.CoverStatus, best.ErrorCategory, best.ProcessingState, best.PdfSize);
+            return new CoverGapGameDto(
+                grp.Key.Id, grp.Key.Title, grp.Key.BggId, cause,
+                best.PdfFileName, best.PdfSize, best.ErrorCategory);
+        })
+        .Where(d => request.Cause is null || d.Cause == request.Cause)
+        .OrderBy(d => d.Cause).ThenBy(d => d.Title)
+        .ToList();
+
+    var total = classified.Count;
+    var items = classified
+        .Skip((request.PageNumber - 1) * request.PageSize)
+        .Take(request.PageSize)
+        .ToList();
+
+    return new PagedResult<CoverGapGameDto>(items, total, request.PageNumber, request.PageSize);
+}
+```
+
+I due helper privati, con le soglie documentate:
+
+```csharp
+/// <summary>
+/// Soglia oltre la quale un fallimento di estrazione si spiega con la dimensione. Allineata al
+/// limite storico del servizio Unstructured (50MB): i fallimenti precedenti al fix #3589 hanno
+/// ErrorCategory "Service" con un messaggio fuorviante ("Failed to connect"), quindi la sola
+/// categoria non basta a riconoscerli.
+/// </summary>
+private const long LargePdfThresholdBytes = 52_428_800;
+
+private static string Classify(string? coverStatus, string? errorCategory, string? processingState, long? sizeBytes)
+{
+    if (coverStatus is null && processingState is null)
+    {
+        return CoverGapCauses.NoSource;
+    }
+
+    if (string.Equals(errorCategory, "PayloadTooLarge", StringComparison.Ordinal)
+        || (string.Equals(processingState, "Failed", StringComparison.Ordinal)
+            && sizeBytes > LargePdfThresholdBytes))
+    {
+        return CoverGapCauses.PdfTooLarge;
+    }
+
+    if (string.Equals(coverStatus, "Skipped", StringComparison.Ordinal))
+    {
+        return CoverGapCauses.HeuristicRejected;
+    }
+
+    return CoverGapCauses.Other;
+}
+
+/// <summary>Precedenza quando un gioco ha più PDF: la causa più azionabile vince.</summary>
+private static int Rank(string cause) => cause switch
+{
+    CoverGapCauses.PdfTooLarge => 3,
+    CoverGapCauses.HeuristicRejected => 2,
+    CoverGapCauses.Other => 1,
+    _ => 0,
+};
+```
+
+Il ctor prende `MeepleAiDbContext` e `ILogger<GetCoverGapQueryHandler>` con le guardie `?? throw new ArgumentNullException(...)`, come gli altri handler del contesto.
+
+- [ ] **Step 5: eseguire i test per verificare che passino**
+
+```bash
+cd apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~GetCoverGapQueryHandlerTests"
+```
+
+Atteso: PASS, 5 test.
+
+- [ ] **Step 6: commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetCoverGap/ \
+        apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetCoverGap/
+git commit -m "feat(catalog): query cover-gap con classificazione per causa (#3590)"
+```
+
+---
+
+### Task 2: endpoint admin
+
+**Files:**
+- Modify: `apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogAdminEndpoints.cs`
+
+**Interfaces:**
+- Consumes: `GetCoverGapQuery` / `CoverGapGameDto` (Task 1).
+- Produces: `GET /api/v1/admin/shared-games/cover-gap`, consumato dal Task 3.
+
+- [ ] **Step 1: registrare la route**
+
+Accanto alle altre `MapGet` admin (modello: `/admin/shared-games/seeding-status`, righe ~443-447):
+
+```csharp
+group.MapGet("/admin/shared-games/cover-gap", HandleGetCoverGap)
+    .RequireAuthorization("AdminOrEditorPolicy")
+    .WithName("GetCoverGap")
+    .WithSummary("Get catalog games with no cover, grouped by cause (Admin/Editor)")
+    .WithDescription("#3590 — i giochi senza alcuna cover, con la causa per cui la pipeline cover-da-PDF non li copre: pdf_too_large, heuristic_rejected, no_source, other.")
+    .Produces<PagedResult<CoverGapGameDto>>();
+```
+
+La route costante non confligge con `{id:guid}`: il constraint disambigua.
+
+- [ ] **Step 2: aggiungere l'handler statico**
+
+```csharp
+private static async Task<IResult> HandleGetCoverGap(
+    IMediator mediator,
+    [FromQuery] string? cause = null,
+    [FromQuery] int pageNumber = 1,
+    [FromQuery] int pageSize = 20,
+    CancellationToken ct = default)
+{
+    var result = await mediator
+        .Send(new GetCoverGapQuery(pageNumber, pageSize, cause), ct)
+        .ConfigureAwait(false);
+    return Results.Ok(result);
+}
+```
+
+Aggiungi il `using` del namespace `...Application.Queries.GetCoverGap`. **Solo `IMediator`**: nessun servizio iniettato, è la regola CQRS del progetto.
+
+- [ ] **Step 3: build**
+
+```bash
+cd apps/api/src/Api && dotnet build --nologo -v q
+```
+
+Atteso: `Avvisi: 0`, `Errori: 0`.
+
+- [ ] **Step 4: commit**
+
+```bash
+git add apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogAdminEndpoints.cs
+git commit -m "feat(catalog): endpoint admin GET /admin/shared-games/cover-gap (#3590)"
+```
+
+---
+
+### Task 3: pagina admin cover-gap
+
+**Files:**
+- Modify: `apps/web/src/lib/api/schemas/admin/admin-cover.schemas.ts`
+- Modify: `apps/web/src/lib/api/clients/admin/adminCoverClient.ts`
+- Create: `apps/web/src/hooks/admin/useCoverGap.ts`
+- Create: `apps/web/src/app/admin/(dashboard)/shared-games/cover-gap/page.tsx`
+
+**Interfaces:**
+- Consumes: `GET /api/v1/admin/shared-games/cover-gap` (Task 2).
+- Produces: la pagina admin; nessun consumatore a valle.
+
+**Prima di scrivere**: leggi `useCoverCandidates.ts` e `adminCoverClient.ts` per riusarne esattamente lo stile (naming delle query key, forma del client, gestione errori). Non introdurre un secondo stile nella stessa cartella.
+
+- [ ] **Step 1: schema Zod**
+
+In `admin-cover.schemas.ts`, accanto agli schemi esistenti:
+
+```ts
+export const coverGapCauseSchema = z.enum([
+  'pdf_too_large',
+  'heuristic_rejected',
+  'no_source',
+  'other',
+]);
+
+export const coverGapGameSchema = z.object({
+  gameId: z.string().uuid(),
+  title: z.string(),
+  bggId: z.number().nullable(),
+  cause: coverGapCauseSchema,
+  pdfFileName: z.string().nullable(),
+  pdfSizeBytes: z.number().nullable(),
+  errorCategory: z.string().nullable(),
+});
+
+export const coverGapPageSchema = z.object({
+  items: z.array(coverGapGameSchema),
+  total: z.number(),
+  page: z.number(),
+  pageSize: z.number(),
+});
+```
+
+⚠️ Prima di stringere qualunque campo a `required`, verifica la nullability effettiva lato C#: `bggId`, `pdfFileName`, `pdfSizeBytes`, `errorCategory` sono nullable nel DTO, quindi `.nullable()` è corretto e non va tolto.
+
+- [ ] **Step 2: client**
+
+In `adminCoverClient.ts`, seguendo la forma dei metodi già presenti:
+
+```ts
+async getCoverGap(params: { cause?: string; pageNumber?: number; pageSize?: number } = {}) {
+  const search = new URLSearchParams();
+  if (params.cause) search.set('cause', params.cause);
+  if (params.pageNumber) search.set('pageNumber', String(params.pageNumber));
+  if (params.pageSize) search.set('pageSize', String(params.pageSize));
+  const qs = search.toString();
+  return coverGapPageSchema.parse(
+    await apiFetch(`/api/v1/admin/shared-games/cover-gap${qs ? `?${qs}` : ''}`)
+  );
+}
+```
+
+Adatta `apiFetch` al helper realmente usato nel file.
+
+- [ ] **Step 3: hook**
+
+`useCoverGap.ts`, sul modello di `useCoverCandidates.ts`:
+
+```ts
+export function useCoverGap(params: { cause?: string; pageNumber?: number } = {}) {
+  return useQuery({
+    queryKey: ['admin', 'cover-gap', params],
+    queryFn: () => adminCoverClient.getCoverGap(params),
+  });
+}
+```
+
+- [ ] **Step 4: pagina**
+
+`cover-gap/page.tsx`. Requisiti concreti:
+- Tabella dei giochi senza cover: titolo, causa (etichetta leggibile), nome del PDF e dimensione in MB quando presenti.
+- Filtro per causa (le quattro dell'enum + "tutte").
+- Conteggio totale in testa — è il numero che si confronta con la copertura del catalogo.
+- Per ogni riga, un link al gioco su `/shared-games` così l'admin raggiunge l'editor cover esistente (affordance a matita, `AdminCoverEditAffordance`). **Non** duplicare l'editor qui.
+- **Token semantici obbligatori**: `bg-background`, `bg-card`, `text-foreground`, `text-muted-foreground`, `border-border`. Le utility hardcoded (`bg-white`, `text-gray-*`, `bg-slate-*`) sono **errore** ESLint (`local/no-hardcoded-color-utility`).
+- Etichette in italiano, coerenti col resto dell'area admin.
+
+- [ ] **Step 5: qualità FE**
+
+```bash
+cd apps/web && pnpm typecheck && pnpm lint
+```
+
+Atteso: nessun errore. Se `lint:tokens` segnala colori hardcoded, correggi i token — non aggiungere eccezioni.
+
+- [ ] **Step 6: commit**
+
+```bash
+git add apps/web/src/lib/api/schemas/admin/admin-cover.schemas.ts \
+        apps/web/src/lib/api/clients/admin/adminCoverClient.ts \
+        apps/web/src/hooks/admin/useCoverGap.ts \
+        apps/web/src/app/admin/\(dashboard\)/shared-games/cover-gap/page.tsx
+git commit -m "feat(catalog): pagina admin cover-gap (#3590)"
+```
+
+---
+
+### Task 4: unstructured-service nella pipeline di deploy
+
+**Files:**
+- Modify: `.github/workflows/deploy-staging.yml`
+
+**Interfaces:** nessuna — CI.
+
+**Perché è in questa PR:** è la causa per cui i 4 PDF grandi risultavano non recuperabili. Verificato il 2026-08-07: staging girava un'immagine del 31 luglio 13:50 UTC, costruita **un'ora prima** che il commit del limite 50→100MB atterrasse — e le mancavano anche i due commit di region-seeding RAG (#3435, #3565). Il servizio non compare in `deploy-staging.yml` né in alcun workflow di build/publish: appare solo come URL nei test. Si ricostruisce a mano, quindi va alla deriva in silenzio.
+
+- [ ] **Step 1: capire come il deploy tratta i servizi buildati da sorgente**
+
+`deploy-staging.yml` (blocco `SERVICES`, righe ~1092-1130) fa `docker pull` di immagini GHCR per `api`, `web`, `embedding-service`, `reranker-service`. `unstructured-service` nel compose è `build:` da sorgente, quindi **non** ha un'immagine GHCR da pullare: il pattern del pull non si applica tale e quale.
+
+Leggi il blocco per intero prima di modificarlo e scegli l'innesto coerente: o si aggiunge il servizio al passo di build sul VPS, o lo si porta su GHCR come embedding/reranker. La seconda è più pulita ma più grande; la prima è locale a questo workflow.
+
+- [ ] **Step 2: implementare il rilevamento del cambiamento e il rebuild**
+
+Aggiungi un ramo che, quando cambiano i file sotto `apps/unstructured-service/`, ricostruisce e ricrea il servizio sul VPS. Vincoli **non negoziabili**, appresi sul campo:
+
+- **Prune PRIMA del build, non dopo.** L'immagine pesa 10.2GB; il 2026-08-07 il build ha portato il disco dal 74% al **99% (873MB liberi)**. `docker builder prune -f` recupera ~6.5GB.
+- Il compose richiede le variabili immagine (`EMBEDDING_IMAGE`, `RERANKER_IMAGE`, `ORCHESTRATION_IMAGE`, `API_IMAGE`), altrimenti fallisce con `required variable ... is missing a value`. I tag dell'ultimo deploy sono in `/opt/meepleai/repo/infra/DEPLOYMENT.json`.
+- Riusa il gate di spazio disco già presente nel workflow per gli altri servizi AI (c'è un fail-safe con soglia: cercalo e applica lo stesso, non inventarne un altro).
+
+- [ ] **Step 3: validare la sintassi del workflow**
+
+```bash
+python -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-staging.yml',encoding='utf-8')); print('YAML valido')"
+```
+
+Atteso: `YAML valido`. Un errore di sintassi qui rompe **tutti** i deploy, non solo questo servizio.
+
+- [ ] **Step 4: commit**
+
+```bash
+git add .github/workflows/deploy-staging.yml
+git commit -m "fix(ci): unstructured-service entra nella pipeline di deploy (#3590)"
+```
+
+---
+
+### Task 5: verifica finale e PR
+
+- [ ] **Step 1: build backend**
+
+Da `apps/api/src/Api`: `dotnet build --nologo -v q` → `Avvisi: 0`, `Errori: 0`.
+
+- [ ] **Step 2: regressione backend**
+
+Da `apps/api`:
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "Category=Unit"
+```
+
+Baseline su questa branch: **21364 passati, 0 falliti, 23 skipped**. Riporta il conteggio esatto; non deve peggiorare.
+
+- [ ] **Step 3: qualità frontend**
+
+```bash
+cd apps/web && pnpm typecheck && pnpm lint
+```
+
+- [ ] **Step 4: formattazione backend**
+
+Dalla root del worktree (non da `apps/api`: i path del git diff sono relativi alla root):
+
+```bash
+dotnet format apps/api/MeepleAI.Api.sln --include $(git diff --name-only feature/issue-3383-single-pod-enforcement...HEAD -- '*.cs' | tr '\n' ' ')
+```
+
+- [ ] **Step 5: push e PR**
+
+```bash
+git push -u origin feature/issue-3590-cover-gap-and-bgg-carveout
+gh pr create --base feature/issue-3383-single-pod-enforcement \
+  --title "feat(catalog): vista admin cover-gap + unstructured nel deploy (#3590 Slice A)" \
+  --body "<vedi sotto>"
+```
+
+Il corpo deve contenere: le quattro cause e come si derivano; che il collo di bottiglia era **trovare** i giochi, non risolverli (il picker manuale esiste da #3545); l'esito della verifica staging (24 giochi senza cover, i 4 PDF grandi risolti); che `unstructured-service` non era in alcuna pipeline; e che **Slice B (carve-out BGG) segue in una PR separata**.
+
+---
+
+## Self-Review
+
+**Copertura**: la vista cover-gap (query, endpoint, pagina) copre la parte «trovare i 24» decisa con l'utente; il fix pipeline copre la causa a monte emersa dalla verifica staging. Il **carve-out BGG è deliberatamente fuori** da questo piano: va in Slice B, come concordato, e richiede prima un `SetBggCover` sull'aggregato (oggi assente — l'unico path che scrive `BggCoverR2Key` mutila l'entità EF direttamente, `CreateSharedGameFromPdfCommandHandler:175`).
+
+**Placeholder**: due punti restano volutamente adattivi e sono segnalati sul posto — il fixture InMemory del Task 1 Step 1 (da riusare dal file di riferimento invece di trascriverlo non verificato) e l'innesto del Task 4 Step 2 (il blocco `SERVICES` va letto per intero: `unstructured` non ha immagine GHCR, quindi il pattern del pull non si applica meccanicamente).
+
+**Coerenza dei tipi**: `PagedResult<T>` è quello di `Api.Models`; `CoverGapGameDto` ha gli stessi campi in C#, nello schema Zod e nella pagina; le quattro stringhe di causa sono definite una volta in `CoverGapCauses` e replicate nell'enum Zod — se cambiano, vanno cambiate in entrambi i punti.
+
+**Rischio noto non coperto**: la classificazione avviene in memoria dopo la proiezione. È deliberato (i rami non si traducono bene in SQL, l'insieme è di decine di righe), ma se il catalogo crescesse di ordini di grandezza andrebbe spinta in SQL. Non è un problema oggi con 160 giochi.


### PR DESCRIPTION
Slice A di #3590. **Slice B (carve-out BGG) segue in una PR separata.**

> **PR impilata** su #3597 → #3596. Da mergiare in coda. Se quelle sotto mergiano prima, questa va ribasata su `main-dev` e la base corretta.

## Il problema non era risolvere, era trovare

Il picker manuale da URL esiste da #3545 e funziona anche sui giochi con zero candidati. Quello che mancava era il modo di **individuare** i giochi da sistemare: nessuna vista dei giochi senza cover, e l'unico accesso all'editor era l'affordance a matita in hover sulla griglia pubblica — bisognava scorrerla a occhio.

## Cosa cambia

**Query cover-gap** — elenca i giochi senza **nessuna** delle quattro chiavi cover (PDF, BGG, Wikidata, manuale), derivando la causa dallo stato dei PDF collegati:

| Causa | Significato | Cosa può fare l'admin |
|---|---|---|
| `no_source` | Nessun PDF collegato, nessuna immagine libera | Cover manuale da URL |
| `heuristic_rejected` | Nessuna pagina è una cover accettabile | Cover manuale — **è l'esito corretto**, non un guasto |
| `pdf_too_large` | Il PDF eccede il limite del servizio di estrazione | Verificare l'immagine di `unstructured-service` prima di intervenire |
| `other` | PDF in lavorazione o fallimento non classificato | Ricontrollare più tardi |

**Endpoint** `GET /api/v1/admin/shared-games/cover-gap` (`AdminOrEditorPolicy`, solo `IMediator` per la regola CQRS).

**Pagina admin** con filtro per causa, conteggio totale e link al gioco nel catalogo. L'editor cover **non è duplicato**: ogni riga porta dove già vive.

**`unstructured-service` nella pipeline di deploy** — vedi sotto.

## Due gotcha rispettati nella query

1. **Il join passa dalla tabella ponte `shared_game_documents`.** `PdfDocumentEntity.SharedGameId` è nullable e popolata solo su alcuni percorsi: usarla come join primario perde righe (l'ho verificato in sessione, un join via `CollectionId` restituiva zero corrispondenze).
2. **`pdf_too_large` guarda anche la dimensione, non solo la categoria.** I fallimenti precedenti al fix #3589 hanno `ErrorCategory = "Service"` con il messaggio fuorviante «Failed to connect to Unstructured service»: filtrare solo su `PayloadTooLarge` li mancherebbe tutti. C'è un test dedicato a questo caso legacy.

## La causa a monte: unstructured-service non era in nessuna pipeline

Verificato su staging il 2026-08-07 (dettaglio completo nel [commento su #3590](https://github.com/meepleAi-app/meepleai-monorepo/issues/3590#issuecomment-5214497502)):

Il container girava con `max_file_size = 50MB` mentre il codice è a 100MB da #3424. L'immagine era stata costruita il **31 luglio 13:50 UTC**, un'ora **prima** che quel commit atterrasse. E non mancava solo quello: `main.py` nel container aveva **0** occorrenze di `region` contro le **3** del checkout — il region-seeding RAG (#3435, #3565) era mergiato ma **non stava girando su staging**.

Il servizio non compariva in `deploy-staging.yml` né in un workflow di build GHCR: nei workflow appariva solo come URL nei test. Si aggiornava solo a mano, quindi andava alla deriva in silenzio.

Il wiring aggiunto qui tiene conto di due vincoli:
- **Resta fuori da `ai_any`**: quel flag gate il job di build+push GHCR, la cui matrice è `[embedding, reranker, orchestration]`. `unstructured` è build-from-source nel compose e si ricostruisce sul VPS — includerlo lì farebbe girare a vuoto il job.
- **Il prune va PRIMA del build.** L'immagine pesa ~10GB e durante il rebuild manuale il disco è passato dal 74% al **99% (873MB liberi)**. Riusa lo stesso `AI_PULL_GATE_GB` degli altri servizi AI.

## Esito su staging (già applicato)

Rebuild eseguito e i 4 PDF grandi riprocessati: tutti `Ready` + `Generated`. **Copertura da 134/160 a 136/160**, giochi senza cover da 26 a **24**.

Correzione al breakdown dell'issue: il guadagno netto è **+2, non +4** — due dei quattro giochi (Mysterium, Spirit Island) avevano già una cover Wikidata e non erano fra i 26.

## Verifica

- `dotnet build`: `Avvisi: 0`, `Errori: 0`
- Categoria `Unit`: **21370 passati, 0 falliti**, 23 skipped (baseline 21364, +6 nuovi)
- `pnpm typecheck`: pulito · `pnpm lint`: **0 errori**
- `dotnet format`: nessuna modifica
- YAML del workflow validato

## Una nota onesta sul lint

La pagina eredita il warning `local/prefer-use-game-title` (non un errore), come la sorella `seeding/client.tsx`. `useGameTitle` richiede `{title, translations}` ed è un hook, quindi non chiamabile dentro `map()`; il DTO admin è una proiezione piatta senza traduzioni, quindi il hook restituirebbe comunque il titolo grezzo. Sistemarlo richiederebbe un componente-riga dedicato e portare le traduzioni nel DTO: fuori scope qui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
