### PR TITLE
fix(health): NonCritical checks degradano invece di 503 (#3618)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1432,24 +1432,47 @@ jobs:
           }
 
           # Critical smoke tests (failure = deployment issue).
-          # #2655 — /health returns 503 when the overall status is Degraded (e.g. a non-critical
-          # slack_queue backlog); the API is still up and serving, so accept 200 OR 503 for the
-          # two /health reachability probes. A truly-down API yields 000/timeout, which still fails.
+          # These two probes assert REACHABILITY only, hence the 503 tolerance: a 503 still
+          # proves the origin answered, whereas a truly-down API yields 000/timeout and fails.
+          # The actual health verdict is asserted below, against the JSON body — see #3618.
           smoke_test "API Health" "https://meepleai.app/health" "200 503"
           smoke_test "Web Root" "https://meepleai.app" "200"
           smoke_test "API Game Catalog" "https://meepleai.app/api/v1/shared-games?pageNumber=1&pageSize=1" "200"
           smoke_test "API Direct Health" "https://api.meepleai.app/health" "200 503"
 
-          # Health endpoint JSON validation
-          echo "  Validating health response structure..."
-          HEALTH_JSON=$(curl -sf --max-time 10 \
+          # Health verdict — BLOCKING (#3618).
+          # Historically this block was non-blocking and the 503 above was tolerated outright,
+          # so a genuinely Unhealthy deploy shipped silently (that is how #3339 stayed hidden).
+          # Note: no `-f` on curl — with -f the body is discarded on 503, i.e. exactly the case
+          # we need to inspect.
+          echo "  Validating health verdict..."
+          HEALTH_JSON=$(curl -s --max-time 10 \
             -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
             -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
             https://meepleai.app/health 2>/dev/null || true)
-          if [ -n "$HEALTH_JSON" ] && echo "$HEALTH_JSON" | jq -e '.status' > /dev/null 2>&1; then
-            echo "  ✅ Health JSON: valid structure"
+          if [ -z "$HEALTH_JSON" ] || ! echo "$HEALTH_JSON" | jq -e '.status' > /dev/null 2>&1; then
+            echo "  ❌ Health JSON: empty or unparseable body — cannot verify deploy health"
+            RESULTS="${RESULTS}| Health verdict | unparseable | ❌ |\n"
+            FAIL=1
           else
-            echo "  ⚠️ Health JSON: unexpected format (non-blocking)"
+            HEALTH_STATUS=$(echo "$HEALTH_JSON" | jq -r '.status')
+            UNHEALTHY=$(echo "$HEALTH_JSON" | jq -r '[.checks[]? | select(.status == "Unhealthy") | .name] | join(", ")')
+            DEGRADED=$(echo "$HEALTH_JSON" | jq -r '[.checks[]? | select(.status == "Degraded") | .name] | join(", ")')
+
+            if [ -n "$DEGRADED" ]; then
+              echo "  ⚠️ Degraded (non-blocking): $DEGRADED"
+            fi
+
+            if [ -n "$UNHEALTHY" ]; then
+              # A NonCritical check must never report Unhealthy (#3618 invariant). Anything
+              # Unhealthy here is either a real outage or a regression of that invariant.
+              echo "  ❌ Health verdict: $HEALTH_STATUS — Unhealthy checks: $UNHEALTHY"
+              RESULTS="${RESULTS}| Health verdict | Unhealthy: $UNHEALTHY | ❌ |\n"
+              FAIL=1
+            else
+              echo "  ✅ Health verdict: $HEALTH_STATUS (no Unhealthy checks)"
+              RESULTS="${RESULTS}| Health verdict | $HEALTH_STATUS | ✅ |\n"
+            fi
           fi
 
           # Response time check

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/HealthChecks/SlackApiHealthCheck.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/HealthChecks/SlackApiHealthCheck.cs
@@ -42,23 +42,23 @@ internal class SlackApiHealthCheck : IHealthCheck
                 "Slack API health check returned {StatusCode}",
                 (int)response.StatusCode);
 
-            return HealthCheckResult.Unhealthy(
+            return HealthCheckResult.Degraded(
                 $"Slack API returned HTTP {(int)response.StatusCode}");
         }
         catch (TaskCanceledException ex) when (ex.InnerException is TimeoutException || !cancellationToken.IsCancellationRequested)
         {
             _logger.LogWarning(ex, "Slack API health check timed out (>5s)");
-            return HealthCheckResult.Unhealthy("Slack API health check timed out");
+            return HealthCheckResult.Degraded("Slack API health check timed out");
         }
         catch (HttpRequestException ex)
         {
             _logger.LogWarning(ex, "Slack API health check failed - HTTP error");
-            return HealthCheckResult.Unhealthy("Slack API unreachable", ex);
+            return HealthCheckResult.Degraded("Slack API unreachable", ex);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Slack API health check failed - unexpected error");
-            return HealthCheckResult.Unhealthy("Slack API health check failed", ex);
+            return HealthCheckResult.Degraded("Slack API health check failed", ex);
         }
     }
 }

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/HealthChecks/SlackQueueHealthCheck.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/HealthChecks/SlackQueueHealthCheck.cs
@@ -6,12 +6,17 @@ namespace Api.BoundedContexts.UserNotifications.Infrastructure.HealthChecks;
 
 /// <summary>
 /// Health check that monitors the Slack notification queue depth.
-/// Returns Unhealthy if the pending count exceeds the threshold (100),
+/// Returns Degraded if the pending count exceeds the threshold (100),
 /// indicating a potential processing bottleneck or Slack API issues.
+/// <para>
+/// Degraded, not Unhealthy: this check is registered NonCritical, and a NonCritical check
+/// returning Unhealthy 503s the aggregate /health endpoint (#3618). Alerting is unaffected —
+/// HealthStateMachine escalates on consecutive non-Healthy results.
+/// </para>
 /// </summary>
 internal class SlackQueueHealthCheck : IHealthCheck
 {
-    private const int UnhealthyThreshold = 100;
+    private const int BacklogThreshold = 100;
 
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<SlackQueueHealthCheck> _logger;
@@ -35,7 +40,7 @@ internal class SlackQueueHealthCheck : IHealthCheck
 
             // Scope the backlog count to the Slack channels only: an unrelated backlog on
             // another channel (e.g. email) must not trip this Slack-specific health check
-            // and mis-attribute an aggregate /health 503 to Slack.
+            // and mis-attribute a Degraded aggregate /health to Slack.
             var pendingCount = await repository.GetPendingCountByChannelsAsync(
                 new[] { NotificationChannelType.SlackUser, NotificationChannelType.SlackTeam },
                 cancellationToken).ConfigureAwait(false);
@@ -43,17 +48,17 @@ internal class SlackQueueHealthCheck : IHealthCheck
             var data = new Dictionary<string, object>(StringComparer.Ordinal)
             {
                 ["pending_count"] = pendingCount,
-                ["threshold"] = UnhealthyThreshold
+                ["threshold"] = BacklogThreshold
             };
 
-            if (pendingCount > UnhealthyThreshold)
+            if (pendingCount > BacklogThreshold)
             {
                 _logger.LogWarning(
                     "Slack queue health check: {PendingCount} pending items exceeds threshold of {Threshold}",
-                    pendingCount, UnhealthyThreshold);
+                    pendingCount, BacklogThreshold);
 
-                return HealthCheckResult.Unhealthy(
-                    $"Slack notification queue backlog: {pendingCount} pending (threshold: {UnhealthyThreshold})",
+                return HealthCheckResult.Degraded(
+                    $"Slack notification queue backlog: {pendingCount} pending (threshold: {BacklogThreshold})",
                     data: data);
             }
 
@@ -64,7 +69,7 @@ internal class SlackQueueHealthCheck : IHealthCheck
         catch (Exception ex)
         {
             _logger.LogError(ex, "Slack queue health check failed");
-            return HealthCheckResult.Unhealthy("Failed to check Slack queue health", ex);
+            return HealthCheckResult.Degraded("Failed to check Slack queue health", ex);
         }
     }
 }

--- a/apps/api/src/Api/Infrastructure/Health/Checks/BggApiHealthCheck.cs
+++ b/apps/api/src/Api/Infrastructure/Health/Checks/BggApiHealthCheck.cs
@@ -47,12 +47,12 @@ public class BggApiHealthCheck : IHealthCheck
         catch (HttpRequestException ex)
         {
             _logger.LogError(ex, "BGG API health check failed - HTTP request error");
-            return HealthCheckResult.Unhealthy("BGG API unavailable", ex);
+            return HealthCheckResult.Degraded("BGG API unavailable", ex);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "BGG API health check failed - unexpected error");
-            return HealthCheckResult.Unhealthy("BGG API connectivity check failed", ex);
+            return HealthCheckResult.Degraded("BGG API connectivity check failed", ex);
         }
     }
 }

--- a/apps/api/src/Api/Infrastructure/Health/Checks/EmailSmtpHealthCheck.cs
+++ b/apps/api/src/Api/Infrastructure/Health/Checks/EmailSmtpHealthCheck.cs
@@ -58,12 +58,12 @@ public class EmailSmtpHealthCheck : IHealthCheck
         {
             var maskedServer = DataMasking.MaskString(smtpServer);
             _logger.LogError(ex, "SMTP health check failed - socket error for {Server}:{Port}", maskedServer, smtpPort);
-            return HealthCheckResult.Unhealthy($"SMTP server {maskedServer}:{smtpPort} unavailable", ex);
+            return HealthCheckResult.Degraded($"SMTP server {maskedServer}:{smtpPort} unavailable", ex);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "SMTP health check failed - unexpected error");
-            return HealthCheckResult.Unhealthy("SMTP connectivity check failed", ex);
+            return HealthCheckResult.Degraded("SMTP connectivity check failed", ex);
         }
     }
 }

--- a/apps/api/src/Api/Infrastructure/Health/Checks/EmbeddingDimensionHealthCheck.cs
+++ b/apps/api/src/Api/Infrastructure/Health/Checks/EmbeddingDimensionHealthCheck.cs
@@ -49,7 +49,7 @@ public class EmbeddingDimensionHealthCheck : IHealthCheck
                 "RAG indexing and search will fail. Change Embedding:Provider config or run a schema migration.",
                 providerDimensions, ExpectedSchemaDimensions);
 
-            return Task.FromResult(HealthCheckResult.Unhealthy(
+            return Task.FromResult(HealthCheckResult.Degraded(
                 $"Embedding dimension mismatch: provider={providerDimensions}, schema expects {ExpectedSchemaDimensions}. " +
                 $"Change Embedding:Provider in config or run a schema migration to vector({providerDimensions})."));
         }

--- a/apps/api/src/Api/Infrastructure/Health/Checks/EmbeddingServiceHealthCheck.cs
+++ b/apps/api/src/Api/Infrastructure/Health/Checks/EmbeddingServiceHealthCheck.cs
@@ -45,12 +45,12 @@ public class EmbeddingServiceHealthCheck : IHealthCheck
         catch (HttpRequestException ex)
         {
             _logger.LogError(ex, "Embedding service health check failed - HTTP request error");
-            return HealthCheckResult.Unhealthy("Embedding service unavailable", ex);
+            return HealthCheckResult.Degraded("Embedding service unavailable", ex);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Embedding service health check failed - unexpected error");
-            return HealthCheckResult.Unhealthy("Embedding service check failed", ex);
+            return HealthCheckResult.Degraded("Embedding service check failed", ex);
         }
     }
 }

--- a/apps/api/src/Api/Infrastructure/Health/Checks/GrafanaHealthCheck.cs
+++ b/apps/api/src/Api/Infrastructure/Health/Checks/GrafanaHealthCheck.cs
@@ -51,12 +51,12 @@ public class GrafanaHealthCheck : IHealthCheck
         catch (HttpRequestException ex)
         {
             _logger.LogError(ex, "Grafana health check failed - HTTP request error");
-            return HealthCheckResult.Unhealthy("Grafana unavailable", ex);
+            return HealthCheckResult.Degraded("Grafana unavailable", ex);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Grafana health check failed - unexpected error");
-            return HealthCheckResult.Unhealthy("Grafana connectivity check failed", ex);
+            return HealthCheckResult.Degraded("Grafana connectivity check failed", ex);
         }
     }
 }

--- a/apps/api/src/Api/Infrastructure/Health/Checks/LiveSessionPersistenceHealthCheck.cs
+++ b/apps/api/src/Api/Infrastructure/Health/Checks/LiveSessionPersistenceHealthCheck.cs
@@ -70,7 +70,7 @@ internal sealed class LiveSessionPersistenceHealthCheck : IHealthCheck
         {
             sw.Stop();
             _logger.LogError(ex, "LiveSessionPersistenceHealthCheck failed (latency {LatencyMs:F0} ms)", sw.Elapsed.TotalMilliseconds);
-            return HealthCheckResult.Unhealthy(
+            return HealthCheckResult.Degraded(
                 "live_game_sessions table unreachable",
                 exception: ex);
         }

--- a/apps/api/src/Api/Infrastructure/Health/Checks/OllamaHealthCheck.cs
+++ b/apps/api/src/Api/Infrastructure/Health/Checks/OllamaHealthCheck.cs
@@ -30,10 +30,11 @@ public class OllamaHealthCheck : IHealthCheck
         var ollamaUrl = _configuration["OLLAMA_URL"];
         if (string.IsNullOrWhiteSpace(ollamaUrl))
         {
-            // Defensive: if registration somehow drifted from configuration, surface
-            // Unhealthy so monitoring catches the misregistration rather than silently
-            // returning Degraded.
-            return HealthCheckResult.Unhealthy("Ollama health check registered without OLLAMA_URL — registration/config drift");
+            // Defensive: registration drifted from configuration. Surface Degraded, not
+            // Unhealthy — ollama is NonCritical/Optional and must not 503 the aggregate
+            // /health (#3618). Monitoring still catches it: HealthStateMachine treats any
+            // non-Healthy result as a failure, and the description names the drift.
+            return HealthCheckResult.Degraded("Ollama health check registered without OLLAMA_URL — registration/config drift");
         }
 
         try
@@ -57,12 +58,12 @@ public class OllamaHealthCheck : IHealthCheck
         catch (HttpRequestException ex)
         {
             _logger.LogError(ex, "Ollama service health check failed - HTTP request error");
-            return HealthCheckResult.Unhealthy("Ollama service unavailable", ex);
+            return HealthCheckResult.Degraded("Ollama service unavailable", ex);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Ollama service health check failed - unexpected error");
-            return HealthCheckResult.Unhealthy("Ollama service check failed", ex);
+            return HealthCheckResult.Degraded("Ollama service check failed", ex);
         }
     }
 }

--- a/apps/api/src/Api/Infrastructure/Health/Checks/OpenRouterHealthCheck.cs
+++ b/apps/api/src/Api/Infrastructure/Health/Checks/OpenRouterHealthCheck.cs
@@ -43,12 +43,12 @@ public class OpenRouterHealthCheck : IHealthCheck
         catch (HttpRequestException ex)
         {
             _logger.LogError(ex, "OpenRouter health check failed - HTTP request error");
-            return HealthCheckResult.Unhealthy("OpenRouter API unavailable", ex);
+            return HealthCheckResult.Degraded("OpenRouter API unavailable", ex);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "OpenRouter health check failed - unexpected error");
-            return HealthCheckResult.Unhealthy("OpenRouter connectivity check failed", ex);
+            return HealthCheckResult.Degraded("OpenRouter connectivity check failed", ex);
         }
     }
 }

--- a/apps/api/src/Api/Infrastructure/Health/Checks/PrometheusHealthCheck.cs
+++ b/apps/api/src/Api/Infrastructure/Health/Checks/PrometheusHealthCheck.cs
@@ -51,12 +51,12 @@ public class PrometheusHealthCheck : IHealthCheck
         catch (HttpRequestException ex)
         {
             _logger.LogError(ex, "Prometheus health check failed - HTTP request error");
-            return HealthCheckResult.Unhealthy("Prometheus unavailable", ex);
+            return HealthCheckResult.Degraded("Prometheus unavailable", ex);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Prometheus health check failed - unexpected error");
-            return HealthCheckResult.Unhealthy("Prometheus connectivity check failed", ex);
+            return HealthCheckResult.Degraded("Prometheus connectivity check failed", ex);
         }
     }
 }

--- a/apps/api/src/Api/Infrastructure/Health/Checks/RerankerHealthCheck.cs
+++ b/apps/api/src/Api/Infrastructure/Health/Checks/RerankerHealthCheck.cs
@@ -55,12 +55,12 @@ public class RerankerHealthCheck : IHealthCheck
         catch (HttpRequestException ex)
         {
             _logger.LogError(ex, "Reranker service health check failed - HTTP request error");
-            return HealthCheckResult.Unhealthy("Reranker service unavailable", ex);
+            return HealthCheckResult.Degraded("Reranker service unavailable", ex);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Reranker service health check failed - unexpected error");
-            return HealthCheckResult.Unhealthy("Reranker service check failed", ex);
+            return HealthCheckResult.Degraded("Reranker service check failed", ex);
         }
     }
 }

--- a/apps/api/src/Api/Infrastructure/Health/Checks/S3StorageHealthCheck.cs
+++ b/apps/api/src/Api/Infrastructure/Health/Checks/S3StorageHealthCheck.cs
@@ -64,7 +64,7 @@ internal sealed class S3StorageHealthCheck : IHealthCheck
         catch (Exception ex)
         {
             _logger.LogError(ex, "S3 health check failed");
-            return HealthCheckResult.Unhealthy($"S3 storage unreachable: {ex.Message}", ex);
+            return HealthCheckResult.Degraded($"S3 storage unreachable: {ex.Message}", ex);
         }
 #pragma warning restore CA1031
     }

--- a/apps/api/src/Api/Infrastructure/Health/Checks/SeedStateHealthCheck.cs
+++ b/apps/api/src/Api/Infrastructure/Health/Checks/SeedStateHealthCheck.cs
@@ -141,7 +141,7 @@ public sealed class SeedStateHealthCheck : IHealthCheck
         catch (Exception ex)
         {
             _logger.LogError(ex, "SeedStateHealthCheck failed to query DB counts");
-            return HealthCheckResult.Unhealthy("Failed to query seed-state counts", ex);
+            return HealthCheckResult.Degraded("Failed to query seed-state counts", ex);
         }
     }
 

--- a/apps/api/src/Api/Infrastructure/Health/Checks/SmolDoclingHealthCheck.cs
+++ b/apps/api/src/Api/Infrastructure/Health/Checks/SmolDoclingHealthCheck.cs
@@ -30,9 +30,11 @@ public class SmolDoclingHealthCheck : IHealthCheck
         var smoldoclingUrl = _configuration["PdfProcessing:Extractor:SmolDocling:ApiUrl"];
         if (string.IsNullOrWhiteSpace(smoldoclingUrl))
         {
-            // Provider selected but URL missing — real misconfiguration, surface as Unhealthy
-            // so monitoring catches it (consistent with OllamaHealthCheck handling).
-            return HealthCheckResult.Unhealthy("SmolDocling API URL missing — provider selected but PdfProcessing:Extractor:SmolDocling:ApiUrl unset");
+            // Provider selected but URL missing — real misconfiguration. Surface Degraded,
+            // not Unhealthy: this check is NonCritical/Optional and must not 503 the
+            // aggregate /health (#3618). Monitoring still catches it — HealthStateMachine
+            // treats any non-Healthy result as a failure (consistent with OllamaHealthCheck).
+            return HealthCheckResult.Degraded("SmolDocling API URL missing — provider selected but PdfProcessing:Extractor:SmolDocling:ApiUrl unset");
         }
 
         try
@@ -56,12 +58,12 @@ public class SmolDoclingHealthCheck : IHealthCheck
         catch (HttpRequestException ex)
         {
             _logger.LogError(ex, "SmolDocling health check failed - HTTP request error");
-            return HealthCheckResult.Unhealthy("SmolDocling service unavailable", ex);
+            return HealthCheckResult.Degraded("SmolDocling service unavailable", ex);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "SmolDocling health check failed - unexpected error");
-            return HealthCheckResult.Unhealthy("SmolDocling service check failed", ex);
+            return HealthCheckResult.Degraded("SmolDocling service check failed", ex);
         }
     }
 }

--- a/apps/api/src/Api/Infrastructure/Health/Checks/UnstructuredHealthCheck.cs
+++ b/apps/api/src/Api/Infrastructure/Health/Checks/UnstructuredHealthCheck.cs
@@ -30,9 +30,11 @@ public class UnstructuredHealthCheck : IHealthCheck
         var unstructuredUrl = _configuration["PdfProcessing:Extractor:Unstructured:ApiUrl"];
         if (string.IsNullOrWhiteSpace(unstructuredUrl))
         {
-            // Provider selected but URL missing — real misconfiguration, surface as Unhealthy
-            // so monitoring catches it (consistent with OllamaHealthCheck handling).
-            return HealthCheckResult.Unhealthy("Unstructured API URL missing — provider selected but PdfProcessing:Extractor:Unstructured:ApiUrl unset");
+            // Provider selected but URL missing — real misconfiguration. Surface Degraded,
+            // not Unhealthy: this check is NonCritical/Optional and must not 503 the
+            // aggregate /health (#3618). Monitoring still catches it — HealthStateMachine
+            // treats any non-Healthy result as a failure (consistent with OllamaHealthCheck).
+            return HealthCheckResult.Degraded("Unstructured API URL missing — provider selected but PdfProcessing:Extractor:Unstructured:ApiUrl unset");
         }
 
         try
@@ -57,12 +59,12 @@ public class UnstructuredHealthCheck : IHealthCheck
         catch (HttpRequestException ex)
         {
             _logger.LogError(ex, "Unstructured API health check failed - HTTP request error");
-            return HealthCheckResult.Unhealthy("Unstructured API unavailable", ex);
+            return HealthCheckResult.Degraded("Unstructured API unavailable", ex);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Unstructured API health check failed - unexpected error");
-            return HealthCheckResult.Unhealthy("Unstructured API check failed", ex);
+            return HealthCheckResult.Degraded("Unstructured API check failed", ex);
         }
     }
 }

--- a/apps/api/src/Api/Infrastructure/Health/Extensions/HealthCheckServiceExtensions.cs
+++ b/apps/api/src/Api/Infrastructure/Health/Extensions/HealthCheckServiceExtensions.cs
@@ -23,6 +23,24 @@ public static class HealthCheckServiceExtensions
     /// registered at all — this prevents the global /health endpoint from reporting Degraded for
     /// services that are intentionally not deployed (avoiding alert fatigue and SLA noise).
     /// </remarks>
+    /// <remarks>
+    /// 🔴 INVARIANT (#3618): a check registered <c>NonCritical</c> MUST NOT return
+    /// <see cref="HealthCheckResult.Unhealthy"/> — it must return <c>Degraded</c> instead.
+    /// <para>
+    /// The <c>failureStatus</c> argument below is NOT a cap on the reported status: ASP.NET Core
+    /// applies it only when a check throws an unhandled exception. A check that catches its own
+    /// exception and returns <c>HealthCheckResult.Unhealthy(...)</c> bypasses it entirely, and that
+    /// value propagates to the aggregate report. Since <c>/health</c> (Program.cs) uses the default
+    /// <c>ResultStatusCodes</c> — Healthy/Degraded → 200, Unhealthy → 503 — a single NonCritical
+    /// check returning Unhealthy 503s the whole endpoint. That was the root cause behind #3339
+    /// (orchestrator) and the reason the staging smoke gate had to tolerate a 503.
+    /// </para>
+    /// <para>
+    /// Returning Degraded does NOT lose the alerting signal: <c>HealthStateMachine</c> treats every
+    /// non-Healthy result as a failure and runs its own Healthy → Degraded → Unhealthy escalation
+    /// on consecutive-failure counts. Only checks tagged <c>Critical</c> may produce a 503.
+    /// </para>
+    /// </remarks>
     public static IHealthChecksBuilder AddComprehensiveHealthChecks(
         this IHealthChecksBuilder builder,
         IConfiguration configuration)

--- a/apps/api/tests/Api.Tests/Architecture/NonCriticalHealthCheckStatusArchitectureTests.cs
+++ b/apps/api/tests/Api.Tests/Architecture/NonCriticalHealthCheckStatusArchitectureTests.cs
@@ -1,0 +1,157 @@
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Architecture;
+
+/// <summary>
+/// Issue #3618 — architecture gate: <b>a NonCritical health check must never report Unhealthy</b>.
+/// <para>
+/// The <c>failureStatus</c> argument passed at registration (<c>AddCheck&lt;T&gt;("x",
+/// HealthStatus.Degraded, …)</c>) is NOT a cap on the reported status. ASP.NET Core applies it only
+/// when a check throws an <i>unhandled</i> exception; a check that catches its own exception and
+/// returns <c>HealthCheckResult.Unhealthy(...)</c> bypasses it entirely and that value propagates
+/// straight into the aggregate report.
+/// </para>
+/// <para>
+/// Because <c>/health</c> uses the default <c>ResultStatusCodes</c> map — Healthy/Degraded → 200,
+/// Unhealthy → 503 — a single NonCritical check returning Unhealthy 503s the whole endpoint even
+/// though the API is serving fine. That was the root cause behind #3339 (orchestrator not deployed
+/// in staging) and the reason the staging smoke gate had to tolerate a 503 and could therefore not
+/// detect a genuinely broken deploy.
+/// </para>
+/// <para>
+/// Returning Degraded does not lose the signal: <c>HealthStateMachine</c> treats every non-Healthy
+/// result as a failure and runs its own Healthy → Degraded → Unhealthy escalation on consecutive
+/// failure counts, so email alerting is unaffected.
+/// </para>
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Architecture")]
+[Trait("Issue", "3618")]
+public sealed class NonCriticalHealthCheckStatusArchitectureTests
+{
+    /// <summary>
+    /// The only checks allowed to report Unhealthy, each with the reason. Everything else is
+    /// NonCritical (or Optional) and must degrade instead of 503-ing the aggregate endpoint.
+    /// <para>
+    /// Adding an entry here is a deliberate operational decision: it means "this failure SHOULD take
+    /// /health to 503 and block a staging deploy".
+    /// </para>
+    /// </summary>
+    private static readonly Dictionary<string, string> MayReportUnhealthy = new(StringComparer.Ordinal)
+    {
+        ["ConfigurationHealthCheck"] =
+            "startup configuration is missing/invalid — the deploy is genuinely broken and must not "
+            + "be promoted silently (registered in ObservabilityServiceExtensions)",
+        ["SharedGameCatalogHealthCheck"] =
+            "shared-catalog full-text search is unusable — a core read path of the product "
+            + "(registered in ObservabilityServiceExtensions)",
+    };
+
+    private const string UnhealthyFactory = "HealthCheckResult.Unhealthy";
+    private const string HealthCheckInterface = ": IHealthCheck";
+
+    [Fact]
+    public void NonCriticalHealthChecks_DoNotReportUnhealthy()
+    {
+        var offenders = ScanHealthChecks()
+            .Where(c => !MayReportUnhealthy.ContainsKey(c.TypeName))
+            .Where(c => c.Text.Contains(UnhealthyFactory, StringComparison.Ordinal))
+            .Select(c => $"{c.Location}  {c.TypeName}")
+            .OrderBy(entry => entry, StringComparer.Ordinal)
+            .ToList();
+
+        offenders.Should().BeEmpty(
+            "a NonCritical health check returning Unhealthy takes the aggregate /health to 503 even "
+            + "though the API is serving (#3618, root cause of #3339). Return "
+            + "HealthCheckResult.Degraded instead — alerting still fires via HealthStateMachine. If "
+            + "the failure genuinely SHOULD block a deploy, add the check to MayReportUnhealthy with "
+            + "a reason and tag it Critical at registration. Offenders:\n"
+            + string.Join('\n', offenders));
+    }
+
+    /// <summary>
+    /// Keeps the allowlist honest: an entry that no longer matches a real check is stale and would
+    /// silently grant an exemption to a future type that reuses the name.
+    /// </summary>
+    [Fact]
+    public void MayReportUnhealthyAllowlist_HasNoStaleEntries()
+    {
+        var discovered = ScanHealthChecks()
+            .Select(c => c.TypeName)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var stale = MayReportUnhealthy.Keys
+            .Where(name => !discovered.Contains(name))
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToList();
+
+        stale.Should().BeEmpty(
+            "every allowlist entry must correspond to an existing IHealthCheck implementation. "
+            + "Stale:\n" + string.Join('\n', stale));
+    }
+
+    [Fact]
+    public void Scanner_FindsTheHealthChecks()
+    {
+        // Guards the gate itself: a scanner that silently matches nothing would make both tests
+        // above pass vacuously.
+        ScanHealthChecks().Should().HaveCountGreaterThan(10,
+            "the API defines ~20 IHealthCheck implementations; finding almost none means the "
+            + "scanner broke, not that the codebase is clean");
+    }
+
+    // -----------------------------------------------------------------------
+    // Source scanning
+    // -----------------------------------------------------------------------
+
+    private sealed record HealthCheckSource(string TypeName, string Text, string Location);
+
+    private static List<HealthCheckSource> ScanHealthChecks()
+    {
+        var apiSrc = LocateApiSrc();
+        var sources = new List<HealthCheckSource>();
+
+        foreach (var path in Directory.EnumerateFiles(apiSrc, "*HealthCheck.cs", SearchOption.AllDirectories))
+        {
+            var relative = Path.GetRelativePath(apiSrc, path).Replace('\\', '/');
+            if (relative.StartsWith("bin/", StringComparison.Ordinal)
+                || relative.StartsWith("obj/", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var text = File.ReadAllText(path);
+            if (!text.Contains(HealthCheckInterface, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            sources.Add(new HealthCheckSource(
+                Path.GetFileNameWithoutExtension(path),
+                text,
+                relative));
+        }
+
+        return sources;
+    }
+
+    private static string LocateApiSrc()
+    {
+        // `.git` is a directory in a normal clone and a FILE inside a git worktree — probe both so
+        // the gate runs identically in CI and in a developer worktree.
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null
+            && !Directory.Exists(Path.Combine(dir.FullName, ".git"))
+            && !File.Exists(Path.Combine(dir.FullName, ".git")))
+        {
+            dir = dir.Parent;
+        }
+
+        dir.Should().NotBeNull("the test binary must live inside the meepleai-monorepo repo");
+        var apiSrc = Path.Combine(dir!.FullName, "apps", "api", "src", "Api");
+        Directory.Exists(apiSrc).Should().BeTrue($"Api source must exist at {apiSrc}");
+        return apiSrc;
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/HealthChecks/SlackQueueHealthCheckTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/HealthChecks/SlackQueueHealthCheckTests.cs
@@ -62,8 +62,13 @@ public class SlackQueueHealthCheckTests
         result.Description!.Should().Contain("50");
     }
 
+    /// <summary>
+    /// #3618: a backlog degrades, it does not 503. This check is registered NonCritical, and a
+    /// NonCritical check returning Unhealthy takes the aggregate /health to 503 (the
+    /// failureStatus argument at registration does NOT cap an explicitly-returned status).
+    /// </summary>
     [Fact]
-    public async Task CheckHealthAsync_PendingAboveThreshold_ReturnsUnhealthy()
+    public async Task CheckHealthAsync_PendingAboveThreshold_ReturnsDegraded()
     {
         // Arrange
         SetupSlackPendingCount(150);
@@ -73,7 +78,7 @@ public class SlackQueueHealthCheckTests
             new HealthCheckContext(), CancellationToken.None);
 
         // Assert
-        result.Status.Should().Be(HealthStatus.Unhealthy);
+        result.Status.Should().Be(HealthStatus.Degraded);
         result.Description!.Should().Contain("150");
         result.Description!.Should().Contain("backlog");
     }
@@ -93,7 +98,7 @@ public class SlackQueueHealthCheckTests
     }
 
     [Fact]
-    public async Task CheckHealthAsync_RepositoryThrows_ReturnsUnhealthy()
+    public async Task CheckHealthAsync_RepositoryThrows_ReturnsDegraded()
     {
         // Arrange
         _repositoryMock.Setup(r => r.GetPendingCountByChannelsAsync(
@@ -104,8 +109,8 @@ public class SlackQueueHealthCheckTests
         var result = await _healthCheck.CheckHealthAsync(
             new HealthCheckContext(), CancellationToken.None);
 
-        // Assert
-        result.Status.Should().Be(HealthStatus.Unhealthy);
+        // Assert — Degraded, not Unhealthy: NonCritical checks must not 503 /health (#3618)
+        result.Status.Should().Be(HealthStatus.Degraded);
         result.Description!.Should().Contain("Failed to check");
     }
 

--- a/apps/api/tests/Api.Tests/Infrastructure/Health/EmbeddingDimensionHealthCheckTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/Health/EmbeddingDimensionHealthCheckTests.cs
@@ -39,11 +39,17 @@ public sealed class EmbeddingDimensionHealthCheckTests
         result.Status.Should().Be(HealthStatus.Healthy);
     }
 
+    /// <summary>
+    /// #3618: a dimension mismatch is a real misconfiguration and is logged at Error level,
+    /// but this check is registered NonCritical — returning Unhealthy would take the aggregate
+    /// /health to 503. The signal is preserved via Degraded: HealthStateMachine treats any
+    /// non-Healthy result as a failure and escalates on consecutive failures.
+    /// </summary>
     [Theory]
     [InlineData(1536, "OpenRouterSmall")]
     [InlineData(1024, "External/HuggingFace")]
     [InlineData(3072, "OpenRouterLarge")]
-    public async Task Should_Return_Unhealthy_When_Dimensions_Mismatch(
+    public async Task Should_Return_Degraded_When_Dimensions_Mismatch(
         int providerDimensions, string scenario)
     {
         // Arrange
@@ -59,8 +65,9 @@ public sealed class EmbeddingDimensionHealthCheckTests
             new HealthCheckContext(), CancellationToken.None);
 
         // Assert
-        result.Status.Should().Be(HealthStatus.Unhealthy,
-            because: $"provider returns {providerDimensions} dims but schema expects 768 ({scenario})");
+        result.Status.Should().Be(HealthStatus.Degraded,
+            because: $"provider returns {providerDimensions} dims but schema expects 768 ({scenario}); " +
+                     "NonCritical checks must never report Unhealthy (#3618)");
         result.Description.Should().Contain("768");
         result.Description.Should().Contain(providerDimensions.ToString());
     }


### PR DESCRIPTION
## Problema (#3618) — causa di classe dietro #3339

Il parametro `failureStatus` di `AddCheck<T>()` **vale solo per le eccezioni non gestite**. Un check che cattura la propria eccezione e ritorna `HealthCheckResult.Unhealthy(...)` esplicito lo bypassa, e quel valore arriva intatto al report aggregato.

Poiché `/health` (`Program.cs:665`) non fa override di `ResultStatusCodes` e usa quindi il default — `Healthy`/`Degraded` → 200, `Unhealthy` → **503** — **un solo check NonCritical Unhealthy manda in 503 l'intero endpoint** con l'API perfettamente funzionante.

Tutti questi check erano registrati `failureStatus: HealthStatus.Degraded` + tag `NonCritical`: l'intento era inequivocabile, il codice non lo rispettava.

Il fix di #3339 (PR #3344) ha corretto **solo** `orchestrator`. Gli altri 15 condividevano lo stesso difetto — bastava un hiccup di BGG API, Grafana, Prometheus, Resend/SMTP, R2 o Slack per riprodurre lo stesso sintomo.

**Evidenza interna**: `OrchestrationHealthCheck.cs:34-36` (dal fix #3344) documenta il problema implicitamente — è stato necessario cambiare il *valore di ritorno* proprio perché tag + `failureStatus` non bastavano. Anche `SlackQueueHealthCheck` conteneva già un commento su una «aggregate /health 503 mis-attributed to Slack».

## Effetto a valle

Lo smoke gate di `deploy-staging.yml` era costretto ad accettare `"200 503"`, quindi **non poteva rilevare un deploy realmente rotto** — ed è così che #3339 è rimasta invisibile fino a un'indagine manuale. Il commento che giustificava la tolleranza attribuiva il 503 allo stato `Degraded`, che invece restituisce 200: diagnosi errata, causa vera questa.

## Modifiche

**Backend** — 33 `return Unhealthy` → `Degraded` su 16 check NonCritical, allineando il codice al `failureStatus` già dichiarato e al ramo `timeout` che era **già** `Degraded` nello stesso file (l'incoerenza era interna a ciascun check).

**Invariante documentata** su `AddComprehensiveHealthChecks`, dove è visibile chi legge il `failureStatus`.

**Gate architetturale** (`NonCriticalHealthCheckStatusArchitectureTests`) — scansiona i sorgenti sul modello di `EgressHttpClientPinArchitectureTests` già presente. Allowlist esplicita: solo `ConfigurationHealthCheck` e `SharedGameCatalogHealthCheck` possono ritornare `Unhealthy`, ognuno con la ragione scritta. Include un test anti-allowlist-stale e uno anti-scanner-vacuo.

**Smoke staging** — il verdetto health è ora **BLOCKING** e nomina i check `Unhealthy`; i probe HTTP restano tolleranti al 503 perché asseriscono solo reachability attraverso Cloudflare. Rimosso `-f` da `curl`: con `-f` il body veniva scartato proprio sul 503, cioè esattamente il caso da ispezionare.

## Alerting: invariato

`HealthStateMachine.cs:44` — `var isFailure = checkResult != HealthStatus.Healthy;`. La macchina a stati che genera le email tratta `Degraded` e `Unhealthy` allo stesso modo e mantiene la propria escalation su fallimenti consecutivi. Il segnale non si perde; si perde solo l'escalation a 503 dell'aggregato, che per un NonCritical era sbagliata.

## Test

- `dotnet test --filter "Category=Unit&(Health|Architecture)"` → **250/250 pass**
- Gate verificato **per mutazione**: reintroducendo `Unhealthy` in `BggApiHealthCheck` il gate fallisce (1 fail / 2 pass), poi ripristinato. Un gate che non può fallire non protegge niente.
- Aggiornati i test che asserivano il vecchio comportamento (`SlackQueueHealthCheckTests`, `EmbeddingDimensionHealthCheckTests`) con la motivazione nel commento.
- YAML del workflow validato.

## Fuori scope (follow-up)

`shared-catalog-fts` e `configuration` non hanno **né** il tag `Critical` **né** `NonCritical` (`ObservabilityServiceExtensions.cs:29-30`) e ritornano `Unhealthy`. Sono in allowlist con la ragione: un loro fallimento *dovrebbe* bloccare un deploy. Ma la loro assenza dal predicate `Critical` significa che non sono in `/health/ready` — incoerenza da decidere separatamente, non la tocco qui.

Refs #3339, #3617

🤖 Generated with [Claude Code](https://claude.com/claude-code)