### PR TITLE
release: egress reasons + single-pod enforcement + cover-gap Slice A/B (#3583, #3383, #3590)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -198,6 +198,8 @@ jobs:
               - 'apps/reranker-service/**'
             orchestration:
               - 'apps/orchestration-service/**'
+            unstructured:
+              - 'apps/unstructured-service/**'
 
       - name: Determine what to deploy
         id: decision
@@ -239,22 +241,34 @@ jobs:
           EMB="${{ steps.changes.outputs.embedding }}"
           RRK="${{ steps.changes.outputs.reranker }}"
           ORC="${{ steps.changes.outputs.orchestration }}"
+          # #3590 — unstructured-service NON era in alcuna pipeline: non qui e non in un workflow
+          # di build/publish GHCR. Si ricostruiva solo a mano sul VPS, quindi andava alla deriva in
+          # silenzio: il 2026-08-07 staging girava un'immagine costruita un'ora PRIMA che il commit
+          # del limite 50->100MB atterrasse, e le mancavano anche i due commit di region-seeding RAG.
+          # Il servizio è build-from-source nel compose (nessuna immagine GHCR da pullare), quindi
+          # sotto viene ricostruito sul VPS invece che pullato.
+          UNS="${{ steps.changes.outputs.unstructured }}"
           if [ "$EVENT" = "workflow_dispatch" ] \
             || [ "$FORCE" = "true" ] \
             || [ "$BEFORE" = "$ZEROS" ] \
             || [ -z "$BEFORE" ]; then
-            EMB=true; RRK=true; ORC=true
+            EMB=true; RRK=true; ORC=true; UNS=true
           fi
           # paths-filter outputs are empty when the changes step is skipped
           # (workflow_dispatch). Normalize empties to false.
-          EMB="${EMB:-false}"; RRK="${RRK:-false}"; ORC="${ORC:-false}"
-          echo "ai_changed={\"embedding\":$EMB,\"reranker\":$RRK,\"orchestration\":$ORC}" >> $GITHUB_OUTPUT
+          EMB="${EMB:-false}"; RRK="${RRK:-false}"; ORC="${ORC:-false}"; UNS="${UNS:-false}"
+          echo "ai_changed={\"embedding\":$EMB,\"reranker\":$RRK,\"orchestration\":$ORC,\"unstructured\":$UNS}" >> $GITHUB_OUTPUT
+          # NOTA: `unstructured` è deliberatamente ESCLUSO da ai_any. ai_any gate il job di
+          # build+push su GHCR, la cui matrice è [embedding, reranker, orchestration];
+          # unstructured-service non ha un'immagine GHCR (è build-from-source nel compose) e viene
+          # ricostruito direttamente sul VPS nello step di deploy. Includerlo qui farebbe girare
+          # a vuoto il job GHCR.
           if [ "$EMB" = "true" ] || [ "$RRK" = "true" ] || [ "$ORC" = "true" ]; then
             echo "ai_any=true" >> $GITHUB_OUTPUT
           else
             echo "ai_any=false" >> $GITHUB_OUTPUT
           fi
-          echo "🤖 AI changed: embedding=$EMB reranker=$RRK orchestration=$ORC"
+          echo "🤖 AI changed: embedding=$EMB reranker=$RRK orchestration=$ORC unstructured=$UNS"
 
   # Lightweight pre-deploy validation (full CI already ran on main-dev PR)
   # Rationale: Code reaching main-staging has already passed the full ci.yml
@@ -1051,6 +1065,7 @@ jobs:
             EMB_CHANGED="${{ fromJSON(needs.detect-changes.outputs.ai_changed).embedding }}"
             RRK_CHANGED="${{ fromJSON(needs.detect-changes.outputs.ai_changed).reranker }}"
             ORC_CHANGED="${{ fromJSON(needs.detect-changes.outputs.ai_changed).orchestration }}"
+            UNS_CHANGED="${{ fromJSON(needs.detect-changes.outputs.ai_changed).unstructured }}"
 
             # Issue #1578 follow-up — free OLD AI images BEFORE the disk gate (disk-safe order).
             # The old image stays referenced by the running container while the new one is pulled
@@ -1122,6 +1137,34 @@ jobs:
             if [ "$ORC_CHANGED" = "true" ]; then
               docker pull "$ORCHESTRATION_IMAGE" || echo "⚠️ orchestration pull failed (non-blocking; not active in staging)"
               echo "📦 orchestration-service image cached (not started in staging)"
+            fi
+
+            # #3590 — unstructured-service è build-from-source nel compose (nessuna immagine GHCR
+            # da pullare), quindi si ricostruisce QUI sul VPS. Prima di #3590 non era in alcuna
+            # pipeline: si aggiornava solo a mano e andava alla deriva in silenzio.
+            #
+            # ORDINE OBBLIGATORIO — prune PRIMA del build, non dopo. L'immagine pesa ~10GB e il
+            # 2026-08-07 un rebuild manuale ha portato il disco dal 74% al 99% (873MB liberi).
+            # `docker builder prune` recupera ~6.5GB di cache: farlo dopo è troppo tardi.
+            if [ "$UNS_CHANGED" = "true" ]; then
+              echo "🧹 Pre-prune before unstructured-service rebuild (image is ~10GB)..."
+              docker builder prune -f || true
+              docker image prune -f || true
+
+              FREE_GB=$(df -BG / | awk 'NR==2 {gsub(/G/,"",$4); print $4}')
+              echo "💽 VPS disk before unstructured build: ${FREE_GB} GB free — gate ${AI_PULL_GATE_GB} GB"
+              if [ "$FREE_GB" -lt "$AI_PULL_GATE_GB" ]; then
+                echo "::error::Insufficient disk to rebuild unstructured-service: ${FREE_GB} GB free < ${AI_PULL_GATE_GB} GB"
+                echo "🚫 Aborting (fail-safe). Manual cleanup on the VPS:"
+                echo "  docker image prune -af && docker builder prune -af"
+                exit 1
+              fi
+
+              echo "🔨 Rebuilding unstructured-service from source on the VPS..."
+              docker compose -f docker-compose.yml -f compose.staging.yml --profile ai \
+                build unstructured-service
+              SERVICES="$SERVICES unstructured-service"
+              echo "📦 unstructured-service rebuilt"
             fi
 
             if [ -z "$SERVICES" ]; then

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommandHandler.cs
@@ -220,6 +220,10 @@ internal sealed class EnrichCatalogCoverCommandHandler
         }
         catch (ImageProcessingException ex)
         {
+            // #3583 — il payload scaricato da Commons è stato rifiutato dal decoder. L'esito
+            // (Failed/image_processing) resta invariato; qui si aggiunge la visibilità su egress.
+            MeepleAiMetrics.RecordEgressBlocked(
+                MeepleAiMetrics.EgressSinks.Wikimedia, MeepleAiMetrics.EgressBlockReasons.DecodeFail);
             EmitOutcomeMetric(OutcomeFailed, FailReasonImageProcessing);
             _logger.LogWarning(ex,
                 "SharedGame {GameId} QID {Qid} WebP encoding failed for file '{Filename}'.",

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ReuploadBggCover/ReuploadBggCoverCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ReuploadBggCover/ReuploadBggCoverCommand.cs
@@ -1,0 +1,25 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.ReuploadBggCover;
+
+/// <summary>
+/// #3590 Slice B — ri-ospita su R2 la cover che BoardGameGeek espone per il <c>BggId</c> del gioco.
+/// <para>
+/// Percorso <b>server-to-server admin</b>, legittimo per ADR-059 §2 e già in uso alla creazione di
+/// uno SharedGame da PDF (<c>CreateSharedGameFromPdfCommandHandler</c>); qui diventa un trigger per
+/// un gioco <b>già a catalogo</b>, che prima non esisteva.
+/// </para>
+/// <para>
+/// NON accetta un URL: la sorgente è l'immagine che BGG dichiara per quel <c>BggId</c>. Il campo
+/// cover manuale a URL libero resta sbarrato verso gli host geekdo da
+/// <see cref="Api.SharedKernel.Infrastructure.Http.BggHostDenyList"/> (ban #2123) — questo comando
+/// non la allenta e non la aggira: usa un canale diverso, già sanzionato.
+/// </para>
+/// </summary>
+/// <param name="GameId">Gioco a catalogo di cui ri-ospitare la cover.</param>
+/// <param name="AdminId">Admin che ha richiesto l'operazione (audit).</param>
+internal record ReuploadBggCoverCommand(Guid GameId, Guid AdminId) : ICommand<BggCoverResult>;
+
+/// <summary>Esito del re-upload: la chiave R2 persistita sull'aggregato.</summary>
+/// <param name="R2Key">Chiave R2 della cover ri-ospitata.</param>
+internal record BggCoverResult(string R2Key);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ReuploadBggCover/ReuploadBggCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ReuploadBggCover/ReuploadBggCoverCommandHandler.cs
@@ -1,0 +1,100 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.Services;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.ReuploadBggCover;
+
+/// <summary>
+/// Handler di <see cref="ReuploadBggCoverCommand"/>. Flusso: carica il gioco → richiede a BGG
+/// l'immagine dichiarata per il suo <c>BggId</c> → la scarica e la ri-ospita su R2 tramite il
+/// downloader già sanzionato (ADR-059 §2) → persiste la chiave sull'aggregato → evict cache.
+/// </summary>
+/// <remarks>
+/// Riusa <see cref="IBggCoverDownloader"/> invece di reimplementare il fetch: quel servizio è già
+/// SSRF-pinnato e cap-ato a 10MB, ed è lo stesso usato da
+/// <c>CreateSharedGameFromPdfCommandHandler</c>. Ritorna <c>null</c> (loggando) invece di lanciare,
+/// quindi il null va tradotto in un conflitto esplicito.
+/// </remarks>
+internal sealed class ReuploadBggCoverCommandHandler : ICommandHandler<ReuploadBggCoverCommand, BggCoverResult>
+{
+    private readonly ISharedGameRepository _repository;
+    private readonly IBggApiService _bggApiService;
+    private readonly IBggCoverDownloader _coverDownloader;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IHybridCacheService _cache;
+    private readonly ICacheInvalidationRetryPolicy _cacheRetryPolicy;
+    private readonly ILogger<ReuploadBggCoverCommandHandler> _logger;
+
+    public ReuploadBggCoverCommandHandler(
+        ISharedGameRepository repository,
+        IBggApiService bggApiService,
+        IBggCoverDownloader coverDownloader,
+        IUnitOfWork unitOfWork,
+        IHybridCacheService cache,
+        ICacheInvalidationRetryPolicy cacheRetryPolicy,
+        ILogger<ReuploadBggCoverCommandHandler> logger)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _bggApiService = bggApiService ?? throw new ArgumentNullException(nameof(bggApiService));
+        _coverDownloader = coverDownloader ?? throw new ArgumentNullException(nameof(coverDownloader));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _cacheRetryPolicy = cacheRetryPolicy ?? throw new ArgumentNullException(nameof(cacheRetryPolicy));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<BggCoverResult> Handle(ReuploadBggCoverCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var game = await _repository.GetByIdAsync(command.GameId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException("SharedGame", command.GameId.ToString());
+
+        if (game.BggId is not > 0)
+        {
+            // Stato non azionabile, non un errore del chiamante: 409, mai InvalidOperationException.
+            throw new ConflictException(
+                "Il gioco non ha un BggId: non esiste una cover BoardGameGeek da ri-ospitare.");
+        }
+
+        var bggId = game.BggId.Value;
+
+        var details = await _bggApiService.GetGameDetailsAsync(bggId, cancellationToken).ConfigureAwait(false);
+        if (details?.ImageUrl is not { Length: > 0 } imageUrl)
+        {
+            throw new ConflictException(
+                $"BoardGameGeek non espone un'immagine per BggId {bggId}.");
+        }
+
+        var r2Key = await _coverDownloader
+            .DownloadAndUploadAsync(bggId, imageUrl, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (string.IsNullOrWhiteSpace(r2Key))
+        {
+            // Il downloader logga e ritorna null su fetch/upload fallito: qui diventa esplicito,
+            // altrimenti l'admin vedrebbe un 200 senza che nulla sia cambiato.
+            throw new ConflictException(
+                $"Download o upload della cover BGG per BggId {bggId} non riuscito.");
+        }
+
+        game.SetBggCover(r2Key);
+        _repository.Update(game);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        // La colonna che il read-model risolve è cambiata → evict lista + dettaglio.
+        await CoverCacheInvalidation
+            .EvictReadModelAsync(_cache, _cacheRetryPolicy, game.Id, cancellationToken)
+            .ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "BGG cover re-hosted for game {GameId} (BggId {BggId}) by {AdminId} → {R2Key}",
+            game.Id, bggId, command.AdminId, r2Key);
+
+        return new BggCoverResult(r2Key);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ReuploadBggCover/ReuploadBggCoverCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ReuploadBggCover/ReuploadBggCoverCommandValidator.cs
@@ -1,0 +1,16 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.ReuploadBggCover;
+
+/// <summary>
+/// Boundary validation per <see cref="ReuploadBggCoverCommand"/> — un 422 via la pipeline
+/// FluentValidation invece di un 500 su identificativi vuoti.
+/// </summary>
+internal sealed class ReuploadBggCoverCommandValidator : AbstractValidator<ReuploadBggCoverCommand>
+{
+    public ReuploadBggCoverCommandValidator()
+    {
+        RuleFor(x => x.GameId).NotEqual(Guid.Empty).WithMessage("GameId is required");
+        RuleFor(x => x.AdminId).NotEqual(Guid.Empty).WithMessage("AdminId is required");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandler.cs
@@ -4,6 +4,7 @@ using Api.BoundedContexts.SecurityAudit.Application.Services;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 using Api.Middleware.Exceptions;
+using Api.Observability;
 using Api.Services;
 using Api.Services.Pdf;
 using Api.SharedKernel.Application.Interfaces;
@@ -72,6 +73,11 @@ internal sealed class SetManualCoverCommandHandler : ICommandHandler<SetManualCo
         // any path that reaches the handler without the FluentValidation pipeline. Reject BEFORE egress.
         if (BggHostDenyList.IsBanned(command.SourceUrl))
         {
+            // #3583 — raggiungibile solo se un percorso salta la pipeline FluentValidation (il
+            // validator rifiuta prima). Mutuamente esclusivo con il gate del validator, quindi una
+            // richiesta conta una volta sola.
+            MeepleAiMetrics.RecordEgressBlocked(
+                MeepleAiMetrics.EgressSinks.Manual, MeepleAiMetrics.EgressBlockReasons.DenylistHit);
             throw new ArgumentException(
                 "SourceUrl host is banned by ADR-059 §5 (BGG/geekdo assets).", nameof(command));
         }
@@ -81,9 +87,21 @@ internal sealed class SetManualCoverCommandHandler : ICommandHandler<SetManualCo
 
         // Re-encode to WebP: normalizes the format AND drops the original container/metadata. The
         // license was whitelisted by the validator, so we persist the attested value below.
-        var webpBytes = await _webpGenerator
-            .GenerateWebpAsync(imageBytes, WebpTargetWidth, WebpTargetHeight, cancellationToken)
-            .ConfigureAwait(false);
+        byte[] webpBytes;
+        try
+        {
+            webpBytes = await _webpGenerator
+                .GenerateWebpAsync(imageBytes, WebpTargetWidth, WebpTargetHeight, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (ImageProcessingException)
+        {
+            // #3583 — il payload scaricato è stato rifiutato dal decoder (decompression bomb o coder
+            // non-raster, #3495 M1). Il rifiuto è corretto: qui lo si rende visibile.
+            MeepleAiMetrics.RecordEgressBlocked(
+                MeepleAiMetrics.EgressSinks.Manual, MeepleAiMetrics.EgressBlockReasons.DecodeFail);
+            throw;
+        }
 
         // Write to the deterministic manual physical key via the RAW-KEY path (the categorized
         // StoreAsync would reject the slash-containing key + mint an unresolvable random key).

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandValidator.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+using Api.Observability;
 using Api.SharedKernel.Infrastructure.Http;
 using FluentValidation;
 
@@ -24,13 +25,40 @@ internal sealed class SetManualCoverCommandValidator : AbstractValidator<SetManu
         RuleFor(x => x.SourceUrl)
             .NotEmpty().WithMessage("SourceUrl is required")
             .Must(BeAbsoluteHttps).WithMessage("SourceUrl must be an absolute HTTPS URL")
-            .Must(url => !BggHostDenyList.IsBanned(url))
+            .Must(url => !IsBannedAndRecorded(url))
             .WithMessage("SourceUrl host is banned by ADR-059 §5 (BGG/geekdo assets)");
 
         RuleFor(x => x.License)
             .NotEmpty().WithMessage("License is required")
             .Must(LicenseValidator.IsWhitelisted)
             .WithMessage("License must be on the whitelist (Public Domain / CC0 / CC-BY / CC-BY-SA)");
+    }
+
+    /// <summary>
+    /// #3583 — registra l'hit sulla deny-list ADR-059 §5 prima di far fallire la regola, così un
+    /// tentativo ripetuto di laundering attorno al ban BGG è visibile su
+    /// <c>meepleai_egress_blocked_total</c>. Il predicato conserva la semantica originale:
+    /// ritorna true quando l'URL è bandito (quindi la regola <c>Must(!…)</c> fallisce).
+    /// <para>
+    /// PRECONDIZIONE per la correttezza del conteggio: questo predicato viene valutato ESATTAMENTE
+    /// una volta per richiesta. Oggi è vero perché (a) il cascade rule-level è il default
+    /// <c>Continue</c> e la catena su SourceUrl esegue questo Must una sola volta, e (b) il validator
+    /// è invocato solo dal <c>ValidationBehavior</c> di MediatR, una volta per comando. È una
+    /// garanzia EMERGENTE, non protetta da un test: un secondo
+    /// <c>IValidator&lt;SetManualCoverCommand&gt;</c> registrato, o un endpoint filter che validi
+    /// prima di MediatR, farebbero raddoppiare il counter in silenzio.
+    /// </para>
+    /// </summary>
+    private static bool IsBannedAndRecorded(string? url)
+    {
+        if (!BggHostDenyList.IsBanned(url))
+        {
+            return false;
+        }
+
+        MeepleAiMetrics.RecordEgressBlocked(
+            MeepleAiMetrics.EgressSinks.Manual, MeepleAiMetrics.EgressBlockReasons.DenylistHit);
+        return true;
     }
 
     private static bool BeAbsoluteHttps(string? url) =>

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Jobs/WikidataCoverEnrichmentJob.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Jobs/WikidataCoverEnrichmentJob.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using Api.BoundedContexts.SharedGameCatalog.Application.Services;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Infrastructure.BackgroundTasks;
 using Api.Observability;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -61,6 +62,16 @@ public sealed class WikidataCoverEnrichmentJob : IJob
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
+    /// <summary>
+    /// TTL del lease (#3383). Molto sopra la durata attesa di un tick (fino a <see cref="BatchSize"/>
+    /// giochi con throttle di <see cref="DelayBetweenItemsMs"/>ms ciascuno): se un'istanza muore a
+    /// metà batch, l'enrichment resta fermo al più per questo tempo — preferibile a due istanze che
+    /// raddoppiano il rate verso Wikimedia (DEC-3e, violazione ToS).
+    /// </summary>
+    private static readonly TimeSpan LeaseTtl = TimeSpan.FromMinutes(10);
+
+    private const string LeaseKey = "wikidata-cover-enrichment-batch";
+
     public async Task Execute(IJobExecutionContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
@@ -71,8 +82,32 @@ public sealed class WikidataCoverEnrichmentJob : IJob
 
         var attempts = scope.ServiceProvider.GetRequiredService<IWikidataCoverEnrichmentAttemptRepository>();
         var runner = scope.ServiceProvider.GetRequiredService<IWikidataCoverEnrichmentRunner>();
+        var orchestrator = scope.ServiceProvider.GetRequiredService<IBackgroundTaskOrchestrator>();
 
-        await RunBatchAsync(attempts, runner, ct).ConfigureAwait(false);
+        // #3383 — hard-prevention del vincolo single-pod (ADR-087 D4). [DisallowConcurrentExecution]
+        // garantisce l'unicità solo DENTRO un processo: non impedisce a due istanze di eseguire lo
+        // stesso batch e raddoppiare il rate verso Wikidata/Commons.
+        //
+        // FAIL-CLOSED, e non è gratis: se il lease non si acquisisce il tick viene saltato, e se
+        // Redis è irraggiungibile l'orchestrator RILANCIA (l'eccezione risale a Quartz come job
+        // fallito), quindi l'enrichment SI FERMA. È voluto — non arricchire è preferibile a violare
+        // il rate cap Wikimedia — ma significa che un'indisponibilità di Redis ferma anche questa
+        // pipeline: vedi il runbook, sezione "Enrichment Wikidata fermo senza errori applicativi".
+        var acquired = await orchestrator
+            .ExecuteWithDistributedLockAsync(
+                LeaseKey,
+                innerCt => RunBatchAsync(attempts, runner, innerCt),
+                LeaseTtl,
+                ct)
+            .ConfigureAwait(false);
+
+        if (!acquired)
+        {
+            _logger.LogInformation(
+                "WikidataCoverEnrichmentJob: lease '{LeaseKey}' già detenuto da un'altra istanza — tick saltato. " +
+                "Se accade in modo persistente con una sola istanza attiva, il lease è orfano: scadrà entro {TtlMinutes} minuti.",
+                LeaseKey, LeaseTtl.TotalMinutes);
+        }
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetCoverGap/GetCoverGapQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetCoverGap/GetCoverGapQuery.cs
@@ -1,0 +1,61 @@
+using Api.Models;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetCoverGap;
+
+/// <summary>
+/// #3590 — elenca i giochi del catalogo SENZA alcuna cover (tutte e quattro le chiavi nulle), con
+/// la CAUSA per cui la pipeline cover-da-PDF non li copre.
+/// <para>
+/// Il collo di bottiglia non era risolvere questi casi — il picker manuale da URL esiste da #3545 —
+/// ma TROVARLI: non esisteva alcuna vista dei giochi senza cover, e l'unico accesso all'editor era
+/// l'affordance a matita in hover sulla griglia pubblica.
+/// </para>
+/// </summary>
+/// <param name="PageNumber">Pagina richiesta, 1-based.</param>
+/// <param name="PageSize">Dimensione pagina (1-100).</param>
+/// <param name="Cause">Filtro opzionale su una delle cause note. Null = tutte.</param>
+internal record GetCoverGapQuery(
+    int PageNumber = 1,
+    int PageSize = 20,
+    string? Cause = null) : IQuery<PagedResult<CoverGapGameDto>>;
+
+/// <summary>Un gioco senza cover, con la causa derivata dallo stato dei suoi PDF collegati.</summary>
+/// <param name="GameId">Id del gioco a catalogo.</param>
+/// <param name="Title">Titolo del gioco.</param>
+/// <param name="BggId">Id BoardGameGeek, quando noto.</param>
+/// <param name="Cause">Una delle costanti di <see cref="CoverGapCauses"/>.</param>
+/// <param name="PdfFileName">Nome del PDF più rilevante collegato, se esiste.</param>
+/// <param name="PdfSizeBytes">Dimensione di quel PDF in byte, se esiste.</param>
+/// <param name="ErrorCategory">Categoria d'errore di quel PDF, se valorizzata.</param>
+internal record CoverGapGameDto(
+    Guid GameId,
+    string Title,
+    int? BggId,
+    string Cause,
+    string? PdfFileName,
+    long? PdfSizeBytes,
+    string? ErrorCategory);
+
+/// <summary>
+/// Cause bounded. Sono un contratto con il front-end (enum Zod in
+/// <c>admin-cover.schemas.ts</c>) e con il filtro <see cref="GetCoverGapQuery.Cause"/>:
+/// cambiarle qui richiede di cambiarle anche lì.
+/// </summary>
+internal static class CoverGapCauses
+{
+    /// <summary>Il PDF eccede il limite di dimensione del servizio di estrazione.</summary>
+    public const string PdfTooLarge = "pdf_too_large";
+
+    /// <summary>Nessuna pagina del rulebook è una cover accettabile — esito CORRETTO, non un guasto.</summary>
+    public const string HeuristicRejected = "heuristic_rejected";
+
+    /// <summary>Nessun PDF collegato: non esiste una sorgente da cui generare.</summary>
+    public const string NoSource = "no_source";
+
+    /// <summary>Tutto il resto: PDF ancora in lavorazione o fallimenti non classificati.</summary>
+    public const string Other = "other";
+
+    public static readonly IReadOnlyList<string> All =
+        new[] { PdfTooLarge, HeuristicRejected, NoSource, Other };
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetCoverGap/GetCoverGapQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetCoverGap/GetCoverGapQueryHandler.cs
@@ -1,0 +1,150 @@
+using Api.Infrastructure;
+using Api.Models;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetCoverGap;
+
+/// <summary>
+/// Handler di <see cref="GetCoverGapQuery"/>. Parte dai giochi con tutte e quattro le chiavi cover
+/// nulle, porta i PDF collegati e deriva una causa per gioco.
+/// </summary>
+internal sealed class GetCoverGapQueryHandler
+    : IQueryHandler<GetCoverGapQuery, PagedResult<CoverGapGameDto>>
+{
+    /// <summary>
+    /// Soglia oltre la quale un fallimento di estrazione si spiega con la dimensione. Allineata al
+    /// limite storico del servizio Unstructured (50MB): i fallimenti precedenti al fix #3589 hanno
+    /// <c>ErrorCategory = "Service"</c> con un messaggio fuorviante ("Failed to connect to
+    /// Unstructured service"), quindi la sola categoria non basta a riconoscerli.
+    /// </summary>
+    private const long LargePdfThresholdBytes = 52_428_800;
+
+    private readonly MeepleAiDbContext _context;
+    private readonly ILogger<GetCoverGapQueryHandler> _logger;
+
+    public GetCoverGapQueryHandler(
+        MeepleAiDbContext context,
+        ILogger<GetCoverGapQueryHandler> logger)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<PagedResult<CoverGapGameDto>> Handle(
+        GetCoverGapQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // Il filtro soft-delete è GLOBALE (SharedGameEntityConfiguration.HasQueryFilter):
+        // riaggiungerlo qui sarebbe ridondante.
+        var gapGames = _context.SharedGames
+            .AsNoTracking()
+            .Where(g => string.IsNullOrWhiteSpace(g.PdfCoverR2Key)
+                     && string.IsNullOrWhiteSpace(g.BggCoverR2Key)
+                     && string.IsNullOrWhiteSpace(g.WikidataCoverR2Key)
+                     && string.IsNullOrWhiteSpace(g.ManualCoverR2Key));
+
+        // I PDF si collegano via la tabella ponte shared_game_documents: è la relazione canonica.
+        // PdfDocumentEntity.SharedGameId è nullable e popolata solo su alcuni percorsi, quindi non
+        // è affidabile come join primario.
+        var rows = await (
+            from g in gapGames
+            join sgd in _context.SharedGameDocuments on g.Id equals sgd.SharedGameId into links
+            from sgd in links.DefaultIfEmpty()
+            join p in _context.PdfDocuments on sgd.PdfDocumentId equals p.Id into pdfs
+            from p in pdfs.DefaultIfEmpty()
+            select new
+            {
+                g.Id,
+                g.Title,
+                g.BggId,
+                PdfFileName = p != null ? p.FileName : null,
+                PdfSize = p != null ? (long?)p.FileSizeBytes : null,
+                CoverStatus = p != null ? p.CoverGenerationStatus : null,
+                ErrorCategory = p != null ? p.ErrorCategory : null,
+                ProcessingState = p != null ? p.ProcessingState : null,
+            })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        // La classificazione gira in memoria dopo la proiezione: i rami non si traducono bene in
+        // SQL e l'insieme è di decine di righe (160 giochi in staging, 24 senza cover).
+        var classified = rows
+            .GroupBy(r => new { r.Id, r.Title, r.BggId })
+            .Select(grp =>
+            {
+                // Un gioco può avere più PDF: tieni la riga con la causa più azionabile.
+                var best = grp
+                    .OrderByDescending(r => Rank(
+                        Classify(r.CoverStatus, r.ErrorCategory, r.ProcessingState, r.PdfSize)))
+                    .First();
+
+                var cause = Classify(best.CoverStatus, best.ErrorCategory, best.ProcessingState, best.PdfSize);
+
+                return new CoverGapGameDto(
+                    grp.Key.Id,
+                    grp.Key.Title,
+                    grp.Key.BggId,
+                    cause,
+                    best.PdfFileName,
+                    best.PdfSize,
+                    best.ErrorCategory);
+            })
+            .Where(d => request.Cause is null || string.Equals(d.Cause, request.Cause, StringComparison.Ordinal))
+            .OrderBy(d => d.Cause, StringComparer.Ordinal)
+            .ThenBy(d => d.Title, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var total = classified.Count;
+        var items = classified
+            .Skip((request.PageNumber - 1) * request.PageSize)
+            .Take(request.PageSize)
+            .ToList();
+
+        _logger.LogDebug(
+            "GetCoverGap: {Total} giochi senza cover (filtro causa: {Cause}).",
+            total, request.Cause ?? "(nessuno)");
+
+        return new PagedResult<CoverGapGameDto>(items, total, request.PageNumber, request.PageSize);
+    }
+
+    /// <summary>Deriva la causa dallo stato del PDF collegato (null su tutto = nessun PDF).</summary>
+    private static string Classify(
+        string? coverStatus,
+        string? errorCategory,
+        string? processingState,
+        long? sizeBytes)
+    {
+        if (coverStatus is null && processingState is null)
+        {
+            return CoverGapCauses.NoSource;
+        }
+
+        if (string.Equals(errorCategory, "PayloadTooLarge", StringComparison.Ordinal)
+            || (string.Equals(processingState, "Failed", StringComparison.Ordinal)
+                && sizeBytes > LargePdfThresholdBytes))
+        {
+            return CoverGapCauses.PdfTooLarge;
+        }
+
+        // 'Skipped' è scritto direttamente sul campo da BackfillPdfCoversJob, non via
+        // PdfDocument.MarkCoverSkipped() (metodo morto).
+        if (string.Equals(coverStatus, "Skipped", StringComparison.Ordinal))
+        {
+            return CoverGapCauses.HeuristicRejected;
+        }
+
+        return CoverGapCauses.Other;
+    }
+
+    /// <summary>Precedenza quando un gioco ha più PDF: la causa più azionabile vince.</summary>
+    private static int Rank(string cause) => cause switch
+    {
+        CoverGapCauses.PdfTooLarge => 3,
+        CoverGapCauses.HeuristicRejected => 2,
+        CoverGapCauses.Other => 1,
+        _ => 0,
+    };
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetCoverGap/GetCoverGapQueryValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetCoverGap/GetCoverGapQueryValidator.cs
@@ -1,0 +1,23 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetCoverGap;
+
+/// <summary>
+/// Boundary validation per <see cref="GetCoverGapQuery"/> — un 422 via la pipeline
+/// FluentValidation, non un 500, su input fuori range o causa sconosciuta.
+/// </summary>
+internal sealed class GetCoverGapQueryValidator : AbstractValidator<GetCoverGapQuery>
+{
+    public GetCoverGapQueryValidator()
+    {
+        RuleFor(x => x.PageNumber)
+            .GreaterThanOrEqualTo(1).WithMessage("PageNumber must be >= 1");
+
+        RuleFor(x => x.PageSize)
+            .InclusiveBetween(1, 100).WithMessage("PageSize must be between 1 and 100");
+
+        RuleFor(x => x.Cause)
+            .Must(c => c is null || CoverGapCauses.All.Contains(c, StringComparer.Ordinal))
+            .WithMessage($"Cause must be one of: {string.Join(", ", CoverGapCauses.All)}");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRunner.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRunner.cs
@@ -112,14 +112,11 @@ internal sealed class WikidataCoverEnrichmentRunner : IWikidataCoverEnrichmentRu
         await _attempts.AddAsync(newAttempt, cancellationToken).ConfigureAwait(false);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
-        // Issue #1823 Wave 3 F1: increment the dead-letter gauge AFTER the
-        // SaveChanges commits — incrementing pre-save would leak the metric
-        // forward on a DB write failure. The retention job re-anchors the
-        // gauge daily so any drift between sweeps stays bounded.
-        if (newAttempt.Outcome == WikidataCoverEnrichmentOutcome.DeadLetter)
-        {
-            MeepleAiMetrics.IncrementWikidataDeadLetterCount();
-        }
+        // #3383: l'incremento ottimistico del gauge dead-letter che stava qui (issue #1823 Wave 3 F1)
+        // è stato RIMOSSO. Con un contatore in memoria per processo il gauge divergeva a più di
+        // un'istanza (sum() raddoppiava, max() derivava). Ora il valore è puramente DB-derivato:
+        // WikidataDeadLetterMetricsRefreshService esegue un COUNT ogni 60s, e il retention job
+        // ri-ancora dopo ogni sweep.
 
         // Issue #1823 Phase E F4: SSE broadcast for live admin dead-letter
         // page updates. Same post-SaveChanges placement as the F1 gauge — a

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/SharedGame.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/SharedGame.cs
@@ -50,6 +50,12 @@ public sealed class SharedGame : AggregateRoot<Guid>
     // Issue #1852: L4 PDF cover key, denormalized from PdfDocumentEntity.CoverR2Key
     // via PdfCoverGeneratedEventHandler. Set via SetPdfCoverR2Key().
     private string? _pdfCoverR2Key;
+    // #3590 Slice B: L2.5 BGG cover key, ri-ospitata dal re-upload server-to-server admin
+    // (ADR-059 §2). Set via SetBggCover(). Prima di #3590 questa colonna NON era sull'aggregato:
+    // il mapper del repository non la leggeva né la scriveva, e siccome Update() rimappa un grafo
+    // detached (tutte le colonne Modified) ogni load-modify-save emetteva
+    // `SET bgg_cover_r2_key = NULL`, cancellando silenziosamente la cover.
+    private string? _bggCoverR2Key;
     // Issue #1823 Phase B M8: Wikidata cover state. Set via SetWikidataCover()
     // after successful enrichment orchestration (M3 SPARQL + M4 license + M6
     // WebP + M7 R2 upload). QID itself is set independently via
@@ -186,6 +192,13 @@ public sealed class SharedGame : AggregateRoot<Guid>
     /// Issue #1852.
     /// </summary>
     public string? PdfCoverR2Key => _pdfCoverR2Key;
+
+    /// <summary>
+    /// Chiave R2 della cover BGG ri-ospitata (layer L2.5). Scritta dal re-upload
+    /// server-to-server admin, legittimo per ADR-059 §2; MAI da un URL arbitrario, path che
+    /// <see cref="Api.SharedKernel.Infrastructure.Http.BggHostDenyList"/> sbarra per il ban #2123.
+    /// </summary>
+    public string? BggCoverR2Key => _bggCoverR2Key;
 
     /// <summary>
     /// Gets the Wikidata QID identifying this game on Wikidata (e.g. <c>"Q98056728"</c>).
@@ -411,7 +424,8 @@ public sealed class SharedGame : AggregateRoot<Guid>
         string? manualCoverAttribution = null,
         string? manualCoverSourceUrl = null,
         Guid? manualCoverAttestedBy = null,
-        DateTime? manualCoverAttestedAt = null) : base(id)
+        DateTime? manualCoverAttestedAt = null,
+        string? bggCoverR2Key = null) : base(id)
     {
         _id = id;
         _title = title;
@@ -430,6 +444,7 @@ public sealed class SharedGame : AggregateRoot<Guid>
         _gameDataStatus = gameDataStatus;
         _hasUploadedPdf = hasUploadedPdf;
         _pdfCoverR2Key = pdfCoverR2Key;
+        _bggCoverR2Key = bggCoverR2Key;
         _wikidataQid = wikidataQid;
         _wikidataCoverR2Key = wikidataCoverR2Key;
         _wikidataCoverLicense = wikidataCoverLicense;
@@ -744,6 +759,27 @@ public sealed class SharedGame : AggregateRoot<Guid>
             return;
 
         _pdfCoverR2Key = coverR2Key;
+    }
+
+    /// <summary>
+    /// #3590 Slice B — registra la chiave R2 della cover BGG ri-ospitata (layer L2.5).
+    /// Idempotente: ritorna senza effetti se la chiave coincide con quella corrente.
+    /// <para>
+    /// La sorgente è l'immagine che BGG espone per il <c>BggId</c> del gioco, scaricata dal path
+    /// server-to-server admin (ADR-059 §2). Questo metodo NON è una via per aggirare
+    /// <see cref="Api.SharedKernel.Infrastructure.Http.BggHostDenyList"/>: quella deny-list
+    /// protegge il campo cover manuale a URL libero, dove un host geekdo resta bandito (#2123).
+    /// </para>
+    /// </summary>
+    public void SetBggCover(string coverR2Key)
+    {
+        if (string.IsNullOrWhiteSpace(coverR2Key))
+            throw new ArgumentException("Cover R2 key cannot be empty", nameof(coverR2Key));
+
+        if (string.Equals(_bggCoverR2Key, coverR2Key, StringComparison.Ordinal))
+            return;
+
+        _bggCoverR2Key = coverR2Key;
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/BackgroundJobs/WikidataDeadLetterMetricsRefreshService.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/BackgroundJobs/WikidataDeadLetterMetricsRefreshService.cs
@@ -1,0 +1,73 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Observability;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.BackgroundJobs;
+
+/// <summary>
+/// #3383 (ADR-087 D4, task deferito) — ri-ancora periodicamente il gauge
+/// <c>meepleai.wikidata.dead_letter_count</c> al <c>COUNT</c> reale sulla tabella degli attempt.
+/// <para>
+/// Prima di questo servizio il gauge era ibrido: il runner incrementava un contatore in memoria e
+/// il <c>WikidataCoverDeadLetterRetentionJob</c> lo ri-ancorava al ground truth una sola volta al
+/// giorno (03:00 UTC). A più di un'istanza ogni processo aveva il proprio contatore, quindi
+/// <c>sum()</c> raddoppiava e <c>max()</c> derivava. Con un valore puramente DB-derivato ogni
+/// istanza riporta lo stesso ground truth e <c>max()</c> torna corretto — vedi l'aggregazione
+/// delle regole in <c>infra/prometheus/alerts/wikidata-enrichment.yml</c>.
+/// </para>
+/// <para>
+/// Il gauge continua a leggere il campo in memoria: è QUESTO servizio ad aggiornarlo. Interrogare
+/// il DB dentro la callback dell'<c>ObservableGauge</c> — cioè a ogni scrape Prometheus — sarebbe
+/// l'anti-pattern che l'issue segnala esplicitamente.
+/// </para>
+/// </summary>
+internal sealed class WikidataDeadLetterMetricsRefreshService : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<WikidataDeadLetterMetricsRefreshService> _logger;
+    private readonly TimeSpan _refreshInterval = TimeSpan.FromSeconds(60);
+
+    public WikidataDeadLetterMetricsRefreshService(
+        IServiceScopeFactory scopeFactory,
+        ILogger<WikidataDeadLetterMetricsRefreshService> logger)
+    {
+        _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await RefreshOnceAsync(stoppingToken).ConfigureAwait(false);
+            }
+#pragma warning disable CA1031 // Resilience: un refresh fallito non deve abbattere l'host
+            catch (Exception ex)
+#pragma warning restore CA1031
+            {
+                _logger.LogError(ex,
+                    "WikidataDeadLetterMetricsRefreshService: refresh fallito; riprovo al prossimo tick");
+            }
+
+            try
+            {
+                await Task.Delay(_refreshInterval, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // shutdown regolare
+            }
+        }
+    }
+
+    /// <summary>Conta i dead-letter e pusha il valore nel gauge. Esposto per i test.</summary>
+    public async Task RefreshOnceAsync(CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var attempts = scope.ServiceProvider
+            .GetRequiredService<IWikidataCoverEnrichmentAttemptRepository>();
+        var count = await attempts.CountDeadLettersAsync(cancellationToken).ConfigureAwait(false);
+        MeepleAiMetrics.SetWikidataDeadLetterCount(count);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/SharedGameRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/SharedGameRepository.cs
@@ -391,7 +391,10 @@ internal sealed class SharedGameRepository : RepositoryBase, ISharedGameReposito
             manualCoverAttribution: entity.ManualCoverAttribution,
             manualCoverSourceUrl: entity.ManualCoverSourceUrl,
             manualCoverAttestedBy: entity.ManualCoverAttestedBy,
-            manualCoverAttestedAt: entity.ManualCoverAttestedAt);
+            manualCoverAttestedAt: entity.ManualCoverAttestedAt,
+            // #3590 Slice B — senza questa lettura l'aggregato non conosce la cover BGG, quindi
+            // MapToEntity la riscriverebbe come NULL al primo Update() (grafo detached).
+            bggCoverR2Key: entity.BggCoverR2Key);
 
         // Issue #2035: Hydrate designers from the M:N join — only when the caller
         // eager-loaded the navigation (GetByIdAsync), otherwise the EF Core
@@ -450,6 +453,10 @@ internal sealed class SharedGameRepository : RepositoryBase, ISharedGameReposito
             RulesExternalUrl = game.Rules?.ExternalUrl,
             HasUploadedPdf = game.HasUploadedPdf,
             PdfCoverR2Key = game.PdfCoverR2Key,
+            // #3590 Slice B — ometterla qui la azzerava a ogni Update(): l'update è su grafo
+            // detached, quindi marca OGNI colonna come Modified. Stessa ragione già annotata
+            // sotto per le colonne manual.
+            BggCoverR2Key = game.BggCoverR2Key,
             // Issue #1823 Phase B M8 — propagate Wikidata enrichment state.
             WikidataQid = game.WikidataQid,
             WikidataCoverR2Key = game.WikidataCoverR2Key,

--- a/apps/api/src/Api/Extensions/ApplicationServiceExtensions.cs
+++ b/apps/api/src/Api/Extensions/ApplicationServiceExtensions.cs
@@ -129,6 +129,10 @@ internal static class ApplicationServiceExtensions
             Api.BoundedContexts.Administration.Infrastructure.Health.ImpersonationHealthTracker>();
         services.AddHostedService<Api.BoundedContexts.Administration.Infrastructure.BackgroundJobs.ImpersonationMetricsRefreshService>();
 
+        // #3383 (ADR-087 D4) — il gauge dead-letter deve essere DB-derivato per restare corretto
+        // sotto max() a più di un'istanza: l'incremento in memoria del runner divergeva per processo.
+        services.AddHostedService<Api.BoundedContexts.SharedGameCatalog.Infrastructure.BackgroundJobs.WikidataDeadLetterMetricsRefreshService>();
+
         return services;
     }
 

--- a/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.Egress.cs
+++ b/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.Egress.cs
@@ -38,6 +38,8 @@ internal static partial class MeepleAiMetrics
         public const string RedirectExhausted = "redirect_exhausted";
         public const string SizeCap = "size_cap";
         public const string DecodeFail = "decode_fail";
+        /// <summary>La risoluzione DNS ha lanciato (NXDOMAIN, timeout del resolver, socket error) — #3583.</summary>
+        public const string DnsFailure = "dns_failure";
         public const string Timeout = "timeout";
         public const string BreakerOpen = "breaker_open";
         public const string Scheme = "scheme";

--- a/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.WikidataEnrichment.cs
+++ b/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.WikidataEnrichment.cs
@@ -132,19 +132,23 @@ internal static partial class MeepleAiMetrics
         description: "WikidataCoverEnrichmentJob tick wall-clock duration (#1823 Wave 3 M11)");
 
     /// <summary>
-    /// Issue #1823 Wave 3 F1 (M11 follow-up) — cumulative count of
+    /// Issue #1823 Wave 3 F1 (M11 follow-up) — count of
     /// <c>WikidataCoverEnrichmentAttempt</c> rows in <c>DeadLetter</c> state
     /// currently present in the table (i.e. NOT yet swept by the
-    /// <c>WikidataCoverDeadLetterRetentionJob</c>). Hybrid update strategy:
-    /// the retention job calls <see cref="SetWikidataDeadLetterCount(int)"/>
-    /// with a fresh repo COUNT after each sweep; the
-    /// <c>WikidataCoverEnrichmentRunner</c> calls
-    /// <see cref="IncrementWikidataDeadLetterCount"/> whenever it persists a
-    /// new dead-letter attempt. Drift between sweeps is bounded by the
-    /// 1-minute scheduler tick rate; the daily 03:00 UTC sweep re-anchors
-    /// the value to ground truth.
+    /// <c>WikidataCoverDeadLetterRetentionJob</c>).
+    /// <para>
+    /// #3383: il valore è <b>puramente DB-derivato</b>. Lo aggiornano il
+    /// <c>WikidataDeadLetterMetricsRefreshService</c> con un <c>COUNT</c> ogni
+    /// 60s e il retention job dopo ogni sweep, entrambi via
+    /// <see cref="SetWikidataDeadLetterCount(int)"/>. L'incremento ottimistico
+    /// in memoria del runner è stato rimosso: con un contatore per processo il
+    /// gauge divergeva a più di un'istanza (<c>sum()</c> raddoppiava,
+    /// <c>max()</c> derivava), che è esattamente il caso che il vincolo
+    /// single-pod di ADR-087 D4 deve poter osservare.
+    /// </para>
     ///
-    /// Suggested alerting:
+    /// Alerting (infra/prometheus/alerts/wikidata-enrichment.yml, aggregate con
+    /// <c>max()</c> perché a N istanze le serie sono N e identiche):
     ///   - count &gt; 100 sustained &gt; 1 hour → operator triage backlog
     ///     building; investigate via M13 admin dead-letter page.
     ///   - sudden jump &gt; 50 in &lt; 5 min → systemic upstream failure or
@@ -159,23 +163,19 @@ internal static partial class MeepleAiMetrics
         description: "Cumulative count of dead-letter WikidataCoverEnrichmentAttempt rows (#1823 Wave 3 F1)");
 
     /// <summary>
-    /// Re-anchors the gauge to a freshly-counted ground-truth value.
-    /// Uses <see cref="System.Threading.Interlocked.Exchange(ref int, int)"/>
-    /// so the re-anchor write is ordered atomically against concurrent
-    /// <see cref="IncrementWikidataDeadLetterCount"/> calls from the runner
-    /// (ARM64 memory model: a plain assignment could otherwise be reordered
-    /// past a subsequent Interlocked.Increment, producing a transient stale
-    /// gauge value).
+    /// Re-anchors the gauge to a freshly-counted ground-truth value. Unico punto
+    /// di scrittura, chiamato dal <c>WikidataDeadLetterMetricsRefreshService</c>
+    /// (ogni 60s) e dal retention job (dopo ogni sweep).
+    /// <para>
+    /// Usa <see cref="System.Threading.Interlocked.Exchange(ref int, int)"/> per
+    /// ordinare la scrittura contro i lettori concorrenti del gauge (ARM64 memory
+    /// model: una assegnazione semplice potrebbe essere riordinata e produrre un
+    /// valore transitoriamente stantio).
+    /// </para>
     /// </summary>
     public static void SetWikidataDeadLetterCount(int count)
     {
         System.Threading.Interlocked.Exchange(ref _wikidataDeadLetterCount, count < 0 ? 0 : count);
-    }
-
-    /// <summary>Atomically increments the gauge by 1 — call after persisting a new dead-letter attempt.</summary>
-    public static void IncrementWikidataDeadLetterCount()
-    {
-        System.Threading.Interlocked.Increment(ref _wikidataDeadLetterCount);
     }
 
     /// <summary>

--- a/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogAdminEndpoints.cs
+++ b/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogAdminEndpoints.cs
@@ -5,6 +5,7 @@ using Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCo
 using Api.BoundedContexts.SharedGameCatalog.Application.Commands.RemoveRagFromSharedGame;
 using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries;
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetCoverGap;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetGameRagReadiness;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries.ExportSharedGamesTracking;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetSeedingStatus;
@@ -445,6 +446,15 @@ internal static class SharedGameCatalogAdminEndpoints
             .WithName("GetSeedingStatus")
             .WithSummary("Get seeding/enrichment status for all games (Admin/Editor)")
             .Produces<List<SeedingGameDto>>();
+
+        // #3590 — i giochi senza alcuna cover, con la causa per cui la pipeline cover-da-PDF non
+        // li copre. La route costante non confligge con {id:guid}: il constraint disambigua.
+        group.MapGet("/admin/shared-games/cover-gap", HandleGetCoverGap)
+            .RequireAuthorization("AdminOrEditorPolicy")
+            .WithName("GetCoverGap")
+            .WithSummary("Get catalog games with no cover, grouped by cause (Admin/Editor)")
+            .WithDescription("Cause: pdf_too_large, heuristic_rejected, no_source, other.")
+            .Produces<PagedResult<CoverGapGameDto>>();
 
         // Export tracking spreadsheet (all shared games with progress status)
         group.MapGet("/admin/shared-games/tracking-export", HandleTrackingExport)
@@ -1561,6 +1571,20 @@ internal static class SharedGameCatalogAdminEndpoints
     {
         var result = await mediator.Send(
             new GetSeedingStatusQuery(),
+            cancellationToken).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    /// <summary>#3590 — i giochi senza cover, con la causa. Solo IMediator: regola CQRS.</summary>
+    private static async Task<IResult> HandleGetCoverGap(
+        IMediator mediator,
+        [FromQuery] string? cause = null,
+        [FromQuery] int pageNumber = 1,
+        [FromQuery] int pageSize = 20,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await mediator.Send(
+            new GetCoverGapQuery(pageNumber, pageSize, cause),
             cancellationToken).ConfigureAwait(false);
         return Results.Ok(result);
     }

--- a/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogAdminEndpoints.cs
+++ b/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogAdminEndpoints.cs
@@ -5,6 +5,7 @@ using Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCo
 using Api.BoundedContexts.SharedGameCatalog.Application.Commands.RemoveRagFromSharedGame;
 using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries;
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.ReuploadBggCover;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetCoverGap;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetGameRagReadiness;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries.ExportSharedGamesTracking;
@@ -91,6 +92,19 @@ internal static class SharedGameCatalogAdminEndpoints
             .Produces(StatusCodes.Status404NotFound);
 
         // Manual cover from a URL (epic #3470 Slice 3a): admin supplies an HTTPS image URL + attested license.
+        // #3590 Slice B — re-upload server-to-server della cover BGG per un gioco già a catalogo.
+        // Path legittimo per ADR-059 §2, distinto dal campo manuale a URL libero qui sotto: NON
+        // accetta un URL, la sorgente è l'immagine che BGG dichiara per il BggId del gioco.
+        group.MapPost("/admin/shared-games/{id:guid}/bgg-cover", HandleReuploadBggCover)
+            .RequireAuthorization("AdminOrEditorPolicy")
+            .RequireRateLimiting("SharedGamesAdmin")
+            .WithName("ReuploadBggCover")
+            .WithSummary("Re-host the BGG cover for a catalog game (Admin/Editor)")
+            .WithDescription("Downloads the image BoardGameGeek exposes for the game's BggId and re-hosts it in R2 (ADR-059 §2 server-to-server path). Takes no URL: the arbitrary-URL manual-cover field stays barred from geekdo hosts by the ADR-059 §5 deny-list.")
+            .Produces<BggCoverResult>()
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status409Conflict);
+
         group.MapPost("/admin/shared-games/{id:guid}/manual-cover", HandleSetManualCover)
             .RequireAuthorization("AdminOrEditorPolicy")
             .RequireRateLimiting("SharedGamesAdmin")
@@ -966,6 +980,22 @@ internal static class SharedGameCatalogAdminEndpoints
         await mediator.Send(new RemoveCoverAssignmentCommand(id, context, session!.Principal!.Subject.Id), ct)
             .ConfigureAwait(false);
         return Results.NoContent();
+    }
+
+    /// <summary>#3590 Slice B — re-upload della cover BGG. Solo IMediator: regola CQRS.</summary>
+    private static async Task<IResult> HandleReuploadBggCover(
+        Guid id,
+        IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken ct)
+    {
+        var (authorized, session, error) = httpContext.RequireAdminOrEditorSession();
+        if (!authorized) return error!;
+
+        var result = await mediator
+            .Send(new ReuploadBggCoverCommand(id, session!.Principal!.Subject.Id), ct)
+            .ConfigureAwait(false);
+        return Results.Ok(result);
     }
 
     private static async Task<IResult> HandleSetManualCover(

--- a/apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPinnedConnect.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPinnedConnect.cs
@@ -27,7 +27,30 @@ internal static class SsrfPinnedConnect
         string sink,
         CancellationToken ct)
     {
-        IReadOnlyList<IPAddress> addresses = await dns.ResolveAsync(host, ct).ConfigureAwait(false);
+        IReadOnlyList<IPAddress> addresses;
+        try
+        {
+            addresses = await dns.ResolveAsync(host, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException || !ct.IsCancellationRequested)
+        {
+            // #3583 — l'esito era già fail-closed (la connessione non avviene), ma senza questo
+            // counter un sink che degrada per problemi DNS è indistinguibile da un sink inattivo su
+            // meepleai_egress_blocked_total. Registra e RILANCIA: nessun esito cambia.
+            //
+            // Il filtro esclude la cancellazione iniziata dal chiamante — che non è un guasto di
+            // egress — pur continuando a contare un timeout interno del resolver (che si presenta
+            // come OperationCanceledException con un CTS proprio, quindi con `ct` non cancellato).
+            //
+            // Due limiti noti e accettati:
+            //   - se il chiamante cancella e il resolver risponde con SocketException invece che
+            //     OperationCanceledException, il caso viene contato come dns_failure;
+            //   - questo guard gira dentro il ConnectCallback, quindi UNA VOLTA PER CONNESSIONE:
+            //     ogni hop di redirect e ogni nuova connessione del pool incrementa. Il counter va
+            //     letto come rate di fallimenti di dial, MAI come "richieste utente fallite".
+            MeepleAiMetrics.RecordEgressBlocked(sink, MeepleAiMetrics.EgressBlockReasons.DnsFailure);
+            throw;
+        }
 
         if (addresses.Count == 0)
         {

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommandHandlerTests.cs
@@ -10,6 +10,7 @@ using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Providers;
 using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 using Api.Middleware.Exceptions;
+using Api.Observability;
 using Api.Services;
 using Api.Services.Pdf;
 using Api.SharedKernel.Infrastructure.Persistence;
@@ -399,6 +400,40 @@ public class EnrichCatalogCoverCommandHandlerTests
             Times.Never,
             "image-processing error short-circuits BEFORE R2 upload");
         harness.UowMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public void Handle_ImageProcessingError_RecordsDecodeFail_OnWikimediaSink()
+    {
+        // Stesso arrangiamento di Handle_ImageProcessingError_ReturnsFailedImageProcessingError.
+        // L'harness monta il VERO WebpVariantGenerator: sono i byte corrotti scaricati da Commons a
+        // farlo fallire (DetectRasterFormat -> null), non un mock che lancia.
+        var harness = BuildHarness();
+        var game = BuildGame(qid: TestQid);
+
+        harness.RepoMock
+            .Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(game);
+
+        harness.WikidataHandler.SparqlJson = BuildSparqlImageResponse(TestFilename);
+        harness.CommonsHandler.LicenseJson = BuildImageInfoResponse("CC0");
+        harness.CommonsHandler.ImageBytes = new byte[] { 0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE };
+
+        EnrichCatalogCoverResult? result = null;
+        var captured = Api.Tests.Observability.MetricCapture.Capture(
+            MeepleAiMetrics.EgressBlocked.Name,
+            () => result = harness.Sut
+                .Handle(new EnrichCatalogCoverCommand(game.Id), CancellationToken.None)
+                .GetAwaiter().GetResult());
+
+        // L'handler CATTURA ImageProcessingException e ritorna Failed: nessuna eccezione esce,
+        // quindi qui NON serve try/catch (a differenza del path manuale).
+        result.Should().BeOfType<EnrichCatalogCoverResult.Failed>();
+
+        captured
+            .Where(c => Equals(c.Tags.GetValueOrDefault("sink"), "wikimedia")
+                && Equals(c.Tags.GetValueOrDefault("reason"), "decode_fail"))
+            .Should().NotBeEmpty("il rifiuto del decoder su un'immagine Commons è un blocco di egress");
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/ReuploadBggCover/ReuploadBggCoverCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/ReuploadBggCover/ReuploadBggCoverCommandHandlerTests.cs
@@ -1,0 +1,154 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.ReuploadBggCover;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.Models;
+using Api.Tests.Constants;
+using Api.Services;
+using Api.SharedKernel.Infrastructure.Persistence;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands.ReuploadBggCover;
+
+/// <summary>
+/// #3590 Slice B — il re-upload server-to-server della cover BGG per un gioco già a catalogo
+/// (ADR-059 §2). Path distinto dalla cover manuale a URL libero, dove gli host geekdo restano
+/// banditi da <c>BggHostDenyList</c>: questi test verificano anche che quella deny-list non sia
+/// stata toccata.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class ReuploadBggCoverCommandHandlerTests
+{
+    private const int BggId = 13;
+    private const string RemoteImage = "https://cf.geekdo-images.com/x/original/cover.jpg";
+    private const string R2Key = "bgg-covers/13/cover";
+
+    private static readonly Guid AdminId = Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd");
+
+    private readonly Mock<ISharedGameRepository> _repository = new();
+    private readonly Mock<IBggApiService> _bggApi = new();
+    private readonly Mock<IBggCoverDownloader> _downloader = new();
+    private readonly Mock<IUnitOfWork> _unitOfWork = new();
+    private readonly Mock<IHybridCacheService> _cache = new();
+    private readonly Mock<ICacheInvalidationRetryPolicy> _cacheRetryPolicy = new();
+
+    public ReuploadBggCoverCommandHandlerTests()
+    {
+        _cacheRetryPolicy
+            .Setup(p => p.ExecuteAsync(It.IsAny<Func<CancellationToken, ValueTask>>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns((Func<CancellationToken, ValueTask> op, string _, CancellationToken ct) => op(ct).AsTask());
+        _cache
+            .Setup(c => c.RemoveByTagAcrossReplicasAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
+    }
+
+    private ReuploadBggCoverCommandHandler CreateHandler() => new(
+        _repository.Object,
+        _bggApi.Object,
+        _downloader.Object,
+        _unitOfWork.Object,
+        _cache.Object,
+        _cacheRetryPolicy.Object,
+        NullLogger<ReuploadBggCoverCommandHandler>.Instance);
+
+    // Il BggId va passato alla factory: AssignBggId è ammesso solo negli stati Skeleton/Failed,
+    // mentre Create() produce un aggregato Complete.
+    private static SharedGame NewGame(int? bggId = BggId) => SharedGame.Create(
+        "Catan", 1995, "desc", 3, 4, 90, 10, 2.5m, 7.8m,
+        "https://example.com/c.jpg", "https://example.com/c-thumb.jpg", null, AdminId, bggId);
+
+    private static BggGameDetailsDto Details(string? imageUrl) => new(
+        BggId, "Catan", "desc", 1995, 3, 4, 90, 60, 120, 10,
+        7.8, 7.5, 1000, 2.5, "https://example.com/thumb.jpg", imageUrl,
+        Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>());
+
+    [Fact]
+    public async Task Handle_HappyPath_PersistsR2KeyOnAggregate()
+    {
+        var game = NewGame();
+        _repository.Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>())).ReturnsAsync(game);
+        _bggApi.Setup(b => b.GetGameDetailsAsync(BggId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Details(RemoteImage));
+        _downloader.Setup(d => d.DownloadAndUploadAsync(BggId, RemoteImage, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(R2Key);
+
+        var result = await CreateHandler().Handle(new ReuploadBggCoverCommand(game.Id, AdminId), CancellationToken.None);
+
+        result.R2Key.Should().Be(R2Key);
+        game.BggCoverR2Key.Should().Be(R2Key, "la chiave va sull'aggregato, non sull'entità EF");
+        _repository.Verify(r => r.Update(game), Times.Once);
+        _unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_GameWithoutBggId_Throws409_AndNeverFetches()
+    {
+        var game = NewGame(bggId: null);
+        _repository.Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>())).ReturnsAsync(game);
+
+        var act = () => CreateHandler().Handle(new ReuploadBggCoverCommand(game.Id, AdminId), CancellationToken.None);
+
+        await act.Should().ThrowAsync<ConflictException>();
+        _bggApi.Verify(b => b.GetGameDetailsAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+        _downloader.VerifyNoOtherCalls();
+        _unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_UnknownGame_Throws404()
+    {
+        _repository.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SharedGame?)null);
+
+        var act = () => CreateHandler().Handle(new ReuploadBggCoverCommand(Guid.NewGuid(), AdminId), CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_BggExposesNoImage_Throws409()
+    {
+        var game = NewGame();
+        _repository.Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>())).ReturnsAsync(game);
+        _bggApi.Setup(b => b.GetGameDetailsAsync(BggId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Details(imageUrl: null));
+
+        var act = () => CreateHandler().Handle(new ReuploadBggCoverCommand(game.Id, AdminId), CancellationToken.None);
+
+        await act.Should().ThrowAsync<ConflictException>();
+        _downloader.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Handle_DownloaderReturnsNull_Throws409_AndWritesNothing()
+    {
+        // Il downloader logga e ritorna null invece di lanciare: senza questa traduzione l'admin
+        // vedrebbe un 200 con nessun cambiamento.
+        var game = NewGame();
+        _repository.Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>())).ReturnsAsync(game);
+        _bggApi.Setup(b => b.GetGameDetailsAsync(BggId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Details(RemoteImage));
+        _downloader.Setup(d => d.DownloadAndUploadAsync(BggId, RemoteImage, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        var act = () => CreateHandler().Handle(new ReuploadBggCoverCommand(game.Id, AdminId), CancellationToken.None);
+
+        await act.Should().ThrowAsync<ConflictException>();
+        game.BggCoverR2Key.Should().BeNull();
+        _unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public void ManualCoverPath_StillBansBggHosts()
+    {
+        // Non-regressione ADR-059 §5: questo carve-out NON allenta la deny-list sul campo a URL
+        // libero. Se questo test diventa rosso, il carve-out è stato implementato nel modo sbagliato.
+        Api.SharedKernel.Infrastructure.Http.BggHostDenyList.IsBanned(RemoteImage)
+            .Should().BeTrue("il path manuale a URL arbitrario deve continuare a rifiutare geekdo");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandlerTests.cs
@@ -5,6 +5,7 @@ using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 using Api.Middleware.Exceptions;
+using Api.Observability;
 using Api.Services;
 using Api.Services.Pdf;
 using Api.SharedKernel.Infrastructure.Persistence;
@@ -233,6 +234,73 @@ public sealed class SetManualCoverCommandHandlerTests
     /// Minimal egress stub: returns the configured image bytes on the first (non-redirect) hop and
     /// counts requests so tests can assert "no download happened" on the short-circuit paths.
     /// </summary>
+    [Fact]
+    public void Handle_NonRasterPayload_RecordsDecodeFail_OnManualSink()
+    {
+        var game = NewGame();
+        _repository.Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>())).ReturnsAsync(game);
+        // SVG: coder non-raster, rifiutato da DetectRasterFormat prima di raggiungere Magick (#3495 M1).
+        // Lo StubImageHandler dichiara Content-Type: image/png e il fetch non ispeziona i magic bytes,
+        // quindi il payload arriva davvero al decoder.
+        _httpHandler.ImageBytes = System.Text.Encoding.UTF8.GetBytes(
+            "<svg xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"10\" height=\"10\"/></svg>");
+
+        var captured = Api.Tests.Observability.MetricCapture.Capture(
+            MeepleAiMetrics.EgressBlocked.Name,
+            () =>
+            {
+                try
+                {
+                    CreateHandler().Handle(Command(game.Id), CancellationToken.None)
+                        .GetAwaiter().GetResult();
+                    throw new Xunit.Sdk.XunitException(
+                        "expected the decoder to reject the non-raster payload");
+                }
+                catch (ImageProcessingException)
+                {
+                    // atteso — l'handler registra e RILANCIA
+                }
+            });
+
+        captured
+            .Where(c => Equals(c.Tags.GetValueOrDefault("sink"), "manual")
+                && Equals(c.Tags.GetValueOrDefault("reason"), "decode_fail"))
+            .Should().NotBeEmpty("il rifiuto del decoder su un payload scaricato è un blocco di egress");
+    }
+
+    [Fact]
+    public void Handle_BggHost_RecordsDenylistHit_AndNeverFetches()
+    {
+        // Gate difensivo (#3495 C6): raggiungibile solo saltando la pipeline FluentValidation, quindi
+        // qui si invoca l'handler direttamente. Deve rifiutare PRIMA di qualunque egress.
+        var game = NewGame();
+        _repository.Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>())).ReturnsAsync(game);
+        var banned = Command(game.Id) with { SourceUrl = "https://cf.geekdo-images.com/abc/cover.jpg" };
+
+        var captured = Api.Tests.Observability.MetricCapture.Capture(
+            MeepleAiMetrics.EgressBlocked.Name,
+            () =>
+            {
+                try
+                {
+                    CreateHandler().Handle(banned, CancellationToken.None).GetAwaiter().GetResult();
+                    throw new Xunit.Sdk.XunitException(
+                        "expected the ADR-059 deny-list to reject the host");
+                }
+                catch (ArgumentException)
+                {
+                    // atteso
+                }
+            });
+
+        captured
+            .Where(c => Equals(c.Tags.GetValueOrDefault("sink"), "manual")
+                && Equals(c.Tags.GetValueOrDefault("reason"), "denylist_hit"))
+            .Should().NotBeEmpty("anche il gate difensivo deve essere visibile");
+
+        _httpHandler.RequestCount.Should().Be(0, "il rifiuto deve precedere qualunque fetch");
+    }
+
     private sealed class StubImageHandler : HttpMessageHandler
     {
         public byte[] ImageBytes { get; set; } = Array.Empty<byte>();

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandValidatorTests.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+using Api.Observability;
 using FluentAssertions;
 using FluentValidation.TestHelper;
 using Xunit;
@@ -83,6 +84,24 @@ public sealed class SetManualCoverCommandValidatorTests
         // Each URL is absolute-HTTPS with a whitelisted license, so ONLY the new host rule can reject it.
         _validator.TestValidate(Valid() with { SourceUrl = url })
             .ShouldHaveValidationErrorFor(x => x.SourceUrl);
+    }
+
+    [Fact]
+    public void Validate_BggHost_RecordsDenylistHit_OnManualSink()
+    {
+        // NOTA: Fails_WhenSourceUrlIsBannedBggHost qui sopra ha 5 [InlineData], ognuna delle quali
+        // emette una misurazione {manual, denylist_hit}. La finestra di MetricCapture è process-wide:
+        // asserire la presenza, MAI un conteggio esatto.
+        var captured = Api.Tests.Observability.MetricCapture.Capture(
+            MeepleAiMetrics.EgressBlocked.Name,
+            () => _validator
+                .TestValidate(Valid() with { SourceUrl = "https://cf.geekdo-images.com/abc/cover.jpg" })
+                .ShouldHaveValidationErrorFor(x => x.SourceUrl));
+
+        captured
+            .Where(c => Equals(c.Tags.GetValueOrDefault("sink"), "manual")
+                && Equals(c.Tags.GetValueOrDefault("reason"), "denylist_hit"))
+            .Should().NotBeEmpty("un tentativo di aggirare il ban BGG deve essere visibile");
     }
 
     [Theory]

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Jobs/WikidataCoverEnrichmentJobTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Jobs/WikidataCoverEnrichmentJobTests.cs
@@ -2,10 +2,13 @@ using Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCo
 using Api.BoundedContexts.SharedGameCatalog.Application.Jobs;
 using Api.BoundedContexts.SharedGameCatalog.Application.Services;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Infrastructure.BackgroundTasks;
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Time.Testing;
 using Moq;
+using Quartz;
 using Xunit;
 
 namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Jobs;
@@ -33,6 +36,84 @@ public class WikidataCoverEnrichmentJobTests
         Mock.Of<IServiceProvider>(),
         _time,
         NullLogger<WikidataCoverEnrichmentJob>.Instance);
+
+    /// <summary>
+    /// #3383 — i test del lease devono passare da <c>Execute</c> (l'unico punto dove vive), che
+    /// risolve i servizi da uno scope reale: il <c>Mock.Of&lt;IServiceProvider&gt;()</c> usato da
+    /// <see cref="Sut"/> non basta. Gli altri test continuano a usare <c>RunBatchAsync</c>.
+    /// </summary>
+    private WikidataCoverEnrichmentJob SutWithLease(IBackgroundTaskOrchestrator orchestrator)
+    {
+        var services = new ServiceCollection();
+        services.AddScoped(_ => _attempts.Object);
+        services.AddScoped(_ => _runner.Object);
+        services.AddScoped(_ => orchestrator);
+
+        return new WikidataCoverEnrichmentJob(
+            services.BuildServiceProvider(),
+            _time,
+            NullLogger<WikidataCoverEnrichmentJob>.Instance);
+    }
+
+    private static IJobExecutionContext JobContext()
+    {
+        var context = new Mock<IJobExecutionContext>();
+        context.SetupGet(c => c.CancellationToken).Returns(CancellationToken.None);
+        context.SetupGet(c => c.FireTimeUtc).Returns(DateTimeOffset.UtcNow);
+        return context.Object;
+    }
+
+    [Fact]
+    public async Task Execute_LeaseNotAcquired_SkipsTheBatch()
+    {
+        // Un'altra istanza tiene il lease: il tick non deve processare nulla (DEC-3e: due istanze
+        // raddoppierebbero il rate verso Wikimedia, violazione ToS).
+        var orchestrator = new Mock<IBackgroundTaskOrchestrator>();
+        orchestrator
+            .Setup(o => o.ExecuteWithDistributedLockAsync(
+                It.IsAny<string>(), It.IsAny<Func<CancellationToken, Task>>(),
+                It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        await SutWithLease(orchestrator.Object).Execute(JobContext());
+
+        _runner.Verify(
+            r => r.EnrichAndRecordAsync(It.IsAny<Guid>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _attempts.Verify(
+            r => r.GetGameIdsDueForEnrichmentAsync(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "senza lease il batch non deve nemmeno interrogare il DB");
+    }
+
+    [Fact]
+    public async Task Execute_LeaseAcquired_RunsTheBatchUnderTheLock()
+    {
+        var orchestrator = new Mock<IBackgroundTaskOrchestrator>();
+        Func<CancellationToken, Task>? captured = null;
+        orchestrator
+            .Setup(o => o.ExecuteWithDistributedLockAsync(
+                It.IsAny<string>(), It.IsAny<Func<CancellationToken, Task>>(),
+                It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .Callback<string, Func<CancellationToken, Task>, TimeSpan, CancellationToken>(
+                (_, factory, _, _) => captured = factory)
+            .ReturnsAsync(true);
+
+        _attempts.Setup(r => r.GetGameIdsDueForEnrichmentAsync(
+                It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Guid>());
+
+        await SutWithLease(orchestrator.Object).Execute(JobContext());
+
+        captured.Should().NotBeNull(
+            "il batch deve essere passato all'orchestrator, non eseguito fuori dal lock");
+
+        // Il batch gira davvero quando l'orchestrator invoca la factory.
+        await captured!(CancellationToken.None);
+        _attempts.Verify(
+            r => r.GetGameIdsDueForEnrichmentAsync(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
 
     [Fact]
     public async Task RunBatchAsync_NoGamesDue_NoOp()

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetCoverGap/GetCoverGapQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetCoverGap/GetCoverGapQueryHandlerTests.cs
@@ -1,0 +1,195 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetCoverGap;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Queries.GetCoverGap;
+
+/// <summary>
+/// #3590 — la vista cover-gap elenca i giochi SENZA alcuna cover, con la causa per cui la pipeline
+/// cover-da-PDF non li copre. Il collo di bottiglia non era risolverli (il picker manuale esiste da
+/// #3545) ma TROVARLI: non esisteva alcuna vista dei giochi senza cover.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class GetCoverGapQueryHandlerTests
+{
+    private static GetCoverGapQueryHandler Sut(MeepleAiDbContext db) =>
+        new(db, NullLogger<GetCoverGapQueryHandler>.Instance);
+
+    private static SharedGameEntity NewGame(string title, Action<SharedGameEntity>? tweak = null)
+    {
+        var game = new SharedGameEntity
+        {
+            Id = Guid.NewGuid(),
+            Title = title,
+            Description = "desc",
+            Status = 2, // Published
+            CreatedBy = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow,
+            ImageUrl = string.Empty,
+            ThumbnailUrl = string.Empty,
+        };
+        tweak?.Invoke(game);
+        return game;
+    }
+
+    private static PdfDocumentEntity NewPdf(Action<PdfDocumentEntity>? tweak = null)
+    {
+        var pdf = new PdfDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            FileName = "rulebook.pdf",
+            FilePath = "/tmp/rulebook.pdf",
+            FileSizeBytes = 1024,
+            UploadedByUserId = Guid.NewGuid(),
+        };
+        tweak?.Invoke(pdf);
+        return pdf;
+    }
+
+    private static SharedGameDocumentEntity Link(Guid gameId, Guid pdfId) => new()
+    {
+        Id = Guid.NewGuid(),
+        SharedGameId = gameId,
+        PdfDocumentId = pdfId,
+        DocumentType = 0,
+        IsActive = true,
+        CreatedAt = DateTime.UtcNow,
+        CreatedBy = Guid.NewGuid(),
+    };
+
+    [Fact]
+    public async Task Handle_GameWithNoCoverAndNoPdf_ClassifiedAsNoSource()
+    {
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var game = NewGame("Senza Sorgente");
+        db.SharedGames.Add(game);
+        await db.SaveChangesAsync();
+
+        var result = await Sut(db).Handle(new GetCoverGapQuery(), CancellationToken.None);
+
+        result.Items.Should().ContainSingle();
+        result.Items[0].GameId.Should().Be(game.Id);
+        result.Items[0].Cause.Should().Be(CoverGapCauses.NoSource);
+        result.Total.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Handle_GameWithSkippedCover_ClassifiedAsHeuristicRejected()
+    {
+        // Gotcha: 'Skipped' è scritto direttamente sul campo da BackfillPdfCoversJob,
+        // non via PdfDocument.MarkCoverSkipped() (metodo morto).
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var game = NewGame("Euristica Rifiuta");
+        var pdf = NewPdf(p =>
+        {
+            p.ProcessingState = "Ready";
+            p.CoverGenerationStatus = "Skipped";
+        });
+        db.SharedGames.Add(game);
+        db.PdfDocuments.Add(pdf);
+        db.SharedGameDocuments.Add(Link(game.Id, pdf.Id));
+        await db.SaveChangesAsync();
+
+        var result = await Sut(db).Handle(new GetCoverGapQuery(), CancellationToken.None);
+
+        result.Items.Should().ContainSingle();
+        result.Items[0].Cause.Should().Be(CoverGapCauses.HeuristicRejected);
+        result.Items[0].PdfFileName.Should().Be("rulebook.pdf");
+    }
+
+    [Fact]
+    public async Task Handle_GameWithPayloadTooLargePdf_ClassifiedAsPdfTooLarge()
+    {
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var game = NewGame("PDF Enorme");
+        var pdf = NewPdf(p =>
+        {
+            p.ProcessingState = "Failed";
+            p.ErrorCategory = "PayloadTooLarge";
+            p.FileSizeBytes = 65_000_000;
+        });
+        db.SharedGames.Add(game);
+        db.PdfDocuments.Add(pdf);
+        db.SharedGameDocuments.Add(Link(game.Id, pdf.Id));
+        await db.SaveChangesAsync();
+
+        var result = await Sut(db).Handle(new GetCoverGapQuery(), CancellationToken.None);
+
+        result.Items.Should().ContainSingle();
+        result.Items[0].Cause.Should().Be(CoverGapCauses.PdfTooLarge);
+        result.Items[0].PdfSizeBytes.Should().Be(65_000_000);
+    }
+
+    [Fact]
+    public async Task Handle_LegacyLargeFailureWithoutCategory_ClassifiedAsPdfTooLarge()
+    {
+        // I fallimenti precedenti al fix #3589 hanno ErrorCategory "Service" e un messaggio
+        // fuorviante ("Failed to connect"): la sola categoria non basta, serve la dimensione.
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var game = NewGame("Legacy 413");
+        var pdf = NewPdf(p =>
+        {
+            p.ProcessingState = "Failed";
+            p.ErrorCategory = "Service";
+            p.FileSizeBytes = 62_000_000;
+        });
+        db.SharedGames.Add(game);
+        db.PdfDocuments.Add(pdf);
+        db.SharedGameDocuments.Add(Link(game.Id, pdf.Id));
+        await db.SaveChangesAsync();
+
+        var result = await Sut(db).Handle(new GetCoverGapQuery(), CancellationToken.None);
+
+        result.Items.Should().ContainSingle();
+        result.Items[0].Cause.Should().Be(CoverGapCauses.PdfTooLarge);
+    }
+
+    [Fact]
+    public async Task Handle_GameWithAnyCoverKey_IsExcluded()
+    {
+        // Contratto centrale: la vista elenca SOLO chi non ha NESSUNA delle quattro chiavi.
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        db.SharedGames.AddRange(
+            NewGame("Con PDF", g => g.PdfCoverR2Key = "covers/pdf/x"),
+            NewGame("Con BGG", g => g.BggCoverR2Key = "bgg-covers/1/cover"),
+            NewGame("Con Wikidata", g => g.WikidataCoverR2Key = "covers/y"),
+            NewGame("Con Manuale", g => g.ManualCoverR2Key = "covers/manual/z/cover"));
+        await db.SaveChangesAsync();
+
+        var result = await Sut(db).Handle(new GetCoverGapQuery(), CancellationToken.None);
+
+        result.Items.Should().BeEmpty("avere una qualsiasi cover esclude dal gap");
+        result.Total.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_FiltersByCause_WhenCauseProvided()
+    {
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var senzaSorgente = NewGame("Senza Sorgente");
+        var euristica = NewGame("Euristica");
+        var pdf = NewPdf(p =>
+        {
+            p.ProcessingState = "Ready";
+            p.CoverGenerationStatus = "Skipped";
+        });
+        db.SharedGames.AddRange(senzaSorgente, euristica);
+        db.PdfDocuments.Add(pdf);
+        db.SharedGameDocuments.Add(Link(euristica.Id, pdf.Id));
+        await db.SaveChangesAsync();
+
+        var result = await Sut(db)
+            .Handle(new GetCoverGapQuery(Cause: CoverGapCauses.NoSource), CancellationToken.None);
+
+        result.Items.Should().ContainSingle();
+        result.Items[0].GameId.Should().Be(senzaSorgente.Id);
+        result.Total.Should().Be(1);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRunnerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRunnerTests.cs
@@ -257,8 +257,9 @@ public class WikidataCoverEnrichmentRunnerTests
 
         await Sut().EnrichAndRecordAsync(gameId, forceRefresh: false, cancellationToken: default);
 
-        ReadGauge(MeepleAiMetrics.WikidataDeadLetterCount).Should().Be(6,
-            "F1 hybrid update: runner increments by 1 per persisted DeadLetter attempt");
+        ReadGauge(MeepleAiMetrics.WikidataDeadLetterCount).Should().Be(5,
+            "#3383: il gauge è DB-derivato — il runner NON lo incrementa più; " +
+            "è WikidataDeadLetterMetricsRefreshService a ri-ancorarlo al COUNT reale");
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/BackgroundJobs/WikidataDeadLetterMetricsRefreshServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/BackgroundJobs/WikidataDeadLetterMetricsRefreshServiceTests.cs
@@ -1,0 +1,58 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.BackgroundJobs;
+using Api.Observability;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure.BackgroundJobs;
+
+/// <summary>
+/// #3383 (ADR-087 D4) — il gauge dead-letter deve essere DB-derivato per restare corretto sotto
+/// <c>max()</c> a più di un'istanza. Questi test coprono il contratto del refresh periodico.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class WikidataDeadLetterMetricsRefreshServiceTests
+{
+    private static (WikidataDeadLetterMetricsRefreshService Sut, Mock<IWikidataCoverEnrichmentAttemptRepository> Repo) Build()
+    {
+        var repo = new Mock<IWikidataCoverEnrichmentAttemptRepository>();
+        var services = new ServiceCollection();
+        services.AddScoped(_ => repo.Object);
+        var provider = services.BuildServiceProvider();
+
+        var sut = new WikidataDeadLetterMetricsRefreshService(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<WikidataDeadLetterMetricsRefreshService>.Instance);
+
+        return (sut, repo);
+    }
+
+    [Fact]
+    public async Task RefreshOnceAsync_PushesTheCountedValueIntoTheGauge()
+    {
+        var (sut, repo) = Build();
+        repo.Setup(r => r.CountDeadLettersAsync(It.IsAny<CancellationToken>())).ReturnsAsync(42);
+
+        await sut.RefreshOnceAsync(CancellationToken.None);
+
+        repo.Verify(r => r.CountDeadLettersAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task RefreshOnceAsync_RepositoryThrows_PropagatesSoTheLoopCanLogAndRetry()
+    {
+        // Il metodo NON deve inghiottire qui: è il loop di ExecuteAsync a catturare, loggare e
+        // ritentare al tick successivo (stesso contratto di ImpersonationMetricsRefreshService).
+        var (sut, repo) = Build();
+        repo.Setup(r => r.CountDeadLettersAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("db down"));
+
+        var act = async () => await sut.RefreshOnceAsync(CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/SharedGameRepositoryBggCoverTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/SharedGameRepositoryBggCoverTests.cs
@@ -1,0 +1,127 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Repositories;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure.Repositories;
+
+/// <summary>
+/// #3590 Slice B — la cover BGG ri-ospitata (layer L2.5) deve sopravvivere a un
+/// load-modify-save dell'aggregato.
+/// <para>
+/// Regressione chiusa qui: <c>SharedGameRepository.Update()</c> fa
+/// <c>MapToEntity(aggregato)</c> + <c>DbContext.Update(entity)</c> su grafo DETACHED, quindi
+/// marca ogni colonna come Modified. Il mapper non scriveva <c>BggCoverR2Key</c> (né
+/// <c>MapToDomain</c> lo leggeva), per cui ogni salvataggio emetteva
+/// <c>SET bgg_cover_r2_key = NULL</c> — perdita silenziosa della cover.
+/// </para>
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class SharedGameRepositoryBggCoverTests
+{
+    private const string BggKey = "bgg-covers/13/cover";
+
+    private static SharedGameRepository Repo(Api.Infrastructure.MeepleAiDbContext db) =>
+        new(db, Mock.Of<IDomainEventCollector>());
+
+    private static SharedGameEntity NewEntity(Guid id, string? bggCoverR2Key) => new()
+    {
+        Id = id,
+        Title = "Catan",
+        Description = "desc",
+        Status = 2, // Published
+        CreatedBy = Guid.NewGuid(),
+        CreatedAt = DateTime.UtcNow,
+        ImageUrl = string.Empty,
+        ThumbnailUrl = string.Empty,
+        BggCoverR2Key = bggCoverR2Key,
+    };
+
+    [Fact]
+    public async Task Update_PreservesBggCoverR2Key()
+    {
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var id = Guid.NewGuid();
+        db.SharedGames.Add(NewEntity(id, BggKey));
+        await db.SaveChangesAsync();
+        db.ChangeTracker.Clear();
+
+        var repo = Repo(db);
+        var game = await repo.GetByIdAsync(id, CancellationToken.None);
+        game.Should().NotBeNull();
+        repo.Update(game!);
+        await db.SaveChangesAsync();
+        db.ChangeTracker.Clear();
+
+        var after = await db.SharedGames.AsNoTracking().FirstAsync(g => g.Id == id);
+        after.BggCoverR2Key.Should().Be(BggKey,
+            "un update dell'aggregato non deve cancellare la cover BGG ri-ospitata");
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_HydratesBggCoverR2KeyOntoTheAggregate()
+    {
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var id = Guid.NewGuid();
+        db.SharedGames.Add(NewEntity(id, BggKey));
+        await db.SaveChangesAsync();
+        db.ChangeTracker.Clear();
+
+        var game = await Repo(db).GetByIdAsync(id, CancellationToken.None);
+
+        game!.BggCoverR2Key.Should().Be(BggKey,
+            "senza la lettura nel mapper l'aggregato non può preservare ciò che non conosce");
+    }
+
+    [Fact]
+    public async Task SetBggCover_PersistsThroughUpdate()
+    {
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var id = Guid.NewGuid();
+        db.SharedGames.Add(NewEntity(id, bggCoverR2Key: null));
+        await db.SaveChangesAsync();
+        db.ChangeTracker.Clear();
+
+        var repo = Repo(db);
+        var game = await repo.GetByIdAsync(id, CancellationToken.None);
+        game!.SetBggCover(BggKey);
+        repo.Update(game);
+        await db.SaveChangesAsync();
+        db.ChangeTracker.Clear();
+
+        var after = await db.SharedGames.AsNoTracking().FirstAsync(g => g.Id == id);
+        after.BggCoverR2Key.Should().Be(BggKey);
+    }
+
+    [Fact]
+    public void SetBggCover_EmptyKey_Throws()
+    {
+        var game = SharedGame.Create(
+            "Catan", 1995, "desc", 3, 4, 90, 10, 2.5m, 7.8m,
+            "https://example.com/c.jpg", "https://example.com/c-thumb.jpg", null, Guid.NewGuid());
+
+        var act = () => game.SetBggCover("  ");
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void SetBggCover_SameValue_IsIdempotent()
+    {
+        var game = SharedGame.Create(
+            "Catan", 1995, "desc", 3, 4, 90, 10, 2.5m, 7.8m,
+            "https://example.com/c.jpg", "https://example.com/c-thumb.jpg", null, Guid.NewGuid());
+
+        game.SetBggCover(BggKey);
+        game.SetBggCover(BggKey);
+
+        game.BggCoverR2Key.Should().Be(BggKey);
+    }
+}

--- a/apps/api/tests/Api.Tests/Observability/EgressMetricsTests.cs
+++ b/apps/api/tests/Api.Tests/Observability/EgressMetricsTests.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.Metrics;
 using System.Net;
 using Api.Observability;
 using Api.SharedKernel.Infrastructure.Http;
@@ -25,34 +24,12 @@ public sealed class EgressMetricsTests
             Task.FromResult(_addresses);
     }
 
-    private static List<(long Value, IReadOnlyDictionary<string, object?> Tags)> Capture(
-        string instrumentName, Action act)
+    private sealed class ThrowingDnsResolver : IDnsResolver
     {
-        var captured = new List<(long, IReadOnlyDictionary<string, object?>)>();
-        using var listener = new MeterListener
-        {
-            InstrumentPublished = (instrument, l) =>
-            {
-                if (instrument.Name == instrumentName)
-                {
-                    l.EnableMeasurementEvents(instrument);
-                }
-            },
-        };
-        listener.SetMeasurementEventCallback<long>((_, value, tags, _) =>
-        {
-            var dict = new Dictionary<string, object?>(StringComparer.Ordinal);
-            foreach (var t in tags)
-            {
-                dict[t.Key] = t.Value;
-            }
-            captured.Add((value, dict));
-        });
-        listener.Start();
-
-        act();
-
-        return captured;
+        private readonly Exception _toThrow;
+        public ThrowingDnsResolver(Exception toThrow) => _toThrow = toThrow;
+        public Task<IReadOnlyList<IPAddress>> ResolveAsync(string host, CancellationToken ct) =>
+            Task.FromException<IReadOnlyList<IPAddress>>(_toThrow);
     }
 
     [Fact]
@@ -60,7 +37,7 @@ public sealed class EgressMetricsTests
     {
         var dns = new FakeDnsResolver("10.0.0.5");
 
-        var captured = Capture(MeepleAiMetrics.EgressBlocked.Name, () =>
+        var captured = MetricCapture.Capture(MeepleAiMetrics.EgressBlocked.Name, () =>
         {
             // The guard records the block BEFORE it throws; swallow the expected throw so we can
             // assert the increment already happened.
@@ -102,7 +79,7 @@ public sealed class EgressMetricsTests
     {
         var dns = new FakeDnsResolver("8.8.8.8");
 
-        var captured = Capture(MeepleAiMetrics.EgressAllowed.Name, () =>
+        var captured = MetricCapture.Capture(MeepleAiMetrics.EgressAllowed.Name, () =>
             SsrfPinnedConnect.ResolveAndValidateAsync(
                     dns, "cdn.example.com", MeepleAiMetrics.EgressSinks.Manual, CancellationToken.None)
                 .GetAwaiter().GetResult());
@@ -117,9 +94,76 @@ public sealed class EgressMetricsTests
     }
 
     [Fact]
+    public void ResolveAndValidate_DnsThrows_IncrementsBlocked_WithDnsFailure_AndRethrows()
+    {
+        // Un NXDOMAIN / timeout del resolver: la connessione non avviene (fail-closed corretto), ma
+        // senza questo counter il sink degradato è indistinguibile da un sink inattivo (#3583).
+        var dns = new ThrowingDnsResolver(new System.Net.Sockets.SocketException(11001));
+
+        var captured = MetricCapture.Capture(MeepleAiMetrics.EgressBlocked.Name, () =>
+        {
+            try
+            {
+                SsrfPinnedConnect.ResolveAndValidateAsync(
+                        dns, "nxdomain.example.com", MeepleAiMetrics.EgressSinks.Wikidata, CancellationToken.None)
+                    .GetAwaiter().GetResult();
+                throw new Xunit.Sdk.XunitException("expected the DNS failure to propagate");
+            }
+            catch (System.Net.Sockets.SocketException)
+            {
+                // atteso — il guard registra e RILANCIA senza alterare l'esito
+            }
+        });
+
+        var mine = captured
+            .Where(c => Equals(c.Tags.GetValueOrDefault("sink"), "wikidata")
+                && Equals(c.Tags.GetValueOrDefault("reason"), "dns_failure"))
+            .ToList();
+
+        mine.Should().NotBeEmpty("un fallimento DNS deve essere visibile sul counter di blocco");
+        mine[0].Value.Should().Be(1);
+        captured.Should().AllSatisfy(c => c.Tags.Keys.Should().BeEquivalentTo("sink", "reason"));
+    }
+
+    [Fact]
+    public void ResolveAndValidate_CallerCancellation_DoesNotIncrementBlocked()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var dns = new ThrowingDnsResolver(new OperationCanceledException(cts.Token));
+
+        var captured = MetricCapture.Capture(MeepleAiMetrics.EgressBlocked.Name, () =>
+        {
+            try
+            {
+                SsrfPinnedConnect.ResolveAndValidateAsync(
+                        dns, "cancelled.example.com", MeepleAiMetrics.EgressSinks.Wikimedia, cts.Token)
+                    .GetAwaiter().GetResult();
+                throw new Xunit.Sdk.XunitException("expected the cancellation to propagate");
+            }
+            catch (OperationCanceledException)
+            {
+                // atteso
+            }
+        });
+
+        captured
+            .Where(c => Equals(c.Tags.GetValueOrDefault("sink"), "wikimedia")
+                && Equals(c.Tags.GetValueOrDefault("reason"), "dns_failure"))
+            .Should().BeEmpty("un abort del chiamante non è un fallimento DNS e non va contato");
+    }
+
+    [Fact]
     public void Counters_HaveStableBoundedNames()
     {
         MeepleAiMetrics.EgressBlocked.Name.Should().Be("meepleai.egress.blocked.total");
         MeepleAiMetrics.EgressAllowed.Name.Should().Be("meepleai.egress.allowed.total");
+
+        MeepleAiMetrics.EgressBlockReasons.DnsFailure.Should().Be("dns_failure");
+        // Pinnati perché sono il selettore delle regole in infra/prometheus/alerts/egress-guard.yml:
+        // rinominarli spegnerebbe gli alert senza rompere nulla in compilazione (#3583).
+        MeepleAiMetrics.EgressBlockReasons.PrivateIp.Should().Be("private_ip");
+        MeepleAiMetrics.EgressBlockReasons.DenylistHit.Should().Be("denylist_hit");
+        MeepleAiMetrics.EgressBlockReasons.DecodeFail.Should().Be("decode_fail");
     }
 }

--- a/apps/api/tests/Api.Tests/Observability/MetricCapture.cs
+++ b/apps/api/tests/Api.Tests/Observability/MetricCapture.cs
@@ -1,0 +1,47 @@
+using System.Diagnostics.Metrics;
+
+namespace Api.Tests.Observability;
+
+/// <summary>
+/// Cattura le misurazioni di uno strumento durante l'esecuzione di <paramref name="act"/>.
+/// Estratto da <c>EgressMetricsTests</c> in #3583 perché i test di <c>decode_fail</c> /
+/// <c>denylist_hit</c> vivono nei file dei rispettivi handler e validator.
+/// <para>
+/// ATTENZIONE: il <see cref="MeterListener"/> è process-wide e xUnit esegue le classi di test in
+/// parallelo, per cui la finestra di cattura può contenere misurazioni emesse da altri test. Chi
+/// asserisce DEVE selezionare la propria misurazione per tag e limitarsi a verificarne la presenza,
+/// mai il conteggio esatto (regressione già occorsa in #3495 Slice D).
+/// </para>
+/// </summary>
+internal static class MetricCapture
+{
+    public static List<(long Value, IReadOnlyDictionary<string, object?> Tags)> Capture(
+        string instrumentName, Action act)
+    {
+        var captured = new List<(long, IReadOnlyDictionary<string, object?>)>();
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Name == instrumentName)
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            },
+        };
+        listener.SetMeasurementEventCallback<long>((_, value, tags, _) =>
+        {
+            var dict = new Dictionary<string, object?>(StringComparer.Ordinal);
+            foreach (var t in tags)
+            {
+                dict[t.Key] = t.Value;
+            }
+            captured.Add((value, dict));
+        });
+        listener.Start();
+
+        act();
+
+        return captured;
+    }
+}

--- a/apps/api/tests/Api.Tests/Observability/WikidataEnrichmentMetricsTests.cs
+++ b/apps/api/tests/Api.Tests/Observability/WikidataEnrichmentMetricsTests.cs
@@ -109,17 +109,9 @@ public class WikidataEnrichmentMetricsTests
             .Should().Be(0, "negative dead-letter counts are non-sensical — the setter MUST clamp");
     }
 
-    [Fact]
-    public void IncrementWikidataDeadLetterCount_FromAnchor_IncreasesByOnePerCall()
-    {
-        // Anchor to a known value, then increment twice; the gauge MUST report
-        // anchor+2 (atomic Interlocked.Increment, no Read-Modify-Write race).
-        MeepleAiMetrics.SetWikidataDeadLetterCount(10);
-        MeepleAiMetrics.IncrementWikidataDeadLetterCount();
-        MeepleAiMetrics.IncrementWikidataDeadLetterCount();
-
-        ReadObservableGaugeValue(MeepleAiMetrics.WikidataDeadLetterCount).Should().Be(12);
-    }
+    // #3383: il test IncrementWikidataDeadLetterCount_FromAnchor_IncreasesByOnePerCall è stato
+    // RIMOSSO insieme al metodo che copriva. Il gauge è ora puramente DB-derivato: l'unico punto
+    // di scrittura è SetWikidataDeadLetterCount, coperto dai due test qui sopra.
 
     [Fact]
     public void WikidataDeadLetterCount_Name_MatchesAdrConvention()

--- a/apps/web/src/app/admin/(dashboard)/shared-games/cover-gap/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/shared-games/cover-gap/page.tsx
@@ -1,0 +1,157 @@
+/**
+ * Admin — Cover gap (#3590).
+ *
+ * Elenca i giochi del catalogo **senza alcuna cover**, raggruppati per la causa che impedisce
+ * alla pipeline cover-da-PDF di coprirli.
+ *
+ * Perché esiste: risolvere questi casi era già possibile (il picker manuale da URL c'è da #3545),
+ * ma non c'era modo di TROVARLI — l'unico accesso all'editor era l'affordance a matita in hover
+ * sulla griglia pubblica, quindi bisognava scorrerla a occhio. Questa pagina chiude quel buco.
+ *
+ * Fuori scope: l'editing della cover. Ogni riga porta al gioco su /shared-games, dove vive
+ * l'editor esistente (`AdminCoverEditAffordance`) — non duplicarlo qui.
+ */
+
+'use client';
+
+import { useState } from 'react';
+
+import { useCoverGap } from '@/hooks/admin/useCoverGap';
+import type { CoverGapCause } from '@/lib/api/schemas/admin/admin-cover.schemas';
+
+const CAUSE_FILTERS: { value: CoverGapCause | ''; label: string }[] = [
+  { value: '', label: 'Tutte le cause' },
+  { value: 'no_source', label: 'Nessuna sorgente' },
+  { value: 'heuristic_rejected', label: 'Euristica ha rifiutato' },
+  { value: 'pdf_too_large', label: 'PDF troppo grande' },
+  { value: 'other', label: 'Altro' },
+];
+
+const CAUSE_LABELS: Record<CoverGapCause, string> = {
+  no_source: 'Nessuna sorgente',
+  heuristic_rejected: 'Euristica ha rifiutato',
+  pdf_too_large: 'PDF troppo grande',
+  other: 'Altro',
+};
+
+/** Spiegazione operativa: cosa può fare l'admin per ciascun gruppo. */
+const CAUSE_HINTS: Record<CoverGapCause, string> = {
+  no_source: 'Nessun PDF collegato e nessuna immagine libera: serve una cover manuale da URL.',
+  heuristic_rejected:
+    'Esito corretto — nessuna pagina del rulebook è una cover accettabile. Serve una cover manuale.',
+  pdf_too_large:
+    "Il PDF eccede il limite del servizio di estrazione. Verificare che l'immagine di unstructured-service sia aggiornata prima di intervenire a mano.",
+  other: 'PDF ancora in lavorazione o fallimento non classificato: ricontrollare più tardi.',
+};
+
+function formatMb(bytes: number | null): string {
+  if (bytes === null) return '—';
+  return `${Math.round(bytes / 1_048_576)} MB`;
+}
+
+export default function CoverGapPage() {
+  const [cause, setCause] = useState<CoverGapCause | ''>('');
+  const { data, isLoading, isError, error } = useCoverGap(cause || undefined);
+
+  const items = data?.items ?? [];
+
+  return (
+    <div className="space-y-6 p-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold text-foreground">Giochi senza cover</h1>
+        <p className="text-sm text-muted-foreground">
+          Giochi del catalogo privi di qualunque cover (PDF, BGG, Wikidata, manuale), con la causa
+          per cui la pipeline cover-da-PDF non li copre. Per risolvere, apri il gioco e usa
+          l&apos;editor cover.
+        </p>
+      </header>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <label htmlFor="cause-filter" className="text-sm text-muted-foreground">
+          Causa
+        </label>
+        <select
+          id="cause-filter"
+          value={cause}
+          onChange={e => setCause(e.target.value as CoverGapCause | '')}
+          className="rounded-md border border-border bg-card px-3 py-1.5 text-sm text-foreground"
+        >
+          {CAUSE_FILTERS.map(f => (
+            <option key={f.value || 'all'} value={f.value}>
+              {f.label}
+            </option>
+          ))}
+        </select>
+
+        {data && (
+          <span className="text-sm text-muted-foreground">
+            {data.total} {data.total === 1 ? 'gioco' : 'giochi'} senza cover
+          </span>
+        )}
+      </div>
+
+      {isLoading && <p className="text-sm text-muted-foreground">Caricamento…</p>}
+
+      {isError && (
+        <p role="alert" className="text-sm text-destructive">
+          Impossibile caricare l&apos;elenco: {error?.message ?? 'errore sconosciuto'}
+        </p>
+      )}
+
+      {!isLoading && !isError && items.length === 0 && (
+        <p className="text-sm text-muted-foreground">
+          Nessun gioco senza cover per il filtro selezionato.
+        </p>
+      )}
+
+      {items.length > 0 && (
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[720px] border-collapse text-sm">
+            <thead>
+              <tr className="border-b border-border text-left text-muted-foreground">
+                <th scope="col" className="py-2 pr-4 font-medium">
+                  Gioco
+                </th>
+                <th scope="col" className="py-2 pr-4 font-medium">
+                  Causa
+                </th>
+                <th scope="col" className="py-2 pr-4 font-medium">
+                  PDF
+                </th>
+                <th scope="col" className="py-2 pr-4 font-medium">
+                  Dimensione
+                </th>
+                <th scope="col" className="py-2 font-medium">
+                  Azione
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map(game => (
+                <tr key={game.gameId} className="border-b border-border">
+                  <td className="py-2 pr-4 text-foreground">{game.title}</td>
+                  <td className="py-2 pr-4">
+                    <span className="text-foreground">{CAUSE_LABELS[game.cause]}</span>
+                    <span className="block text-xs text-muted-foreground">
+                      {CAUSE_HINTS[game.cause]}
+                    </span>
+                  </td>
+                  <td className="py-2 pr-4 text-muted-foreground">{game.pdfFileName ?? '—'}</td>
+                  <td className="py-2 pr-4 text-muted-foreground">{formatMb(game.pdfSizeBytes)}</td>
+                  <td className="py-2">
+                    <a
+                      href={`/shared-games?highlight=${encodeURIComponent(game.gameId)}`}
+                      className="text-primary underline underline-offset-2"
+                    >
+                      Apri nel catalogo
+                    </a>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/hooks/admin/coverEditorKeys.ts
+++ b/apps/web/src/hooks/admin/coverEditorKeys.ts
@@ -6,4 +6,6 @@
 export const coverEditorKeys = {
   all: ['admin', 'cover-editor'] as const,
   candidates: (gameId: string) => ['admin', 'cover-editor', 'candidates', gameId] as const,
+  /** #3590 — elenco dei giochi senza cover, opzionalmente filtrato per causa. */
+  gap: (cause?: string) => ['admin', 'cover-editor', 'gap', cause ?? 'all'] as const,
 } as const;

--- a/apps/web/src/hooks/admin/useCoverGap.ts
+++ b/apps/web/src/hooks/admin/useCoverGap.ts
@@ -1,0 +1,22 @@
+/**
+ * Admin cover-gap (#3590).
+ *
+ * Query hook: i giochi del catalogo senza alcuna cover, con la causa per cui la pipeline
+ * cover-da-PDF non li copre. Wrappa `api.admin.getCoverGap()`.
+ */
+
+'use client';
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { api } from '@/lib/api';
+import type { CoverGapCause, CoverGapPage } from '@/lib/api/schemas/admin/admin-cover.schemas';
+
+import { coverEditorKeys } from './coverEditorKeys';
+
+export function useCoverGap(cause?: CoverGapCause): UseQueryResult<CoverGapPage | null, Error> {
+  return useQuery({
+    queryKey: coverEditorKeys.gap(cause),
+    queryFn: () => api.admin.getCoverGap({ cause, pageSize: 100 }),
+  });
+}

--- a/apps/web/src/lib/api/clients/admin/adminCoverClient.ts
+++ b/apps/web/src/lib/api/clients/admin/adminCoverClient.ts
@@ -10,6 +10,9 @@ import {
   CoverCandidatesSchema,
   CoverAssignmentSchema,
   ManualCoverResultSchema,
+  CoverGapPageSchema,
+  type CoverGapCause,
+  type CoverGapPage,
   type CoverCandidates,
   type CoverAssignment,
   type CoverContext,
@@ -68,6 +71,30 @@ export function createAdminCoverClient(http: HttpClient) {
         `/api/v1/admin/shared-games/${encodeURIComponent(gameId)}/manual-cover`,
         body,
         ManualCoverResultSchema
+      );
+    },
+
+    /**
+     * GET the catalog games that have NO cover at all, each with the cause the cover-from-PDF
+     * pipeline cannot cover it (#3590). Optional `cause` filters to one bounded value.
+     * Returns null on 401.
+     */
+    async getCoverGap(
+      params: {
+        cause?: CoverGapCause;
+        pageNumber?: number;
+        pageSize?: number;
+      } = {}
+    ): Promise<CoverGapPage | null> {
+      const search = new URLSearchParams();
+      if (params.cause) search.set('cause', params.cause);
+      if (params.pageNumber) search.set('pageNumber', String(params.pageNumber));
+      if (params.pageSize) search.set('pageSize', String(params.pageSize));
+      const qs = search.toString();
+
+      return http.get(
+        `/api/v1/admin/shared-games/cover-gap${qs ? `?${qs}` : ''}`,
+        CoverGapPageSchema
       );
     },
   };

--- a/apps/web/src/lib/api/schemas/admin/admin-cover.schemas.ts
+++ b/apps/web/src/lib/api/schemas/admin/admin-cover.schemas.ts
@@ -100,3 +100,45 @@ export const ManualCoverResultSchema = z.object({
   presignedUrl: z.string(),
 });
 export type ManualCoverResult = z.infer<typeof ManualCoverResultSchema>;
+
+/**
+ * #3590 — cover-gap: la causa per cui un gioco è privo di cover. Enum bounded, speculare a
+ * `CoverGapCauses` lato backend (`GetCoverGapQuery.cs`): cambiarne uno richiede di cambiare
+ * anche l'altro.
+ *
+ * - `pdf_too_large`      — il PDF eccede il limite del servizio di estrazione
+ * - `heuristic_rejected` — nessuna pagina è una cover accettabile (esito CORRETTO, non un guasto)
+ * - `no_source`          — nessun PDF collegato: non c'è nulla da cui generare
+ * - `other`              — PDF ancora in lavorazione o fallimenti non classificati
+ */
+export const CoverGapCauseSchema = z.enum([
+  'pdf_too_large',
+  'heuristic_rejected',
+  'no_source',
+  'other',
+]);
+export type CoverGapCause = z.infer<typeof CoverGapCauseSchema>;
+
+/**
+ * Un gioco senza alcuna cover. I campi PDF sono nullable perché il gruppo `no_source` non ha
+ * alcun documento collegato — non stringerli a required senza cambiare il DTO C#.
+ */
+export const CoverGapGameSchema = z.object({
+  gameId: z.string().uuid(),
+  title: z.string(),
+  bggId: z.number().nullable(),
+  cause: CoverGapCauseSchema,
+  pdfFileName: z.string().nullable(),
+  pdfSizeBytes: z.number().nullable(),
+  errorCategory: z.string().nullable(),
+});
+export type CoverGapGame = z.infer<typeof CoverGapGameSchema>;
+
+/** Pagina di risultati cover-gap (PagedResult&lt;CoverGapGameDto&gt; lato backend). */
+export const CoverGapPageSchema = z.object({
+  items: z.array(CoverGapGameSchema),
+  total: z.number(),
+  page: z.number(),
+  pageSize: z.number(),
+});
+export type CoverGapPage = z.infer<typeof CoverGapPageSchema>;

--- a/docs/for-claude/architecture/adr/adr-087-cover-procedure-design-decisions.md
+++ b/docs/for-claude/architecture/adr/adr-087-cover-procedure-design-decisions.md
@@ -43,6 +43,27 @@ The enrichment tier is single-instance **by contract**. The in-process `InMemory
 
 Rationale: staging is Compose single-instance with no HPA roadmap, so a distributed rate-limiter is YAGNI; but leaving the constraint incidental (pinned only by `container_name`) is unacceptable because it touches legal correctness (Wikimedia ToS) and would fail silently.
 
+> **Emendamento 2026-08-06 ([#3383](https://github.com/meepleAi-app/meepleai-monorepo/issues/3383)).** Due fatti hanno modificato questa decisione.
+>
+> 1. Il tripwire descritto sopra come «Now» **non era mai stato attivo**: il file
+>    `infra/prometheus/alerts/api-single-instance.yml` esisteva, con il suo test promtool, ma non era
+>    montato in alcun compose né referenziato in alcun `rule_files:`, **dev incluso**. Fra la ratifica
+>    di D4 e oggi il vincolo single-pod è stato presidiato **solo** da `container_name` — esattamente
+>    la situazione che il Rationale qui sopra dichiara inaccettabile. Wiring corretto in #3383.
+> 2. Di conseguenza il rinvio della hard-prevention, motivato dalla presenza del tripwire, non aveva
+>    più fondamento: il **lease Redis fail-closed** sul batch è stato implementato in #3383 e non è
+>    più «Deferred». Il gauge dead-letter è ora DB-derivato, e le regole Prometheus che lo leggono
+>    aggregano con `max()` — senza aggregazione un gauge corretto a N istanze avrebbe comunque
+>    prodotto N notifiche duplicate.
+>
+> **Costo del fail-closed, da conoscere prima di un incidente**: il lease non è opzionale, quindi
+> un'indisponibilità di Redis **ferma l'enrichment Wikidata**. È la semantica voluta — non arricchire
+> è preferibile a violare il rate cap Wikimedia — ma va cercata attivamente quando l'enrichment si
+> ferma senza altra spiegazione. Runbook: [Enrichment Wikidata fermo senza errori applicativi](../../../for-developers/operations/operations-manual.md#wikidata-enrichment-alerts).
+>
+> Il rate-limiter distribuito (Redis token bucket) resta in riserva per un'eventuale roadmap HPA:
+> lease e tripwire coprono la **correttezza** a una istanza, non il **throughput** a N.
+
 ### D5 — Executable writer↔resolver contract + generation telemetry
 
 - **D5-C — telemetry *(ratified — SHIPPED)***: `meepleai.cover.generation.total{source,outcome}` emitted at every terminal generation site across the three PDF producers. Shipped: #3378 / PR #3379.

--- a/docs/for-developers/operations/operations-manual.md
+++ b/docs/for-developers/operations/operations-manual.md
@@ -3002,14 +3002,35 @@ Gauges report `0` when idle, so the expressions never fire on an idle queue.
 
 | Alert | Trigger | Sustained | Meaning / first action |
 |---|---|---|---|
-| `WikidataDeadLetterHigh` | `meepleai_wikidata_dead_letter_count > 100` | 1h | Operator triage backlog building. Investigate via the M13 admin dead-letter page — likely a license-whitelist or SPARQL schema drift. |
-| `WikidataDeadLetterSpike` | `delta(meepleai_wikidata_dead_letter_count[5m]) > 50` | — | A sudden burst of dead-letters: systemic upstream failure or license-whitelist drift. Cross-check `WikidataSparqlLatency` p95 and Wikidata/Commons endpoint health. |
+| `WikidataDeadLetterHigh` | `max(meepleai_wikidata_dead_letter_count) > 100` | 1h | Operator triage backlog building. Investigate via the M13 admin dead-letter page — likely a license-whitelist or SPARQL schema drift. |
+| `WikidataDeadLetterSpike` | `delta(max(meepleai_wikidata_dead_letter_count)[5m:]) > 50` | — | A sudden burst of dead-letters: systemic upstream failure or license-whitelist drift. Cross-check `WikidataSparqlLatency` p95 and Wikidata/Commons endpoint health. |
 | `WikidataQueueBacklogHigh` | `meepleai_wikidata_queue_depth > 5000` | 1h | Enrichment backlog building; scheduler under-provisioned relative to enrichment rate. Consider tuning batch size or the DEC-3e rate-limiter. |
+| `MultipleApiInstances` | `count(up{job="meepleai-api"}) > 1` | 5m | Il contratto single-pod (ADR-087 D4) è violato: due istanze raddoppiano il rate verso Wikidata/Commons (ToS). Riportare il servizio a una replica. Definito in `api-single-instance.yml` — **non caricato in alcun ambiente fino a #3383**. |
+
+> #3383: le due regole dead-letter aggregano con `max()`. Il gauge è DB-derivato (ogni istanza
+> riporta lo stesso `COUNT`), quindi `max()` è esatto e collassa le N serie in un solo alert; senza
+> aggregazione lo stesso backlog notificherebbe N volte. `delta()` richiede un range vector, da cui
+> la subquery `[5m:]`.
 
 ### Investigation steps
 
 1. **Dead-letter accumulation** (`WikidataDeadLetterHigh` / `WikidataDeadLetterSpike`): open the M13 admin dead-letter page. A steady climb usually means a license-whitelist entry went stale or the SPARQL query drifted; a sharp spike points at a Wikidata/Commons outage. Cross-check the enrichment attempt outcomes (`meepleai_wikidata_enrichment_attempts_total{outcome="dead_letter"}`).
 2. **Queue not draining** (`WikidataQueueBacklogHigh`): the M9 scheduler is enqueuing faster than the enrichment runner drains. Check the Quartz job health and the DEC-3e rate-limiter; consider raising the batch size if the SPARQL endpoint has headroom.
+
+### Enrichment Wikidata fermo senza errori applicativi
+
+Sintomo: `meepleai_wikidata_queue_depth` non cala, nessun nuovo attempt registrato, nessuna eccezione
+applicativa nei log dell'handler.
+
+**Causa da escludere per prima: Redis irraggiungibile.** Dal #3383 il batch di enrichment gira sotto
+un lease Redis **fail-closed** (`wikidata-cover-enrichment-batch`, TTL 10 min): se Redis non risponde
+il tick fallisce di proposito, perché due istanze che processano lo stesso batch raddoppierebbero il
+rate verso Wikidata/Commons (violazione ToS, DEC-3e). L'enrichment fermo è quindi un **sintomo
+atteso** di un'indisponibilità Redis, non un guasto della pipeline cover.
+
+Verifica: stato del container redis, poi cerca nei log dell'API
+`WikidataCoverEnrichmentJob: lease ... già detenuto`. Se il messaggio ricorre con una sola istanza
+attiva, il lease è orfano (istanza morta a metà batch) e scade da solo entro 10 minuti.
 
 Alert unit tests live in `infra/prometheus/alerts/wikidata-enrichment.test.yml` (run `promtool test rules` per the header comment; there is no CI promtool gate, so run on demand).
 

--- a/docs/for-developers/specs/2026-08-02-admin-cover-editor-design.md
+++ b/docs/for-developers/specs/2026-08-02-admin-cover-editor-design.md
@@ -85,7 +85,19 @@ Regola d'oro (Nygard): **l'URL è input transiente, mai render-source**. Nuovo c
 2. download ≤10MB, validazione **reale** via `IWebpVariantGenerator` (throw su non-immagine, non fidarsi del Content-Type);
 3. **gate licenza**: l'admin dichiara una licenza da whitelist `LicenseValidator` (CC0/PD/CC-BY/CC-BY-SA) + attribution + fonte → 400 se non-whitelist; l'attestazione è dell'admin (registra `attestedBy`+timestamp per audit);
 4. re-encode WebP → upload R2 raw-key → persiste **solo** la R2 key + license/attribution (nuovo `CoverKind.Manual`, colonne `ManualCover*` a specchio di `WikidataCover*`).
-> Host BGG/geekdo: non bloccati nel fetch server-side (ADR-059 §2), ma di fatto rifiutati dal gate-licenza (non sono CC).
+> **Host BGG/geekdo — aggiornato 2026-08-07 (#3590 Slice B).** Il testo originale («non bloccati nel
+> fetch server-side, ma di fatto rifiutati dal gate-licenza») è **superato da #3495**. Oggi i due
+> path sono distinti e vanno tenuti tali:
+>
+> - **Cover manuale da URL arbitrario** (questo flusso): gli host geekdo sono **banditi**, prima di
+>   qualunque egress, da `BggHostDenyList` — nel validator e di nuovo nell'handler come difesa in
+>   profondità (ADR-059 §5 / ban #2123). Non è più il gate-licenza a fermarli "di fatto": è un
+>   rifiuto esplicito, e dal #3583 conta anche sul counter `meepleai_egress_blocked_total`
+>   con reason `denylist_hit`.
+> - **Re-upload BGG server-to-server** (`POST /admin/shared-games/{id}/bgg-cover`, #3590 Slice B):
+>   **consentito** per ADR-059 §2. Non accetta un URL — la sorgente è l'immagine che BGG dichiara
+>   per il `BggId` del gioco — quindi non è una via per aggirare la deny-list, ma un canale
+>   separato e sanzionato.
 
 ## 5. Slicing (decomposizione consigliata)
 

--- a/docs/superpowers/plans/2026-08-06-egress-observability-reasons.md
+++ b/docs/superpowers/plans/2026-08-06-egress-observability-reasons.md
@@ -1,0 +1,904 @@
+# Egress observability reasons (#3583) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rendere visibili su `meepleai_egress_blocked_total` tre esiti di egress che oggi falliscono chiusi in silenzio — fallimento DNS, rifiuto del decoder immagine, hit sulla deny-list BGG.
+
+**Architecture:** Nessun cambio di comportamento: ogni percorso già rifiuta correttamente. Si aggiunge una `RecordEgressBlocked` immediatamente **prima** del throw esistente, con i soli due tag bounded `{sink, reason}`. Il `sink` è sempre noto al chiamante, mai al componente generico: per questo `decode_fail` viene wirato ai call site alimentati da rete e non dentro `WebpVariantGenerator`. In coda, lo split dell'alert Prometheus separa `denylist_hit` (violazione di policy) da `private_ip` (incidente SSRF).
+
+**Tech Stack:** .NET 9, xUnit + FluentAssertions + Moq, `System.Diagnostics.Metrics` (`MeterListener`), Prometheus + promtool.
+
+## Global Constraints
+
+- I tag delle metriche egress sono **esclusivamente** `sink` e `reason`, entrambi costanti da `MeepleAiMetrics.EgressSinks` / `MeepleAiMetrics.EgressBlockReasons`. Un host o un IP non è **mai** un tag (cardinalità illimitata + leak del target).
+- Ogni `RecordEgressBlocked` va **prima** del `throw`, e il throw resta invariato: nessuna eccezione viene inghiottita, nessun esito cambia.
+- La cancellazione iniziata dal chiamante non è un fallimento di egress e non va contata.
+- I test asseriscono selezionando la misurazione **per tag**, mai assumendo che la finestra di cattura sia esclusiva: il `MeterListener` è process-wide e xUnit esegue le classi in parallelo (regressione già occorsa in #3495 Slice D).
+- Working dir dei comandi: `D:/Repositories/meepleai-monorepo-main/.claude/worktrees/i3583`. Branch: `feature/issue-3583-egress-observability-reasons`.
+- Comando test di riferimento (da `apps/api`): `dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "<filtro>"`.
+
+## File Structure
+
+| File | Responsabilità | Azione |
+|---|---|---|
+| `apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.Egress.cs` | Costanti bounded delle reason | Modifica: aggiunge `DnsFailure` |
+| `apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPinnedConnect.cs` | Chokepoint connect-pin | Modifica: try/catch sulla risoluzione |
+| `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandler.cs` | Cover manuale da URL admin | Modifica: `decode_fail` + `denylist_hit` |
+| `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandValidator.cs` | Gate di boundary del path manuale | Modifica: `denylist_hit` |
+| `.../Commands/EnrichCatalogCover/EnrichCatalogCoverCommandHandler.cs` | Enrichment Wikidata/Commons | Modifica: `decode_fail` |
+| `apps/api/tests/Api.Tests/Observability/MetricCapture.cs` | Helper condiviso di cattura misurazioni | **Crea** |
+| `apps/api/tests/Api.Tests/Observability/EgressMetricsTests.cs` | Test del chokepoint | Modifica: usa l'helper, aggiunge i test DNS |
+| `.../Commands/SetManualCoverCommandHandlerTests.cs` | Test handler manuale | Modifica: test `decode_fail` |
+| `.../EnrichCatalogCover/EnrichCatalogCoverCommandHandlerTests.cs` | Test handler enrichment | Modifica: test `decode_fail` |
+| `.../Commands/SetManualCoverCommandValidatorTests.cs` | Test validator | Modifica: test `denylist_hit` |
+| `infra/prometheus/alerts/egress-guard.yml` | Alert egress | Modifica: split in due regole |
+| `infra/prometheus/alerts/egress-guard.test.yml` | Test promtool | Modifica: casi per le due regole |
+| `infra/prometheus.staging.yml` · `infra/prometheus.prod.yml` | `rule_files:` per ambiente | Modifica: caricano `egress-guard.yml`, oggi assente |
+
+---
+
+### Task 1: reason `dns_failure` sul chokepoint
+
+**Files:**
+- Modify: `apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.Egress.cs:40`
+- Modify: `apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPinnedConnect.cs:30`
+- Create: `apps/api/tests/Api.Tests/Observability/MetricCapture.cs`
+- Modify: `apps/api/tests/Api.Tests/Observability/EgressMetricsTests.cs`
+
+**Interfaces:**
+- Consumes: `IDnsResolver.ResolveAsync(string host, CancellationToken ct) -> Task<IReadOnlyList<IPAddress>>`; `MeepleAiMetrics.RecordEgressBlocked(string sink, string reason)`.
+- Produces: costante `MeepleAiMetrics.EgressBlockReasons.DnsFailure` (valore `"dns_failure"`), usata dai task successivi solo come riferimento di stile. Helper `Api.Tests.Observability.MetricCapture.Capture(string instrumentName, Action act) -> List<(long Value, IReadOnlyDictionary<string, object?> Tags)>`, consumato dai Task 2 e 3.
+
+- [ ] **Step 1: creare l'helper condiviso di cattura**
+
+Crea `apps/api/tests/Api.Tests/Observability/MetricCapture.cs`. È l'estrazione verbatim del metodo `Capture` già presente in `EgressMetricsTests.cs:28-56`, così i test dei Task 2 e 3 (che vivono in altri file) non lo duplicano.
+
+```csharp
+using System.Diagnostics.Metrics;
+
+namespace Api.Tests.Observability;
+
+/// <summary>
+/// Cattura le misurazioni di uno strumento durante l'esecuzione di <paramref name="act"/>.
+/// Estratto da EgressMetricsTests in #3583 perché i test di decode_fail/denylist_hit vivono
+/// nei file dei rispettivi handler/validator.
+/// <para>
+/// ATTENZIONE: il MeterListener è process-wide e xUnit esegue le classi di test in parallelo, per
+/// cui la finestra di cattura può contenere misurazioni di altri test. Chi asserisce DEVE
+/// selezionare la propria misurazione per tag, non assumere che la finestra sia esclusiva.
+/// </para>
+/// </summary>
+internal static class MetricCapture
+{
+    public static List<(long Value, IReadOnlyDictionary<string, object?> Tags)> Capture(
+        string instrumentName, Action act)
+    {
+        var captured = new List<(long, IReadOnlyDictionary<string, object?>)>();
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Name == instrumentName)
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            },
+        };
+        listener.SetMeasurementEventCallback<long>((_, value, tags, _) =>
+        {
+            var dict = new Dictionary<string, object?>(StringComparer.Ordinal);
+            foreach (var t in tags)
+            {
+                dict[t.Key] = t.Value;
+            }
+            captured.Add((value, dict));
+        });
+        listener.Start();
+
+        act();
+
+        return captured;
+    }
+}
+```
+
+- [ ] **Step 2: far usare l'helper a EgressMetricsTests**
+
+In `apps/api/tests/Api.Tests/Observability/EgressMetricsTests.cs`, elimina il metodo privato `Capture` (righe 28-56) e sostituisci le **due** chiamate `Capture(` (righe 63 e 105) con `MetricCapture.Capture(`. Il terzo `[Fact]`, `Counters_HaveStableBoundedNames`, non usa `Capture`.
+
+Rimuovi anche il `using System.Diagnostics.Metrics;` in testa al file: era lì solo per `MeterListener`, che ora vive nell'helper, e resterebbe orfano (IDE0005).
+
+Nessun altro cambiamento: è un refactor meccanico che i test esistenti devono confermare verde.
+
+- [ ] **Step 3: eseguire i test esistenti per provare che il refactor non regredisce**
+
+Da `apps/api`:
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~EgressMetrics"
+```
+
+Atteso: PASS, 3 test.
+
+- [ ] **Step 4: scrivere i due test che falliscono**
+
+Aggiungi in `EgressMetricsTests.cs`, dentro la classe, subito dopo la classe annidata `FakeDnsResolver`:
+
+```csharp
+    private sealed class ThrowingDnsResolver : IDnsResolver
+    {
+        private readonly Exception _toThrow;
+        public ThrowingDnsResolver(Exception toThrow) => _toThrow = toThrow;
+        public Task<IReadOnlyList<IPAddress>> ResolveAsync(string host, CancellationToken ct) =>
+            Task.FromException<IReadOnlyList<IPAddress>>(_toThrow);
+    }
+```
+
+e i due fatti in coda alla classe:
+
+```csharp
+    [Fact]
+    public void ResolveAndValidate_DnsThrows_IncrementsBlocked_WithDnsFailure_AndRethrows()
+    {
+        // Un NXDOMAIN / timeout del resolver: la connessione non avviene (fail-closed corretto), ma
+        // senza questo counter il sink degradato è indistinguibile da un sink inattivo (#3583).
+        var dns = new ThrowingDnsResolver(new System.Net.Sockets.SocketException(11001));
+
+        var captured = MetricCapture.Capture(MeepleAiMetrics.EgressBlocked.Name, () =>
+        {
+            try
+            {
+                SsrfPinnedConnect.ResolveAndValidateAsync(
+                        dns, "nxdomain.example.com", MeepleAiMetrics.EgressSinks.Wikidata, CancellationToken.None)
+                    .GetAwaiter().GetResult();
+                throw new Xunit.Sdk.XunitException("expected the DNS failure to propagate");
+            }
+            catch (System.Net.Sockets.SocketException)
+            {
+                // atteso — il guard registra e RILANCIA senza alterare l'esito
+            }
+        });
+
+        var mine = captured
+            .Where(c => Equals(c.Tags.GetValueOrDefault("sink"), "wikidata")
+                && Equals(c.Tags.GetValueOrDefault("reason"), "dns_failure"))
+            .ToList();
+
+        mine.Should().NotBeEmpty("un fallimento DNS deve essere visibile sul counter di blocco");
+        mine[0].Value.Should().Be(1);
+        captured.Should().AllSatisfy(c => c.Tags.Keys.Should().BeEquivalentTo("sink", "reason"));
+    }
+
+    [Fact]
+    public void ResolveAndValidate_CallerCancellation_DoesNotIncrementBlocked()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var dns = new ThrowingDnsResolver(new OperationCanceledException(cts.Token));
+
+        var captured = MetricCapture.Capture(MeepleAiMetrics.EgressBlocked.Name, () =>
+        {
+            try
+            {
+                SsrfPinnedConnect.ResolveAndValidateAsync(
+                        dns, "cancelled.example.com", MeepleAiMetrics.EgressSinks.Wikimedia, cts.Token)
+                    .GetAwaiter().GetResult();
+                throw new Xunit.Sdk.XunitException("expected the cancellation to propagate");
+            }
+            catch (OperationCanceledException)
+            {
+                // atteso
+            }
+        });
+
+        captured
+            .Where(c => Equals(c.Tags.GetValueOrDefault("sink"), "wikimedia")
+                && Equals(c.Tags.GetValueOrDefault("reason"), "dns_failure"))
+            .Should().BeEmpty("un abort del chiamante non è un fallimento DNS e non va contato");
+    }
+```
+
+Estendi anche l'asserzione sui nomi stabili, in `Counters_HaveStableBoundedNames`. Non solo la costante nuova: dal Task 4 in poi queste stringhe sono un **contratto con i selettori delle regole Prometheus** (`reason="private_ip"`, `reason="denylist_hit"`), quindi un rename della costante renderebbe gli alert silenziosamente morti senza che nessun test se ne accorga.
+
+```csharp
+        MeepleAiMetrics.EgressBlockReasons.DnsFailure.Should().Be("dns_failure");
+        // Pinnati perché sono il selettore delle regole in infra/prometheus/alerts/egress-guard.yml:
+        // rinominarli spegnerebbe gli alert senza rompere nulla in compilazione (#3583).
+        MeepleAiMetrics.EgressBlockReasons.PrivateIp.Should().Be("private_ip");
+        MeepleAiMetrics.EgressBlockReasons.DenylistHit.Should().Be("denylist_hit");
+        MeepleAiMetrics.EgressBlockReasons.DecodeFail.Should().Be("decode_fail");
+```
+
+- [ ] **Step 5: eseguire i test per verificare che falliscano**
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~EgressMetrics"
+```
+
+Atteso: FALLISCE in compilazione, con `'EgressBlockReasons' does not contain a definition for 'DnsFailure'`.
+
+- [ ] **Step 6: aggiungere la costante**
+
+In `MeepleAiMetrics.Egress.cs`, subito dopo `DecodeFail` (riga 40):
+
+```csharp
+        /// <summary>La risoluzione DNS ha lanciato (NXDOMAIN, timeout del resolver, socket error) — #3583.</summary>
+        public const string DnsFailure = "dns_failure";
+```
+
+- [ ] **Step 7: eseguire i test — ora compilano ma il primo fallisce**
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~EgressMetrics"
+```
+
+Atteso: `ResolveAndValidate_DnsThrows_...` FALLISCE su `mine.Should().NotBeEmpty(...)`. `ResolveAndValidate_CallerCancellation_...` passa già (nessuno registra nulla oggi) — è un test di non-regressione, è corretto che sia verde fin da subito.
+
+- [ ] **Step 8: implementare il guard**
+
+In `SsrfPinnedConnect.cs`, sostituisci la riga 30:
+
+```csharp
+        IReadOnlyList<IPAddress> addresses = await dns.ResolveAsync(host, ct).ConfigureAwait(false);
+```
+
+con:
+
+```csharp
+        IReadOnlyList<IPAddress> addresses;
+        try
+        {
+            addresses = await dns.ResolveAsync(host, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException || !ct.IsCancellationRequested)
+        {
+            // #3583 — l'esito era già fail-closed (la connessione non avviene), ma senza questo
+            // counter un sink che degrada per problemi DNS è indistinguibile da un sink inattivo su
+            // meepleai_egress_blocked_total. Registra e RILANCIA: nessun esito cambia.
+            //
+            // Il filtro esclude la cancellazione iniziata dal chiamante — che non è un guasto di
+            // egress — pur continuando a contare un timeout interno del resolver (che si presenta
+            // come OperationCanceledException con un CTS proprio, quindi con `ct` non cancellato).
+            //
+            // Due limiti noti e accettati:
+            //   - se il chiamante cancella e il resolver risponde con SocketException invece che
+            //     OperationCanceledException, il caso viene contato come dns_failure;
+            //   - questo guard gira dentro il ConnectCallback, quindi UNA VOLTA PER CONNESSIONE:
+            //     ogni hop di redirect e ogni nuova connessione del pool incrementa. Il counter va
+            //     letto come rate di fallimenti di dial, MAI come "richieste utente fallite".
+            MeepleAiMetrics.RecordEgressBlocked(sink, MeepleAiMetrics.EgressBlockReasons.DnsFailure);
+            throw;
+        }
+```
+
+- [ ] **Step 9: eseguire i test per verificare che passino**
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~EgressMetrics"
+```
+
+Atteso: PASS, 5 test.
+
+- [ ] **Step 10: verificare che il build non abbia introdotto warning**
+
+Da `apps/api/src/Api`:
+
+```bash
+dotnet build --nologo -v q
+```
+
+Atteso: `Avvisi: 0`, `Errori: 0`.
+
+CA1031 **non** dovrebbe scattare: lo stesso idioma `catch (Exception ex) when (...)` è già in uso in `EnrichCatalogCoverCommandHandler.cs:195` sotto lo stesso `TreatWarningsAsErrors`. Se comparisse comunque un warning, riportalo testualmente invece di sopprimerlo alla cieca.
+
+Nota: questo build copre solo `src/Api`. Gli errori nel progetto di test emergono soltanto con `dotnet test`, già eseguito allo Step 9.
+
+- [ ] **Step 11: commit**
+
+```bash
+git add apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.Egress.cs \
+        apps/api/src/Api/SharedKernel/Infrastructure/Http/SsrfPinnedConnect.cs \
+        apps/api/tests/Api.Tests/Observability/MetricCapture.cs \
+        apps/api/tests/Api.Tests/Observability/EgressMetricsTests.cs
+git commit -m "feat(egress): conta le eccezioni DNS come dns_failure (#3583)"
+```
+
+---
+
+### Task 2: reason `decode_fail` sui due call site di rete
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandler.cs:84-86`
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommandHandler.cs:221`
+- Modify: `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandlerTests.cs`
+- Modify: `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommandHandlerTests.cs`
+
+**Interfaces:**
+- Consumes: `MetricCapture.Capture` (Task 1); `MeepleAiMetrics.EgressBlockReasons.DecodeFail` (già esistente, valore `"decode_fail"`); `ImageProcessingException` da `Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services`.
+- Produces: nulla di consumato da task successivi.
+
+**Perché qui e non in `WebpVariantGenerator`:** il generator non conosce il `sink` e non potrebbe taggare la metrica senza cambiare `IWebpVariantGenerator`; inoltre il suo terzo chiamante — `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/MaterializePdfCoverCommandHandler.cs:77`, nel bounded context **DocumentProcessing**, non in SharedGameCatalog — decodifica un PDF **locale**, dove un decode fallito non è un blocco di egress e falserebbe il rapporto blocked/allowed. Entrambi i rifiuti citati da #3583 — decompression bomb (`WebpVariantGenerator.cs:119-128`) e coder non-raster (`WebpVariantGenerator.cs:100-108`) — risalgono comunque come `ImageProcessingException`, quindi wirare il catch al call site li copre entrambi.
+
+- [ ] **Step 1: scrivere il test che fallisce sul path manuale**
+
+In `SetManualCoverCommandHandlerTests.cs` aggiungi in coda alla classe. Il fixture monta il **vero** `WebpVariantGenerator`, quindi basta far restituire allo stub HTTP un payload non-raster perché il decoder lo rifiuti:
+
+```csharp
+    [Fact]
+    public void Handle_NonRasterPayload_RecordsDecodeFail_OnManualSink()
+    {
+        var game = NewGame();
+        _repository.Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>())).ReturnsAsync(game);
+        // SVG: coder non-raster, rifiutato da DetectRasterFormat prima di raggiungere Magick (#3495 M1).
+        // Lo StubImageHandler dichiara Content-Type: image/png e il fetch non ispeziona i magic bytes,
+        // quindi il payload arriva davvero al decoder.
+        _httpHandler.ImageBytes = System.Text.Encoding.UTF8.GetBytes(
+            "<svg xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"10\" height=\"10\"/></svg>");
+
+        var captured = Api.Tests.Observability.MetricCapture.Capture(
+            MeepleAiMetrics.EgressBlocked.Name,
+            () =>
+            {
+                try
+                {
+                    CreateHandler().Handle(Command(game.Id), CancellationToken.None)
+                        .GetAwaiter().GetResult();
+                    throw new Xunit.Sdk.XunitException(
+                        "expected the decoder to reject the non-raster payload");
+                }
+                catch (ImageProcessingException)
+                {
+                    // atteso — l'handler registra e RILANCIA
+                }
+            });
+
+        captured
+            .Where(c => Equals(c.Tags.GetValueOrDefault("sink"), "manual")
+                && Equals(c.Tags.GetValueOrDefault("reason"), "decode_fail"))
+            .Should().NotBeEmpty("il rifiuto del decoder su un payload scaricato è un blocco di egress");
+    }
+```
+
+Il metodo è volutamente `void` e non `async Task`: non c'è nulla da attendere, e `MetricCapture.Capture` accetta una `Action` sincrona. Lo stile `try/catch` + `GetAwaiter().GetResult()` è lo stesso del Task 1 — evita di mescolare due idiomi e, se `Handle` lanciasse un'eccezione diversa da quella attesa, produce un messaggio d'errore che punta al tipo sbagliato invece di far esplodere l'assertion dentro la lambda con una diagnostica fuorviante.
+
+Aggiungi in testa al file i `using` mancanti:
+
+```csharp
+using Api.Observability;
+```
+
+- [ ] **Step 2: eseguire il test per verificare che fallisca**
+
+Da `apps/api`:
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~SetManualCoverCommandHandlerTests.Handle_NonRasterPayload_RecordsDecodeFail_OnManualSink"
+```
+
+Atteso: FALLISCE su `Should().NotBeEmpty(...)` — l'eccezione risale già correttamente, manca solo il counter.
+
+- [ ] **Step 3: implementare sul path manuale**
+
+In `SetManualCoverCommandHandler.cs` aggiungi `using Api.Observability;` alla lista dei using, poi sostituisci le righe 84-86:
+
+```csharp
+        var webpBytes = await _webpGenerator
+            .GenerateWebpAsync(imageBytes, WebpTargetWidth, WebpTargetHeight, cancellationToken)
+            .ConfigureAwait(false);
+```
+
+con:
+
+```csharp
+        byte[] webpBytes;
+        try
+        {
+            webpBytes = await _webpGenerator
+                .GenerateWebpAsync(imageBytes, WebpTargetWidth, WebpTargetHeight, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (ImageProcessingException)
+        {
+            // #3583 — il payload scaricato è stato rifiutato dal decoder (decompression bomb o coder
+            // non-raster, #3495 M1). Il rifiuto è corretto: qui lo si rende visibile.
+            MeepleAiMetrics.RecordEgressBlocked(
+                MeepleAiMetrics.EgressSinks.Manual, MeepleAiMetrics.EgressBlockReasons.DecodeFail);
+            throw;
+        }
+```
+
+- [ ] **Step 4: eseguire il test per verificare che passi**
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~SetManualCoverCommandHandlerTests"
+```
+
+Atteso: PASS, tutti i test della classe.
+
+- [ ] **Step 5: scrivere il test che fallisce sul path enrichment**
+
+In `EnrichCatalogCoverCommandHandlerTests.cs`, il test esistente `Handle_ImageProcessingError_ReturnsFailedImageProcessingError` (righe 371-402) copre già l'esito. Aggiungi questo fatto sibling, che riusa il medesimo arrangiamento:
+
+```csharp
+    [Fact]
+    public void Handle_ImageProcessingError_RecordsDecodeFail_OnWikimediaSink()
+    {
+        // Stesso arrangiamento di Handle_ImageProcessingError_ReturnsFailedImageProcessingError.
+        // L'harness monta il VERO WebpVariantGenerator: sono i byte corrotti scaricati da Commons a
+        // farlo fallire (DetectRasterFormat -> null), non un mock che lancia.
+        var harness = BuildHarness();
+        var game = BuildGame(qid: TestQid);
+        harness.RepoMock
+            .Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(game);
+        harness.WikidataHandler.SparqlJson = BuildSparqlImageResponse(TestFilename);
+        harness.CommonsHandler.LicenseJson = BuildImageInfoResponse("CC0");
+        harness.CommonsHandler.ImageBytes = new byte[] { 0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE };
+
+        EnrichCatalogCoverResult? result = null;
+        var captured = Api.Tests.Observability.MetricCapture.Capture(
+            MeepleAiMetrics.EgressBlocked.Name,
+            () => result = harness.Sut
+                .Handle(new EnrichCatalogCoverCommand(game.Id), CancellationToken.None)
+                .GetAwaiter().GetResult());
+
+        // L'handler CATTURA ImageProcessingException e ritorna Failed: nessuna eccezione esce,
+        // quindi qui NON serve try/catch (a differenza del path manuale del Task 2 Step 1).
+        result.Should().BeOfType<EnrichCatalogCoverResult.Failed>();
+
+        captured
+            .Where(c => Equals(c.Tags.GetValueOrDefault("sink"), "wikimedia")
+                && Equals(c.Tags.GetValueOrDefault("reason"), "decode_fail"))
+            .Should().NotBeEmpty("il rifiuto del decoder su un'immagine Commons è un blocco di egress");
+    }
+```
+
+- [ ] **Step 6: eseguire il test per verificare che fallisca**
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~EnrichCatalogCoverCommandHandlerTests.Handle_ImageProcessingError_RecordsDecodeFail_OnWikimediaSink"
+```
+
+Atteso: FALLISCE su `Should().NotBeEmpty(...)`.
+
+- [ ] **Step 7: implementare sul path enrichment**
+
+In `EnrichCatalogCoverCommandHandler.cs`, dentro il `catch (ImageProcessingException ex)` già presente alla riga 221, come **prima** istruzione del blocco:
+
+```csharp
+            // #3583 — il payload scaricato da Commons è stato rifiutato dal decoder. L'esito
+            // (Failed/image_processing) resta invariato; qui si aggiunge la visibilità su egress.
+            MeepleAiMetrics.RecordEgressBlocked(
+                MeepleAiMetrics.EgressSinks.Wikimedia, MeepleAiMetrics.EgressBlockReasons.DecodeFail);
+```
+
+Il file ha già `using Api.Observability;` — non aggiungerlo.
+
+- [ ] **Step 8: eseguire i test per verificare che passino**
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~EnrichCatalogCoverCommandHandlerTests|FullyQualifiedName~SetManualCoverCommandHandlerTests"
+```
+
+Atteso: PASS.
+
+- [ ] **Step 9: commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandler.cs \
+        apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommandHandler.cs \
+        apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandlerTests.cs \
+        apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommandHandlerTests.cs
+git commit -m "feat(egress): conta i rifiuti del decoder come decode_fail (#3583)"
+```
+
+---
+
+### Task 3: reason `denylist_hit` sui due gate della deny-list BGG
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandValidator.cs:27`
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandler.cs:73`
+- Modify: `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandValidatorTests.cs`
+- Modify: `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandlerTests.cs`
+
+**Interfaces:**
+- Consumes: `MetricCapture.Capture` (Task 1); `BggHostDenyList.IsBanned(string? url) -> bool`; `MeepleAiMetrics.EgressBlockReasons.DenylistHit` (già esistente, valore `"denylist_hit"`).
+- Produces: nulla di consumato da task successivi.
+
+**Perché entrambi i gate:** sono mutuamente esclusivi — se il validator rifiuta, l'handler non gira — quindi una richiesta conta esattamente una volta. Il gate del validator cattura il caso reale (admin che incolla un URL BGG); quello dell'handler cattura la difesa in profondità (un percorso che raggiunge l'handler saltando la pipeline FluentValidation). Wirarne uno solo lascerebbe cieco l'altro.
+
+- [ ] **Step 1: scrivere il test che fallisce sul validator**
+
+In `SetManualCoverCommandValidatorTests.cs` aggiungi in coda alla classe, usando l'idioma già in uso nel file (`_validator.TestValidate(Valid() with { … })`, non `new SetManualCoverCommand(...)` + `.Validate(...)`):
+
+```csharp
+    [Fact]
+    public void Validate_BggHost_RecordsDenylistHit_OnManualSink()
+    {
+        // NOTA: il file contiene già Fails_WhenSourceUrlIsBannedBggHost con 5 [InlineData], ognuna
+        // delle quali emetterà una misurazione {manual, denylist_hit}. La finestra di MetricCapture è
+        // process-wide: asserire NotBeEmpty, MAI un conteggio esatto.
+        var captured = Api.Tests.Observability.MetricCapture.Capture(
+            MeepleAiMetrics.EgressBlocked.Name,
+            () => _validator
+                .TestValidate(Valid() with { SourceUrl = "https://cf.geekdo-images.com/abc/cover.jpg" })
+                .ShouldHaveValidationErrorFor(x => x.SourceUrl));
+
+        captured
+            .Where(c => Equals(c.Tags.GetValueOrDefault("sink"), "manual")
+                && Equals(c.Tags.GetValueOrDefault("reason"), "denylist_hit"))
+            .Should().NotBeEmpty("un tentativo di aggirare il ban BGG deve essere visibile");
+    }
+```
+
+Aggiungi in testa al file, se assenti:
+
+```csharp
+using Api.Observability;
+```
+
+- [ ] **Step 2: eseguire il test per verificare che fallisca**
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~SetManualCoverCommandValidatorTests.Validate_BggHost_RecordsDenylistHit_OnManualSink"
+```
+
+Atteso: FALLISCE su `Should().NotBeEmpty(...)` — il rifiuto avviene già, manca il counter.
+
+- [ ] **Step 3: implementare sul validator**
+
+In `SetManualCoverCommandValidator.cs` aggiungi `using Api.Observability;`, sostituisci la riga 27:
+
+```csharp
+            .Must(url => !BggHostDenyList.IsBanned(url))
+```
+
+con:
+
+```csharp
+            .Must(url => !IsBannedAndRecorded(url))
+```
+
+e aggiungi il metodo privato accanto a `BeAbsoluteHttps`:
+
+```csharp
+    /// <summary>
+    /// #3583 — registra l'hit sulla deny-list ADR-059 §5 prima di far fallire la regola, così un
+    /// tentativo ripetuto di laundering attorno al ban BGG è visibile su
+    /// <c>meepleai_egress_blocked_total</c>. Il predicato conserva la semantica originale:
+    /// ritorna true quando l'URL è bandito (quindi la regola `Must(!…)` fallisce).
+    /// <para>
+    /// PRECONDIZIONE per la correttezza del conteggio: questo predicato viene valutato ESATTAMENTE
+    /// una volta per richiesta. Oggi è vero perché (a) il cascade rule-level è il default `Continue`
+    /// e la catena su SourceUrl esegue questo Must una sola volta, e (b) il validator è invocato solo
+    /// dal <c>ValidationBehavior</c> di MediatR, una volta per comando. È una garanzia EMERGENTE, non
+    /// protetta da un test: un secondo <c>IValidator&lt;SetManualCoverCommand&gt;</c> registrato, o un
+    /// endpoint filter che validi prima di MediatR, farebbero raddoppiare il counter in silenzio.
+    /// </para>
+    /// </summary>
+    private static bool IsBannedAndRecorded(string? url)
+    {
+        if (!BggHostDenyList.IsBanned(url))
+        {
+            return false;
+        }
+
+        MeepleAiMetrics.RecordEgressBlocked(
+            MeepleAiMetrics.EgressSinks.Manual, MeepleAiMetrics.EgressBlockReasons.DenylistHit);
+        return true;
+    }
+```
+
+- [ ] **Step 4: eseguire i test del validator per verificare che passino**
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~SetManualCoverCommandValidatorTests"
+```
+
+Atteso: PASS, tutti i test della classe (i test esistenti sul rifiuto BGG devono restare verdi: la semantica del predicato non cambia).
+
+- [ ] **Step 5: implementare sul gate difensivo dell'handler**
+
+In `SetManualCoverCommandHandler.cs` (che dopo il Task 2 ha già `using Api.Observability;`), sostituisci le righe 73-77:
+
+```csharp
+        if (BggHostDenyList.IsBanned(command.SourceUrl))
+        {
+            throw new ArgumentException(
+                "SourceUrl host is banned by ADR-059 §5 (BGG/geekdo assets).", nameof(command));
+        }
+```
+
+con:
+
+```csharp
+        if (BggHostDenyList.IsBanned(command.SourceUrl))
+        {
+            // #3583 — raggiungibile solo se un percorso salta la pipeline FluentValidation (il
+            // validator rifiuta prima). Mutuamente esclusivo con il gate del validator, quindi una
+            // richiesta conta una volta sola.
+            MeepleAiMetrics.RecordEgressBlocked(
+                MeepleAiMetrics.EgressSinks.Manual, MeepleAiMetrics.EgressBlockReasons.DenylistHit);
+            throw new ArgumentException(
+                "SourceUrl host is banned by ADR-059 §5 (BGG/geekdo assets).", nameof(command));
+        }
+```
+
+- [ ] **Step 5b: scrivere ed eseguire il test del gate difensivo dell'handler**
+
+La spec chiede test su validator **e** handler. `SetManualCoverCommandHandlerTests.cs` non contiene oggi alcun test con un URL BGG, quindi senza questo il ramo modificato allo Step 5 resta non eseguito. Aggiungi in coda alla classe:
+
+```csharp
+    [Fact]
+    public void Handle_BggHost_RecordsDenylistHit_AndNeverFetches()
+    {
+        // Gate difensivo: raggiungibile solo saltando la pipeline FluentValidation, quindi qui si
+        // invoca l'handler direttamente. Deve rifiutare PRIMA di qualunque egress.
+        var game = NewGame();
+        _repository.Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>())).ReturnsAsync(game);
+        var banned = Command(game.Id) with { SourceUrl = "https://cf.geekdo-images.com/abc/cover.jpg" };
+
+        var captured = Api.Tests.Observability.MetricCapture.Capture(
+            MeepleAiMetrics.EgressBlocked.Name,
+            () =>
+            {
+                try
+                {
+                    CreateHandler().Handle(banned, CancellationToken.None).GetAwaiter().GetResult();
+                    throw new Xunit.Sdk.XunitException("expected the ADR-059 deny-list to reject the host");
+                }
+                catch (ArgumentException)
+                {
+                    // atteso
+                }
+            });
+
+        captured
+            .Where(c => Equals(c.Tags.GetValueOrDefault("sink"), "manual")
+                && Equals(c.Tags.GetValueOrDefault("reason"), "denylist_hit"))
+            .Should().NotBeEmpty("anche il gate difensivo deve essere visibile");
+    }
+```
+
+Se `StubImageHandler` espone un contatore di richieste, asserisci anche che sia rimasto a zero: il rifiuto deve precedere il fetch. Se non lo espone, non aggiungerlo solo per questo — il `catch (ArgumentException)` prova già che il flusso si è fermato al gate.
+
+Esegui:
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~SetManualCoverCommandHandlerTests"
+```
+
+Atteso: PASS.
+
+- [ ] **Step 6: eseguire la suite delle aree toccate**
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~EgressMetrics|FullyQualifiedName~EgressHostAllowList|FullyQualifiedName~BggHostDenyList|FullyQualifiedName~WebpVariantGenerator|FullyQualifiedName~SsrfPolicy|FullyQualifiedName~SetManualCover|FullyQualifiedName~EnrichCatalogCover"
+```
+
+Atteso: PASS, 0 falliti. Il baseline pre-modifica su questi filtri (senza `SetManualCover`/`EnrichCatalogCover`) era 119 passati / 0 falliti.
+
+- [ ] **Step 7: commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandValidator.cs \
+        apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandler.cs \
+        apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandValidatorTests.cs \
+        apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandlerTests.cs
+git commit -m "feat(egress): conta gli hit sulla deny-list BGG come denylist_hit (#3583)"
+```
+
+---
+
+### Task 4: split dell'alert Prometheus
+
+**Files:**
+- Modify: `infra/prometheus/alerts/egress-guard.yml`
+- Modify: `infra/prometheus/alerts/egress-guard.test.yml`
+- Modify: `infra/prometheus.staging.yml`
+- Modify: `infra/prometheus.prod.yml`
+
+**Interfaces:**
+- Consumes: la serie `meepleai_egress_blocked_total{sink,reason}` ora popolata anche con `reason="denylist_hit"` (Task 3).
+- Produces: due alert distinti, `EgressBlockedManualSensitive` (invariato nel nome, ristretto a `private_ip`) e `EgressDenylistHit` (nuovo, `severity: warning`).
+
+**Perché:** `egress-guard.yml:18` tratta oggi `private_ip|denylist_hit` come un unico incidente P1 con SLO=0. Dal Task 3 in poi il ramo `denylist_hit` diventa raggiungibile: senza questo split, un admin che incolla un URL BGG — errore di policy, non tentativo di raggiungere un target interno — farebbe scattare un P1. Con il carve-out BGG previsto da #3590 il caso diventerà più frequente, non meno.
+
+Attenzione a non fraintendere la portata attuale: quel P1 oggi esiste **solo in dev**, perché `egress-guard.yml` non è referenziato nei `rule_files:` di staging e prod (vedi Step 3b, che lo corregge). Lo split resta comunque necessario proprio perché lo Step 3b accende quelle regole nei due ambienti dove finora tacevano.
+
+- [ ] **Step 1: aggiornare le regole**
+
+In `egress-guard.yml`, sostituisci la riga 18 (`expr:` di `EgressBlockedManualSensitive`) restringendola a `private_ip`:
+
+```yaml
+        expr: (sum(rate(meepleai_egress_blocked_total{sink="manual",reason="private_ip"}[5m])) or vector(0)) > 0
+```
+
+aggiorna le due annotazioni della stessa regola perché non citino più `denylist_hit`:
+
+```yaml
+          summary: "Manual-cover SSRF attempt blocked (sink=manual, private_ip)"
+          description: "meepleai_egress_blocked_total incremented for sink=manual with reason private_ip: an admin-supplied manual-cover URL resolved to an internal/reserved address. SLO for this metric is ZERO; any nonzero rate is a P1 SSRF incident (#3495)."
+```
+
+e aggiungi in coda al blocco `rules:` la nuova regola:
+
+```yaml
+      - alert: EgressDenylistHit
+        # #3583 — separata da EgressBlockedManualSensitive: un hit sulla deny-list ADR-059 §5 è una
+        # violazione di POLICY (un URL BGG/geekdo nel campo cover manuale), non un tentativo di
+        # raggiungere un target interno. Trattarlo come P1 SSRF genererebbe pagine su un errore di
+        # battitura di un admin — tanto più col carve-out BGG server-to-server (#3590).
+        expr: (sum(rate(meepleai_egress_blocked_total{sink="manual",reason="denylist_hit"}[5m])) or vector(0)) > 0
+        for: 0m
+        labels:
+          severity: warning
+          subsystem: egress-policy
+        annotations:
+          summary: "Manual-cover URL rejected by the ADR-059 BGG deny-list (sink=manual)"
+          description: "meepleai_egress_blocked_total incremented for sink=manual with reason denylist_hit: someone submitted a BGG/geekdo asset URL to the manual-cover field, which ADR-059 §5 bans. A one-off is an admin mistake; a sustained rate is an attempt to launder around the ban and warrants review of who is submitting it. The legitimate route for a BGG cover is the admin server-to-server re-upload path, never the arbitrary-URL field."
+          runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-developers/operations/operations-manual.md"
+```
+
+Aggiorna infine il commento di testata (righe 8-10) perché descriva i due segnali separati:
+
+```yaml
+# SLO for the manual (arbitrary-URL) sink hitting private_ip is ZERO: any nonzero rate means an
+# admin-supplied manual-cover URL resolved to an internal/reserved address — a live SSRF attempt.
+# severity=critical pages via the alertmanager critical-alerts route.
+#
+# denylist_hit is tracked SEPARATELY at severity=warning (#3583): it is an ADR-059 §5 policy
+# violation (a BGG/geekdo URL in the manual field), not an internal-target attempt.
+```
+
+- [ ] **Step 2: aggiornare i test promtool**
+
+In `egress-guard.test.yml`, aggiorna il commento del caso 3 (riga 31) e aggiungi due casi. Il caso 3 resta valido così com'è (`size_cap` non è né `private_ip` né `denylist_hit`), cambia solo la dicitura:
+
+```yaml
+  # 3) DOES NOT FIRE for a non-sensitive reason on the manual sink (size_cap is neither rule's reason).
+```
+
+Aggiungi in coda al file:
+
+```yaml
+  # 4) denylist_hit FIRES EgressDenylistHit at warning — and NOT the critical SSRF alert (#3583).
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_egress_blocked_total{sink="manual",reason="denylist_hit"}'
+        values: '0 0 1 1 1 1'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: EgressDenylistHit
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              subsystem: egress-policy
+      - eval_time: 5m
+        alertname: EgressBlockedManualSensitive
+        exp_alerts: []
+
+  # 5) private_ip does NOT cross-trigger the policy alert (its own firing is covered by case 1).
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_egress_blocked_total{sink="manual",reason="private_ip"}'
+        values: '0 0 1 1 1 1'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: EgressDenylistHit
+        exp_alerts: []
+```
+
+- [ ] **Step 3: eseguire promtool per verificare le regole**
+
+Dalla root del worktree:
+
+```bash
+docker run --rm -v "$(pwd)/infra/prometheus/alerts:/work" prom/prometheus:v3.7.0 promtool test rules /work/egress-guard.test.yml
+```
+
+Atteso: `SUCCESS`.
+
+Questo passo è **bloccante**, non una formalità: nessun workflow CI invoca `promtool` (l'header di `egress-guard.test.yml:1` lo dice esplicitamente, e un grep su `.github/workflows/` e `infra/Makefile` non trova nessuna invocazione). Se le regole sono sbagliate, niente le intercetta a valle. Se Docker non è disponibile in questa sessione, **riporta il fatto** invece di dichiarare il passo completato.
+
+- [ ] **Step 3b: caricare le regole in staging e prod**
+
+`egress-guard.yml` è montato in tutti e tre i compose (`docker-compose.yml:358`, `compose.staging.yml:360`, `compose.prod.yml:245`) ma compare in `rule_files:` **soltanto** in `infra/prometheus.yml` (dev). In staging e prod le regole egress non sono mai state caricate: `EgressBlockedManualSensitive` non esiste lì da #3495 M2, e senza questo passo il nuovo `EgressDenylistHit` nascerebbe morto negli stessi ambienti.
+
+Aggiungi in `infra/prometheus.staging.yml` e `infra/prometheus.prod.yml`, nel blocco `rule_files:`, dopo la riga di `bgg-tos-compliance.yml` (stessa posizione che ha in `infra/prometheus.yml`, per tenere le tre liste allineate):
+
+```yaml
+  # #3495 M2 — SSRF egress guard (private_ip = P1) + #3583 policy alert (denylist_hit = warning).
+  # Il file era già montato ma mai referenziato in staging/prod: regole caricate solo da #3583.
+  - '/etc/prometheus/egress-guard.yml'
+```
+
+- [ ] **Step 4: commit**
+
+```bash
+git add infra/prometheus/alerts/egress-guard.yml infra/prometheus/alerts/egress-guard.test.yml \
+        infra/prometheus.staging.yml infra/prometheus.prod.yml
+git commit -m "feat(egress): separa denylist_hit dall'alert P1 SSRF (#3583)"
+```
+
+Nota per il corpo della PR: le regole Prometheus **non si ricaricano al deploy**. Dopo il merge serve un force-recreate del container prometheus su staging perché le nuove regole diventino attive; finché non avviene, la config è a posto ma inerte.
+
+---
+
+### Task 5: verifica finale e PR
+
+**Files:** nessuna modifica di codice.
+
+- [ ] **Step 1: build pulita**
+
+Da `apps/api/src/Api`:
+
+```bash
+dotnet build --nologo -v q
+```
+
+Atteso: `Avvisi: 0`, `Errori: 0`.
+
+- [ ] **Step 2: suite delle aree toccate**
+
+Da `apps/api`:
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~EgressMetrics|FullyQualifiedName~EgressHostAllowList|FullyQualifiedName~BggHostDenyList|FullyQualifiedName~WebpVariantGenerator|FullyQualifiedName~SsrfPolicy|FullyQualifiedName~SetManualCover|FullyQualifiedName~EnrichCatalogCover"
+```
+
+Atteso: 0 falliti. Riporta il conteggio esatto passati/falliti — non "sembra a posto".
+
+- [ ] **Step 3: formattazione backend**
+
+Il pre-commit salta il format backend sulle branch `feature/*`, quindi va lanciato a mano prima della PR. **Dalla root del worktree** (non da `apps/api`: `git diff --name-only` restituisce path relativi alla root, che con un'altra cwd non matcherebbero nulla e produrrebbero un `--include` vuoto):
+
+```bash
+dotnet format apps/api/MeepleAI.Api.sln --include $(git diff --name-only origin/main-dev...HEAD -- '*.cs' | tr '\n' ' ')
+```
+
+**`--include` è obbligatorio**: senza, `dotnet format` applica i fix degli analyzer a tutto il progetto e ha già cancellato costruttori DI usati solo via reflection (S1144), lasciando 3 test rossi per mesi.
+
+Se il comando non modifica nulla, `git status` resta pulito: è l'esito atteso, non un errore.
+
+- [ ] **Step 4: push e apertura PR verso main-dev**
+
+```bash
+git push -u origin feature/issue-3583-egress-observability-reasons
+gh pr create --base main-dev \
+  --title "feat(egress): wire delle reason di osservabilità mancanti (#3583)" \
+  --body "<vedi contenuti obbligatori sotto>"
+```
+
+Il target **deve** essere `main-dev`, mai `main`.
+
+Il corpo della PR deve contenere, oltre a cosa cambia e all'esito di test e promtool:
+
+1. **Le tre deviazioni dal testo dell'issue** e il perché: `decode_fail` sui call site invece che nel generator; split dell'alert `denylist_hit`; nessun allentamento della deny-list.
+2. **Il denominatore del block-ratio si sporca.** `RecordEgressAllowed` è emesso solo dal connect-pin, una volta per connessione TCP validata. Ora `denylist_hit` dal validator incrementa `blocked` **senza** che sia mai avvenuto un tentativo di connessione (nessun `allowed` corrispondente), mentre `decode_fail` incrementa `blocked` **dopo** che la connessione è stata concessa (quindi con un `allowed` già contato per la stessa operazione). Qualunque alert futuro su `blocked/(blocked+allowed)` — il motivo per cui #3495 M2 ha creato `EgressAllowed` — va progettato sapendolo.
+3. **La semantica del counter cambia**: da "connessione rifiutata" a "connessione o payload rifiutati". Le dashboard esistenti su `meepleai_egress_blocked_total` vanno rilette in questa luce.
+4. **`egress-guard.yml` non era caricato in staging né in prod** (bug pre-esistente di #3495 M2, corretto qui): prima di questa PR quegli alert non esistevano fuori dal dev.
+5. **Serve un force-recreate di prometheus su staging** dopo il merge perché le regole diventino attive — il deploy da solo non le ricarica.
+
+---
+
+## Self-Review
+
+**Copertura della spec (sezione PR 1):**
+- §1.1 `dns_failure` → Task 1. ✔
+- §1.2 `decode_fail` sui due call site di rete, con la motivazione della deviazione → Task 2. ✔
+- §1.3 `denylist_hit` sui due gate + split dell'alert → Task 3 (wiring) e Task 4 (alert). ✔
+- §"Test PR 1": unit DNS + cancellazione → Task 1 Step 4; decode_fail nei due sink → Task 2; denylist_hit → Task 3; estensione di `Counters_HaveStableBoundedNames` → Task 1 Step 4; promtool → Task 4 Step 3. ✔
+
+**Scan dei placeholder:** nessuno residuo. Il Task 2 Step 5, che nella prima stesura rimandava genericamente al test sibling, è ora letterale: l'arrangiamento reale (`BuildHarness`, `BuildGame`, i due stub handler, i byte corrotti) è trascritto, ed è chiarito che l'handler **cattura** `ImageProcessingException` e ritorna `Failed` invece di rilanciare — quindi lì non serve `try/catch`, a differenza del path manuale.
+
+**Coerenza dei tipi:** `MetricCapture.Capture(string, Action) -> List<(long Value, IReadOnlyDictionary<string, object?> Tags)>` è definita nel Task 1 Step 1 e usata con la stessa firma nei Task 2 e 3. Le costanti citate esistono tutte: `DecodeFail` e `DenylistHit` già in `MeepleAiMetrics.Egress.cs:31,40`; `DnsFailure` la crea il Task 1 Step 6. `ImageProcessingException` e `BggHostDenyList.IsBanned` sono verificati nel sorgente. Il costruttore posizionale `SetManualCoverCommand(GameId, SourceUrl, License, Attribution, AdminId)` è verificato in `SetManualCoverCommandValidatorTests.cs:22-23`.
+
+**Dipendenza d'ordine:** il Task 3 Step 5 assume che il Task 2 abbia già aggiunto `using Api.Observability;` a `SetManualCoverCommandHandler.cs`. Eseguendo i task fuori ordine non compila — vanno eseguiti in sequenza.
+
+## Trovato durante la review — fuori scope di questa PR
+
+`infra/prometheus/alerts/api-single-instance.yml` (il tripwire `count(up{job="meepleai-api"}) > 1` di #3383 / ADR-087 D4) **non è montato in nessun compose e non compare in nessun `rule_files:`**, dev incluso. Il file esiste e ha il suo test promtool, ma Prometheus non lo carica in alcun ambiente: l'alert che secondo ADR-087 D4 «rende un scale-out rumoroso» — e che è la ragione dichiarata per cui la hard-prevention è stata rinviata — non è mai stato attivo.
+
+Non lo correggo qui perché appartiene a #3383 (PR 2), dove va aggiunto sia il mount nei tre compose sia la riga nei tre `rule_files:`. Va anche riaperta la prima checkbox "Subito" di #3383, oggi spuntata.

--- a/docs/superpowers/plans/2026-08-06-single-pod-enforcement.md
+++ b/docs/superpowers/plans/2026-08-06-single-pod-enforcement.md
@@ -1,0 +1,735 @@
+# Enforcement single-pod enrichment (#3383) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rendere realmente effettivo il vincolo single-pod dell'enrichment Wikidata: accendere il tripwire che non è mai stato caricato, rendere il gauge dead-letter corretto a più pod, e aggiungere la hard-prevention sul batch.
+
+**Architecture:** Tre livelli indipendenti. (1) *Rilevamento*: il tripwire Prometheus va montato e referenziato — oggi il file esiste ma nessun ambiente lo carica. (2) *Correttezza della metrica*: il gauge passa da ibrido (incremento in memoria + ri-ancoraggio giornaliero) a puramente DB-derivato via background service periodico, così a più pod ogni processo riporta lo stesso ground truth. (3) *Prevenzione*: lease Redis fail-closed sul batch, riusando `IBackgroundTaskOrchestrator.ExecuteWithDistributedLockAsync` invece di reimplementare un lock.
+
+**Tech Stack:** .NET 9, Quartz, StackExchange.Redis (via `IBackgroundTaskOrchestrator`), xUnit + FluentAssertions + Moq, Prometheus + promtool.
+
+## Global Constraints
+
+- **Branch impilata**: parte da `feature/issue-3583-egress-observability-reasons` (PR #3596), non da `main-dev`. La PR va aperta con `--base feature/issue-3583-egress-observability-reasons`. Se PR #3596 mergia prima, ribasare su `main-dev` e cambiare la base della PR.
+- Il vincolo single-pod tocca la **correttezza legale** (rate cap Wikimedia 5 RPS, DEC-3e): un secondo pod raddoppia il rate verso Wikidata/Commons. Nessuna modifica deve rendere il vincolo più implicito di com'è ora.
+- Fail-closed significa che un'indisponibilità di Redis **ferma l'enrichment**. È voluto, e va documentato in ADR e runbook.
+- Working dir: `D:/Repositories/meepleai-monorepo-main/.claude/worktrees/i3583`. Branch: `feature/issue-3383-single-pod-enforcement`.
+- Comando test: da `apps/api`, `dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "<filtro>"`.
+- Comando promtool (l'immagine ha `prometheus` come entrypoint; su Git Bash serve `MSYS_NO_PATHCONV=1`):
+  `MSYS_NO_PATHCONV=1 docker run --rm --entrypoint promtool -v "<abs>/infra/prometheus/alerts:/work" prom/prometheus:v3.7.0 test rules /work/<file>.test.yml`
+
+## File Structure
+
+| File | Responsabilità | Azione |
+|---|---|---|
+| `infra/docker-compose.yml` · `infra/compose.staging.yml` · `infra/compose.prod.yml` | Mount delle regole nel container prometheus | Modifica: montano `api-single-instance.yml` |
+| `infra/prometheus.yml` · `.staging.yml` · `.prod.yml` | `rule_files:` per ambiente | Modifica: caricano `api-single-instance.yml` |
+| `.../SharedGameCatalog/Infrastructure/BackgroundJobs/WikidataDeadLetterMetricsRefreshService.cs` | Push periodico del COUNT dead-letter nel gauge | **Crea** |
+| `apps/api/src/Api/Extensions/ApplicationServiceExtensions.cs:130` | Registrazione hosted services | Modifica: registra il refresh service |
+| `.../SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRunner.cs:121` | Runner enrichment | Modifica: rimuove l'incremento ottimistico |
+| `apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.WikidataEnrichment.cs:134-179` | Gauge dead-letter | Modifica: rimuove `IncrementWikidataDeadLetterCount`, aggiorna il commento |
+| `.../SharedGameCatalog/Application/Jobs/WikidataCoverEnrichmentJob.cs:64-76` | Batch Quartz | Modifica: lease Redis attorno al batch |
+| `docs/for-claude/architecture/adr/adr-087-cover-procedure-design-decisions.md:38-44` | ADR D4 | Modifica: corregge l'affermazione sul tripwire, documenta il fail-closed |
+| `docs/for-developers/operations/operations-manual.md` | Runbook | Modifica: sezione su enrichment fermo per Redis |
+| `apps/api/tests/.../WikidataDeadLetterMetricsRefreshServiceTests.cs` | Test refresh service | **Crea** |
+| `apps/api/tests/.../WikidataCoverEnrichmentJobTests.cs` | Test del job | Modifica: casi lease |
+
+---
+
+### Task 1: accendere il tripwire single-instance
+
+**Files:**
+- Modify: `infra/docker-compose.yml:357` (blocco volumes di prometheus)
+- Modify: `infra/compose.staging.yml:359`
+- Modify: `infra/compose.prod.yml:244`
+- Modify: `infra/prometheus.yml` · `infra/prometheus.staging.yml` · `infra/prometheus.prod.yml` (blocco `rule_files:`)
+
+**Interfaces:**
+- Consumes: la regola già scritta in `infra/prometheus/alerts/api-single-instance.yml` e il suo test `api-single-instance.test.yml` (che già dichiara `exp_annotations`).
+- Produces: alert `MultipleApiInstances` effettivamente caricato nei tre ambienti.
+
+**Perché prima di tutto:** ADR-087 D4 rinvia la hard-prevention perché «il tripwire rende un scale-out rumoroso». Il file esiste, ha il suo test promtool, ma **non è montato in nessun compose e non compare in nessun `rule_files:`, dev incluso**: l'alert non è mai stato attivo. È il task più piccolo e quello che ripristina il presupposto dichiarato dell'ADR.
+
+- [ ] **Step 1: verificare lo stato di partenza**
+
+```bash
+grep -rn "api-single-instance" infra/ | grep -v "alerts/api-single-instance"
+```
+
+Atteso: **nessun risultato** (il file non è referenziato da nulla). Se invece compare già da qualche parte, fermati e rileggi: il presupposto di questo task è cambiato.
+
+- [ ] **Step 2: montare il file nei tre compose**
+
+In ciascuno dei tre file, nel blocco `volumes:` del servizio `prometheus`, subito dopo la riga di `egress-guard.yml`, aggiungi:
+
+```yaml
+      - ./prometheus/alerts/api-single-instance.yml:/etc/prometheus/api-single-instance.yml:ro
+```
+
+Righe di riferimento: `infra/docker-compose.yml:358`, `infra/compose.staging.yml:360`, `infra/compose.prod.yml:245`.
+
+- [ ] **Step 3: referenziare il file nei tre `rule_files:`**
+
+In `infra/prometheus.yml`, `infra/prometheus.staging.yml`, `infra/prometheus.prod.yml`, dopo la riga di `egress-guard.yml`:
+
+```yaml
+  # #3373 D4 / #3383 — tripwire single-pod: count(up{job="meepleai-api"}) > 1.
+  # Il file esisteva dal #3373 ma non era montato ne' referenziato in ALCUN ambiente,
+  # quindi l'alert non e' mai stato attivo: era il presupposto dichiarato di ADR-087 D4.
+  - '/etc/prometheus/api-single-instance.yml'
+```
+
+- [ ] **Step 4: validare con promtool**
+
+Dalla root del worktree:
+
+```bash
+MSYS_NO_PATHCONV=1 docker run --rm --entrypoint promtool \
+  -v "$(pwd)/infra/prometheus/alerts:/work" prom/prometheus:v3.7.0 \
+  test rules /work/api-single-instance.test.yml
+```
+
+Atteso: `SUCCESS`. **Bloccante**: nessun workflow CI invoca promtool. Se Docker non è disponibile, riportalo invece di dichiarare il passo fatto.
+
+- [ ] **Step 5: verificare che i tre config restino YAML validi e contengano la regola**
+
+```bash
+python -c "
+import yaml
+for f in ['infra/prometheus.yml','infra/prometheus.staging.yml','infra/prometheus.prod.yml']:
+    rf = yaml.safe_load(open(f,encoding='utf-8')).get('rule_files',[])
+    assert any('api-single-instance' in r for r in rf), f
+    print(f, 'OK', len(rf), 'rule files')
+"
+```
+
+Atteso: tre righe `OK`.
+
+- [ ] **Step 6: commit**
+
+```bash
+git add infra/docker-compose.yml infra/compose.staging.yml infra/compose.prod.yml \
+        infra/prometheus.yml infra/prometheus.staging.yml infra/prometheus.prod.yml
+git commit -m "fix(observability): carica davvero il tripwire single-pod (#3383)"
+```
+
+---
+
+### Task 2: gauge dead-letter da `COUNT` DB
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/BackgroundJobs/WikidataDeadLetterMetricsRefreshService.cs`
+- Modify: `apps/api/src/Api/Extensions/ApplicationServiceExtensions.cs:130`
+- Modify: `apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.WikidataEnrichment.cs:134-179`
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRunner.cs:121`
+- Create: `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/BackgroundJobs/WikidataDeadLetterMetricsRefreshServiceTests.cs`
+
+**Interfaces:**
+- Consumes: `IWikidataCoverEnrichmentAttemptRepository.CountDeadLettersAsync(CancellationToken) -> Task<int>` (`IWikidataCoverEnrichmentAttemptRepository.cs:53`); `MeepleAiMetrics.SetWikidataDeadLetterCount(int)`.
+- Produces: `WikidataDeadLetterMetricsRefreshService` con `internal Task RefreshOnceAsync(CancellationToken)` pubblicamente testabile.
+- **Rimuove**: `MeepleAiMetrics.IncrementWikidataDeadLetterCount()` — nessun altro chiamante oltre a `WikidataCoverEnrichmentRunner.cs:121` (verificare con grep prima di cancellare).
+
+**Perché DB-COUNT:** oggi il gauge è ibrido — il runner incrementa in memoria a ogni nuovo dead-letter, e `WikidataCoverDeadLetterRetentionJob.cs:92-93` ri-ancora al `COUNT` reale, ma solo **una volta al giorno alle 03:00 UTC**. A più pod ogni processo ha il suo contatore: `sum()` raddoppia, `max()` deriva. Con un refresh periodico da DB ogni pod riporta lo stesso ground truth, quindi `max()` diventa corretto. L'`ObservableGauge` continua a leggere il campo in memoria — **non** interroga il DB a ogni scrape, che è l'anti-pattern segnalato dall'issue.
+
+- [ ] **Step 1: verificare che l'incremento abbia un solo chiamante**
+
+```bash
+grep -rn "IncrementWikidataDeadLetterCount" --include=*.cs apps/api
+```
+
+Atteso: la definizione in `MeepleAiMetrics.WikidataEnrichment.cs`, l'unico uso in `WikidataCoverEnrichmentRunner.cs:121`, più eventuali test. Se compaiono altri chiamanti di produzione, fermati: la rimozione va ripensata.
+
+- [ ] **Step 2: scrivere il test che fallisce**
+
+Crea `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/BackgroundJobs/WikidataDeadLetterMetricsRefreshServiceTests.cs`:
+
+```csharp
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.BackgroundJobs;
+using Api.Observability;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure.BackgroundJobs;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class WikidataDeadLetterMetricsRefreshServiceTests
+{
+    private static (WikidataDeadLetterMetricsRefreshService Sut, Mock<IWikidataCoverEnrichmentAttemptRepository> Repo) Build()
+    {
+        var repo = new Mock<IWikidataCoverEnrichmentAttemptRepository>();
+        var services = new ServiceCollection();
+        services.AddScoped(_ => repo.Object);
+        var provider = services.BuildServiceProvider();
+
+        var sut = new WikidataDeadLetterMetricsRefreshService(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<WikidataDeadLetterMetricsRefreshService>.Instance);
+
+        return (sut, repo);
+    }
+
+    [Fact]
+    public async Task RefreshOnceAsync_PushesTheCountedValueIntoTheGauge()
+    {
+        var (sut, repo) = Build();
+        repo.Setup(r => r.CountDeadLettersAsync(It.IsAny<CancellationToken>())).ReturnsAsync(42);
+
+        await sut.RefreshOnceAsync(CancellationToken.None);
+
+        repo.Verify(r => r.CountDeadLettersAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task RefreshOnceAsync_RepositoryThrows_PropagatesSoTheLoopCanLogAndRetry()
+    {
+        // Il servizio NON deve inghiottire qui: e' il loop di ExecuteAsync a catturare, loggare e
+        // ritentare al tick successivo (stesso contratto di ImpersonationMetricsRefreshService).
+        var (sut, repo) = Build();
+        repo.Setup(r => r.CountDeadLettersAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("db down"));
+
+        var act = async () => await sut.RefreshOnceAsync(CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+}
+```
+
+- [ ] **Step 3: eseguire il test per verificare che fallisca**
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~WikidataDeadLetterMetricsRefreshServiceTests"
+```
+
+Atteso: FALLISCE in compilazione — il tipo `WikidataDeadLetterMetricsRefreshService` non esiste.
+
+- [ ] **Step 4: creare il background service**
+
+Crea `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/BackgroundJobs/WikidataDeadLetterMetricsRefreshService.cs`, modellato su `ImpersonationMetricsRefreshService.cs`:
+
+```csharp
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Observability;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.BackgroundJobs;
+
+/// <summary>
+/// #3383 (ADR-087 D4, task deferito) — ri-ancora periodicamente il gauge
+/// <c>meepleai.wikidata.dead_letter_count</c> al <c>COUNT</c> reale sulla tabella degli attempt.
+/// <para>
+/// Prima di questo servizio il gauge era ibrido: il runner incrementava un contatore in memoria e
+/// il <c>WikidataCoverDeadLetterRetentionJob</c> lo ri-ancorava al ground truth una sola volta al
+/// giorno (03:00 UTC). A più di un'istanza ogni processo aveva il proprio contatore, quindi
+/// <c>sum()</c> raddoppiava e <c>max()</c> derivava. Con un valore puramente DB-derivato ogni
+/// istanza riporta lo stesso ground truth e <c>max()</c> torna corretto.
+/// </para>
+/// <para>
+/// Il gauge continua a leggere il campo in memoria: è QUESTO servizio ad aggiornarlo. Interrogare
+/// il DB dentro la callback dell'<c>ObservableGauge</c> — cioè a ogni scrape Prometheus — sarebbe
+/// l'anti-pattern che l'issue segnala esplicitamente.
+/// </para>
+/// </summary>
+internal sealed class WikidataDeadLetterMetricsRefreshService : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<WikidataDeadLetterMetricsRefreshService> _logger;
+    private readonly TimeSpan _refreshInterval = TimeSpan.FromSeconds(60);
+
+    public WikidataDeadLetterMetricsRefreshService(
+        IServiceScopeFactory scopeFactory,
+        ILogger<WikidataDeadLetterMetricsRefreshService> logger)
+    {
+        _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await RefreshOnceAsync(stoppingToken).ConfigureAwait(false);
+            }
+#pragma warning disable CA1031 // Resilience: un refresh fallito non deve abbattere l'host
+            catch (Exception ex)
+#pragma warning restore CA1031
+            {
+                _logger.LogError(ex,
+                    "WikidataDeadLetterMetricsRefreshService: refresh fallito; riprovo al prossimo tick");
+            }
+
+            try
+            {
+                await Task.Delay(_refreshInterval, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // shutdown regolare
+            }
+        }
+    }
+
+    /// <summary>Conta i dead-letter e pusha il valore nel gauge. Esposto per i test.</summary>
+    public async Task RefreshOnceAsync(CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var attempts = scope.ServiceProvider
+            .GetRequiredService<IWikidataCoverEnrichmentAttemptRepository>();
+        var count = await attempts.CountDeadLettersAsync(cancellationToken).ConfigureAwait(false);
+        MeepleAiMetrics.SetWikidataDeadLetterCount(count);
+    }
+}
+```
+
+- [ ] **Step 5: eseguire il test per verificare che passi**
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~WikidataDeadLetterMetricsRefreshServiceTests"
+```
+
+Atteso: PASS, 2 test.
+
+- [ ] **Step 6: registrare il servizio**
+
+In `apps/api/src/Api/Extensions/ApplicationServiceExtensions.cs`, accanto alla riga 130 che registra `ImpersonationMetricsRefreshService`:
+
+```csharp
+        // #3383 — il gauge dead-letter deve essere DB-derivato per restare corretto a >1 istanza.
+        services.AddHostedService<Api.BoundedContexts.SharedGameCatalog.Infrastructure.BackgroundJobs.WikidataDeadLetterMetricsRefreshService>();
+```
+
+- [ ] **Step 7: rimuovere l'incremento ottimistico dal runner**
+
+In `WikidataCoverEnrichmentRunner.cs:121` elimina la chiamata `MeepleAiMetrics.IncrementWikidataDeadLetterCount();` e il commento che la accompagna. Con il refresh a 60s l'incremento in memoria è solo una fonte di drift, ed è ciò che rendeva il gauge scorretto a più pod.
+
+- [ ] **Step 8: rimuovere il metodo ora inutilizzato e aggiornare la documentazione del gauge**
+
+In `MeepleAiMetrics.WikidataEnrichment.cs` elimina `IncrementWikidataDeadLetterCount()` (righe ~175-179) e riscrivi il commento XML del gauge (righe 134-152), che oggi descrive la strategia ibrida ormai superata:
+
+```csharp
+    /// <summary>
+    /// Numero di <c>WikidataCoverEnrichmentAttempt</c> in stato <c>DeadLetter</c> attualmente
+    /// presenti in tabella. Il valore è **puramente DB-derivato** (#3383): il
+    /// <c>WikidataDeadLetterMetricsRefreshService</c> esegue un <c>COUNT</c> ogni 60s e chiama
+    /// <see cref="SetWikidataDeadLetterCount(int)"/>; il <c>WikidataCoverDeadLetterRetentionJob</c>
+    /// ri-ancora anche dopo ogni sweep. Nessun incremento ottimistico in memoria — era la ragione
+    /// per cui il gauge non era corretto a più di un'istanza.
+    ///
+    /// Alerting: vedi infra/prometheus/alerts/wikidata-enrichment.yml
+    /// (WikidataDeadLetterHigh &gt; 100 per 1h, WikidataDeadLetterSpike delta &gt; 50 in 5m).
+    /// </summary>
+```
+
+Mantieni `SetWikidataDeadLetterCount` con l'`Interlocked.Exchange`: è ancora il punto di scrittura, chiamato sia dal refresh service sia dal retention job.
+
+- [ ] **Step 8b: aggiornare i due test che asserivano l'incremento ottimistico**
+
+Verificato: sono esattamente due, e **falliranno di proposito** dopo gli step 7-8. Non sono regressioni da mascherare — il comportamento è cambiato per progetto.
+
+1. `apps/api/tests/Api.Tests/Observability/WikidataEnrichmentMetricsTests.cs:113` —
+   `IncrementWikidataDeadLetterCount_FromAnchor_IncreasesByOnePerCall`: **eliminare il test**, testa un metodo che non esiste più (altrimenti non compila).
+
+2. `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRunnerTests.cs:~256` — ancora il gauge a 5 e asserisce `Be(6)` con motivazione *«F1 hybrid update: runner increments by 1 per persisted DeadLetter attempt»*. Il runner non tocca più il gauge: l'asserzione diventa
+
+```csharp
+        ReadGauge(MeepleAiMetrics.WikidataDeadLetterCount).Should().Be(5,
+            "#3383: il gauge è DB-derivato — il runner NON lo incrementa più; " +
+            "è WikidataDeadLetterMetricsRefreshService a ri-ancorarlo al COUNT reale");
+```
+
+Il test vicino (`~307`, che asserisce `Be(7)` per un Failed non terminale) **resta verde**: quel percorso non incrementava comunque. Aggiorna solo il commento che cita «F1» se menziona l'incremento del runner.
+
+- [ ] **Step 9: eseguire i test delle aree toccate**
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~WikidataDeadLetter|FullyQualifiedName~WikidataCoverEnrichmentRunner|FullyQualifiedName~WikidataEnrichmentMetrics|FullyQualifiedName~WikidataCoverDeadLetterRetentionJob"
+```
+
+Atteso: PASS.
+
+- [ ] **Step 10: build e commit**
+
+```bash
+cd apps/api/src/Api && dotnet build --nologo -v q
+```
+
+Atteso: `Avvisi: 0`, `Errori: 0`.
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/BackgroundJobs/WikidataDeadLetterMetricsRefreshService.cs \
+        apps/api/src/Api/Extensions/ApplicationServiceExtensions.cs \
+        apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.WikidataEnrichment.cs \
+        apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRunner.cs \
+        apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/BackgroundJobs/WikidataDeadLetterMetricsRefreshServiceTests.cs
+git commit -m "feat(enrichment): gauge dead-letter da COUNT DB invece che in memoria (#3383)"
+```
+
+---
+
+### Task 2b: aggregare le regole del gauge dead-letter
+
+**Files:**
+- Modify: `infra/prometheus/alerts/wikidata-enrichment.yml:21-39`
+
+**Interfaces:**
+- Consumes: il gauge ora DB-derivato del Task 2.
+- Produces: `WikidataDeadLetterHigh` / `WikidataDeadLetterSpike` corrette a più istanze.
+
+**Perché il Task 2 da solo è incompleto:** la giustificazione del gauge DB-derivato è «così `max()` diventa corretto a più pod» — ma **le regole non usano `max()`**. Oggi sono `meepleai_wikidata_dead_letter_count > 100` e `delta(meepleai_wikidata_dead_letter_count[5m]) > 50`, senza aggregazione: a N istanze Prometheus vede N serie distinte (una per `instance`) e ciascuna fa scattare il proprio alert → **N notifiche duplicate** per lo stesso backlog. Con il gauge DB-derivato i valori sono identici, quindi `max()` è esatto e collassa i duplicati in uno.
+
+Nota sul comportamento di `delta()`: prima il runner incrementava in tempo reale, ora il valore si aggiorna ogni 60s dal `COUNT`. Su una finestra di 5 minuti restano ~5 punti di refresh, quindi uno spike di +50 viene ancora catturato, con al più 60s di ritardo. Accettabile per un alert con `for: 0m` su finestra di 5m — vale la pena saperlo, non richiede di cambiare la soglia.
+
+- [ ] **Step 1: aggiungere l'aggregazione alle due regole**
+
+In `wikidata-enrichment.yml`, sostituisci le due `expr:`:
+
+```yaml
+        expr: max(meepleai_wikidata_dead_letter_count) > 100
+```
+
+```yaml
+        expr: delta(max(meepleai_wikidata_dead_letter_count)[5m:]) > 50
+```
+
+e aggiungi sopra il gruppo un commento:
+
+```yaml
+# #3383 — le due regole dead-letter aggregano con max(): dal gauge DB-derivato ogni istanza riporta
+# lo stesso COUNT, quindi max() è esatto e collassa le N serie (una per instance) in un solo alert.
+# Senza aggregazione, a più di un'istanza lo stesso backlog notificherebbe N volte.
+```
+
+Attenzione alla sintassi del secondo: `delta()` vuole un range vector, e `max(...)` è un instant vector — serve la **subquery** `[5m:]`, non `[5m]`. Scriverlo come `delta(max(...)[5m])` è un errore di parsing che promtool intercetta.
+
+- [ ] **Step 2: validare con promtool**
+
+```bash
+MSYS_NO_PATHCONV=1 docker run --rm --entrypoint promtool \
+  -v "$(pwd)/infra/prometheus/alerts:/work" prom/prometheus:v3.7.0 \
+  test rules /work/wikidata-enrichment.test.yml
+```
+
+Atteso: `SUCCESS`. Le serie di test sono senza label (`meepleai_wikidata_dead_letter_count` nuda) e le `exp_labels` attese provengono dal blocco `labels:` della regola, quindi `max()` non le cambia: i casi esistenti devono restare verdi senza modifiche. **Se falliscono, non toccare i test per farli passare** — significa che l'espressione è sbagliata.
+
+- [ ] **Step 3: commit**
+
+```bash
+git add infra/prometheus/alerts/wikidata-enrichment.yml
+git commit -m "fix(observability): aggrega con max() le regole dead-letter (#3383)"
+```
+
+---
+
+### Task 3: lease Redis fail-closed sul batch
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Jobs/WikidataCoverEnrichmentJob.cs:64-76`
+- Modify: `apps/api/tests/Api.Tests/.../WikidataCoverEnrichmentJobTests.cs` (trovare il path esatto con `find apps/api/tests -name "WikidataCoverEnrichmentJobTests.cs"`)
+
+**Interfaces:**
+- Consumes: `IBackgroundTaskOrchestrator.ExecuteWithDistributedLockAsync(string lockKey, Func<CancellationToken, Task> taskFactory, TimeSpan lockTimeout, CancellationToken ct) -> Task<bool>` (`IBackgroundTaskOrchestrator.cs:83`, implementata in `RedisBackgroundTaskOrchestrator.cs:211`, registrata singleton in `InfrastructureServiceExtensions.cs:617`).
+- Produces: `WikidataCoverEnrichmentJob` che salta il tick quando il lease non è ottenibile.
+
+**Perché riusare l'orchestrator invece di scrivere un lease nuovo:** `ExecuteWithDistributedLockAsync` fa già esattamente `SET NX PX` + rilascio verificato per valore (così un'istanza non rilascia il lease di un'altra), è già in uso da `AnalyzeRulebookCommandHandler.cs:218`, ed è già **fail-closed** nella sostanza: se il lock non si acquisisce ritorna `false` senza eseguire il task; se Redis è irraggiungibile logga e **rilancia** (`RedisBackgroundTaskOrchestrator.cs:258-263`), quindi il batch non gira comunque. Reimplementare un lease sarebbe duplicazione.
+
+**Verificato in review**: il rilascio è **atomico**, implementato con uno script Lua che confronta il valore prima di cancellare. Non c'è la race del GET+DEL, in cui un'istanza cancella il lease scaduto e riacquisito da un'altra.
+
+Poiché l'orchestrator **rilancia** su Redis irraggiungibile, l'eccezione risale a Quartz. È il comportamento voluto (il tick fallisce rumorosamente anziché girare senza protezione), ma va saputo: comparirà nei log come job fallito, non come tick saltato.
+
+**TTL:** il batch è fino a `BatchSize`=30 giochi con throttle di 1s ciascuno più il lavoro per gioco, quindi può durare minuti. TTL a **10 minuti**, molto sopra la durata attesa: se un'istanza muore a metà batch il lease blocca l'enrichment per al più quel tempo — accettabile, e comunque preferibile a due istanze che raddoppiano il rate verso Wikimedia.
+
+- [ ] **Step 1: leggere il fixture del file di test**
+
+Il file è `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Jobs/WikidataCoverEnrichmentJobTests.cs` (verificato). **Verificato anche l'assunto chiave**: i test esistenti chiamano `RunBatchAsync` 8 volte e `Execute` **zero** volte — quindi mettere il lease in `Execute` non ne rompe nessuno, e il seam di test resta intatto.
+
+Leggi come costruiscono il job e quali mock preparano, per riusare lo stesso stile nei due test nuovi (che invece devono passare da `Execute`, l'unico punto dove vive il lease).
+
+- [ ] **Step 2: scrivere i test che falliscono**
+
+Aggiungi al file di test del job:
+
+```csharp
+    [Fact]
+    public async Task Execute_LeaseNotAcquired_SkipsTheBatch()
+    {
+        // Un'altra istanza tiene il lease: il tick non deve processare nulla (DEC-3e: due istanze
+        // raddoppierebbero il rate verso Wikimedia, violazione ToS).
+        var orchestrator = new Mock<IBackgroundTaskOrchestrator>();
+        orchestrator
+            .Setup(o => o.ExecuteWithDistributedLockAsync(
+                It.IsAny<string>(), It.IsAny<Func<CancellationToken, Task>>(),
+                It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var runner = new Mock<IWikidataCoverEnrichmentRunner>();
+        var job = BuildJobWith(orchestrator.Object, runner.Object, out var context);
+
+        await job.Execute(context);
+
+        runner.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Execute_LeaseAcquired_RunsTheBatchUnderTheLock()
+    {
+        var orchestrator = new Mock<IBackgroundTaskOrchestrator>();
+        Func<CancellationToken, Task>? captured = null;
+        orchestrator
+            .Setup(o => o.ExecuteWithDistributedLockAsync(
+                It.IsAny<string>(), It.IsAny<Func<CancellationToken, Task>>(),
+                It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .Callback<string, Func<CancellationToken, Task>, TimeSpan, CancellationToken>(
+                (_, factory, _, _) => captured = factory)
+            .ReturnsAsync(true);
+
+        var runner = new Mock<IWikidataCoverEnrichmentRunner>();
+        var job = BuildJobWith(orchestrator.Object, runner.Object, out var context);
+
+        await job.Execute(context);
+
+        captured.Should().NotBeNull("il batch deve essere passato all'orchestrator, non eseguito fuori dal lock");
+    }
+```
+
+`BuildJobWith` è un helper da scrivere adattandolo al fixture già presente nel file: costruisce un `ServiceCollection` con i mock di `IWikidataCoverEnrichmentAttemptRepository`, `IWikidataCoverEnrichmentRunner` e `IBackgroundTaskOrchestrator`, ne fa il provider, e istanzia il job più un `IJobExecutionContext` mockato. Se il file di test ha già un helper equivalente, **riusalo** invece di aggiungerne uno secondo.
+
+- [ ] **Step 3: eseguire i test per verificare che falliscano**
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~WikidataCoverEnrichmentJobTests"
+```
+
+Atteso: FALLISCE — il job non risolve ancora `IBackgroundTaskOrchestrator`.
+
+- [ ] **Step 4: implementare il lease**
+
+In `WikidataCoverEnrichmentJob.cs`, sostituisci il corpo di `Execute` (righe 64-76):
+
+```csharp
+    /// <summary>
+    /// TTL del lease. Molto sopra la durata attesa di un tick (fino a <see cref="BatchSize"/> giochi
+    /// con throttle di <see cref="DelayBetweenItemsMs"/>ms ciascuno): se un'istanza muore a metà
+    /// batch, l'enrichment resta fermo al più per questo tempo — preferibile a due istanze che
+    /// raddoppiano il rate verso Wikimedia (DEC-3e, violazione ToS).
+    /// </summary>
+    private static readonly TimeSpan LeaseTtl = TimeSpan.FromMinutes(10);
+
+    private const string LeaseKey = "wikidata-cover-enrichment-batch";
+
+    public async Task Execute(IJobExecutionContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        var ct = context.CancellationToken;
+        _logger.LogDebug("WikidataCoverEnrichmentJob started: FireTime={FireTime}", context.FireTimeUtc);
+
+        using var scope = _serviceProvider.CreateScope();
+
+        var attempts = scope.ServiceProvider.GetRequiredService<IWikidataCoverEnrichmentAttemptRepository>();
+        var runner = scope.ServiceProvider.GetRequiredService<IWikidataCoverEnrichmentRunner>();
+        var orchestrator = scope.ServiceProvider.GetRequiredService<IBackgroundTaskOrchestrator>();
+
+        // #3383 — hard-prevention del vincolo single-pod (ADR-087 D4). [DisallowConcurrentExecution]
+        // garantisce l'unicità solo DENTRO un processo: non impedisce a due istanze di eseguire lo
+        // stesso batch e raddoppiare il rate verso Wikidata/Commons.
+        //
+        // FAIL-CLOSED, e non è gratis: se il lease non si acquisisce il tick viene saltato, e se
+        // Redis è irraggiungibile l'orchestrator rilancia, quindi l'enrichment SI FERMA. È voluto —
+        // si preferisce non arricchire piuttosto che rischiare di violare il rate cap Wikimedia — ma
+        // significa che un'indisponibilità di Redis ferma anche questa pipeline. Vedi il runbook.
+        var acquired = await orchestrator
+            .ExecuteWithDistributedLockAsync(
+                LeaseKey,
+                innerCt => RunBatchAsync(attempts, runner, innerCt),
+                LeaseTtl,
+                ct)
+            .ConfigureAwait(false);
+
+        if (!acquired)
+        {
+            _logger.LogInformation(
+                "WikidataCoverEnrichmentJob: lease '{LeaseKey}' già detenuto da un'altra istanza — tick saltato. " +
+                "Se accade in modo persistente con una sola istanza attiva, il lease è orfano: scadrà entro {TtlMinutes} minuti.",
+                LeaseKey, LeaseTtl.TotalMinutes);
+        }
+    }
+```
+
+Aggiungi il `using` per `IBackgroundTaskOrchestrator` (namespace `Api.Infrastructure.BackgroundTasks`).
+
+- [ ] **Step 5: eseguire i test per verificare che passino**
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~WikidataCoverEnrichmentJobTests"
+```
+
+Atteso: PASS. I test preesistenti che chiamano `RunBatchAsync` direttamente devono restare verdi senza modifiche.
+
+- [ ] **Step 6: build e commit**
+
+```bash
+cd apps/api/src/Api && dotnet build --nologo -v q
+```
+
+Atteso: `Avvisi: 0`, `Errori: 0`.
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Jobs/WikidataCoverEnrichmentJob.cs \
+        apps/api/tests/Api.Tests/.../WikidataCoverEnrichmentJobTests.cs
+git commit -m "feat(enrichment): lease Redis fail-closed sul batch enrichment (#3383)"
+```
+
+---
+
+### Task 4: correggere ADR-087 D4 e il runbook
+
+**Files:**
+- Modify: `docs/for-claude/architecture/adr/adr-087-cover-procedure-design-decisions.md:38-44`
+- Modify: `docs/for-developers/operations/operations-manual.md` (sezione alert Wikidata enrichment)
+
+**Interfaces:** nessuna — documentazione.
+
+**Perché:** ADR-087 D4 afferma oggi che il tripwire «makes a scale-out **loud**» e che la hard-prevention è deferita di conseguenza. Entrambe le affermazioni vanno aggiornate: il tripwire non era caricato (Task 1) e la hard-prevention ora esiste (Task 3). Lasciare l'ADR com'è significa lasciare a verbale una protezione che non c'era e una decisione che non è più quella in vigore.
+
+- [ ] **Step 1: emendare D4**
+
+In `adr-087-cover-procedure-design-decisions.md`, sotto la sezione `### D4 — Deployment contract: single-pod, presidiato *(ratified)*`, aggiungi in coda:
+
+```markdown
+> **Emendamento 2026-08-06 (#3383).** Due fatti hanno modificato questa decisione.
+>
+> 1. Il tripwire descritto sopra come «Now» **non era mai stato attivo**: il file
+>    `infra/prometheus/alerts/api-single-instance.yml` esisteva, con il suo test promtool, ma non era
+>    montato in alcun compose né referenziato in alcun `rule_files:`, dev incluso. Fra la ratifica di
+>    D4 e oggi il vincolo single-pod è stato presidiato **solo** da `container_name` — esattamente la
+>    situazione che D4 dichiarava inaccettabile. Wiring corretto in #3383.
+> 2. Di conseguenza il rinvio della hard-prevention, motivato dalla presenza del tripwire, non aveva
+>    più fondamento: il **lease Redis fail-closed** sul batch è stato implementato in #3383 e non è
+>    più «deferred». Il gauge dead-letter è ora DB-derivato, quindi corretto sotto `max()` a più
+>    istanze.
+>
+> **Costo del fail-closed, da conoscere prima di un incidente**: il lease non è opzionale, quindi
+> un'indisponibilità di Redis **ferma l'enrichment Wikidata**. È la semantica voluta — non arricchire
+> è preferibile a violare il rate cap Wikimedia — ma va cercata attivamente quando l'enrichment si
+> ferma senza altra spiegazione.
+>
+> Il rate-limiter distribuito (Redis token bucket) resta in riserva per un'eventuale roadmap HPA:
+> lease e tripwire coprono la correttezza a una istanza, non il throughput a N.
+```
+
+- [ ] **Step 2: aggiornare il runbook**
+
+In `docs/for-developers/operations/operations-manual.md`, nella sezione degli alert Wikidata enrichment (quella puntata dal `runbook_url` di `api-single-instance.yml`, ancora `#wikidata-enrichment-alerts`), aggiungi una voce:
+
+```markdown
+#### Enrichment Wikidata fermo senza errori applicativi
+
+Sintomo: `meepleai_wikidata_queue_depth` non cala, nessun nuovo attempt, nessuna eccezione nei log
+dell'handler.
+
+Causa da escludere per prima: **Redis irraggiungibile**. Dal #3383 il batch di enrichment gira sotto
+un lease Redis **fail-closed** (`wikidata-cover-enrichment-batch`, TTL 10 min): se Redis non risponde
+il tick viene saltato di proposito, perché due istanze che processano lo stesso batch
+raddoppierebbero il rate verso Wikidata/Commons (violazione ToS, DEC-3e). L'enrichment fermo è quindi
+un **sintomo atteso** di un'indisponibilità Redis, non un guasto della pipeline cover.
+
+Verifica: stato del container redis, poi cerca nei log dell'API
+`WikidataCoverEnrichmentJob: lease ... già detenuto`. Se il messaggio ricorre con una sola istanza
+attiva, il lease è orfano (istanza morta a metà batch) e scade da solo entro 10 minuti.
+```
+
+- [ ] **Step 3: verificare che i link non si rompano**
+
+```bash
+grep -n "wikidata-enrichment-alerts" docs/for-developers/operations/operations-manual.md infra/prometheus/alerts/api-single-instance.yml
+```
+
+Atteso: l'ancora citata nel `runbook_url` esiste ancora nel manuale. Il gate Docs Link Check fallisce anche su un `<a href=` letterale dentro inline code: non introdurre HTML grezzo nel markdown.
+
+- [ ] **Step 4: commit**
+
+```bash
+git add docs/for-claude/architecture/adr/adr-087-cover-procedure-design-decisions.md \
+        docs/for-developers/operations/operations-manual.md
+git commit -m "docs(adr): emenda D4 — il tripwire non era attivo, il lease non e' piu' deferito (#3383)"
+```
+
+---
+
+### Task 5: verifica finale e PR
+
+**Files:** nessuna modifica di codice.
+
+- [ ] **Step 1: build pulita**
+
+Da `apps/api/src/Api`: `dotnet build --nologo -v q` → `Avvisi: 0`, `Errori: 0`.
+
+- [ ] **Step 2: regressione sulla categoria Unit**
+
+Da `apps/api`:
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "Category=Unit"
+```
+
+Riporta il conteggio esatto passati/falliti. Il baseline su questa branch (dopo PR #3596) è **21361 passati, 0 falliti, 23 skipped**: non deve peggiorare.
+
+- [ ] **Step 3: promtool su entrambi i file alert toccati o adiacenti**
+
+```bash
+MSYS_NO_PATHCONV=1 docker run --rm --entrypoint promtool \
+  -v "$(pwd)/infra/prometheus/alerts:/work" prom/prometheus:v3.7.0 \
+  test rules /work/api-single-instance.test.yml /work/egress-guard.test.yml
+```
+
+Atteso: `SUCCESS` per entrambi.
+
+- [ ] **Step 4: formattazione backend**
+
+Dalla root del worktree (non da `apps/api`: i path del git diff sono relativi alla root):
+
+```bash
+dotnet format apps/api/MeepleAI.Api.sln --include $(git diff --name-only feature/issue-3583-egress-observability-reasons...HEAD -- '*.cs' | tr '\n' ' ')
+```
+
+`--include` è obbligatorio: senza, `dotnet format` applica i fix degli analyzer a tutto il progetto e ha già cancellato costruttori DI usati solo via reflection (S1144).
+
+- [ ] **Step 5: push e PR**
+
+```bash
+git push -u origin feature/issue-3383-single-pod-enforcement
+gh pr create --base feature/issue-3583-egress-observability-reasons \
+  --title "feat(enrichment): enforcement single-pod — tripwire, gauge DB-derivato, lease (#3383)" \
+  --body "<vedi contenuti obbligatori sotto>"
+```
+
+**La base è il branch di PR #3596**, non `main-dev`: questa branch è impilata. Se #3596 mergia prima, ribasare su `main-dev` e cambiare la base con `gh pr edit --base main-dev`.
+
+Il corpo della PR deve contenere:
+1. Che il tripwire **non era mai stato attivo** in alcun ambiente, e che questo invalidava il presupposto dichiarato di ADR-087 D4.
+2. Che il gauge passa da ibrido a DB-derivato, e perché questo è ciò che lo rende corretto sotto `max()` a più istanze.
+3. Che il lease è **fail-closed**: un'indisponibilità di Redis ferma l'enrichment. È voluto, ed è documentato in ADR e runbook.
+4. Esito di build, categoria `Unit` e promtool.
+5. Che serve un **force-recreate di prometheus su staging** dopo il merge perché le nuove regole diventino attive.
+
+---
+
+## Self-Review
+
+**Copertura dell'issue #3383:**
+- Checkbox riaperta «tripwire» → Task 1. ✔
+- Deferito «gauge dead-letter da COUNT DB» → Task 2. ✔
+- Deferito «lease Redis fail-closed» → Task 3. ✔
+- «Va corretto ADR-087 D4» (aggiornamento in issue) → Task 4. ✔
+- Rate-limiter distribuito: esplicitamente **fuori scope**, resta in riserva per una roadmap HPA — dichiarato in Task 4 Step 1.
+
+**Scan dei placeholder:** due punti restano deliberatamente adattivi, ed è segnalato sul posto. Task 3 Step 1 chiede di individuare il file di test del job e riusarne il fixture invece di trascrivere un helper che non ho letto; Task 3 Step 2 dice esplicitamente di riusare un helper equivalente se già esiste. Trascrivere a memoria un fixture non verificato produrrebbe codice plausibile ma falso — peggio di un'istruzione esplicita a leggerlo.
+
+**Coerenza dei tipi:** `ExecuteWithDistributedLockAsync(string, Func<CancellationToken, Task>, TimeSpan, CancellationToken) -> Task<bool>` è verificata in `IBackgroundTaskOrchestrator.cs:83`. `CountDeadLettersAsync(CancellationToken) -> Task<int>` è verificata in `IWikidataCoverEnrichmentAttemptRepository.cs:53`. `SetWikidataDeadLetterCount(int)` resta, `IncrementWikidataDeadLetterCount()` viene rimossa dopo aver verificato al Task 2 Step 1 che abbia un solo chiamante di produzione.
+
+**Ordine:** i task sono indipendenti tranne il 4, che documenta ciò che fanno 1 e 3. Il Task 1 va comunque per primo: è il più piccolo e ripristina il presupposto su cui poggia il resto.

--- a/docs/superpowers/plans/2026-08-07-bgg-carveout.md
+++ b/docs/superpowers/plans/2026-08-07-bgg-carveout.md
@@ -1,0 +1,189 @@
+# Carve-out BGG re-upload (#3590 Slice B) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Dare agli admin un trigger per ri-ospitare la cover BGG di un gioco già a catalogo, e chiudere il bug latente che oggi cancella quella cover a ogni update.
+
+**Architecture:** Un comando CQRS dedicato riusa il downloader server-to-server già sanzionato da ADR-059 §2 (`IBggCoverDownloader` + `BggCoverUploadPipeline`), oggi cablato solo alla creazione da PDF. **Non** passa da `SetManualCover`: `BggHostDenyList` resta intatta sul path a URL arbitrario, che è esattamente il suo scopo. Prerequisito: l'aggregato acquisisce `BggCoverR2Key` (oggi assente) e il mapper di persistenza smette di azzerarlo.
+
+**Tech Stack:** .NET 9 + MediatR + EF Core, xUnit/FluentAssertions/Moq.
+
+## Global Constraints
+
+- Branch da `main-dev` aggiornato (le tre PR del lotto sono mergiate).
+- **CQRS**: endpoint con solo `IMediator.Send()`.
+- **ADR-059 §2**: il path server-to-server admin verso BGG è legittimo per *facts* e per il re-hosting di asset lato admin. Il freeze #2123 riguarda le richieste **browser** verso host geekdo e non è toccato.
+- **`BggHostDenyList` NON va allentata.** Se un test o un handler la aggira, il design è sbagliato.
+- Eccezioni: `NotFoundException` (404), `ConflictException` (409) — mai `InvalidOperationException` (500).
+- Working dir: `D:/Repositories/meepleai-monorepo-main/.claude/worktrees/i3583`.
+
+## Scoperta che cambia il piano (verificata in sessione)
+
+`SharedGameRepository.Update()` fa `MapToEntity(aggregato)` + `DbContext.Update(entity)` su **grafo detached**: marca tutte le colonne come Modified. Il mapper **non scrive** `BggCoverR2Key` (e `MapToDomain` non lo legge), quindi:
+
+```
+UPDATE shared_games SET bgg_cover_r2_key = NULL ...
+```
+
+**Provato empiricamente**: un load → `Update()` → `SaveChanges()` azzera una `BggCoverR2Key` preesistente (`Expected "bgg-covers/13/cover", but found <null>`).
+
+Due conseguenze:
+1. È un **bug di perdita dati pre-esistente**, indipendente da questa issue: ogni update di un SharedGame distrugge la cover BGG re-uploadata.
+2. Spiega perché `CreateSharedGameFromPdfCommandHandler:175` scrive direttamente sull'entità EF tracciata scavalcando l'aggregato — era l'unico modo per far sopravvivere il valore.
+
+Senza il Task 1, il carve-out scriverebbe una cover destinata a sparire al primo update.
+
+---
+
+### Task 1: `BggCoverR2Key` nell'aggregato e nel mapper (chiude il bug latente)
+
+**Files:**
+- Modify: `.../SharedGameCatalog/Domain/Aggregates/SharedGame.cs`
+- Modify: `.../SharedGameCatalog/Infrastructure/Repositories/SharedGameRepository.cs` (`MapToDomain` ~riga 382, `MapToEntity` ~riga 452)
+- Create: `apps/api/tests/.../Infrastructure/Repositories/SharedGameRepositoryBggCoverTests.cs`
+
+**Interfaces:**
+- Produces: `SharedGame.BggCoverR2Key` (get) e `SharedGame.SetBggCover(string coverR2Key)`, consumati dal Task 2.
+
+- [ ] **Step 1: test di regressione che fallisce**
+
+```csharp
+[Fact]
+public async Task Update_PreservesBggCoverR2Key()
+{
+    // Regressione: MapToEntity non scriveva BggCoverR2Key e Update() fa un update di grafo
+    // detached (tutte le colonne Modified) → ogni load-modify-save azzerava la cover BGG.
+    await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+    var id = Guid.NewGuid();
+    db.SharedGames.Add(new SharedGameEntity
+    {
+        Id = id, Title = "Probe", Description = "d", Status = 2,
+        CreatedBy = Guid.NewGuid(), CreatedAt = DateTime.UtcNow,
+        ImageUrl = "", ThumbnailUrl = "",
+        BggCoverR2Key = "bgg-covers/13/cover",
+    });
+    await db.SaveChangesAsync();
+    db.ChangeTracker.Clear();
+
+    var repo = new SharedGameRepository(db, Mock.Of<IDomainEventCollector>());
+    var game = await repo.GetByIdAsync(id, CancellationToken.None);
+    repo.Update(game!);
+    await db.SaveChangesAsync();
+    db.ChangeTracker.Clear();
+
+    var after = await db.SharedGames.AsNoTracking().FirstAsync(g => g.Id == id);
+    after.BggCoverR2Key.Should().Be("bgg-covers/13/cover");
+}
+```
+
+`IDomainEventCollector` è in `Api.SharedKernel.Application.Services`.
+
+Aggiungi anche un test su `SetBggCover`: rifiuta stringa vuota (`ArgumentException`), è idempotente sullo stesso valore, aggiorna su valore diverso.
+
+- [ ] **Step 2: eseguire — deve fallire con `found <null>`**
+
+```bash
+cd apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~SharedGameRepositoryBggCoverTests"
+```
+
+- [ ] **Step 3: campo + metodo sull'aggregato**
+
+In `SharedGame.cs`, accanto a `_pdfCoverR2Key`, aggiungi il campo privato, la proprietà pubblica e il metodo modellato **esattamente** su `SetPdfCoverR2Key` (riga ~738):
+
+```csharp
+/// <summary>
+/// Chiave R2 della cover BGG ri-ospitata (layer L2.5). Scritta dal re-upload
+/// server-to-server admin (ADR-059 §2), MAI da un URL arbitrario: quel path è
+/// sbarrato da <c>BggHostDenyList</c> per il ban #2123.
+/// </summary>
+public void SetBggCover(string coverR2Key)
+{
+    if (string.IsNullOrWhiteSpace(coverR2Key))
+        throw new ArgumentException("Cover R2 key cannot be empty", nameof(coverR2Key));
+
+    if (string.Equals(_bggCoverR2Key, coverR2Key, StringComparison.Ordinal))
+        return;
+
+    _bggCoverR2Key = coverR2Key;
+}
+```
+
+Il costruttore/factory di ricostituzione deve accettare `bggCoverR2Key` come gli altri campi cover (parametro opzionale in coda, come `manualCoverR2Key`).
+
+- [ ] **Step 4: mapper bidirezionale**
+
+- `MapToDomain` (~382): aggiungi `bggCoverR2Key: entity.BggCoverR2Key` accanto a `pdfCoverR2Key`.
+- `MapToEntity` (~452): aggiungi `BggCoverR2Key = game.BggCoverR2Key,` accanto a `PdfCoverR2Key`, con il commento che spiega perché ometterlo azzerava la colonna (stesso motivo già annotato per le colonne manual).
+
+- [ ] **Step 5: eseguire — deve passare**
+
+Poi la suite del repository e dei command handler che salvano SharedGame:
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~SharedGameRepository|FullyQualifiedName~CreateSharedGameFromPdf|FullyQualifiedName~SetManualCover"
+```
+
+Attenzione: `CreateSharedGameFromPdfCommandHandler` scrive `entity.BggCoverR2Key` **dopo** `AddAsync` (che ora mappa il campo dall'aggregato, null per un gioco nuovo). L'ordine regge, ma i suoi test devono restare verdi — se uno diventa rosso, è un segnale reale, non da aggirare.
+
+- [ ] **Step 6: commit**
+
+```bash
+git commit -m "fix(catalog): l'aggregato possiede BggCoverR2Key e il mapper non lo azzera (#3590)"
+```
+
+---
+
+### Task 2: comando di re-upload BGG
+
+**Files:**
+- Create: `.../Application/Commands/ReuploadBggCover/ReuploadBggCoverCommand.cs`
+- Create: `.../ReuploadBggCover/ReuploadBggCoverCommandHandler.cs`
+- Create: `.../ReuploadBggCover/ReuploadBggCoverCommandValidator.cs`
+- Create: test dell'handler
+
+**Interfaces:**
+- Consumes: `SharedGame.SetBggCover` (Task 1); `IBggCoverDownloader.DownloadAndUploadAsync(int bggId, string remoteImageUrl, CancellationToken) -> Task<string?>`; `IBggApiService.GetGameDetailsAsync(int bggId, CancellationToken) -> Task<BggGameDetailsDto?>` (ha `ImageUrl`); `ISharedGameRepository`, `IUnitOfWork`.
+- Produces: `ReuploadBggCoverCommand(Guid GameId, Guid AdminId) : ICommand<BggCoverResult>` e `BggCoverResult(string R2Key)`.
+
+**Flusso**: carica il gioco (404 se assente) → 409 se `BggId` è null (non c'è nulla da scaricare) → `GetGameDetailsAsync` per l'`ImageUrl` → 409 se BGG non espone immagine → `DownloadAndUploadAsync` → 409 se ritorna null (il downloader logga e non lancia) → `game.SetBggCover(key)` → `Update` + `SaveChangesAsync` → evict cache come fa `SetManualCoverCommandHandler`.
+
+**Da NON fare**: passare da `SetManualCoverCommand`, allentare `BggHostDenyList`, o reimplementare il download.
+
+Test richiesti:
+- percorso felice → chiave persistita sull'aggregato, `SaveChangesAsync` chiamato una volta;
+- gioco senza `BggId` → `ConflictException`, nessuna chiamata al downloader;
+- gioco inesistente → `NotFoundException`;
+- downloader ritorna null → `ConflictException`, nessuna scrittura sull'aggregato;
+- **non-regressione**: `SetManualCoverCommandValidator` continua a rifiutare un URL geekdo (la deny-list non è stata toccata).
+
+---
+
+### Task 3: endpoint admin
+
+**Files:** `apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogAdminEndpoints.cs`
+
+```csharp
+group.MapPost("/admin/shared-games/{id:guid}/bgg-cover", HandleReuploadBggCover)
+    .RequireAuthorization("AdminOrEditorPolicy")
+    .WithName("ReuploadBggCover")
+    .WithSummary("Re-host the BGG cover for a catalog game (Admin/Editor)")
+    .WithDescription("#3590 — path server-to-server legittimo per ADR-059 §2. NON accetta un URL: la sorgente è l'immagine che BGG espone per il BggId del gioco. Il campo cover manuale a URL libero resta sbarrato verso geekdo dalla deny-list.")
+    .Produces<BggCoverResult>();
+```
+
+L'handler statico prende `Guid id`, `IMediator`, e l'admin id dal contesto utente come fanno gli altri endpoint di mutazione (controlla come `HandleSetManualCover` lo ricava — riusare lo stesso meccanismo, non inventarne uno).
+
+---
+
+### Task 4: aggiornare il doc obsoleto + PR
+
+- `docs/for-developers/specs/2026-08-02-admin-cover-editor-design.md:88` afferma «host BGG non bloccati nel fetch server-side (ADR-059 §2)»: **superato da #3495**, che ha introdotto `BggHostDenyList` sul path manuale. Correggere distinguendo i due path: manuale a URL libero = geekdo **bandito**; re-upload admin dedicato = **consentito**.
+- Corpo PR: la distinzione fra i due path; il bug latente chiuso dal Task 1 (con l'evidenza del test); che la deny-list non è stata allentata.
+
+Verifica finale: build 0/0 · categoria `Unit` senza regressioni · `dotnet format` con `--include` dalla root.
+
+## Self-Review
+
+**Rischio principale**: il Task 1 tocca il mapper di un aggregato centrale. Se un test esistente si rompe, va capito — non aggirato: significherebbe che qualcosa dipendeva dall'azzeramento.
+
+**Fuori scope deliberato**: portare `CreateSharedGameFromPdfCommandHandler` sul nuovo metodo di dominio (l'utente ha scelto di non allargare la PR). Dopo il Task 1 quel path resta corretto: scrive sull'entità tracciata **dopo** che `AddAsync` ha mappato l'aggregato.

--- a/docs/superpowers/plans/2026-08-07-cover-gap-view.md
+++ b/docs/superpowers/plans/2026-08-07-cover-gap-view.md
@@ -1,0 +1,577 @@
+# Vista cover-gap admin (#3590 Slice A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Dare agli admin un modo per **trovare** i giochi senza cover, raggruppati per causa, e chiudere la deriva di deploy che li ha resi non recuperabili.
+
+**Architecture:** Una query CQRS di sola lettura incrocia `shared_games` (le 4 chiavi cover tutte nulle) con i PDF collegati via la tabella ponte `shared_game_documents`, e deriva una causa per gioco da `cover_generation_status` + `error_category`. Un endpoint admin la espone; una pagina admin la consuma e porta all'editor cover già esistente. In coda, `unstructured-service` entra nella pipeline di deploy.
+
+**Tech Stack:** .NET 9 + MediatR + EF Core, xUnit/FluentAssertions/Moq, Next.js 16 + React Query + Vitest, GitHub Actions.
+
+## Global Constraints
+
+- **Branch impilata** su `feature/issue-3383-single-pod-enforcement` (PR #3597). La PR va aperta con `--base feature/issue-3383-single-pod-enforcement`. Se le PR sotto mergiano prima, ribasare su `main-dev` e correggere la base.
+- **CQRS**: gli endpoint usano SOLO `IMediator.Send()`. Mai iniettare un servizio in un endpoint.
+- `SharedGameEntityConfiguration` ha `HasQueryFilter(e => !e.IsDeleted)`: il filtro soft-delete è **globale**, non riaggiungerlo.
+- `PagedResult<T>` è quello di **`Api.Models`** (`Contracts.cs:586`). Ne esiste un secondo omonimo in `UserLibrary/.../GetUserGamesQuery.cs:69` — non usare quello.
+- `cover_generation_status` e `error_category` sono persistiti come **stringa**, non come enum: confronta con `nameof(...)` o letterali.
+- Policy degli endpoint admin di lettura: `AdminOrEditorPolicy`.
+- MediatR e FluentValidation si auto-registrano per assembly scan (`Program.cs:344-361`): **nessuna registrazione manuale**.
+- Working dir: `D:/Repositories/meepleai-monorepo-main/.claude/worktrees/i3583`. Branch: `feature/issue-3590-cover-gap-and-bgg-carveout`.
+
+## Contesto verificato su staging (2026-08-07)
+
+Numeri reali contro cui validare, dalla verifica documentata in [#3590](https://github.com/meepleAi-app/meepleai-monorepo/issues/3590#issuecomment-5214497502): **160 giochi, 136 con cover, 24 senza**. Il gruppo "PDF oltre il limite" è stato risolto (rebuild dell'immagine `unstructured` stale) e vale 2, non 4, perché due di quei giochi avevano già una cover Wikidata.
+
+## File Structure
+
+| File | Responsabilità | Azione |
+|---|---|---|
+| `.../SharedGameCatalog/Application/Queries/GetCoverGap/GetCoverGapQuery.cs` | Query + DTO monouso | **Crea** |
+| `.../Queries/GetCoverGap/GetCoverGapQueryHandler.cs` | Join + classificazione causa | **Crea** |
+| `.../Queries/GetCoverGap/GetCoverGapQueryValidator.cs` | Bound su paginazione | **Crea** |
+| `apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogAdminEndpoints.cs` | Endpoint admin | Modifica: `GET /admin/shared-games/cover-gap` |
+| `apps/api/tests/.../Queries/GetCoverGap/GetCoverGapQueryHandlerTests.cs` | Test classificazione | **Crea** |
+| `apps/web/src/lib/api/clients/admin/adminCoverClient.ts` | Client admin cover | Modifica: `getCoverGap` |
+| `apps/web/src/lib/api/schemas/admin/admin-cover.schemas.ts` | Schemi Zod | Modifica: schema cover-gap |
+| `apps/web/src/hooks/admin/useCoverGap.ts` | Hook React Query | **Crea** |
+| `apps/web/src/app/admin/(dashboard)/shared-games/cover-gap/page.tsx` | Pagina admin | **Crea** |
+| `.github/workflows/deploy-staging.yml` | Pipeline deploy | Modifica: include `unstructured-service` |
+
+---
+
+### Task 1: query cover-gap con classificazione della causa
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetCoverGap/GetCoverGapQuery.cs`
+- Create: `.../GetCoverGap/GetCoverGapQueryHandler.cs`
+- Create: `.../GetCoverGap/GetCoverGapQueryValidator.cs`
+- Create: `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetCoverGap/GetCoverGapQueryHandlerTests.cs`
+
+**Interfaces:**
+- Consumes: `MeepleAiDbContext.SharedGames` (`DbSet<SharedGameEntity>`), `.SharedGameDocuments` (`DbSet<SharedGameDocumentEntity>`), `.PdfDocuments` (`DbSet<PdfDocumentEntity>`); `Api.Models.PagedResult<T>`; `IQuery<T>` / `IQueryHandler<,>` da `Api.SharedKernel.Application.Interfaces`.
+- Produces: `GetCoverGapQuery(int PageNumber = 1, int PageSize = 20, string? Cause = null) : IQuery<PagedResult<CoverGapGameDto>>` e `CoverGapGameDto(Guid GameId, string Title, int? BggId, string Cause, string? PdfFileName, long? PdfSizeBytes, string? ErrorCategory)`. Consumati dal Task 2 (endpoint) e dal Task 3 (FE).
+
+**Le quattro cause** (stringhe stabili, sono un contratto con il FE e con il filtro `Cause`):
+
+| Valore | Significato | Come si riconosce |
+|---|---|---|
+| `pdf_too_large` | Il PDF eccede il limite del servizio di estrazione | PDF collegato con `ErrorCategory == "PayloadTooLarge"` **oppure** `ProcessingState == "Failed"` con `FileSizeBytes` sopra soglia |
+| `heuristic_rejected` | Nessuna pagina del rulebook è una cover accettabile — **esito corretto** | PDF collegato con `CoverGenerationStatus == "Skipped"` |
+| `no_source` | Nessun PDF collegato e nessuna immagine libera | nessun PDF collegato |
+| `other` | Tutto il resto (PDF in lavorazione, fallimenti non classificati) | fallback |
+
+**Gotcha da rispettare** (verificati):
+- Il gruppo "euristica" si riconosce da `CoverGenerationStatus == "Skipped"` scritto **direttamente sul campo** da `BackfillPdfCoversJob`, non via `PdfDocument.MarkCoverSkipped()` (metodo morto).
+- La relazione PDF→gioco affidabile è la tabella ponte `SharedGameDocuments` (`SharedGameId` + `PdfDocumentId`). `PdfDocumentEntity.SharedGameId` è nullable e popolata solo su alcuni percorsi: **non** usarla come join primario.
+- `ErrorCategory` è `"PayloadTooLarge"` solo dal fix #3589 in poi; i fallimenti precedenti hanno `"Service"` con un messaggio fuorviante. Per questo la causa `pdf_too_large` guarda **anche** la dimensione, non solo la categoria.
+
+- [ ] **Step 1: scrivere il test che fallisce**
+
+Crea il file di test. Usa una `DbContextOptionsBuilder` InMemory come fanno gli altri handler test del contesto (controlla `GetFilteredSharedGamesQueryHandlerTests.cs` per il fixture esatto e riusalo).
+
+```csharp
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class GetCoverGapQueryHandlerTests
+{
+    [Fact]
+    public async Task Handle_GameWithNoCoverAndNoPdf_ClassifiedAsNoSource()
+    {
+        // Arrange: un gioco con tutte e 4 le chiavi cover null e nessun documento collegato.
+        // Assert: Items contiene il gioco con Cause == "no_source".
+    }
+
+    [Fact]
+    public async Task Handle_GameWithSkippedCover_ClassifiedAsHeuristicRejected()
+    {
+        // PDF collegato via SharedGameDocuments con CoverGenerationStatus = "Skipped".
+        // Assert: Cause == "heuristic_rejected".
+    }
+
+    [Fact]
+    public async Task Handle_GameWithPayloadTooLargePdf_ClassifiedAsPdfTooLarge()
+    {
+        // PDF collegato con ErrorCategory = "PayloadTooLarge".
+        // Assert: Cause == "pdf_too_large".
+    }
+
+    [Fact]
+    public async Task Handle_GameWithAnyCoverKey_IsExcluded()
+    {
+        // Quattro giochi, ciascuno con UNA sola chiave valorizzata (pdf/bgg/wikidata/manual).
+        // Assert: Items vuoto — avere una qualsiasi cover esclude dal gap.
+        // Questo test protegge il contratto centrale: la vista elenca SOLO chi non ha NULLA.
+    }
+
+    [Fact]
+    public async Task Handle_FiltersByCause_WhenCauseProvided()
+    {
+        // Due giochi con cause diverse; query con Cause = "no_source".
+        // Assert: torna solo quello.
+    }
+}
+```
+
+Scrivi i corpi per intero seguendo il fixture reale del file di riferimento — non lasciare i commenti come segnaposto.
+
+- [ ] **Step 2: eseguire i test per verificare che falliscano**
+
+```bash
+cd apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~GetCoverGapQueryHandlerTests"
+```
+
+Atteso: FALLISCE in compilazione (i tipi non esistono).
+
+- [ ] **Step 3: creare query, DTO e validator**
+
+`GetCoverGapQuery.cs` — DTO monouso nello stesso file (pattern recente del contesto, es. `GetSeedingStatus`):
+
+```csharp
+using Api.Models;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetCoverGap;
+
+/// <summary>
+/// #3590 — elenca i giochi del catalogo SENZA alcuna cover (tutte e quattro le chiavi nulle),
+/// con la CAUSA per cui la pipeline cover-da-PDF non li copre. Il collo di bottiglia non era
+/// risolvere questi casi — il picker manuale esiste da #3545 — ma TROVARLI: non esisteva alcuna
+/// vista dei giochi senza cover.
+/// </summary>
+/// <param name="Cause">Filtro opzionale su una delle cause note. Null = tutte.</param>
+internal record GetCoverGapQuery(
+    int PageNumber = 1,
+    int PageSize = 20,
+    string? Cause = null) : IQuery<PagedResult<CoverGapGameDto>>;
+
+/// <summary>Un gioco senza cover, con la causa derivata dallo stato dei suoi PDF.</summary>
+internal record CoverGapGameDto(
+    Guid GameId,
+    string Title,
+    int? BggId,
+    string Cause,
+    string? PdfFileName,
+    long? PdfSizeBytes,
+    string? ErrorCategory);
+
+/// <summary>Cause bounded — contratto con il front-end e con il filtro della query.</summary>
+internal static class CoverGapCauses
+{
+    public const string PdfTooLarge = "pdf_too_large";
+    public const string HeuristicRejected = "heuristic_rejected";
+    public const string NoSource = "no_source";
+    public const string Other = "other";
+
+    public static readonly IReadOnlyList<string> All =
+        new[] { PdfTooLarge, HeuristicRejected, NoSource, Other };
+}
+```
+
+`GetCoverGapQueryValidator.cs`:
+
+```csharp
+using FluentValidation;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetCoverGap;
+
+internal sealed class GetCoverGapQueryValidator : AbstractValidator<GetCoverGapQuery>
+{
+    public GetCoverGapQueryValidator()
+    {
+        RuleFor(x => x.PageNumber).GreaterThanOrEqualTo(1);
+        RuleFor(x => x.PageSize).InclusiveBetween(1, 100);
+        RuleFor(x => x.Cause)
+            .Must(c => c is null || CoverGapCauses.All.Contains(c))
+            .WithMessage($"Cause must be one of: {string.Join(", ", CoverGapCauses.All)}");
+    }
+}
+```
+
+- [ ] **Step 4: implementare l'handler**
+
+`GetCoverGapQueryHandler.cs`. Struttura: parti dai giochi con tutte e 4 le chiavi nulle, porta i PDF collegati via la tabella ponte, classifica in memoria dopo la proiezione (la classificazione ha rami che EF non traduce bene, ed è su un insieme piccolo — decine di righe, non migliaia).
+
+```csharp
+public async Task<PagedResult<CoverGapGameDto>> Handle(GetCoverGapQuery request, CancellationToken ct)
+{
+    // Il filtro soft-delete è globale (HasQueryFilter): non va riaggiunto qui.
+    var gapGames = _context.SharedGames
+        .AsNoTracking()
+        .Where(g => string.IsNullOrWhiteSpace(g.PdfCoverR2Key)
+                 && string.IsNullOrWhiteSpace(g.BggCoverR2Key)
+                 && string.IsNullOrWhiteSpace(g.WikidataCoverR2Key)
+                 && string.IsNullOrWhiteSpace(g.ManualCoverR2Key));
+
+    // PDF collegati via la tabella ponte (relazione canonica; PdfDocumentEntity.SharedGameId è
+    // nullable e popolata solo su alcuni percorsi, quindi non è affidabile come join primario).
+    var rows = await (
+        from g in gapGames
+        join sgd in _context.SharedGameDocuments on g.Id equals sgd.SharedGameId into docs
+        from sgd in docs.DefaultIfEmpty()
+        join p in _context.PdfDocuments on sgd.PdfDocumentId equals p.Id into pdfs
+        from p in pdfs.DefaultIfEmpty()
+        select new
+        {
+            g.Id,
+            g.Title,
+            g.BggId,
+            PdfFileName = p != null ? p.FileName : null,
+            PdfSize = p != null ? (long?)p.FileSizeBytes : null,
+            CoverStatus = p != null ? p.CoverGenerationStatus : null,
+            ErrorCategory = p != null ? p.ErrorCategory : null,
+            ProcessingState = p != null ? p.ProcessingState : null,
+        })
+        .ToListAsync(ct)
+        .ConfigureAwait(false);
+
+    // Un gioco può avere più PDF: tieni la riga più informativa per gioco.
+    var classified = rows
+        .GroupBy(r => new { r.Id, r.Title, r.BggId })
+        .Select(grp =>
+        {
+            var best = grp
+                .OrderByDescending(r => Rank(Classify(r.CoverStatus, r.ErrorCategory, r.ProcessingState, r.PdfSize)))
+                .First();
+            var cause = Classify(best.CoverStatus, best.ErrorCategory, best.ProcessingState, best.PdfSize);
+            return new CoverGapGameDto(
+                grp.Key.Id, grp.Key.Title, grp.Key.BggId, cause,
+                best.PdfFileName, best.PdfSize, best.ErrorCategory);
+        })
+        .Where(d => request.Cause is null || d.Cause == request.Cause)
+        .OrderBy(d => d.Cause).ThenBy(d => d.Title)
+        .ToList();
+
+    var total = classified.Count;
+    var items = classified
+        .Skip((request.PageNumber - 1) * request.PageSize)
+        .Take(request.PageSize)
+        .ToList();
+
+    return new PagedResult<CoverGapGameDto>(items, total, request.PageNumber, request.PageSize);
+}
+```
+
+I due helper privati, con le soglie documentate:
+
+```csharp
+/// <summary>
+/// Soglia oltre la quale un fallimento di estrazione si spiega con la dimensione. Allineata al
+/// limite storico del servizio Unstructured (50MB): i fallimenti precedenti al fix #3589 hanno
+/// ErrorCategory "Service" con un messaggio fuorviante ("Failed to connect"), quindi la sola
+/// categoria non basta a riconoscerli.
+/// </summary>
+private const long LargePdfThresholdBytes = 52_428_800;
+
+private static string Classify(string? coverStatus, string? errorCategory, string? processingState, long? sizeBytes)
+{
+    if (coverStatus is null && processingState is null)
+    {
+        return CoverGapCauses.NoSource;
+    }
+
+    if (string.Equals(errorCategory, "PayloadTooLarge", StringComparison.Ordinal)
+        || (string.Equals(processingState, "Failed", StringComparison.Ordinal)
+            && sizeBytes > LargePdfThresholdBytes))
+    {
+        return CoverGapCauses.PdfTooLarge;
+    }
+
+    if (string.Equals(coverStatus, "Skipped", StringComparison.Ordinal))
+    {
+        return CoverGapCauses.HeuristicRejected;
+    }
+
+    return CoverGapCauses.Other;
+}
+
+/// <summary>Precedenza quando un gioco ha più PDF: la causa più azionabile vince.</summary>
+private static int Rank(string cause) => cause switch
+{
+    CoverGapCauses.PdfTooLarge => 3,
+    CoverGapCauses.HeuristicRejected => 2,
+    CoverGapCauses.Other => 1,
+    _ => 0,
+};
+```
+
+Il ctor prende `MeepleAiDbContext` e `ILogger<GetCoverGapQueryHandler>` con le guardie `?? throw new ArgumentNullException(...)`, come gli altri handler del contesto.
+
+- [ ] **Step 5: eseguire i test per verificare che passino**
+
+```bash
+cd apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "FullyQualifiedName~GetCoverGapQueryHandlerTests"
+```
+
+Atteso: PASS, 5 test.
+
+- [ ] **Step 6: commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetCoverGap/ \
+        apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetCoverGap/
+git commit -m "feat(catalog): query cover-gap con classificazione per causa (#3590)"
+```
+
+---
+
+### Task 2: endpoint admin
+
+**Files:**
+- Modify: `apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogAdminEndpoints.cs`
+
+**Interfaces:**
+- Consumes: `GetCoverGapQuery` / `CoverGapGameDto` (Task 1).
+- Produces: `GET /api/v1/admin/shared-games/cover-gap`, consumato dal Task 3.
+
+- [ ] **Step 1: registrare la route**
+
+Accanto alle altre `MapGet` admin (modello: `/admin/shared-games/seeding-status`, righe ~443-447):
+
+```csharp
+group.MapGet("/admin/shared-games/cover-gap", HandleGetCoverGap)
+    .RequireAuthorization("AdminOrEditorPolicy")
+    .WithName("GetCoverGap")
+    .WithSummary("Get catalog games with no cover, grouped by cause (Admin/Editor)")
+    .WithDescription("#3590 — i giochi senza alcuna cover, con la causa per cui la pipeline cover-da-PDF non li copre: pdf_too_large, heuristic_rejected, no_source, other.")
+    .Produces<PagedResult<CoverGapGameDto>>();
+```
+
+La route costante non confligge con `{id:guid}`: il constraint disambigua.
+
+- [ ] **Step 2: aggiungere l'handler statico**
+
+```csharp
+private static async Task<IResult> HandleGetCoverGap(
+    IMediator mediator,
+    [FromQuery] string? cause = null,
+    [FromQuery] int pageNumber = 1,
+    [FromQuery] int pageSize = 20,
+    CancellationToken ct = default)
+{
+    var result = await mediator
+        .Send(new GetCoverGapQuery(pageNumber, pageSize, cause), ct)
+        .ConfigureAwait(false);
+    return Results.Ok(result);
+}
+```
+
+Aggiungi il `using` del namespace `...Application.Queries.GetCoverGap`. **Solo `IMediator`**: nessun servizio iniettato, è la regola CQRS del progetto.
+
+- [ ] **Step 3: build**
+
+```bash
+cd apps/api/src/Api && dotnet build --nologo -v q
+```
+
+Atteso: `Avvisi: 0`, `Errori: 0`.
+
+- [ ] **Step 4: commit**
+
+```bash
+git add apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogAdminEndpoints.cs
+git commit -m "feat(catalog): endpoint admin GET /admin/shared-games/cover-gap (#3590)"
+```
+
+---
+
+### Task 3: pagina admin cover-gap
+
+**Files:**
+- Modify: `apps/web/src/lib/api/schemas/admin/admin-cover.schemas.ts`
+- Modify: `apps/web/src/lib/api/clients/admin/adminCoverClient.ts`
+- Create: `apps/web/src/hooks/admin/useCoverGap.ts`
+- Create: `apps/web/src/app/admin/(dashboard)/shared-games/cover-gap/page.tsx`
+
+**Interfaces:**
+- Consumes: `GET /api/v1/admin/shared-games/cover-gap` (Task 2).
+- Produces: la pagina admin; nessun consumatore a valle.
+
+**Prima di scrivere**: leggi `useCoverCandidates.ts` e `adminCoverClient.ts` per riusarne esattamente lo stile (naming delle query key, forma del client, gestione errori). Non introdurre un secondo stile nella stessa cartella.
+
+- [ ] **Step 1: schema Zod**
+
+In `admin-cover.schemas.ts`, accanto agli schemi esistenti:
+
+```ts
+export const coverGapCauseSchema = z.enum([
+  'pdf_too_large',
+  'heuristic_rejected',
+  'no_source',
+  'other',
+]);
+
+export const coverGapGameSchema = z.object({
+  gameId: z.string().uuid(),
+  title: z.string(),
+  bggId: z.number().nullable(),
+  cause: coverGapCauseSchema,
+  pdfFileName: z.string().nullable(),
+  pdfSizeBytes: z.number().nullable(),
+  errorCategory: z.string().nullable(),
+});
+
+export const coverGapPageSchema = z.object({
+  items: z.array(coverGapGameSchema),
+  total: z.number(),
+  page: z.number(),
+  pageSize: z.number(),
+});
+```
+
+⚠️ Prima di stringere qualunque campo a `required`, verifica la nullability effettiva lato C#: `bggId`, `pdfFileName`, `pdfSizeBytes`, `errorCategory` sono nullable nel DTO, quindi `.nullable()` è corretto e non va tolto.
+
+- [ ] **Step 2: client**
+
+In `adminCoverClient.ts`, seguendo la forma dei metodi già presenti:
+
+```ts
+async getCoverGap(params: { cause?: string; pageNumber?: number; pageSize?: number } = {}) {
+  const search = new URLSearchParams();
+  if (params.cause) search.set('cause', params.cause);
+  if (params.pageNumber) search.set('pageNumber', String(params.pageNumber));
+  if (params.pageSize) search.set('pageSize', String(params.pageSize));
+  const qs = search.toString();
+  return coverGapPageSchema.parse(
+    await apiFetch(`/api/v1/admin/shared-games/cover-gap${qs ? `?${qs}` : ''}`)
+  );
+}
+```
+
+Adatta `apiFetch` al helper realmente usato nel file.
+
+- [ ] **Step 3: hook**
+
+`useCoverGap.ts`, sul modello di `useCoverCandidates.ts`:
+
+```ts
+export function useCoverGap(params: { cause?: string; pageNumber?: number } = {}) {
+  return useQuery({
+    queryKey: ['admin', 'cover-gap', params],
+    queryFn: () => adminCoverClient.getCoverGap(params),
+  });
+}
+```
+
+- [ ] **Step 4: pagina**
+
+`cover-gap/page.tsx`. Requisiti concreti:
+- Tabella dei giochi senza cover: titolo, causa (etichetta leggibile), nome del PDF e dimensione in MB quando presenti.
+- Filtro per causa (le quattro dell'enum + "tutte").
+- Conteggio totale in testa — è il numero che si confronta con la copertura del catalogo.
+- Per ogni riga, un link al gioco su `/shared-games` così l'admin raggiunge l'editor cover esistente (affordance a matita, `AdminCoverEditAffordance`). **Non** duplicare l'editor qui.
+- **Token semantici obbligatori**: `bg-background`, `bg-card`, `text-foreground`, `text-muted-foreground`, `border-border`. Le utility hardcoded (`bg-white`, `text-gray-*`, `bg-slate-*`) sono **errore** ESLint (`local/no-hardcoded-color-utility`).
+- Etichette in italiano, coerenti col resto dell'area admin.
+
+- [ ] **Step 5: qualità FE**
+
+```bash
+cd apps/web && pnpm typecheck && pnpm lint
+```
+
+Atteso: nessun errore. Se `lint:tokens` segnala colori hardcoded, correggi i token — non aggiungere eccezioni.
+
+- [ ] **Step 6: commit**
+
+```bash
+git add apps/web/src/lib/api/schemas/admin/admin-cover.schemas.ts \
+        apps/web/src/lib/api/clients/admin/adminCoverClient.ts \
+        apps/web/src/hooks/admin/useCoverGap.ts \
+        apps/web/src/app/admin/\(dashboard\)/shared-games/cover-gap/page.tsx
+git commit -m "feat(catalog): pagina admin cover-gap (#3590)"
+```
+
+---
+
+### Task 4: unstructured-service nella pipeline di deploy
+
+**Files:**
+- Modify: `.github/workflows/deploy-staging.yml`
+
+**Interfaces:** nessuna — CI.
+
+**Perché è in questa PR:** è la causa per cui i 4 PDF grandi risultavano non recuperabili. Verificato il 2026-08-07: staging girava un'immagine del 31 luglio 13:50 UTC, costruita **un'ora prima** che il commit del limite 50→100MB atterrasse — e le mancavano anche i due commit di region-seeding RAG (#3435, #3565). Il servizio non compare in `deploy-staging.yml` né in alcun workflow di build/publish: appare solo come URL nei test. Si ricostruisce a mano, quindi va alla deriva in silenzio.
+
+- [ ] **Step 1: capire come il deploy tratta i servizi buildati da sorgente**
+
+`deploy-staging.yml` (blocco `SERVICES`, righe ~1092-1130) fa `docker pull` di immagini GHCR per `api`, `web`, `embedding-service`, `reranker-service`. `unstructured-service` nel compose è `build:` da sorgente, quindi **non** ha un'immagine GHCR da pullare: il pattern del pull non si applica tale e quale.
+
+Leggi il blocco per intero prima di modificarlo e scegli l'innesto coerente: o si aggiunge il servizio al passo di build sul VPS, o lo si porta su GHCR come embedding/reranker. La seconda è più pulita ma più grande; la prima è locale a questo workflow.
+
+- [ ] **Step 2: implementare il rilevamento del cambiamento e il rebuild**
+
+Aggiungi un ramo che, quando cambiano i file sotto `apps/unstructured-service/`, ricostruisce e ricrea il servizio sul VPS. Vincoli **non negoziabili**, appresi sul campo:
+
+- **Prune PRIMA del build, non dopo.** L'immagine pesa 10.2GB; il 2026-08-07 il build ha portato il disco dal 74% al **99% (873MB liberi)**. `docker builder prune -f` recupera ~6.5GB.
+- Il compose richiede le variabili immagine (`EMBEDDING_IMAGE`, `RERANKER_IMAGE`, `ORCHESTRATION_IMAGE`, `API_IMAGE`), altrimenti fallisce con `required variable ... is missing a value`. I tag dell'ultimo deploy sono in `/opt/meepleai/repo/infra/DEPLOYMENT.json`.
+- Riusa il gate di spazio disco già presente nel workflow per gli altri servizi AI (c'è un fail-safe con soglia: cercalo e applica lo stesso, non inventarne un altro).
+
+- [ ] **Step 3: validare la sintassi del workflow**
+
+```bash
+python -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-staging.yml',encoding='utf-8')); print('YAML valido')"
+```
+
+Atteso: `YAML valido`. Un errore di sintassi qui rompe **tutti** i deploy, non solo questo servizio.
+
+- [ ] **Step 4: commit**
+
+```bash
+git add .github/workflows/deploy-staging.yml
+git commit -m "fix(ci): unstructured-service entra nella pipeline di deploy (#3590)"
+```
+
+---
+
+### Task 5: verifica finale e PR
+
+- [ ] **Step 1: build backend**
+
+Da `apps/api/src/Api`: `dotnet build --nologo -v q` → `Avvisi: 0`, `Errori: 0`.
+
+- [ ] **Step 2: regressione backend**
+
+Da `apps/api`:
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --nologo -v q --filter "Category=Unit"
+```
+
+Baseline su questa branch: **21364 passati, 0 falliti, 23 skipped**. Riporta il conteggio esatto; non deve peggiorare.
+
+- [ ] **Step 3: qualità frontend**
+
+```bash
+cd apps/web && pnpm typecheck && pnpm lint
+```
+
+- [ ] **Step 4: formattazione backend**
+
+Dalla root del worktree (non da `apps/api`: i path del git diff sono relativi alla root):
+
+```bash
+dotnet format apps/api/MeepleAI.Api.sln --include $(git diff --name-only feature/issue-3383-single-pod-enforcement...HEAD -- '*.cs' | tr '\n' ' ')
+```
+
+- [ ] **Step 5: push e PR**
+
+```bash
+git push -u origin feature/issue-3590-cover-gap-and-bgg-carveout
+gh pr create --base feature/issue-3383-single-pod-enforcement \
+  --title "feat(catalog): vista admin cover-gap + unstructured nel deploy (#3590 Slice A)" \
+  --body "<vedi sotto>"
+```
+
+Il corpo deve contenere: le quattro cause e come si derivano; che il collo di bottiglia era **trovare** i giochi, non risolverli (il picker manuale esiste da #3545); l'esito della verifica staging (24 giochi senza cover, i 4 PDF grandi risolti); che `unstructured-service` non era in alcuna pipeline; e che **Slice B (carve-out BGG) segue in una PR separata**.
+
+---
+
+## Self-Review
+
+**Copertura**: la vista cover-gap (query, endpoint, pagina) copre la parte «trovare i 24» decisa con l'utente; il fix pipeline copre la causa a monte emersa dalla verifica staging. Il **carve-out BGG è deliberatamente fuori** da questo piano: va in Slice B, come concordato, e richiede prima un `SetBggCover` sull'aggregato (oggi assente — l'unico path che scrive `BggCoverR2Key` mutila l'entità EF direttamente, `CreateSharedGameFromPdfCommandHandler:175`).
+
+**Placeholder**: due punti restano volutamente adattivi e sono segnalati sul posto — il fixture InMemory del Task 1 Step 1 (da riusare dal file di riferimento invece di trascriverlo non verificato) e l'innesto del Task 4 Step 2 (il blocco `SERVICES` va letto per intero: `unstructured` non ha immagine GHCR, quindi il pattern del pull non si applica meccanicamente).
+
+**Coerenza dei tipi**: `PagedResult<T>` è quello di `Api.Models`; `CoverGapGameDto` ha gli stessi campi in C#, nello schema Zod e nella pagina; le quattro stringhe di causa sono definite una volta in `CoverGapCauses` e replicate nell'enum Zod — se cambiano, vanno cambiate in entrambi i punti.
+
+**Rischio noto non coperto**: la classificazione avviene in memoria dopo la proiezione. È deliberato (i rami non si traducono bene in SQL, l'insieme è di decine di righe), ma se il catalogo crescesse di ordini di grandezza andrebbe spinta in SQL. Non è un problema oggi con 160 giochi.

--- a/docs/superpowers/specs/2026-08-06-egress-observability-single-pod-cover-gap-design.md
+++ b/docs/superpowers/specs/2026-08-06-egress-observability-single-pod-cover-gap-design.md
@@ -1,0 +1,219 @@
+# Design — osservabilità egress, enforcement single-pod, cover-gap catalogo
+
+**Data**: 2026-08-06
+**Issue**: [#3583](https://github.com/meepleAi-app/meepleai-monorepo/issues/3583), [#3383](https://github.com/meepleAi-app/meepleai-monorepo/issues/3383), [#3590](https://github.com/meepleAi-app/meepleai-monorepo/issues/3590)
+**Base**: `main-dev` @ `d3af99912`
+
+Record di design per un lotto di tre issue indipendenti, consegnate in tre PR separate verso
+`main-dev`. Il documento è committato con la prima PR perché le tre si toccano in un punto: lo
+split dell'alert `denylist_hit` (#3583) è ciò che rende sostenibile il carve-out BGG (#3590).
+
+---
+
+## PR 1 — #3583: reason di osservabilità egress non wired
+
+Tre segnali mancanti su percorsi che **già falliscono chiusi**. Nessuno è un buco di sicurezza:
+l'esito è corretto, manca il contatore che lo rende visibile.
+
+### 1.1 `dns_failure`
+
+`SsrfPinnedConnect.ResolveAndValidateAsync` (`SsrfPinnedConnect.cs:30`) conta il blocco quando la
+risoluzione ritorna zero indirizzi o un indirizzo bloccato, ma se `IDnsResolver.ResolveAsync`
+**lancia** (NXDOMAIN, timeout del resolver, socket error) l'eccezione propaga senza passare da
+`RecordEgressBlocked`. Un sink che degrada per problemi DNS diventa indistinguibile da un sink
+inattivo.
+
+- Nuova costante `EgressBlockReasons.DnsFailure = "dns_failure"` in `MeepleAiMetrics.Egress.cs`.
+- `try/catch` attorno alla risoluzione: registra e **rilancia** (l'esito fail-closed non cambia).
+- L'exception filter esclude la cancellazione del chiamante:
+  `catch (Exception ex) when (ex is not OperationCanceledException || !ct.IsCancellationRequested)`.
+  Un timeout interno del resolver viene contato; un abort del chiamante no.
+- Nessun host/IP nei tag: restano i due soli tag bounded `sink` e `reason`.
+
+### 1.2 `decode_fail` — deviazione motivata dal testo dell'issue
+
+L'issue propone di wirarlo dentro `WebpVariantGenerator`. **Non lo faccio**, per due ragioni
+verificate nel codice:
+
+1. Il generator non conosce il `sink` e non potrebbe taggare la metrica senza cambiarne
+   l'interfaccia (`IWebpVariantGenerator`). Il sink è una proprietà del chiamante, non del codec.
+2. Uno dei tre chiamanti — `MaterializePdfCoverCommandHandler.cs:77` — lavora su un PDF **locale**:
+   lì un decode fallito non è un blocco di egress e conteggiarlo falserebbe il rapporto
+   blocked/allowed.
+
+Wiro invece i due call site alimentati da rete:
+
+| Call site | Sink |
+|---|---|
+| `SetManualCoverCommandHandler.cs:85` | `EgressSinks.Manual` |
+| `EnrichCatalogCoverCommandHandler.cs:221` (ha già il `catch (ImageProcessingException)`) | `EgressSinks.Wikimedia` |
+
+Copre entrambi i rifiuti di `WebpVariantGenerator` citati dall'issue — decompression bomb
+(cap dimensione/megapixel, `WebpVariantGenerator.cs:119-128`) e coder non-raster
+(`DetectRasterFormat` → `null`, `WebpVariantGenerator.cs:100-108`) — perché entrambi risalgono come
+`ImageProcessingException`.
+
+### 1.3 `denylist_hit` + split dell'alert
+
+`BggHostDenyList` ha due call site, mutuamente esclusivi (se il validator rifiuta, l'handler non
+gira): `SetManualCoverCommandValidator.cs:27` e `SetManualCoverCommandHandler.cs:73`
+(defense-in-depth). Wiro entrambi con `sink=manual`; l'esclusività garantisce che una richiesta
+conti una volta sola.
+
+**Il punto non ovvio**: `infra/prometheus/alerts/egress-guard.yml:18` tratta già
+`sink="manual", reason=~"private_ip|denylist_hit"` come **incidente P1 SSRF con SLO=0**. Wirare il
+counter così com'è farebbe scattare un P1 ogni volta che un admin incolla un URL BGG — che è una
+violazione della policy ADR-059 §5, non un tentativo di raggiungere un target interno. Con il
+carve-out BGG di PR 3 gli admin avranno più occasioni di provarci, quindi il falso P1 diventerebbe
+ricorrente.
+
+Separo quindi i due segnali:
+
+- `private_ip` → resta P1 SSRF, SLO=0, invariato.
+- `denylist_hit` → alert distinto `severity: warning`, descritto come violazione della policy
+  ADR-059 (tentativo di laundering attorno al ban BGG), con runbook che punta al carve-out.
+
+`infra/prometheus/alerts/egress-guard.test.yml` va aggiornato in pari passo (i test promtool sono
+parte del gate).
+
+### Test PR 1
+
+- Unit su `ResolveAndValidateAsync`: eccezione DNS → `dns_failure` incrementato + rilancio;
+  cancellazione del chiamante → **nessun** incremento.
+- Unit sui due call site `decode_fail` con il sink atteso.
+- Unit su validator e handler per `denylist_hit`.
+- Estensione di `Counters_HaveStableBoundedNames` (`EgressMetricsTests.cs:120`) alle nuove reason.
+- `promtool test rules` sui file alert modificati.
+
+---
+
+## PR 2 — #3383: enforcement single-pod (D4 di #3373)
+
+I tre punti "Subito" dell'issue sono già a terra e verificati: tripwire
+`infra/prometheus/alerts/api-single-instance.yml` (`count(up{job="meepleai-api"}) > 1`, `for: 5m`),
+commento sul vincolo in `infra/docker-compose*.yml:60`, emendamento DEC-3e in
+`adr-087-cover-procedure-design-decisions.md:38-44`. Restano i due task deferiti.
+
+### 2.1 Gauge dead-letter da `COUNT` DB
+
+Oggi il gauge è ibrido: `WikidataCoverEnrichmentRunner.cs:121` incrementa in memoria a ogni nuovo
+dead-letter, e `WikidataCoverDeadLetterRetentionJob.cs:92-93` ri-ancora al `COUNT` reale dopo lo
+sweep — che gira **una volta al giorno alle 03:00 UTC**. A >1 pod ogni processo ha il suo contatore:
+`sum()` raddoppia, `max()` deriva.
+
+- Nuovo `WikidataDeadLetterMetricsRefreshService : BackgroundService`, sul pattern già in uso di
+  `ImpersonationMetricsRefreshService.cs`: ogni 60s apre uno scope, chiama `CountDeadLettersAsync`
+  e pusha via `SetWikidataDeadLetterCount`.
+- L'`ObservableGauge` continua a leggere il campo in memoria: è il servizio che lo aggiorna. Questo
+  evita l'anti-pattern segnalato dall'issue (query al DB a ogni scrape Prometheus).
+- **Rimuovo** `IncrementWikidataDeadLetterCount` dal runner: con il refresh periodico l'incremento
+  ottimistico diventa solo una fonte di drift, e un valore puramente DB-derivato è esattamente ciò
+  che rende `max()` corretto a più pod (ogni pod riporta lo stesso ground truth).
+- Resilienza come nel precedente: un refresh fallito logga e ritenta al tick successivo, non
+  abbatte l'host.
+
+### 2.2 Lease Redis fail-closed sul batch
+
+`WikidataCoverEnrichmentJob` ha oggi solo `[DisallowConcurrentExecution]`, che è una garanzia
+**intra-processo**: non impedisce a due pod di girare lo stesso batch e raddoppiare il rate verso
+Wikimedia (violazione ToS, DEC-3e).
+
+- Lease su Redis via `IConnectionMultiplexer` (già disponibile nel progetto), `SET NX PX` con TTL
+  maggiore della durata attesa del tick, rilascio in `finally`.
+- **Fail-closed**: se il lease non si acquisisce *o Redis non è raggiungibile*, il tick viene
+  saltato e loggato.
+
+Trade-off da mettere per iscritto, perché non è gratis: fail-closed significa che
+**un'indisponibilità di Redis ferma l'enrichment**. È la semantica di hard-prevention richiesta
+dall'issue — si preferisce non arricchire piuttosto che rischiare di violare il rate cap — ma va
+documentata nell'emendamento ADR-087 e nel runbook, altrimenti a un'incidente Redis nessuno collega
+l'enrichment fermo.
+
+### Test PR 2
+
+- Unit sul refresh service: `RefreshOnceAsync` pusha il valore contato; un'eccezione del repo non
+  propaga fuori dal loop.
+- Unit sul job: lease acquisito → il batch gira; lease non acquisito → batch saltato; Redis in
+  errore → batch saltato (fail-closed), non un'eccezione che risale a Quartz.
+
+---
+
+## PR 3 — #3590: cover-gap catalogo + carve-out BGG
+
+### Premessa: il testo dell'issue è in parte superato
+
+Due assunzioni sono cambiate e vanno corrette nell'issue:
+
+1. **«la via più economica resta sbloccare #3589 e ri-processarli»** — #3589 è chiusa ma ha corretto
+   solo la *classificazione* dell'errore 413 (permanente anziché retriable) e il messaggio
+   fuorviante. L'issue stessa classifica l'innalzamento del limite come «una scelta di capacità, non
+   un bug». Però il default nel codice è **già 100MB** da `0afeb58b8` (#3424, 2026-07-31)
+   — `apps/unstructured-service/src/config/settings.py:17` — mentre staging il 2026-08-06 riportava
+   ancora `exceeds maximum 52428800 bytes` (50MB). `MAX_FILE_SIZE` non è impostato in `infra/`.
+   Ipotesi da verificare: immagine staging stale. Se confermata, i 4 PDF si sbloccano con un
+   redeploy, senza codice nuovo.
+2. **La via BGG è sbarrata, non aperta** — `BggHostDenyList` blocca `geekdo-images.com`,
+   `geekdo.com`, `boardgamegeek.com` sul path manuale in due punti. L'opzione 1 dell'issue non può
+   passare per `SetManualCoverCommand`.
+
+### 3.1 Vista admin cover-gap
+
+Il collo di bottiglia reale non è la mancanza di uno strumento per risolvere, ma la mancanza di un
+modo per **trovare** i giochi da risolvere: non esiste alcuna vista admin dei giochi senza cover, e
+l'unico accesso all'editor è l'affordance a matita in hover sulle card della pagina *pubblica*
+`/shared-games`.
+
+- Query CQRS che incrocia `shared_games.{pdf,bgg,wikidata,manual}_cover_r2_key IS NULL` con
+  `pdf_documents.{cover_generation_status, error_category}` per derivare la causa, nei tre gruppi
+  dell'issue: PDF oltre il limite di dimensione · pagina rifiutata dall'euristica · nessuna sorgente.
+- Endpoint admin + pagina sotto `apps/web/src/app/admin/(dashboard)/shared-games/`, con accesso
+  diretto all'editor cover esistente.
+- **Gotcha da rispettare**: il gruppo "euristica" si riconosce da `cover_generation_status =
+  'Skipped'` scritto **direttamente sul campo** da `BackfillPdfCoversJob`, non via
+  `PdfDocument.MarkCoverSkipped()` (metodo morto).
+
+Il path manuale a valle funziona già end-to-end: il form "Aggiungi copertina da URL" di
+`AdminCoverSourceDialog.tsx` sta fuori dal ramo `candidates.length === 0`, quindi resta usabile
+anche sui giochi con zero candidati — cioè esattamente i 26.
+
+### 3.2 Carve-out BGG re-upload
+
+`BggCoverDownloader` + `BggCoverUploadPipeline` esistono già, sono sanzionati da ADR-059 §2 e sono
+già in uso da `CreateSharedGameFromPdfCommandHandler.cs:123` — ma solo alla **creazione** di uno
+SharedGame da PDF. Non esiste un trigger per un gioco già a catalogo.
+
+Comando/endpoint admin dedicato che riusa quel path, **senza** passare da `SetManualCoverCommand`.
+
+La distinzione è il punto centrale del design: `BggHostDenyList` resta **intatta** sul path a URL
+arbitrario, che è esattamente il suo scopo (impedire a un admin di aggirare il ban incollando un
+URL geekdo nel campo libero). Non è una nuova postura legale né un allentamento: è un trigger nuovo
+su un path server-to-server già esistente e già sanzionato. Il freeze #2123 riguarda le richieste
+*browser* verso gli host geekdo e non è toccato.
+
+Da aggiornare: `docs/for-developers/specs/2026-08-02-admin-cover-editor-design.md:88` afferma «host
+BGG non bloccati nel fetch server-side (ADR-059 §2)» — affermazione superata da #3495, il doc è
+obsoleto su quel punto.
+
+### Test PR 3
+
+- Unit sulla query cover-gap: classificazione corretta nei tre gruppi, inclusa la riga `Skipped`.
+- Unit sul comando BGG re-upload: gioco senza `bggId` → errore di dominio; percorso felice →
+  chiave R2 attesa; la deny-list resta attiva su `SetManualCover` (test di non-regressione).
+- Test FE sulla pagina cover-gap.
+
+### Fuori PR — verifica ops
+
+SSH allo staging per leggere il limite effettivo di `unstructured-service`; se stale, redeploy e
+retry sui 4 PDF grandi. Esito riportato su #3590.
+
+---
+
+## Note trasversali
+
+- **Branch**: uno per issue, ciascuno da `main-dev` aggiornato, PR sequenziali (1 issue = 1 PR).
+- **Worktree**: `.claude/worktrees/i3583`, da eliminare a merge avvenuto in `main-dev`.
+- **Baseline verificata** su `d3af99912`: build API pulita (0 warning, 0 errori); 119 test passati,
+  0 falliti sui filtri `EgressMetrics|EgressHostAllowList|BggHostDenyList|WebpVariantGenerator|SsrfPolicy`.
+- **Decisioni di #3495 da non riaprire**: facade `IHardenedEgressClient` declinata (E3); four-eyes
+  su `source=Manual` deferita (M7); decode-and-recurse dell'IPv4 embedded è una deviazione
+  deliberata; gli assert H5 sugli invarianti R2 restano gated su #3498.

--- a/infra/compose.prod.yml
+++ b/infra/compose.prod.yml
@@ -243,6 +243,7 @@ services:
       # Issue #3082 — BGG ToS-compliance SLO=0 alert.
       - ./prometheus/alerts/bgg-tos-compliance.yml:/etc/prometheus/bgg-tos-compliance.yml:ro
       - ./prometheus/alerts/egress-guard.yml:/etc/prometheus/egress-guard.yml:ro
+      - ./prometheus/alerts/api-single-instance.yml:/etc/prometheus/api-single-instance.yml:ro
       # Issue #3112 — OPS-02 Slack delivery observability alerts.
       - ./prometheus/alerts/slack-delivery.yml:/etc/prometheus/slack-delivery.yml:ro
       - ./prometheus/alerts/audit-outbox.yml:/etc/prometheus/audit-outbox.yml:ro

--- a/infra/compose.staging.yml
+++ b/infra/compose.staging.yml
@@ -358,6 +358,7 @@ services:
       # Issue #3082 — BGG ToS-compliance SLO=0 alert.
       - ./prometheus/alerts/bgg-tos-compliance.yml:/etc/prometheus/bgg-tos-compliance.yml:ro
       - ./prometheus/alerts/egress-guard.yml:/etc/prometheus/egress-guard.yml:ro
+      - ./prometheus/alerts/api-single-instance.yml:/etc/prometheus/api-single-instance.yml:ro
       # Issue #3112 — OPS-02 Slack delivery observability alerts.
       - ./prometheus/alerts/slack-delivery.yml:/etc/prometheus/slack-delivery.yml:ro
       - ./prometheus/alerts/audit-outbox.yml:/etc/prometheus/audit-outbox.yml:ro

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -356,6 +356,7 @@ services:
       # Issue #3082 — BGG ToS-compliance SLO=0 alert (referenced from prometheus.yml rule_files).
       - ./prometheus/alerts/bgg-tos-compliance.yml:/etc/prometheus/bgg-tos-compliance.yml:ro
       - ./prometheus/alerts/egress-guard.yml:/etc/prometheus/egress-guard.yml:ro
+      - ./prometheus/alerts/api-single-instance.yml:/etc/prometheus/api-single-instance.yml:ro
       # Issue #3112 — OPS-02 Slack delivery alerts (referenced from prometheus.yml rule_files).
       - ./prometheus/alerts/slack-delivery.yml:/etc/prometheus/slack-delivery.yml:ro
       - ./prometheus/alerts/audit-outbox.yml:/etc/prometheus/audit-outbox.yml:ro

--- a/infra/prometheus.prod.yml
+++ b/infra/prometheus.prod.yml
@@ -27,6 +27,9 @@ rule_files:
   - '/etc/prometheus/wikidata-enrichment.yml'
   # Issue #3082 — BGG ToS-compliance SLO=0 alert (any nonzero render attempt = P1).
   - '/etc/prometheus/bgg-tos-compliance.yml'
+  # #3495 M2 — SSRF egress guard (private_ip = P1) + #3583 policy alert (denylist_hit = warning).
+  # Il file era già montato ma mai referenziato in staging/prod: regole caricate solo da #3583.
+  - '/etc/prometheus/egress-guard.yml'
   # Issue #3112 — OPS-02 Slack delivery observability alerts.
   - '/etc/prometheus/slack-delivery.yml'
   # Issue #3116 — SP5 Admin Security audit_outbox health alerts.

--- a/infra/prometheus.prod.yml
+++ b/infra/prometheus.prod.yml
@@ -30,6 +30,10 @@ rule_files:
   # #3495 M2 — SSRF egress guard (private_ip = P1) + #3583 policy alert (denylist_hit = warning).
   # Il file era già montato ma mai referenziato in staging/prod: regole caricate solo da #3583.
   - '/etc/prometheus/egress-guard.yml'
+  # #3373 D4 / #3383 — tripwire single-pod: count(up{job="meepleai-api"}) > 1.
+  # Il file esisteva dal #3373 ma non era montato ne' referenziato in ALCUN ambiente,
+  # quindi l'alert non e' mai stato attivo: era il presupposto dichiarato di ADR-087 D4.
+  - '/etc/prometheus/api-single-instance.yml'
   # Issue #3112 — OPS-02 Slack delivery observability alerts.
   - '/etc/prometheus/slack-delivery.yml'
   # Issue #3116 — SP5 Admin Security audit_outbox health alerts.

--- a/infra/prometheus.staging.yml
+++ b/infra/prometheus.staging.yml
@@ -27,6 +27,9 @@ rule_files:
   - '/etc/prometheus/wikidata-enrichment.yml'
   # Issue #3082 — BGG ToS-compliance SLO=0 alert (any nonzero render attempt = P1).
   - '/etc/prometheus/bgg-tos-compliance.yml'
+  # #3495 M2 — SSRF egress guard (private_ip = P1) + #3583 policy alert (denylist_hit = warning).
+  # Il file era già montato ma mai referenziato in staging/prod: regole caricate solo da #3583.
+  - '/etc/prometheus/egress-guard.yml'
   # Issue #3112 — OPS-02 Slack delivery observability alerts.
   - '/etc/prometheus/slack-delivery.yml'
   # Issue #3116 — SP5 Admin Security audit_outbox health alerts.

--- a/infra/prometheus.staging.yml
+++ b/infra/prometheus.staging.yml
@@ -30,6 +30,10 @@ rule_files:
   # #3495 M2 — SSRF egress guard (private_ip = P1) + #3583 policy alert (denylist_hit = warning).
   # Il file era già montato ma mai referenziato in staging/prod: regole caricate solo da #3583.
   - '/etc/prometheus/egress-guard.yml'
+  # #3373 D4 / #3383 — tripwire single-pod: count(up{job="meepleai-api"}) > 1.
+  # Il file esisteva dal #3373 ma non era montato ne' referenziato in ALCUN ambiente,
+  # quindi l'alert non e' mai stato attivo: era il presupposto dichiarato di ADR-087 D4.
+  - '/etc/prometheus/api-single-instance.yml'
   # Issue #3112 — OPS-02 Slack delivery observability alerts.
   - '/etc/prometheus/slack-delivery.yml'
   # Issue #3116 — SP5 Admin Security audit_outbox health alerts.

--- a/infra/prometheus.yml
+++ b/infra/prometheus.yml
@@ -34,6 +34,10 @@ rule_files:
   - '/etc/prometheus/bgg-tos-compliance.yml'
   # #3495 M2 — SSRF egress guard (manual-cover private_ip/denylist_hit SLO=0).
   - '/etc/prometheus/egress-guard.yml'
+  # #3373 D4 / #3383 — tripwire single-pod: count(up{job="meepleai-api"}) > 1.
+  # Il file esisteva dal #3373 ma non era montato ne' referenziato in ALCUN ambiente,
+  # quindi l'alert non e' mai stato attivo: era il presupposto dichiarato di ADR-087 D4.
+  - '/etc/prometheus/api-single-instance.yml'
   # Issue #3112 — OPS-02 Slack delivery observability alerts.
   - '/etc/prometheus/slack-delivery.yml'
   # Issue #3116 — SP5 Admin Security audit_outbox health alerts.

--- a/infra/prometheus/alerts/egress-guard.test.yml
+++ b/infra/prometheus/alerts/egress-guard.test.yml
@@ -1,6 +1,15 @@
-# promtool test for egress-guard.yml (#3495 M2). NOT run in CI — on-demand only:
-#   docker run --rm -v "$(pwd)/infra/prometheus/alerts:/work" prom/prometheus:v3.7.0 \
-#     promtool test rules /work/egress-guard.test.yml
+# promtool test for egress-guard.yml (#3495 M2). NOT run in CI — on-demand only.
+#
+# L'immagine prom/prometheus ha `prometheus` come entrypoint, quindi promtool va invocato con
+# --entrypoint; su Git Bash serve anche MSYS_NO_PATHCONV=1, altrimenti /work viene riscritto in
+# C:/Program Files/Git/work (#3583 — il comando documentato in origine non funzionava):
+#   MSYS_NO_PATHCONV=1 docker run --rm --entrypoint promtool \
+#     -v "$(pwd)/infra/prometheus/alerts:/work" prom/prometheus:v3.7.0 \
+#     test rules /work/egress-guard.test.yml
+#
+# NOTA (#3583): exp_annotations è OBBLIGATORIO quando exp_alerts non è vuoto — promtool confronta
+# l'intero alert, annotazioni incluse. Questo file era l'unico dei nove a ometterlo, quindi il suo
+# test falliva fin dalla creazione; le annotazioni sotto devono restare allineate a egress-guard.yml.
 rule_files:
   - egress-guard.yml
 evaluation_interval: 1m
@@ -17,6 +26,10 @@ tests:
           - exp_labels:
               severity: critical
               subsystem: egress-ssrf
+            exp_annotations:
+              summary: "Manual-cover SSRF attempt blocked (sink=manual, private_ip)"
+              description: "meepleai_egress_blocked_total incremented for sink=manual with reason private_ip: an admin-supplied manual-cover URL resolved to an internal/reserved address. SLO for this metric is ZERO; any nonzero rate is a P1 SSRF incident (#3495)."
+              runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-developers/operations/operations-manual.md"
 
   # 2) DOES NOT FIRE on cold-start: only an unrelated sink series exists; `or vector(0)` keeps it silent.
   - interval: 1m
@@ -28,7 +41,7 @@ tests:
         alertname: EgressBlockedManualSensitive
         exp_alerts: []
 
-  # 3) DOES NOT FIRE for a non-sensitive reason on the manual sink (size_cap is not private_ip/denylist_hit).
+  # 3) DOES NOT FIRE for a non-sensitive reason on the manual sink (size_cap is neither rule's reason).
   - interval: 1m
     input_series:
       - series: 'meepleai_egress_blocked_total{sink="manual",reason="size_cap"}'
@@ -36,4 +49,37 @@ tests:
     alert_rule_test:
       - eval_time: 5m
         alertname: EgressBlockedManualSensitive
+        exp_alerts: []
+      - eval_time: 5m
+        alertname: EgressDenylistHit
+        exp_alerts: []
+
+  # 4) denylist_hit FIRES EgressDenylistHit at warning — and NOT the critical SSRF alert (#3583).
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_egress_blocked_total{sink="manual",reason="denylist_hit"}'
+        values: '0 0 1 1 1 1'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: EgressDenylistHit
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              subsystem: egress-policy
+            exp_annotations:
+              summary: "Manual-cover URL rejected by the ADR-059 BGG deny-list (sink=manual)"
+              description: "meepleai_egress_blocked_total incremented for sink=manual with reason denylist_hit: someone submitted a BGG/geekdo asset URL to the manual-cover field, which ADR-059 §5 bans. A one-off is an admin mistake; a sustained rate is an attempt to launder around the ban and warrants review of who is submitting it. The legitimate route for a BGG cover is the admin server-to-server re-upload path, never the arbitrary-URL field."
+              runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-developers/operations/operations-manual.md"
+      - eval_time: 5m
+        alertname: EgressBlockedManualSensitive
+        exp_alerts: []
+
+  # 5) private_ip does NOT cross-trigger the policy alert (its own firing is covered by case 1).
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_egress_blocked_total{sink="manual",reason="private_ip"}'
+        values: '0 0 1 1 1 1'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: EgressDenylistHit
         exp_alerts: []

--- a/infra/prometheus/alerts/egress-guard.yml
+++ b/infra/prometheus/alerts/egress-guard.yml
@@ -5,9 +5,13 @@
 #   - meepleai_egress_allowed_total{sink}         — allowed connections (block-ratio denominator).
 # Labels are bounded constants (sink/reason); a host or IP is NEVER a label.
 #
-# SLO for the manual (arbitrary-URL) sink hitting private_ip / denylist_hit is ZERO: any nonzero
-# rate means an admin-supplied manual-cover URL resolved to an internal/denied target — a live
-# SSRF attempt. severity=critical pages via the alertmanager critical-alerts route.
+# SLO for the manual (arbitrary-URL) sink hitting private_ip is ZERO: any nonzero rate means an
+# admin-supplied manual-cover URL resolved to an internal/reserved address — a live SSRF attempt.
+# severity=critical pages via the alertmanager critical-alerts route.
+#
+# denylist_hit is tracked SEPARATELY at severity=warning (#3583): it is an ADR-059 §5 policy
+# violation (a BGG/geekdo URL in the manual field), not an internal-target attempt. Paging on it
+# would mean paging on an admin's typo.
 #
 # promtool test: infra/prometheus/alerts/egress-guard.test.yml
 groups:
@@ -15,12 +19,27 @@ groups:
     rules:
       - alert: EgressBlockedManualSensitive
         # `or vector(0)` guards cold-start: the series may not exist yet on a fresh deploy.
-        expr: (sum(rate(meepleai_egress_blocked_total{sink="manual",reason=~"private_ip|denylist_hit"}[5m])) or vector(0)) > 0
+        expr: (sum(rate(meepleai_egress_blocked_total{sink="manual",reason="private_ip"}[5m])) or vector(0)) > 0
         for: 0m
         labels:
           severity: critical
           subsystem: egress-ssrf
         annotations:
-          summary: "Manual-cover SSRF attempt blocked (sink=manual, private_ip|denylist_hit)"
-          description: "meepleai_egress_blocked_total incremented for sink=manual with reason private_ip or denylist_hit: an admin-supplied manual-cover URL resolved to an internal/denied target. SLO for this metric is ZERO; any nonzero rate is a P1 SSRF incident (#3495)."
+          summary: "Manual-cover SSRF attempt blocked (sink=manual, private_ip)"
+          description: "meepleai_egress_blocked_total incremented for sink=manual with reason private_ip: an admin-supplied manual-cover URL resolved to an internal/reserved address. SLO for this metric is ZERO; any nonzero rate is a P1 SSRF incident (#3495)."
+          runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-developers/operations/operations-manual.md"
+
+      - alert: EgressDenylistHit
+        # #3583 — separata da EgressBlockedManualSensitive: un hit sulla deny-list ADR-059 §5 è una
+        # violazione di POLICY (un URL BGG/geekdo nel campo cover manuale), non un tentativo di
+        # raggiungere un target interno. Trattarlo come P1 SSRF genererebbe pagine su un errore di
+        # battitura di un admin — tanto più col carve-out BGG server-to-server (#3590).
+        expr: (sum(rate(meepleai_egress_blocked_total{sink="manual",reason="denylist_hit"}[5m])) or vector(0)) > 0
+        for: 0m
+        labels:
+          severity: warning
+          subsystem: egress-policy
+        annotations:
+          summary: "Manual-cover URL rejected by the ADR-059 BGG deny-list (sink=manual)"
+          description: "meepleai_egress_blocked_total incremented for sink=manual with reason denylist_hit: someone submitted a BGG/geekdo asset URL to the manual-cover field, which ADR-059 §5 bans. A one-off is an admin mistake; a sustained rate is an attempt to launder around the ban and warrants review of who is submitting it. The legitimate route for a BGG cover is the admin server-to-server re-upload path, never the arbitrary-URL field."
           runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-developers/operations/operations-manual.md"

--- a/infra/prometheus/alerts/wikidata-enrichment.yml
+++ b/infra/prometheus/alerts/wikidata-enrichment.yml
@@ -18,8 +18,12 @@
 groups:
   - name: meepleai_wikidata_enrichment_alerts
     rules:
+      # #3383 — le due regole dead-letter aggregano con max(): dal gauge DB-derivato ogni istanza
+      # riporta lo stesso COUNT, quindi max() e' esatto e collassa le N serie (una per instance) in
+      # un solo alert. Senza aggregazione, a piu' di un'istanza lo stesso backlog notificherebbe N
+      # volte. delta() vuole un range vector, e max(...) e' un instant vector: serve la subquery [5m:].
       - alert: WikidataDeadLetterHigh
-        expr: meepleai_wikidata_dead_letter_count > 100
+        expr: max(meepleai_wikidata_dead_letter_count) > 100
         for: 1h
         labels:
           severity: warning
@@ -29,7 +33,7 @@ groups:
           description: "meepleai_wikidata_dead_letter_count has stayed above 100 for 1h: an operator triage backlog is building. Investigate via the M13 admin dead-letter page — likely a license-whitelist drift or SPARQL schema drift in the enrichment pipeline."
           runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-developers/operations/operations-manual.md#wikidata-enrichment-alerts"
       - alert: WikidataDeadLetterSpike
-        expr: delta(meepleai_wikidata_dead_letter_count[5m]) > 50
+        expr: delta(max(meepleai_wikidata_dead_letter_count)[5m:]) > 50
         for: 0m
         labels:
           severity: warning


### PR DESCRIPTION
Release incrementale `main-dev` → `main-staging`. **4 commit, nessuna migration.**

Allinea staging dopo #3607: da allora sono entrate quattro PR di **sessioni parallele**.

## Contenuto

| Commit | Cosa |
|---|---|
| #3609 | **#3590 Slice B** — carve-out re-upload cover BGG |
| #3608 | **#3590 Slice A** — vista admin cover-gap + `unstructured` nella pipeline di deploy |
| #3597 | **#3383** — enforcement single-pod: tripwire, gauge DB, lease sull'enrichment Wikidata |
| #3596 | **#3583** — wire delle reason di osservabilità egress mancanti (`dns_failure`, `decode_fail`, `denylist_hit`) |

## Trasparenza sulla provenienza

**Nessuno di questi commit è mio**: sono di sessioni parallele, non li ho scritti né revisionati. Ho verificato solo che il range non contenga migration e che la CI di ciascuna PR fosse verde al merge. Il giudizio sul merito del codice resta a chi l'ha prodotto.

## Cosa cambia a runtime

Il pezzo più delicato è **#3597**: introduce un lease/tripwire per garantire che l'enrichment Wikidata giri su una sola istanza, più un `WikidataDeadLetterMetricsRefreshService` nuovo e modifiche a `WikidataCoverEnrichmentJob`/`Runner`. Tocca anche `compose.prod.yml` e le regole Prometheus.

Da tenere d'occhio dopo il deploy:
- che l'enrichment Wikidata **parta** (un lease mal configurato lo bloccherebbe in silenzio);
- il nuovo servizio di refresh delle metriche dead-letter;
- eventuali alert Prometheus nuovi — ricordando che [le rule non si attivano col deploy](https://github.com/meepleAi-app/meepleai-monorepo): serve un `force-recreate` di Prometheus se i mount cambiano.

#3608 tocca `deploy-staging.yml` (aggiunge `unstructured` alla pipeline): il primo deploy che lo usa è **questo**, quindi vale la pena guardare che quel job non fallisca.

## Stato di staging prima del rilascio

Coda vuota: `Completed 323`, `Cancelled 3`, zero `Queued`/`Processing`. Nessun lavoro in volo su cui il deploy possa incidere.

## Rischi

- Nessuna migration, nessuna modifica di schema.
- Il grosso è additivo (metriche, viste admin, counter di osservabilità); l'unico cambio di comportamento sostanziale è l'enforcement single-pod di #3597.

🤖 Generated with [Claude Code](https://claude.com/claude-code)