### PR TITLE
feat(catalog): carve-out re-upload cover BGG (#3590 Slice B)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ReuploadBggCover/ReuploadBggCoverCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ReuploadBggCover/ReuploadBggCoverCommand.cs
@@ -1,0 +1,25 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.ReuploadBggCover;
+
+/// <summary>
+/// #3590 Slice B — ri-ospita su R2 la cover che BoardGameGeek espone per il <c>BggId</c> del gioco.
+/// <para>
+/// Percorso <b>server-to-server admin</b>, legittimo per ADR-059 §2 e già in uso alla creazione di
+/// uno SharedGame da PDF (<c>CreateSharedGameFromPdfCommandHandler</c>); qui diventa un trigger per
+/// un gioco <b>già a catalogo</b>, che prima non esisteva.
+/// </para>
+/// <para>
+/// NON accetta un URL: la sorgente è l'immagine che BGG dichiara per quel <c>BggId</c>. Il campo
+/// cover manuale a URL libero resta sbarrato verso gli host geekdo da
+/// <see cref="Api.SharedKernel.Infrastructure.Http.BggHostDenyList"/> (ban #2123) — questo comando
+/// non la allenta e non la aggira: usa un canale diverso, già sanzionato.
+/// </para>
+/// </summary>
+/// <param name="GameId">Gioco a catalogo di cui ri-ospitare la cover.</param>
+/// <param name="AdminId">Admin che ha richiesto l'operazione (audit).</param>
+internal record ReuploadBggCoverCommand(Guid GameId, Guid AdminId) : ICommand<BggCoverResult>;
+
+/// <summary>Esito del re-upload: la chiave R2 persistita sull'aggregato.</summary>
+/// <param name="R2Key">Chiave R2 della cover ri-ospitata.</param>
+internal record BggCoverResult(string R2Key);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ReuploadBggCover/ReuploadBggCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ReuploadBggCover/ReuploadBggCoverCommandHandler.cs
@@ -1,0 +1,100 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.Services;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.ReuploadBggCover;
+
+/// <summary>
+/// Handler di <see cref="ReuploadBggCoverCommand"/>. Flusso: carica il gioco → richiede a BGG
+/// l'immagine dichiarata per il suo <c>BggId</c> → la scarica e la ri-ospita su R2 tramite il
+/// downloader già sanzionato (ADR-059 §2) → persiste la chiave sull'aggregato → evict cache.
+/// </summary>
+/// <remarks>
+/// Riusa <see cref="IBggCoverDownloader"/> invece di reimplementare il fetch: quel servizio è già
+/// SSRF-pinnato e cap-ato a 10MB, ed è lo stesso usato da
+/// <c>CreateSharedGameFromPdfCommandHandler</c>. Ritorna <c>null</c> (loggando) invece di lanciare,
+/// quindi il null va tradotto in un conflitto esplicito.
+/// </remarks>
+internal sealed class ReuploadBggCoverCommandHandler : ICommandHandler<ReuploadBggCoverCommand, BggCoverResult>
+{
+    private readonly ISharedGameRepository _repository;
+    private readonly IBggApiService _bggApiService;
+    private readonly IBggCoverDownloader _coverDownloader;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IHybridCacheService _cache;
+    private readonly ICacheInvalidationRetryPolicy _cacheRetryPolicy;
+    private readonly ILogger<ReuploadBggCoverCommandHandler> _logger;
+
+    public ReuploadBggCoverCommandHandler(
+        ISharedGameRepository repository,
+        IBggApiService bggApiService,
+        IBggCoverDownloader coverDownloader,
+        IUnitOfWork unitOfWork,
+        IHybridCacheService cache,
+        ICacheInvalidationRetryPolicy cacheRetryPolicy,
+        ILogger<ReuploadBggCoverCommandHandler> logger)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _bggApiService = bggApiService ?? throw new ArgumentNullException(nameof(bggApiService));
+        _coverDownloader = coverDownloader ?? throw new ArgumentNullException(nameof(coverDownloader));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _cacheRetryPolicy = cacheRetryPolicy ?? throw new ArgumentNullException(nameof(cacheRetryPolicy));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<BggCoverResult> Handle(ReuploadBggCoverCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var game = await _repository.GetByIdAsync(command.GameId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException("SharedGame", command.GameId.ToString());
+
+        if (game.BggId is not > 0)
+        {
+            // Stato non azionabile, non un errore del chiamante: 409, mai InvalidOperationException.
+            throw new ConflictException(
+                "Il gioco non ha un BggId: non esiste una cover BoardGameGeek da ri-ospitare.");
+        }
+
+        var bggId = game.BggId.Value;
+
+        var details = await _bggApiService.GetGameDetailsAsync(bggId, cancellationToken).ConfigureAwait(false);
+        if (details?.ImageUrl is not { Length: > 0 } imageUrl)
+        {
+            throw new ConflictException(
+                $"BoardGameGeek non espone un'immagine per BggId {bggId}.");
+        }
+
+        var r2Key = await _coverDownloader
+            .DownloadAndUploadAsync(bggId, imageUrl, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (string.IsNullOrWhiteSpace(r2Key))
+        {
+            // Il downloader logga e ritorna null su fetch/upload fallito: qui diventa esplicito,
+            // altrimenti l'admin vedrebbe un 200 senza che nulla sia cambiato.
+            throw new ConflictException(
+                $"Download o upload della cover BGG per BggId {bggId} non riuscito.");
+        }
+
+        game.SetBggCover(r2Key);
+        _repository.Update(game);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        // La colonna che il read-model risolve è cambiata → evict lista + dettaglio.
+        await CoverCacheInvalidation
+            .EvictReadModelAsync(_cache, _cacheRetryPolicy, game.Id, cancellationToken)
+            .ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "BGG cover re-hosted for game {GameId} (BggId {BggId}) by {AdminId} → {R2Key}",
+            game.Id, bggId, command.AdminId, r2Key);
+
+        return new BggCoverResult(r2Key);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ReuploadBggCover/ReuploadBggCoverCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ReuploadBggCover/ReuploadBggCoverCommandValidator.cs
@@ -1,0 +1,16 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.ReuploadBggCover;
+
+/// <summary>
+/// Boundary validation per <see cref="ReuploadBggCoverCommand"/> — un 422 via la pipeline
+/// FluentValidation invece di un 500 su identificativi vuoti.
+/// </summary>
+internal sealed class ReuploadBggCoverCommandValidator : AbstractValidator<ReuploadBggCoverCommand>
+{
+    public ReuploadBggCoverCommandValidator()
+    {
+        RuleFor(x => x.GameId).NotEqual(Guid.Empty).WithMessage("GameId is required");
+        RuleFor(x => x.AdminId).NotEqual(Guid.Empty).WithMessage("AdminId is required");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/SharedGame.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/SharedGame.cs
@@ -50,6 +50,12 @@ public sealed class SharedGame : AggregateRoot<Guid>
     // Issue #1852: L4 PDF cover key, denormalized from PdfDocumentEntity.CoverR2Key
     // via PdfCoverGeneratedEventHandler. Set via SetPdfCoverR2Key().
     private string? _pdfCoverR2Key;
+    // #3590 Slice B: L2.5 BGG cover key, ri-ospitata dal re-upload server-to-server admin
+    // (ADR-059 §2). Set via SetBggCover(). Prima di #3590 questa colonna NON era sull'aggregato:
+    // il mapper del repository non la leggeva né la scriveva, e siccome Update() rimappa un grafo
+    // detached (tutte le colonne Modified) ogni load-modify-save emetteva
+    // `SET bgg_cover_r2_key = NULL`, cancellando silenziosamente la cover.
+    private string? _bggCoverR2Key;
     // Issue #1823 Phase B M8: Wikidata cover state. Set via SetWikidataCover()
     // after successful enrichment orchestration (M3 SPARQL + M4 license + M6
     // WebP + M7 R2 upload). QID itself is set independently via
@@ -186,6 +192,13 @@ public sealed class SharedGame : AggregateRoot<Guid>
     /// Issue #1852.
     /// </summary>
     public string? PdfCoverR2Key => _pdfCoverR2Key;
+
+    /// <summary>
+    /// Chiave R2 della cover BGG ri-ospitata (layer L2.5). Scritta dal re-upload
+    /// server-to-server admin, legittimo per ADR-059 §2; MAI da un URL arbitrario, path che
+    /// <see cref="Api.SharedKernel.Infrastructure.Http.BggHostDenyList"/> sbarra per il ban #2123.
+    /// </summary>
+    public string? BggCoverR2Key => _bggCoverR2Key;
 
     /// <summary>
     /// Gets the Wikidata QID identifying this game on Wikidata (e.g. <c>"Q98056728"</c>).
@@ -411,7 +424,8 @@ public sealed class SharedGame : AggregateRoot<Guid>
         string? manualCoverAttribution = null,
         string? manualCoverSourceUrl = null,
         Guid? manualCoverAttestedBy = null,
-        DateTime? manualCoverAttestedAt = null) : base(id)
+        DateTime? manualCoverAttestedAt = null,
+        string? bggCoverR2Key = null) : base(id)
     {
         _id = id;
         _title = title;
@@ -430,6 +444,7 @@ public sealed class SharedGame : AggregateRoot<Guid>
         _gameDataStatus = gameDataStatus;
         _hasUploadedPdf = hasUploadedPdf;
         _pdfCoverR2Key = pdfCoverR2Key;
+        _bggCoverR2Key = bggCoverR2Key;
         _wikidataQid = wikidataQid;
         _wikidataCoverR2Key = wikidataCoverR2Key;
         _wikidataCoverLicense = wikidataCoverLicense;
@@ -744,6 +759,27 @@ public sealed class SharedGame : AggregateRoot<Guid>
             return;
 
         _pdfCoverR2Key = coverR2Key;
+    }
+
+    /// <summary>
+    /// #3590 Slice B — registra la chiave R2 della cover BGG ri-ospitata (layer L2.5).
+    /// Idempotente: ritorna senza effetti se la chiave coincide con quella corrente.
+    /// <para>
+    /// La sorgente è l'immagine che BGG espone per il <c>BggId</c> del gioco, scaricata dal path
+    /// server-to-server admin (ADR-059 §2). Questo metodo NON è una via per aggirare
+    /// <see cref="Api.SharedKernel.Infrastructure.Http.BggHostDenyList"/>: quella deny-list
+    /// protegge il campo cover manuale a URL libero, dove un host geekdo resta bandito (#2123).
+    /// </para>
+    /// </summary>
+    public void SetBggCover(string coverR2Key)
+    {
+        if (string.IsNullOrWhiteSpace(coverR2Key))
+            throw new ArgumentException("Cover R2 key cannot be empty", nameof(coverR2Key));
+
+        if (string.Equals(_bggCoverR2Key, coverR2Key, StringComparison.Ordinal))
+            return;
+
+        _bggCoverR2Key = coverR2Key;
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/SharedGameRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/SharedGameRepository.cs
@@ -391,7 +391,10 @@ internal sealed class SharedGameRepository : RepositoryBase, ISharedGameReposito
             manualCoverAttribution: entity.ManualCoverAttribution,
             manualCoverSourceUrl: entity.ManualCoverSourceUrl,
             manualCoverAttestedBy: entity.ManualCoverAttestedBy,
-            manualCoverAttestedAt: entity.ManualCoverAttestedAt);
+            manualCoverAttestedAt: entity.ManualCoverAttestedAt,
+            // #3590 Slice B — senza questa lettura l'aggregato non conosce la cover BGG, quindi
+            // MapToEntity la riscriverebbe come NULL al primo Update() (grafo detached).
+            bggCoverR2Key: entity.BggCoverR2Key);
 
         // Issue #2035: Hydrate designers from the M:N join — only when the caller
         // eager-loaded the navigation (GetByIdAsync), otherwise the EF Core
@@ -450,6 +453,10 @@ internal sealed class SharedGameRepository : RepositoryBase, ISharedGameReposito
             RulesExternalUrl = game.Rules?.ExternalUrl,
             HasUploadedPdf = game.HasUploadedPdf,
             PdfCoverR2Key = game.PdfCoverR2Key,
+            // #3590 Slice B — ometterla qui la azzerava a ogni Update(): l'update è su grafo
+            // detached, quindi marca OGNI colonna come Modified. Stessa ragione già annotata
+            // sotto per le colonne manual.
+            BggCoverR2Key = game.BggCoverR2Key,
             // Issue #1823 Phase B M8 — propagate Wikidata enrichment state.
             WikidataQid = game.WikidataQid,
             WikidataCoverR2Key = game.WikidataCoverR2Key,

--- a/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogAdminEndpoints.cs
+++ b/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogAdminEndpoints.cs
@@ -5,6 +5,7 @@ using Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCo
 using Api.BoundedContexts.SharedGameCatalog.Application.Commands.RemoveRagFromSharedGame;
 using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries;
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.ReuploadBggCover;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetCoverGap;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetGameRagReadiness;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries.ExportSharedGamesTracking;
@@ -91,6 +92,19 @@ internal static class SharedGameCatalogAdminEndpoints
             .Produces(StatusCodes.Status404NotFound);
 
         // Manual cover from a URL (epic #3470 Slice 3a): admin supplies an HTTPS image URL + attested license.
+        // #3590 Slice B — re-upload server-to-server della cover BGG per un gioco già a catalogo.
+        // Path legittimo per ADR-059 §2, distinto dal campo manuale a URL libero qui sotto: NON
+        // accetta un URL, la sorgente è l'immagine che BGG dichiara per il BggId del gioco.
+        group.MapPost("/admin/shared-games/{id:guid}/bgg-cover", HandleReuploadBggCover)
+            .RequireAuthorization("AdminOrEditorPolicy")
+            .RequireRateLimiting("SharedGamesAdmin")
+            .WithName("ReuploadBggCover")
+            .WithSummary("Re-host the BGG cover for a catalog game (Admin/Editor)")
+            .WithDescription("Downloads the image BoardGameGeek exposes for the game's BggId and re-hosts it in R2 (ADR-059 §2 server-to-server path). Takes no URL: the arbitrary-URL manual-cover field stays barred from geekdo hosts by the ADR-059 §5 deny-list.")
+            .Produces<BggCoverResult>()
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status409Conflict);
+
         group.MapPost("/admin/shared-games/{id:guid}/manual-cover", HandleSetManualCover)
             .RequireAuthorization("AdminOrEditorPolicy")
             .RequireRateLimiting("SharedGamesAdmin")
@@ -966,6 +980,22 @@ internal static class SharedGameCatalogAdminEndpoints
         await mediator.Send(new RemoveCoverAssignmentCommand(id, context, session!.Principal!.Subject.Id), ct)
             .ConfigureAwait(false);
         return Results.NoContent();
+    }
+
+    /// <summary>#3590 Slice B — re-upload della cover BGG. Solo IMediator: regola CQRS.</summary>
+    private static async Task<IResult> HandleReuploadBggCover(
+        Guid id,
+        IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken ct)
+    {
+        var (authorized, session, error) = httpContext.RequireAdminOrEditorSession();
+        if (!authorized) return error!;
+
+        var result = await mediator
+            .Send(new ReuploadBggCoverCommand(id, session!.Principal!.Subject.Id), ct)
+            .ConfigureAwait(false);
+        return Results.Ok(result);
     }
 
     private static async Task<IResult> HandleSetManualCover(

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/ReuploadBggCover/ReuploadBggCoverCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/ReuploadBggCover/ReuploadBggCoverCommandHandlerTests.cs
@@ -1,0 +1,154 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.ReuploadBggCover;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.Models;
+using Api.Tests.Constants;
+using Api.Services;
+using Api.SharedKernel.Infrastructure.Persistence;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands.ReuploadBggCover;
+
+/// <summary>
+/// #3590 Slice B — il re-upload server-to-server della cover BGG per un gioco già a catalogo
+/// (ADR-059 §2). Path distinto dalla cover manuale a URL libero, dove gli host geekdo restano
+/// banditi da <c>BggHostDenyList</c>: questi test verificano anche che quella deny-list non sia
+/// stata toccata.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class ReuploadBggCoverCommandHandlerTests
+{
+    private const int BggId = 13;
+    private const string RemoteImage = "https://cf.geekdo-images.com/x/original/cover.jpg";
+    private const string R2Key = "bgg-covers/13/cover";
+
+    private static readonly Guid AdminId = Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd");
+
+    private readonly Mock<ISharedGameRepository> _repository = new();
+    private readonly Mock<IBggApiService> _bggApi = new();
+    private readonly Mock<IBggCoverDownloader> _downloader = new();
+    private readonly Mock<IUnitOfWork> _unitOfWork = new();
+    private readonly Mock<IHybridCacheService> _cache = new();
+    private readonly Mock<ICacheInvalidationRetryPolicy> _cacheRetryPolicy = new();
+
+    public ReuploadBggCoverCommandHandlerTests()
+    {
+        _cacheRetryPolicy
+            .Setup(p => p.ExecuteAsync(It.IsAny<Func<CancellationToken, ValueTask>>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns((Func<CancellationToken, ValueTask> op, string _, CancellationToken ct) => op(ct).AsTask());
+        _cache
+            .Setup(c => c.RemoveByTagAcrossReplicasAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
+    }
+
+    private ReuploadBggCoverCommandHandler CreateHandler() => new(
+        _repository.Object,
+        _bggApi.Object,
+        _downloader.Object,
+        _unitOfWork.Object,
+        _cache.Object,
+        _cacheRetryPolicy.Object,
+        NullLogger<ReuploadBggCoverCommandHandler>.Instance);
+
+    // Il BggId va passato alla factory: AssignBggId è ammesso solo negli stati Skeleton/Failed,
+    // mentre Create() produce un aggregato Complete.
+    private static SharedGame NewGame(int? bggId = BggId) => SharedGame.Create(
+        "Catan", 1995, "desc", 3, 4, 90, 10, 2.5m, 7.8m,
+        "https://example.com/c.jpg", "https://example.com/c-thumb.jpg", null, AdminId, bggId);
+
+    private static BggGameDetailsDto Details(string? imageUrl) => new(
+        BggId, "Catan", "desc", 1995, 3, 4, 90, 60, 120, 10,
+        7.8, 7.5, 1000, 2.5, "https://example.com/thumb.jpg", imageUrl,
+        Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>());
+
+    [Fact]
+    public async Task Handle_HappyPath_PersistsR2KeyOnAggregate()
+    {
+        var game = NewGame();
+        _repository.Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>())).ReturnsAsync(game);
+        _bggApi.Setup(b => b.GetGameDetailsAsync(BggId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Details(RemoteImage));
+        _downloader.Setup(d => d.DownloadAndUploadAsync(BggId, RemoteImage, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(R2Key);
+
+        var result = await CreateHandler().Handle(new ReuploadBggCoverCommand(game.Id, AdminId), CancellationToken.None);
+
+        result.R2Key.Should().Be(R2Key);
+        game.BggCoverR2Key.Should().Be(R2Key, "la chiave va sull'aggregato, non sull'entità EF");
+        _repository.Verify(r => r.Update(game), Times.Once);
+        _unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_GameWithoutBggId_Throws409_AndNeverFetches()
+    {
+        var game = NewGame(bggId: null);
+        _repository.Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>())).ReturnsAsync(game);
+
+        var act = () => CreateHandler().Handle(new ReuploadBggCoverCommand(game.Id, AdminId), CancellationToken.None);
+
+        await act.Should().ThrowAsync<ConflictException>();
+        _bggApi.Verify(b => b.GetGameDetailsAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+        _downloader.VerifyNoOtherCalls();
+        _unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_UnknownGame_Throws404()
+    {
+        _repository.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SharedGame?)null);
+
+        var act = () => CreateHandler().Handle(new ReuploadBggCoverCommand(Guid.NewGuid(), AdminId), CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_BggExposesNoImage_Throws409()
+    {
+        var game = NewGame();
+        _repository.Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>())).ReturnsAsync(game);
+        _bggApi.Setup(b => b.GetGameDetailsAsync(BggId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Details(imageUrl: null));
+
+        var act = () => CreateHandler().Handle(new ReuploadBggCoverCommand(game.Id, AdminId), CancellationToken.None);
+
+        await act.Should().ThrowAsync<ConflictException>();
+        _downloader.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Handle_DownloaderReturnsNull_Throws409_AndWritesNothing()
+    {
+        // Il downloader logga e ritorna null invece di lanciare: senza questa traduzione l'admin
+        // vedrebbe un 200 con nessun cambiamento.
+        var game = NewGame();
+        _repository.Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>())).ReturnsAsync(game);
+        _bggApi.Setup(b => b.GetGameDetailsAsync(BggId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Details(RemoteImage));
+        _downloader.Setup(d => d.DownloadAndUploadAsync(BggId, RemoteImage, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        var act = () => CreateHandler().Handle(new ReuploadBggCoverCommand(game.Id, AdminId), CancellationToken.None);
+
+        await act.Should().ThrowAsync<ConflictException>();
+        game.BggCoverR2Key.Should().BeNull();
+        _unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public void ManualCoverPath_StillBansBggHosts()
+    {
+        // Non-regressione ADR-059 §5: questo carve-out NON allenta la deny-list sul campo a URL
+        // libero. Se questo test diventa rosso, il carve-out è stato implementato nel modo sbagliato.
+        Api.SharedKernel.Infrastructure.Http.BggHostDenyList.IsBanned(RemoteImage)
+            .Should().BeTrue("il path manuale a URL arbitrario deve continuare a rifiutare geekdo");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/SharedGameRepositoryBggCoverTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/SharedGameRepositoryBggCoverTests.cs
@@ -1,0 +1,127 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Repositories;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure.Repositories;
+
+/// <summary>
+/// #3590 Slice B — la cover BGG ri-ospitata (layer L2.5) deve sopravvivere a un
+/// load-modify-save dell'aggregato.
+/// <para>
+/// Regressione chiusa qui: <c>SharedGameRepository.Update()</c> fa
+/// <c>MapToEntity(aggregato)</c> + <c>DbContext.Update(entity)</c> su grafo DETACHED, quindi
+/// marca ogni colonna come Modified. Il mapper non scriveva <c>BggCoverR2Key</c> (né
+/// <c>MapToDomain</c> lo leggeva), per cui ogni salvataggio emetteva
+/// <c>SET bgg_cover_r2_key = NULL</c> — perdita silenziosa della cover.
+/// </para>
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class SharedGameRepositoryBggCoverTests
+{
+    private const string BggKey = "bgg-covers/13/cover";
+
+    private static SharedGameRepository Repo(Api.Infrastructure.MeepleAiDbContext db) =>
+        new(db, Mock.Of<IDomainEventCollector>());
+
+    private static SharedGameEntity NewEntity(Guid id, string? bggCoverR2Key) => new()
+    {
+        Id = id,
+        Title = "Catan",
+        Description = "desc",
+        Status = 2, // Published
+        CreatedBy = Guid.NewGuid(),
+        CreatedAt = DateTime.UtcNow,
+        ImageUrl = string.Empty,
+        ThumbnailUrl = string.Empty,
+        BggCoverR2Key = bggCoverR2Key,
+    };
+
+    [Fact]
+    public async Task Update_PreservesBggCoverR2Key()
+    {
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var id = Guid.NewGuid();
+        db.SharedGames.Add(NewEntity(id, BggKey));
+        await db.SaveChangesAsync();
+        db.ChangeTracker.Clear();
+
+        var repo = Repo(db);
+        var game = await repo.GetByIdAsync(id, CancellationToken.None);
+        game.Should().NotBeNull();
+        repo.Update(game!);
+        await db.SaveChangesAsync();
+        db.ChangeTracker.Clear();
+
+        var after = await db.SharedGames.AsNoTracking().FirstAsync(g => g.Id == id);
+        after.BggCoverR2Key.Should().Be(BggKey,
+            "un update dell'aggregato non deve cancellare la cover BGG ri-ospitata");
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_HydratesBggCoverR2KeyOntoTheAggregate()
+    {
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var id = Guid.NewGuid();
+        db.SharedGames.Add(NewEntity(id, BggKey));
+        await db.SaveChangesAsync();
+        db.ChangeTracker.Clear();
+
+        var game = await Repo(db).GetByIdAsync(id, CancellationToken.None);
+
+        game!.BggCoverR2Key.Should().Be(BggKey,
+            "senza la lettura nel mapper l'aggregato non può preservare ciò che non conosce");
+    }
+
+    [Fact]
+    public async Task SetBggCover_PersistsThroughUpdate()
+    {
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var id = Guid.NewGuid();
+        db.SharedGames.Add(NewEntity(id, bggCoverR2Key: null));
+        await db.SaveChangesAsync();
+        db.ChangeTracker.Clear();
+
+        var repo = Repo(db);
+        var game = await repo.GetByIdAsync(id, CancellationToken.None);
+        game!.SetBggCover(BggKey);
+        repo.Update(game);
+        await db.SaveChangesAsync();
+        db.ChangeTracker.Clear();
+
+        var after = await db.SharedGames.AsNoTracking().FirstAsync(g => g.Id == id);
+        after.BggCoverR2Key.Should().Be(BggKey);
+    }
+
+    [Fact]
+    public void SetBggCover_EmptyKey_Throws()
+    {
+        var game = SharedGame.Create(
+            "Catan", 1995, "desc", 3, 4, 90, 10, 2.5m, 7.8m,
+            "https://example.com/c.jpg", "https://example.com/c-thumb.jpg", null, Guid.NewGuid());
+
+        var act = () => game.SetBggCover("  ");
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void SetBggCover_SameValue_IsIdempotent()
+    {
+        var game = SharedGame.Create(
+            "Catan", 1995, "desc", 3, 4, 90, 10, 2.5m, 7.8m,
+            "https://example.com/c.jpg", "https://example.com/c-thumb.jpg", null, Guid.NewGuid());
+
+        game.SetBggCover(BggKey);
+        game.SetBggCover(BggKey);
+
+        game.BggCoverR2Key.Should().Be(BggKey);
+    }
+}

--- a/docs/for-developers/specs/2026-08-02-admin-cover-editor-design.md
+++ b/docs/for-developers/specs/2026-08-02-admin-cover-editor-design.md
@@ -85,7 +85,19 @@ Regola d'oro (Nygard): **l'URL è input transiente, mai render-source**. Nuovo c
 2. download ≤10MB, validazione **reale** via `IWebpVariantGenerator` (throw su non-immagine, non fidarsi del Content-Type);
 3. **gate licenza**: l'admin dichiara una licenza da whitelist `LicenseValidator` (CC0/PD/CC-BY/CC-BY-SA) + attribution + fonte → 400 se non-whitelist; l'attestazione è dell'admin (registra `attestedBy`+timestamp per audit);
 4. re-encode WebP → upload R2 raw-key → persiste **solo** la R2 key + license/attribution (nuovo `CoverKind.Manual`, colonne `ManualCover*` a specchio di `WikidataCover*`).
-> Host BGG/geekdo: non bloccati nel fetch server-side (ADR-059 §2), ma di fatto rifiutati dal gate-licenza (non sono CC).
+> **Host BGG/geekdo — aggiornato 2026-08-07 (#3590 Slice B).** Il testo originale («non bloccati nel
+> fetch server-side, ma di fatto rifiutati dal gate-licenza») è **superato da #3495**. Oggi i due
+> path sono distinti e vanno tenuti tali:
+>
+> - **Cover manuale da URL arbitrario** (questo flusso): gli host geekdo sono **banditi**, prima di
+>   qualunque egress, da `BggHostDenyList` — nel validator e di nuovo nell'handler come difesa in
+>   profondità (ADR-059 §5 / ban #2123). Non è più il gate-licenza a fermarli "di fatto": è un
+>   rifiuto esplicito, e dal #3583 conta anche sul counter `meepleai_egress_blocked_total`
+>   con reason `denylist_hit`.
+> - **Re-upload BGG server-to-server** (`POST /admin/shared-games/{id}/bgg-cover`, #3590 Slice B):
+>   **consentito** per ADR-059 §2. Non accetta un URL — la sorgente è l'immagine che BGG dichiara
+>   per il `BggId` del gioco — quindi non è una via per aggirare la deny-list, ma un canale
+>   separato e sanzionato.
 
 ## 5. Slicing (decomposizione consigliata)
 

--- a/docs/superpowers/plans/2026-08-07-bgg-carveout.md
+++ b/docs/superpowers/plans/2026-08-07-bgg-carveout.md
@@ -1,0 +1,189 @@
+# Carve-out BGG re-upload (#3590 Slice B) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Dare agli admin un trigger per ri-ospitare la cover BGG di un gioco già a catalogo, e chiudere il bug latente che oggi cancella quella cover a ogni update.
+
+**Architecture:** Un comando CQRS dedicato riusa il downloader server-to-server già sanzionato da ADR-059 §2 (`IBggCoverDownloader` + `BggCoverUploadPipeline`), oggi cablato solo alla creazione da PDF. **Non** passa da `SetManualCover`: `BggHostDenyList` resta intatta sul path a URL arbitrario, che è esattamente il suo scopo. Prerequisito: l'aggregato acquisisce `BggCoverR2Key` (oggi assente) e il mapper di persistenza smette di azzerarlo.
+
+**Tech Stack:** .NET 9 + MediatR + EF Core, xUnit/FluentAssertions/Moq.
+
+## Global Constraints
+
+- Branch da `main-dev` aggiornato (le tre PR del lotto sono mergiate).
+- **CQRS**: endpoint con solo `IMediator.Send()`.
+- **ADR-059 §2**: il path server-to-server admin verso BGG è legittimo per *facts* e per il re-hosting di asset lato admin. Il freeze #2123 riguarda le richieste **browser** verso host geekdo e non è toccato.
+- **`BggHostDenyList` NON va allentata.** Se un test o un handler la aggira, il design è sbagliato.
+- Eccezioni: `NotFoundException` (404), `ConflictException` (409) — mai `InvalidOperationException` (500).
+- Working dir: `D:/Repositories/meepleai-monorepo-main/.claude/worktrees/i3583`.
+
+## Scoperta che cambia il piano (verificata in sessione)
+
+`SharedGameRepository.Update()` fa `MapToEntity(aggregato)` + `DbContext.Update(entity)` su **grafo detached**: marca tutte le colonne come Modified. Il mapper **non scrive** `BggCoverR2Key` (e `MapToDomain` non lo legge), quindi:
+
+```
+UPDATE shared_games SET bgg_cover_r2_key = NULL ...
+```
+
+**Provato empiricamente**: un load → `Update()` → `SaveChanges()` azzera una `BggCoverR2Key` preesistente (`Expected "bgg-covers/13/cover", but found <null>`).
+
+Due conseguenze:
+1. È un **bug di perdita dati pre-esistente**, indipendente da questa issue: ogni update di un SharedGame distrugge la cover BGG re-uploadata.
+2. Spiega perché `CreateSharedGameFromPdfCommandHandler:175` scrive direttamente sull'entità EF tracciata scavalcando l'aggregato — era l'unico modo per far sopravvivere il valore.
+
+Senza il Task 1, il carve-out scriverebbe una cover destinata a sparire al primo update.
+
+---
+
+### Task 1: `BggCoverR2Key` nell'aggregato e nel mapper (chiude il bug latente)
+
+**Files:**
+- Modify: `.../SharedGameCatalog/Domain/Aggregates/SharedGame.cs`
+- Modify: `.../SharedGameCatalog/Infrastructure/Repositories/SharedGameRepository.cs` (`MapToDomain` ~riga 382, `MapToEntity` ~riga 452)
+- Create: `apps/api/tests/.../Infrastructure/Repositories/SharedGameRepositoryBggCoverTests.cs`
+
+**Interfaces:**
+- Produces: `SharedGame.BggCoverR2Key` (get) e `SharedGame.SetBggCover(string coverR2Key)`, consumati dal Task 2.
+
+- [ ] **Step 1: test di regressione che fallisce**
+
+```csharp
+[Fact]
+public async Task Update_PreservesBggCoverR2Key()
+{
+    // Regressione: MapToEntity non scriveva BggCoverR2Key e Update() fa un update di grafo
+    // detached (tutte le colonne Modified) → ogni load-modify-save azzerava la cover BGG.
+    await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+    var id = Guid.NewGuid();
+    db.SharedGames.Add(new SharedGameEntity
+    {
+        Id = id, Title = "Probe", Description = "d", Status = 2,
+        CreatedBy = Guid.NewGuid(), CreatedAt = DateTime.UtcNow,
+        ImageUrl = "", ThumbnailUrl = "",
+        BggCoverR2Key = "bgg-covers/13/cover",
+    });
+    await db.SaveChangesAsync();
+    db.ChangeTracker.Clear();
+
+    var repo = new SharedGameRepository(db, Mock.Of<IDomainEventCollector>());
+    var game = await repo.GetByIdAsync(id, CancellationToken.None);
+    repo.Update(game!);
+    await db.SaveChangesAsync();
+    db.ChangeTracker.Clear();
+
+    var after = await db.SharedGames.AsNoTracking().FirstAsync(g => g.Id == id);
+    after.BggCoverR2Key.Should().Be("bgg-covers/13/cover");
+}
+```
+
+`IDomainEventCollector` è in `Api.SharedKernel.Application.Services`.
+
+Aggiungi anche un test su `SetBggCover`: rifiuta stringa vuota (`ArgumentException`), è idempotente sullo stesso valore, aggiorna su valore diverso.
+
+- [ ] **Step 2: eseguire — deve fallire con `found <null>`**
+
+```bash
+cd apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~SharedGameRepositoryBggCoverTests"
+```
+
+- [ ] **Step 3: campo + metodo sull'aggregato**
+
+In `SharedGame.cs`, accanto a `_pdfCoverR2Key`, aggiungi il campo privato, la proprietà pubblica e il metodo modellato **esattamente** su `SetPdfCoverR2Key` (riga ~738):
+
+```csharp
+/// <summary>
+/// Chiave R2 della cover BGG ri-ospitata (layer L2.5). Scritta dal re-upload
+/// server-to-server admin (ADR-059 §2), MAI da un URL arbitrario: quel path è
+/// sbarrato da <c>BggHostDenyList</c> per il ban #2123.
+/// </summary>
+public void SetBggCover(string coverR2Key)
+{
+    if (string.IsNullOrWhiteSpace(coverR2Key))
+        throw new ArgumentException("Cover R2 key cannot be empty", nameof(coverR2Key));
+
+    if (string.Equals(_bggCoverR2Key, coverR2Key, StringComparison.Ordinal))
+        return;
+
+    _bggCoverR2Key = coverR2Key;
+}
+```
+
+Il costruttore/factory di ricostituzione deve accettare `bggCoverR2Key` come gli altri campi cover (parametro opzionale in coda, come `manualCoverR2Key`).
+
+- [ ] **Step 4: mapper bidirezionale**
+
+- `MapToDomain` (~382): aggiungi `bggCoverR2Key: entity.BggCoverR2Key` accanto a `pdfCoverR2Key`.
+- `MapToEntity` (~452): aggiungi `BggCoverR2Key = game.BggCoverR2Key,` accanto a `PdfCoverR2Key`, con il commento che spiega perché ometterlo azzerava la colonna (stesso motivo già annotato per le colonne manual).
+
+- [ ] **Step 5: eseguire — deve passare**
+
+Poi la suite del repository e dei command handler che salvano SharedGame:
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~SharedGameRepository|FullyQualifiedName~CreateSharedGameFromPdf|FullyQualifiedName~SetManualCover"
+```
+
+Attenzione: `CreateSharedGameFromPdfCommandHandler` scrive `entity.BggCoverR2Key` **dopo** `AddAsync` (che ora mappa il campo dall'aggregato, null per un gioco nuovo). L'ordine regge, ma i suoi test devono restare verdi — se uno diventa rosso, è un segnale reale, non da aggirare.
+
+- [ ] **Step 6: commit**
+
+```bash
+git commit -m "fix(catalog): l'aggregato possiede BggCoverR2Key e il mapper non lo azzera (#3590)"
+```
+
+---
+
+### Task 2: comando di re-upload BGG
+
+**Files:**
+- Create: `.../Application/Commands/ReuploadBggCover/ReuploadBggCoverCommand.cs`
+- Create: `.../ReuploadBggCover/ReuploadBggCoverCommandHandler.cs`
+- Create: `.../ReuploadBggCover/ReuploadBggCoverCommandValidator.cs`
+- Create: test dell'handler
+
+**Interfaces:**
+- Consumes: `SharedGame.SetBggCover` (Task 1); `IBggCoverDownloader.DownloadAndUploadAsync(int bggId, string remoteImageUrl, CancellationToken) -> Task<string?>`; `IBggApiService.GetGameDetailsAsync(int bggId, CancellationToken) -> Task<BggGameDetailsDto?>` (ha `ImageUrl`); `ISharedGameRepository`, `IUnitOfWork`.
+- Produces: `ReuploadBggCoverCommand(Guid GameId, Guid AdminId) : ICommand<BggCoverResult>` e `BggCoverResult(string R2Key)`.
+
+**Flusso**: carica il gioco (404 se assente) → 409 se `BggId` è null (non c'è nulla da scaricare) → `GetGameDetailsAsync` per l'`ImageUrl` → 409 se BGG non espone immagine → `DownloadAndUploadAsync` → 409 se ritorna null (il downloader logga e non lancia) → `game.SetBggCover(key)` → `Update` + `SaveChangesAsync` → evict cache come fa `SetManualCoverCommandHandler`.
+
+**Da NON fare**: passare da `SetManualCoverCommand`, allentare `BggHostDenyList`, o reimplementare il download.
+
+Test richiesti:
+- percorso felice → chiave persistita sull'aggregato, `SaveChangesAsync` chiamato una volta;
+- gioco senza `BggId` → `ConflictException`, nessuna chiamata al downloader;
+- gioco inesistente → `NotFoundException`;
+- downloader ritorna null → `ConflictException`, nessuna scrittura sull'aggregato;
+- **non-regressione**: `SetManualCoverCommandValidator` continua a rifiutare un URL geekdo (la deny-list non è stata toccata).
+
+---
+
+### Task 3: endpoint admin
+
+**Files:** `apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogAdminEndpoints.cs`
+
+```csharp
+group.MapPost("/admin/shared-games/{id:guid}/bgg-cover", HandleReuploadBggCover)
+    .RequireAuthorization("AdminOrEditorPolicy")
+    .WithName("ReuploadBggCover")
+    .WithSummary("Re-host the BGG cover for a catalog game (Admin/Editor)")
+    .WithDescription("#3590 — path server-to-server legittimo per ADR-059 §2. NON accetta un URL: la sorgente è l'immagine che BGG espone per il BggId del gioco. Il campo cover manuale a URL libero resta sbarrato verso geekdo dalla deny-list.")
+    .Produces<BggCoverResult>();
+```
+
+L'handler statico prende `Guid id`, `IMediator`, e l'admin id dal contesto utente come fanno gli altri endpoint di mutazione (controlla come `HandleSetManualCover` lo ricava — riusare lo stesso meccanismo, non inventarne uno).
+
+---
+
+### Task 4: aggiornare il doc obsoleto + PR
+
+- `docs/for-developers/specs/2026-08-02-admin-cover-editor-design.md:88` afferma «host BGG non bloccati nel fetch server-side (ADR-059 §2)»: **superato da #3495**, che ha introdotto `BggHostDenyList` sul path manuale. Correggere distinguendo i due path: manuale a URL libero = geekdo **bandito**; re-upload admin dedicato = **consentito**.
+- Corpo PR: la distinzione fra i due path; il bug latente chiuso dal Task 1 (con l'evidenza del test); che la deny-list non è stata allentata.
+
+Verifica finale: build 0/0 · categoria `Unit` senza regressioni · `dotnet format` con `--include` dalla root.
+
+## Self-Review
+
+**Rischio principale**: il Task 1 tocca il mapper di un aggregato centrale. Se un test esistente si rompe, va capito — non aggirato: significherebbe che qualcosa dipendeva dall'azzeramento.
+
+**Fuori scope deliberato**: portare `CreateSharedGameFromPdfCommandHandler` sul nuovo metodo di dominio (l'utente ha scelto di non allargare la PR). Dopo il Task 1 quel path resta corretto: scrive sull'entità tracciata **dopo** che `AddAsync` ha mappato l'aggregato.


### PR DESCRIPTION
Slice B di #3590, completa l'issue. Segue #3608 (Slice A), già mergiata.

## Un bug di perdita dati trovato strada facendo

Il prerequisito del carve-out era che l'aggregato `SharedGame` non ha un `SetBggCover`. Indagando **perché**, ho trovato qualcosa di più serio, provato con un test:

```
Expected after.BggCoverR2Key to be "bgg-covers/13/cover", but found <null>.
```

`SharedGameRepository.Update()` fa `MapToEntity(aggregato)` + `DbContext.Update(entity)` su **grafo detached**, quindi marca ogni colonna come Modified. Il mapper non scriveva `BggCoverR2Key` e `MapToDomain` non la leggeva, per cui ogni load-modify-save di un gioco emetteva `SET bgg_cover_r2_key = NULL`: **la cover BGG ri-ospitata veniva cancellata in silenzio**.

Spiega anche perché `CreateSharedGameFromPdfCommandHandler:175` scavalca l'aggregato scrivendo sull'entità EF tracciata — era l'unico modo per far sopravvivere il valore. Quel path resta corretto: scrive **dopo** che `AddAsync` ha mappato.

Senza chiudere questo, il carve-out avrebbe scritto una cover destinata a sparire al primo salvataggio.

## Cosa cambia

**1. L'aggregato possiede `BggCoverR2Key`** — campo, proprietà e `SetBggCover()` modellato su `SetPdfCoverR2Key` (validazione + idempotenza), più il mapper bidirezionale. Cinque test, incluso quello di regressione sopra.

**2. Carve-out re-upload** — `ReuploadBggCoverCommand` + handler + validator + `POST /api/v1/admin/shared-games/{id}/bgg-cover` (`AdminOrEditorPolicy`, solo `IMediator`).

Riusa `IBggCoverDownloader` e `IBggApiService`, già sanzionati da ADR-059 §2 e già in uso alla creazione da PDF: qui diventano un trigger per un gioco **già a catalogo**, che prima non esisteva.

## Perché non allenta la postura ADR-059

I due path restano distinti, ed è il punto centrale del design:

| Path | Host geekdo |
|---|---|
| Cover manuale da **URL arbitrario** | **Bandito** da `BggHostDenyList`, prima di ogni egress, in validator + handler |
| **Re-upload server-to-server** (questo) | **Consentito** per ADR-059 §2 |

L'endpoint **non accetta un URL**: la sorgente è l'immagine che BGG dichiara per il `BggId` del gioco. Non è una via per aggirare la deny-list, è un canale separato. Un test di non-regressione verifica esplicitamente che il path manuale continui a rifiutare geekdo — se diventa rosso, il carve-out è stato implementato male.

Il freeze #2123 riguarda le richieste **browser** verso host geekdo e non è toccato.

## Esiti espliciti invece di silenzi

`IBggCoverDownloader` logga e ritorna `null` invece di lanciare. Tradotto in `ConflictException` (409), altrimenti l'admin vedrebbe un 200 senza che nulla sia cambiato. Stesso trattamento per gioco senza `BggId` e per BGG che non espone immagine — 409, mai `InvalidOperationException` (che sarebbe 500).

## Doc corretto

`2026-08-02-admin-cover-editor-design.md:88` affermava che gli host geekdo «non sono bloccati nel fetch server-side» e che a fermarli è «di fatto» il gate-licenza. **Superato da #3495**: oggi il rifiuto è esplicito. Riscritto distinguendo i due path.

## Verifica

- `dotnet build`: `Avvisi: 0`, `Errori: 0`
- Categoria `Unit`: **21392 passati, 0 falliti**, 23 skipped (+11 nuovi)
- Non-regressione sui path che salvano `SharedGame` (repository, create-from-PDF, manual cover, cover resolver, candidates): 143 test verdi
- `dotnet format`: nessuna modifica di contenuto

## Chiude #3590

Con Slice A (vista cover-gap) e questa, l'issue è coperta: gli admin possono **trovare** i giochi senza cover e **risolverli** — cover manuale da URL per chi non ha sorgenti, re-upload BGG per chi ha un `BggId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
