### PR TITLE
fix(pdf): page-image risponde 503 quando smoldocling non e' deployato (#3578)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetPdfPageImageQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetPdfPageImageQueryHandler.cs
@@ -83,14 +83,60 @@ internal sealed class GetPdfPageImageQueryHandler : IQueryHandler<GetPdfPageImag
             "Calling SmolDocling page-image: PdfDocumentId=..., page={Page}",
             pageNumber);
 
-        using var response = await client.PostAsync(url, form, cancellationToken).ConfigureAwait(false);
+        HttpResponseMessage response;
+        try
+        {
+            response = await client.PostAsync(url, form, cancellationToken).ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+        {
+            // Issue #3578: the container is simply not deployed here (staging omits smoldocling —
+            // the 256M model is impractical on CPU). A transport failure is not a server bug.
+            throw ServiceUnavailable(ex);
+        }
+        catch (TaskCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+        {
+            // HttpClient surfaces its own timeout as TaskCanceledException. The `when` guard is what
+            // keeps a genuinely cancelled caller (client disconnected) from being reported as an
+            // outage — that case must keep propagating as cancellation.
+            throw ServiceUnavailable(ex);
+        }
 
-        if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
-            throw new NotFoundException($"Page {pageNumber} not found in PDF");
+        using (response)
+        {
+            if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+                throw new NotFoundException($"Page {pageNumber} not found in PDF");
 
-        response.EnsureSuccessStatusCode();
+            // Upstream 5xx: the dependency is reachable but broken — still "unavailable" to the caller.
+            // Upstream 4xx deliberately falls through to EnsureSuccessStatusCode: it means WE sent a
+            // bad request, which is a real bug and must not be buried under a 503.
+            if ((int)response.StatusCode >= 500)
+                throw ServiceUnavailable(null, response.StatusCode);
 
-        return await response.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+
+            return await response.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Issue #3578 — 503 instead of 500 when the page-image dependency cannot serve the request.
+    /// The message names the missing service so whoever hits it does not have to read container
+    /// logs to find out a container is absent.
+    /// </summary>
+    private ExternalServiceException ServiceUnavailable(
+        Exception? inner,
+        System.Net.HttpStatusCode? upstreamStatus = null)
+    {
+        _logger.LogWarning(
+            inner,
+            "SmolDocling page-image unavailable (upstreamStatus={UpstreamStatus})",
+            upstreamStatus);
+
+        return new ExternalServiceException(
+            "Page preview requires the SmolDocling service, which is not available in this environment.",
+            "page_image_service_unavailable",
+            inner);
     }
 
     private static string ExtractFileIdFromPath(string filePath)

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Queries/GetPdfPageImageQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Queries/GetPdfPageImageQueryHandlerTests.cs
@@ -1,0 +1,179 @@
+using System.Net;
+using Api.BoundedContexts.DocumentProcessing.Application.Queries;
+using Api.BoundedContexts.DocumentProcessing.Domain.Entities;
+using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
+using Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects;
+using Api.Middleware.Exceptions;
+using Api.Services.Pdf;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Queries;
+
+/// <summary>
+/// Issue #3578 — "dependency not deployed here" must not be reported as a server bug.
+///
+/// `smoldocling-service` is deliberately absent from staging (the 256M model is impractical on CPU),
+/// so GET /api/v1/ingest/pdf/{id}/page-image used to answer 500 with a socket error. A 500 says
+/// "the server is broken" and forces whoever investigates to read container logs to discover that a
+/// service is simply missing. 503 says "this dependency is unavailable", which is both true and
+/// actionable.
+///
+/// The boundary matters: only transport failures, upstream 5xx and timeouts become 503. An upstream
+/// 4xx means WE sent something wrong — that is a real bug and must keep surfacing as such, otherwise
+/// this mapping would bury it.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+public class GetPdfPageImageQueryHandlerTests
+{
+    private static readonly Guid PdfId = Guid.Parse("aaaaaaaa-1111-4000-8000-000000000001");
+    private const string StoredFileId = "728c58a174b4425ab5330a64276eecad";
+
+    private static PdfDocument CreatePdf() =>
+        new(
+            PdfId,
+            Guid.NewGuid(),
+            new FileName("rulebook.pdf"),
+            $"pdfs/{PdfId:N}/{StoredFileId}_rulebook.pdf",
+            new FileSize(1024),
+            Guid.NewGuid());
+
+    private static GetPdfPageImageQueryHandler CreateHandler(HttpMessageHandler httpHandler)
+    {
+        var repo = new Mock<IPdfDocumentRepository>();
+        repo.Setup(r => r.GetByIdAsync(PdfId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreatePdf());
+
+        var blob = new Mock<IBlobStorageService>();
+        blob.Setup(b => b.RetrieveAsync(
+                It.IsAny<string>(), BlobCategory.Pdf, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new MemoryStream([0x25, 0x50, 0x44, 0x46]));
+
+        var httpClient = new HttpClient(httpHandler) { BaseAddress = new Uri("http://smoldocling-service:8002") };
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient("SmolDoclingService")).Returns(httpClient);
+
+        return new GetPdfPageImageQueryHandler(
+            repo.Object,
+            blob.Object,
+            factory.Object,
+            NullLogger<GetPdfPageImageQueryHandler>.Instance);
+    }
+
+    private static GetPdfPageImageQuery Query() => new(PdfId, 1);
+
+    [Fact]
+    public async Task Handle_ServiceUnreachable_Throws503NotAServerError()
+    {
+        // The exact shape of a missing container: a transport failure, no StatusCode.
+        var handler = CreateHandler(new ThrowingHandler(
+            new HttpRequestException("Resource temporarily unavailable (smoldocling-service:8002)")));
+
+        var act = () => handler.Handle(Query(), CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<ExternalServiceException>();
+        ex.Which.StatusCode.Should().Be(503);
+    }
+
+    [Fact]
+    public async Task Handle_ServiceReturns5xx_Throws503()
+    {
+        var handler = CreateHandler(new StatusHandler(HttpStatusCode.InternalServerError));
+
+        var act = () => handler.Handle(Query(), CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<ExternalServiceException>();
+        ex.Which.StatusCode.Should().Be(503);
+    }
+
+    [Fact]
+    public async Task Handle_ServiceTimesOut_Throws503()
+    {
+        // HttpClient surfaces its own timeout as TaskCanceledException with an uncancelled caller token.
+        var handler = CreateHandler(new ThrowingHandler(new TaskCanceledException("The request timed out.")));
+
+        var act = () => handler.Handle(Query(), CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<ExternalServiceException>();
+        ex.Which.StatusCode.Should().Be(503);
+    }
+
+    [Fact]
+    public async Task Handle_CallerCancels_PropagatesCancellation_NotA503()
+    {
+        // 🔴 A disconnected client must NOT be reported as "the dependency is down".
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+        var handler = CreateHandler(new ThrowingHandler(new TaskCanceledException("cancelled")));
+
+        var act = () => handler.Handle(Query(), cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task Handle_ServiceReturns404_StillThrowsNotFound()
+    {
+        // Pre-existing contract: a page outside the document is a 404, not an outage.
+        var handler = CreateHandler(new StatusHandler(HttpStatusCode.NotFound));
+
+        var act = () => handler.Handle(Query(), CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_ServiceReturns400_DoesNotMasqueradeAs503()
+    {
+        // 🔴 An upstream 4xx means WE sent a bad request — a real bug. Mapping it to 503 would bury it.
+        var handler = CreateHandler(new StatusHandler(HttpStatusCode.BadRequest));
+
+        var act = () => handler.Handle(Query(), CancellationToken.None);
+
+        await act.Should().ThrowAsync<HttpRequestException>();
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_ReturnsImageBytes()
+    {
+        var handler = CreateHandler(new StatusHandler(HttpStatusCode.OK, [0xFF, 0xD8, 0xFF]));
+
+        var bytes = await handler.Handle(Query(), CancellationToken.None);
+
+        bytes.Should().Equal(0xFF, 0xD8, 0xFF);
+    }
+
+    private sealed class ThrowingHandler : HttpMessageHandler
+    {
+        private readonly Exception _toThrow;
+
+        public ThrowingHandler(Exception toThrow) => _toThrow = toThrow;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            throw _toThrow;
+        }
+    }
+
+    private sealed class StatusHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _status;
+        private readonly byte[] _body;
+
+        public StatusHandler(HttpStatusCode status, byte[]? body = null)
+        {
+            _status = status;
+            _body = body ?? [];
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(new HttpResponseMessage(_status) { Content = new ByteArrayContent(_body) });
+    }
+}


### PR DESCRIPTION
Chiude #3578.

## Il problema

`smoldocling-service` è deliberatamente assente da staging (il modello 256M è
impraticabile su CPU), quindi `GET /api/v1/ingest/pdf/{id}/page-image` rispondeva
**500** con un socket error. Un 500 dice «il server è rotto» e costringe chi indaga
a leggere i log dei container per scoprire che manca semplicemente un servizio.

## Il fix

`ExternalServiceException` (già mappata a 503 dal middleware) al posto della
propagazione grezza, con un messaggio che nomina il servizio mancante.

Il confine è la parte che conta, ed è coperta da test:

| Caso | Esito | Perché |
|---|---|---|
| fallimento di trasporto (container assente) | **503** | la dipendenza non c'è |
| 5xx dall'upstream | **503** | raggiungibile ma rotto: per il chiamante è comunque indisponibile |
| timeout di HttpClient | **503** | idem |
| **cancellazione del chiamante** | `OperationCanceledException` | un client disconnesso non è un'avaria: il guard `when (!cancellationToken.IsCancellationRequested)` distingue i due `TaskCanceledException` |
| **4xx dall'upstream** | invariato | vuol dire che siamo **noi** a mandare una richiesta sbagliata: è un bug vero e mapparlo a 503 lo seppellirebbe |
| 404 dall'upstream | `NotFoundException` | contratto preesistente: pagina fuori dal documento |

## Fuori scope, deliberatamente

L'issue suggerisce di valutare anche un fail-fast più corto dei ~14s attuali. Non
l'ho toccato: il timeout del client `SmolDoclingService` copre anche il rendering
legittimo, che è un'operazione ML e può essere lenta. Accorciarlo alla cieca
romperebbe il percorso buono per migliorare quello degenere. Va misurato prima,
e separatamente.

## Test

7 nuovi test unitari; `BoundedContext=DocumentProcessing&Category=Unit` verde
(688/688).

🤖 Generated with [Claude Code](https://claude.com/claude-code)