### PR TITLE
fix(catalog): la penalità testo non è più un veto nell'euristica cover (#3590)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfCoverExtractor.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfCoverExtractor.cs
@@ -57,6 +57,18 @@ internal sealed class PdfCoverExtractor : IPdfCoverExtractor
     private const double MinScoreThreshold = 0.10;
 
     /// <summary>
+    /// Ceiling on the text-density penalty (Issue #3590). Without it the penalty
+    /// dominates the score — <c>imageRatio</c> maxes at 1.0, so 2000+ characters
+    /// alone drove any page negative regardless of its artwork, rejecting 27 of the
+    /// 28 PDFs that were skipped on staging even though they had a near-full-bleed
+    /// page. 0.5 was chosen by measuring the alternatives against the 89 covers
+    /// already generated: it moves 9 of them to a different page, loses none, and
+    /// recovers 20 of the 28. A wider page scan or a document-relative penalty
+    /// recovered more but rewrote up to 43 of the 89 existing choices.
+    /// </summary>
+    internal const double MaxTextPenalty = 0.5;
+
+    /// <summary>
     /// Quality flag for SkiaSharp webp encoding. 80 balances size (~30-50 KB
     /// per thumbnail) with visible quality. Tune as we collect post-deploy data.
     /// </summary>
@@ -198,10 +210,21 @@ internal sealed class PdfCoverExtractor : IPdfCoverExtractor
         var text = pageReader.GetText() ?? string.Empty;
         var textLen = text.Length;
 
-        // Score: penalise text density by ~one unit per 2000 chars. Tuned so a
-        // page with 4000 chars (typical legal page) drops below a moderately
-        // image-heavy cover (ratio 0.25 → score 0.25 - 2.0 = -1.75).
-        var score = imageRatio - (textLen / 2000.0d);
+        // Score: penalise text density by ~one unit per 2000 chars, but CAPPED.
+        //
+        // #3590: uncapped, the penalty was not a correction but a veto. imageRatio
+        // saturates at 1.0, so any page above 2000 chars scored below zero however
+        // graphic it was — and a modern rulebook cover is full-bleed art *plus*
+        // title, publisher and claim, which PDFium extracts as text. Measured on the
+        // 28 staging PDFs marked Skipped: 27 had a page with imageRatio ≥ 0.20 (most
+        // near 1.0) and were rejected anyway, every one of them above 2000 chars.
+        //
+        // The cap keeps the ordering the penalty was written for — among comparably
+        // graphic pages the wordier one still loses — while stopping a single
+        // text-heavy-but-graphic page from being vetoed outright. Validated against
+        // the 89 covers already generated: 9 change page, 0 are lost, and 20 of the
+        // 28 rejected PDFs recover a cover.
+        var score = imageRatio - Math.Min(textLen / 2000.0d, MaxTextPenalty);
         return score;
     }
 

--- a/apps/api/tests/Api.Tests/Unit/DocumentProcessing/PdfCoverExtractorTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/DocumentProcessing/PdfCoverExtractorTests.cs
@@ -69,4 +69,121 @@ public class PdfCoverExtractorTests
 
         Assert.NotEqual(PdfCoverExtractionOutcome.Generated, result.Outcome);
     }
+
+    // -- Euristica di selezione pagina (#3590) --------------------------------
+    //
+    // Fino a questo punto la classe copriva solo i percorsi d'errore: l'euristica
+    // non era esercitata da alcun test, ed e' il motivo per cui la sua taratura ha
+    // potuto rigettare 27 dei 28 PDF poi risultati Skipped in staging senza che
+    // nulla lo segnalasse. Le fixture sono PDF generati con caratteristiche
+    // misurate, incorporati in base64 per non dipendere da file esterni.
+
+    private const string COVER_WITH_TEXT =
+        "JVBERi0xLjcKJcK1wrYKCjEgMCBvYmoKPDwvVHlwZS9DYXRhbG9nL1BhZ2VzIDIgMCBSPj4KZW5kb2JqCgoyIDAgb2JqCjw8L1R5cGUvUGFnZX"
+        + "MvQ291bnQgMS9LaWRzWzQgMCBSXT4+CmVuZG9iagoKMyAwIG9iago8PC9Gb250PDwvaGVsdiA3IDAgUj4+Pj4KZW5kb2JqCgo0IDAgb2JqCjw8"
+        + "L1R5cGUvUGFnZS9NZWRpYUJveFswIDAgMzAwIDQyMF0vUm90YXRlIDAvUmVzb3VyY2VzIDMgMCBSL1BhcmVudCAyIDAgUi9Db250ZW50c1s1ID"
+        + "AgUiA2IDAgUiA4IDAgUl0+PgplbmRvYmoKCjUgMCBvYmoKPDwvTGVuZ3RoIDQyPj4Kc3RyZWFtCgpxCjAgMCAzMDAgNDIwIHJlCmgKMSAxIDEg"
+        + "UkcgMSAxIDEgcmcgQgpRCgplbmRzdHJlYW0KZW5kb2JqCgo2IDAgb2JqCjw8L0xlbmd0aCA0OS9GaWx0ZXIvRmxhdGVEZWNvZGU+PgpzdHJlYW"
+        + "0KeNrjKuQyUDBQMDYwUDAxMlAoSuXK4NIzVNAzNFXQM1YIcldAcIrSFZy4ArkA8X8JowplbmRzdHJlYW0KZW5kb2JqCgo3IDAgb2JqCjw8L1R5"
+        + "cGUvRm9udC9TdWJ0eXBlL1R5cGUxL0Jhc2VGb250L0hlbHZldGljYS9FbmNvZGluZy9XaW5BbnNpRW5jb2Rpbmc+PgplbmRvYmoKCjggMCBvYm"
+        + "oKPDwvTGVuZ3RoIDU1MC9GaWx0ZXIvRmxhdGVEZWNvZGU+PgpzdHJlYW0KeNrll82O1DAMx+/zFH0CE9uJPyTEAQkhcQPNDXHaduAABzjw/Djp"
+        + "sBIbENnZw3S2qiqlTuLkZyvxv4fvh9fHA04pHpwoTewMpUzHb9OLL8vXn5NMx1P01OfD23Pjx+fp48t8JyclKTJTEtekrGs7y0laH4UtenLYUG"
+        + "YprcXRu4S9CGuuNi11ZIzI1Uu8HGNcFtGwlvDUPLQZefXe7B7zOLyeqrV6kjlmt1Xb7Ooj1zd2tTQP6/p3sRKtO3/16fjuD3TLIKY6AH+GuUeV"
+        + "El9zuNZYGhtO3TjG4ni/dGwkNjSvsG28/7aonHuxfdV5EYgYs4T3CJSSVvyF0iVh70C1gFHJI6Abylf189iwd+gi4MI4lONr5eupx6SDLgaYko"
+        + "1AXzlflxyTDjc7ENvIJbaNfF1+THr0BKxCA+jXy9fTjkmHzAgF2Ueyvcky9L+wd8BEIAXLIPGG6tDj4t5xI4Oa89jVvbE6NB72DjtlcBoRJVsr"
+        + "QyNRf0hLLhDThjTYxsrQeNg7aFOgRHmwPt+Guv5b2DtwNYiSNaTGNquu/xX2DlYcsqoO3ts3Ia8fxr1nTiBYso9l+Eb09eq9Yy0IWhh9rEDdsM"
+        + "CmTGCezHeosIkzJDLZkcImKoAitB+JTSjAiX1vEjv8Qc4otjONjW5Q1Id+Ip+DykZzCI7ku5LZaAmsZLXd6WxUBHfKtguhjcKAnHBPQjs0NpCo"
+        + "PR+h3QjfHA/vD78AAL8FjgplbmRzdHJlYW0KZW5kb2JqCgp4cmVmCjAgOQowMDAwMDAwMDAwIDY1NTM1IGYgCjAwMDAwMDAwMTYgMDAwMDAgbi"
+        + "AKMDAwMDAwMDA2MiAwMDAwMCBuIAowMDAwMDAwMTE0IDAwMDAwIG4gCjAwMDAwMDAxNTUgMDAwMDAgbiAKMDAwMDAwMDI3NCAwMDAwMCBuIAow"
+        + "MDAwMDAwMzY1IDAwMDAwIG4gCjAwMDAwMDA0ODIgMDAwMDAgbiAKMDAwMDAwMDU3MSAwMDAwMCBuIAoKdHJhaWxlcgo8PC9TaXplIDkvUm9vdC"
+        + "AxIDAgUi9JRFs8QzI5RkMyOUQyMzM2MTFDMjlGMTJDMkEzMEIzMUMyODE+PEY0OUUyMUZBRDNBNjEyQjJDQjNBRDM1OTA0QjY5NEYzPl0+Pgpz"
+        + "dGFydHhyZWYKMTE5MAolJUVPRgo=";
+
+    private const string PLAIN_TEXT =
+        "JVBERi0xLjcKJcK1wrYKCjEgMCBvYmoKPDwvVHlwZS9DYXRhbG9nL1BhZ2VzIDIgMCBSPj4KZW5kb2JqCgoyIDAgb2JqCjw8L1R5cGUvUGFnZX"
+        + "MvQ291bnQgMS9LaWRzWzQgMCBSXT4+CmVuZG9iagoKMyAwIG9iago8PC9Gb250PDwvaGVsdiA2IDAgUj4+Pj4KZW5kb2JqCgo0IDAgb2JqCjw8"
+        + "L1R5cGUvUGFnZS9NZWRpYUJveFswIDAgMzAwIDQyMF0vUm90YXRlIDAvUmVzb3VyY2VzIDMgMCBSL1BhcmVudCAyIDAgUi9Db250ZW50c1s1ID"
+        + "AgUiA3IDAgUl0+PgplbmRvYmoKCjUgMCBvYmoKPDwvTGVuZ3RoIDQyPj4Kc3RyZWFtCgpxCjAgMCAzMDAgNDIwIHJlCmgKMSAxIDEgUkcgMSAx"
+        + "IDEgcmcgQgpRCgplbmRzdHJlYW0KZW5kb2JqCgo2IDAgb2JqCjw8L1R5cGUvRm9udC9TdWJ0eXBlL1R5cGUxL0Jhc2VGb250L0hlbHZldGljYS"
+        + "9FbmNvZGluZy9XaW5BbnNpRW5jb2Rpbmc+PgplbmRvYmoKCjcgMCBvYmoKPDwvTGVuZ3RoIDQ3Ny9GaWx0ZXIvRmxhdGVEZWNvZGU+PgpzdHJl"
+        + "YW0KeNrdl8Fu3CAQhu9+Cp5gwsAwA1KVQ6WqUm6JfKt6iu320B7SQ54/A95UTam2s5J3nUSWJTzAD59/g4fhYfg4Dui8XuhCdlECkCQ3/nRX3+"
+        + "cfj07cuLRq7+4+Hwq/vrkvH+ieFwmceAqei3iJspaJF251QWNaQxpDnji1UtTaWeOJo1CNSaottQVVFb2jtik8s2g0qVJTaD1oVW/xov2iqi41"
+        + "WpV40t466vXX8eYFESMUMgC1QevQVG+FmdvA67TvdYJhBa7DC/0J2mKTthBVwAZTp42qgb8VVE91pxW1tS/PEeFDLban2k9fQweSEMhbrFGtRe"
+        + "0gCVJf2hz8fmZ1FOQhiwXiiMcVYh+zOpzoIUaLKf82WbV3NavjwQLZQmNej5f1quPxBQJTKZYv7r9Lch+3/mYKJYNE2xI6efu8lF0dVM6AxbS7"
+        + "GffPc5vVEYgAsxFgm3/ddmZ1MCyAwWjHBj+7rczqOBJDMi3+sycmp5rVoRCDTyZLzpyZ2M3qGGKChMW2He+cSB7zq+MKBCWbvNkhkzzuV8eCBG"
+        + "RCecVZf/ARCqZ3kPZjiRDFuGReceKPOUAmYyb2JnJ/1LNyxHeT+qMelMV09H8ryT/qiTnEcuHkv83i0zjcDk/qQeyjCmVuZHN0cmVhbQplbmRv"
+        + "YmoKCnhyZWYKMCA4CjAwMDAwMDAwMDAgNjU1MzUgZiAKMDAwMDAwMDAxNiAwMDAwMCBuIAowMDAwMDAwMDYyIDAwMDAwIG4gCjAwMDAwMDAxMT"
+        + "QgMDAwMDAgbiAKMDAwMDAwMDE1NSAwMDAwMCBuIAowMDAwMDAwMjY4IDAwMDAwIG4gCjAwMDAwMDAzNTkgMDAwMDAgbiAKMDAwMDAwMDQ0OCAw"
+        + "MDAwMCBuIAoKdHJhaWxlcgo8PC9TaXplIDgvUm9vdCAxIDAgUi9JRFs8NkM3REMzOUY0OUMzODgzQUMyQjVDM0I5NUM0MTQ3QzI+PDBDMDAwN0"
+        + "JFRTFFN0NGMTcxNTE5NTY5MDM5NUM4MzNGPl0+PgpzdGFydHhyZWYKOTk0CiUlRU9GCg==";
+
+    private const string CLEAN_COVER =
+        "JVBERi0xLjcKJcK1wrYKCjEgMCBvYmoKPDwvVHlwZS9DYXRhbG9nL1BhZ2VzIDIgMCBSPj4KZW5kb2JqCgoyIDAgb2JqCjw8L1R5cGUvUGFnZX"
+        + "MvQ291bnQgMS9LaWRzWzQgMCBSXT4+CmVuZG9iagoKMyAwIG9iago8PC9Gb250PDwvaGVsdiA3IDAgUj4+Pj4KZW5kb2JqCgo0IDAgb2JqCjw8"
+        + "L1R5cGUvUGFnZS9NZWRpYUJveFswIDAgMzAwIDQyMF0vUm90YXRlIDAvUmVzb3VyY2VzIDMgMCBSL1BhcmVudCAyIDAgUi9Db250ZW50c1s1ID"
+        + "AgUiA2IDAgUiA4IDAgUl0+PgplbmRvYmoKCjUgMCBvYmoKPDwvTGVuZ3RoIDQyPj4Kc3RyZWFtCgpxCjAgMCAzMDAgNDIwIHJlCmgKMSAxIDEg"
+        + "UkcgMSAxIDEgcmcgQgpRCgplbmRzdHJlYW0KZW5kb2JqCgo2IDAgb2JqCjw8L0xlbmd0aCA0OS9GaWx0ZXIvRmxhdGVEZWNvZGU+PgpzdHJlYW"
+        + "0KeNrjKuQyUDBQMDYwUDAxMlAoSuXK4NIzVNAzNFXQM1YIcldAcIrSFZy4ArkA8X8JowplbmRzdHJlYW0KZW5kb2JqCgo3IDAgb2JqCjw8L1R5"
+        + "cGUvRm9udC9TdWJ0eXBlL1R5cGUxL0Jhc2VGb250L0hlbHZldGljYS9FbmNvZGluZy9XaW5BbnNpRW5jb2Rpbmc+PgplbmRvYmoKCjggMCBvYm"
+        + "oKPDwvTGVuZ3RoIDk0L0ZpbHRlci9GbGF0ZURlY29kZT4+CnN0cmVhbQp42uMq5HIK4TJUMABCQwUjAwVjCws9Q3NThZBcBf2M1JwyBUNDhZA0"
+        + "oBwIBrlDGUXpCtE2JslmaeZGZqZmKUYGZpbmBubG5hC2iVmaGVDOLjbEi8s1hCuQCwBw0RcJCmVuZHN0cmVhbQplbmRvYmoKCnhyZWYKMCA5Cj"
+        + "AwMDAwMDAwMDAgNjU1MzUgZiAKMDAwMDAwMDAxNiAwMDAwMCBuIAowMDAwMDAwMDYyIDAwMDAwIG4gCjAwMDAwMDAxMTQgMDAwMDAgbiAKMDAw"
+        + "MDAwMDE1NSAwMDAwMCBuIAowMDAwMDAwMjc0IDAwMDAwIG4gCjAwMDAwMDAzNjUgMDAwMDAgbiAKMDAwMDAwMDQ4MiAwMDAwMCBuIAowMDAwMD"
+        + "AwNTcxIDAwMDAwIG4gCgp0cmFpbGVyCjw8L1NpemUgOS9Sb290IDEgMCBSL0lEWzw3QjBCQzNBNDBFQzJBQjVCQzM5MEMzOENDM0FCQzJCOD48"
+        + "RkVBMzYxMTU1NTYxQ0RGQTc2MzI1MjdBRTFDNDA5M0M+XT4+CnN0YXJ0eHJlZgo3MzMKJSVFT0YK";
+
+    private static byte[] Pdf(string base64) => System.Convert.FromBase64String(base64);
+
+    /// <summary>
+    /// Il caso che #3590 ha scoperto: pagina a grafica piena CON molto testo
+    /// (titolo, editore, claim - cio' che ha ogni copertina di rulebook moderna).
+    /// Senza il cap la penalita' da sola supera l'imageRatio, che satura a 1.0, e
+    /// la pagina viene rigettata per quanto sia grafica.
+    /// </summary>
+    [Fact]
+    [Trait("Issue", "3590")]
+    public async Task ExtractAsync_GraphicPageWithMuchText_IsStillSelected()
+    {
+        var result = await _sut.ExtractAsync(Pdf(COVER_WITH_TEXT), CancellationToken.None);
+
+        Assert.Equal(PdfCoverExtractionOutcome.Generated, result.Outcome);
+        Assert.Equal(0, result.SelectedPageIndex);
+    }
+
+    /// <summary>
+    /// Il guard che impedisce al cap di degenerare: una pagina di solo testo non ha
+    /// grafica da compensare, quindi resta sotto soglia e il PDF e' Skipped. Senza
+    /// questo, "non penalizzare mai" soddisferebbe banalmente il test sopra.
+    /// </summary>
+    [Fact]
+    [Trait("Issue", "3590")]
+    public async Task ExtractAsync_TextOnlyPage_IsStillSkipped()
+    {
+        var result = await _sut.ExtractAsync(Pdf(PLAIN_TEXT), CancellationToken.None);
+
+        Assert.Equal(PdfCoverExtractionOutcome.Skipped, result.Outcome);
+    }
+
+    /// <summary>Non-regressione: una copertina pulita passava prima e passa ancora.</summary>
+    [Fact]
+    [Trait("Issue", "3590")]
+    public async Task ExtractAsync_CleanCover_StillSelected()
+    {
+        var result = await _sut.ExtractAsync(Pdf(CLEAN_COVER), CancellationToken.None);
+
+        Assert.Equal(PdfCoverExtractionOutcome.Generated, result.Outcome);
+        Assert.Equal(0, result.SelectedPageIndex);
+    }
+
+    /// <summary>
+    /// Pinna il valore del cap. Non e' pedanteria: e' la costante che decide fra
+    /// "correzione" e "veto", e cambiarla sposta le cover in silenzio su tutto il
+    /// catalogo - 9 su 89 gia' con questo valore.
+    /// </summary>
+    [Fact]
+    [Trait("Issue", "3590")]
+    public void MaxTextPenalty_IsPinnedTo_HalfOfMaxImageRatio()
+    {
+        Assert.Equal(0.5d, PdfCoverExtractor.MaxTextPenalty);
+    }
 }


### PR DESCRIPTION
Parte di #3590. Sblocca 20 dei 28 PDF che in staging non producono cover.

## Il difetto

```csharp
var score = imageRatio - (textLen / 2000.0d);
//          └── max 1.0 ──┘   └── 2000 char = 1.0 ──┘
```

`imageRatio` satura a 1.0, quindi **qualsiasi pagina sopra i 2000 caratteri finisce negativa** per quanto sia grafica. La penalità non correggeva: vietava.

Misurato sui 28 PDF `Skipped` in staging: **27 avevano una pagina con `imageRatio ≥ 0.20`** (la maggior parte vicina a 1.0) ed erano respinti lo stesso — tutti sopra i 2000 caratteri. Le copertine dei rulebook moderni sono a piena pagina *e* contengono titolo, editore e claim, che PDFium estrae come testo.

Il cap a 0.5 preserva l'ordinamento per cui la penalità era stata scritta — fra pagine altrettanto grafiche vince la meno verbosa — ma impedisce che una singola pagina grafica-e-testuale sia esclusa a priori.

## Validazione contro le cover esistenti

Il baseline è **reale**, non stimato: estratti da staging `cover_generation_status` + `cover_page_index` per tutti i 127 PDF. La replica dell'algoritmo riproduce le scelte di produzione con **0 differenze di pagina su 89** — senza questo, il confronto fra varianti non avrebbe avuto valore.

| Variante | Cover perse | Pagina spostata | Recuperate |
|---|---|---|---|
| attuale | 0 | 0 | 0/28 |
| **cap 0.5, scan 3** ← scelta | **0** | **9** | **20/28** |
| cap 0.5, scan 8 | 0 | 19 | 20/28 |
| penalità relativa alla media, scan 8 | 0 | 43 | 28/28 |

Le varianti più aggressive recuperano di più ma riscrivono fino a 43 scelte su 89. Ispezione visiva delle differenze (contact sheet oggi/A/C affiancate): il cap semplice produce le scelte corrette più spesso. Scelta la meno invasiva a parità di beneficio pratico.

## Test

La classe copriva finora **solo i percorsi d'errore** — l'euristica non era esercitata da alcun test. È il motivo per cui questa taratura ha potuto respingere 27 PDF per mesi senza che nulla lo segnalasse.

- `GraphicPageWithMuchText_IsStillSelected` — il caso che #3590 ha scoperto
- `TextOnlyPage_IsStillSkipped` — impedisce al cap di degenerare in "non penalizzare mai", che soddisferebbe banalmente il test sopra
- `CleanCover_StillSelected` — non-regressione
- `MaxTextPenalty_IsPinnedTo…` — pinna la costante: cambiarla sposta le cover in silenzio su tutto il catalogo

Verificato con **mutazione**: rimettendo la formula vecchia cade esattamente il primo test e nient'altro.

⚠️ **Trappola sulle fixture**, documentata nel codice: i PDF di test vanno generati con **sfondo bianco esplicito**. Senza, PDFium legge l'intera pagina come non-bianca (`imageRatio = 1.0`) e il test misura un fenomeno inesistente — ci sono cascato, e il test guard è ciò che l'ha rivelato.

## Dopo il merge

I 27 PDF **non si ri-processano da soli**: `BackfillPdfCoversJob` seleziona `CoverGenerationStatus == Pending`, mentre loro sono `Skipped`. Serve un reset `Skipped → Pending` su staging **dopo** il deploy di questa modifica — farlo prima li rimarcherebbe `Skipped` col codice vecchio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)