### PR TITLE
ci(tests): il gate esegue tutto tranne lento e infra (#3622)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -575,9 +575,12 @@ jobs:
         run: |
           echo "🧪 Running unit tests with dotnet-coverage..."
           mkdir -p coverage
+          # Issue #3622: deny-list anziché `Category=Unit` — un test privo di trait non finiva in
+          # alcun filtro e non veniva eseguito da NESSUN workflow. Tenere allineata a dev-fast.yml;
+          # le categorie escluse sono pinnate da TestCategoryGateArchitectureTests.
           dotnet-coverage collect \
             "dotnet test MeepleAI.Api.sln \
-              --filter Category=Unit \
+              --filter \"Category!=Integration&Category!=E2E&Category!=Performance&Category!=Manual&Category!=Slow\" \
               --settings tests/Api.Tests/unit.runsettings \
               --no-build \
               --configuration Release \

--- a/.github/workflows/dev-fast.yml
+++ b/.github/workflows/dev-fast.yml
@@ -215,9 +215,21 @@ jobs:
         working-directory: apps/api
         run: dotnet build --no-restore --configuration Release
 
-      - name: Unit tests
+      # Issue #3622: deny-list, NON `Category=Unit`. Con la allow-list un test privo di
+      # `[Trait("Category", …)]` non finiva in alcun filtro e quindi non veniva eseguito da NESSUN
+      # workflow — non falliva e non risultava saltato: semplicemente non esisteva per la CI (1326
+      # test, 82 file). La dimenticanza era silenziosa in entrambe le direzioni: chi scriveva un
+      # test nuovo non riceveva alcun segnale che non sarebbe mai stato eseguito.
+      #
+      # Invertendo il default il comportamento predefinito diventa sicuro: si esegue tutto tranne
+      # ciò che è esplicitamente marcato come lento o infra-dipendente. Le categorie escluse sono
+      # pinnate da TestCategoryGateArchitectureTests, che fallisce se ne compare una nuova — senza
+      # quel guard la deny-list tornerebbe incompleta al primo `Category` inedito.
+      - name: Unit tests (everything not explicitly slow/infra — #3622)
         working-directory: apps/api/tests/Api.Tests
-        run: dotnet test --no-build --configuration Release --filter "Category=Unit" --verbosity quiet
+        run: |
+          dotnet test --no-build --configuration Release --verbosity quiet \
+            --filter "Category!=Integration&Category!=E2E&Category!=Performance&Category!=Manual&Category!=Slow"
 
   migration-safety:
     # Issue #1087: block PRs that introduce forbidden migration patterns per

--- a/apps/api/tests/Api.Tests/Architecture/TestCategoryGateArchitectureTests.cs
+++ b/apps/api/tests/Api.Tests/Architecture/TestCategoryGateArchitectureTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Architecture;
+
+/// <summary>
+/// Issue #3622 — pins the set of <c>Category</c> trait values against the CI gate filters.
+///
+/// <para>
+/// The fast gate selects tests by EXCLUSION (<c>Category!=Integration&amp;Category!=E2E&amp;…</c>)
+/// so that a test which forgets its trait still runs. That inversion made the default safe, but it
+/// moved the fragility one step: the deny-list is a literal string in two workflow files, and the
+/// day someone introduces a new category — say <c>Chaos</c> — its tests silently join the fast
+/// gate. If they need Docker or take a minute each, the blocking gate on every PR breaks or blows
+/// its SLO, and nothing here would have warned anyone.
+/// </para>
+/// <para>
+/// So this test enumerates every <c>Category</c> actually used in the assembly and fails on any
+/// value that is not classified below. It does not judge whether a category belongs in the fast
+/// gate — that is a human call. It only guarantees the call gets made, once, deliberately, instead
+/// of being inherited by accident.
+/// </para>
+/// </summary>
+[Trait("Category", "Unit")]
+public sealed class TestCategoryGateArchitectureTests
+{
+    /// <summary>
+    /// Categories the fast gate EXCLUDES. Must stay byte-identical to the <c>--filter</c> in
+    /// <c>.github/workflows/dev-fast.yml</c> and <c>.github/workflows/ci.yml</c>.
+    /// </summary>
+    private static readonly HashSet<string> ExcludedFromFastGate = new(StringComparer.Ordinal)
+    {
+        "Integration",  // real infrastructure (Testcontainers, databases)
+        "E2E",          // full stack through WebApplicationFactory + containers
+        "Performance",  // throughput/latency benchmarks, 10-30s per test
+        "Manual",       // run on demand by a human, never in CI
+        "Slow",         // declared in TestCategories; reserved for long-running work
+    };
+
+    /// <summary>
+    /// Categories that DO run in the fast gate. Each one is here because it was checked to need no
+    /// external service: Security and Unit are in-process; Contract spins up an in-process
+    /// WireMock; PDF and CrossContext always appear alongside Integration, which already excludes
+    /// them (they are listed for completeness, not as an independent grant).
+    /// </summary>
+    private static readonly HashSet<string> AllowedInFastGate = new(StringComparer.Ordinal)
+    {
+        "Unit",
+        "Security",
+        "Contract",
+        "PDF",
+        "CrossContext",
+    };
+
+    [Fact]
+    public void EveryCategoryInUse_IsClassifiedAgainstTheFastGate()
+    {
+        var unclassified = CategoriesInUse()
+            .Where(c => !ExcludedFromFastGate.Contains(c) && !AllowedInFastGate.Contains(c))
+            .OrderBy(c => c, StringComparer.Ordinal)
+            .ToList();
+
+        unclassified.Should().BeEmpty(
+            "a new test Category must be classified before it can reach CI. Decide whether " +
+            "'{0}' belongs in the blocking fast gate: if it needs infrastructure or is slow, add " +
+            "it to the --filter in dev-fast.yml AND ci.yml and to ExcludedFromFastGate; otherwise " +
+            "add it to AllowedInFastGate. Leaving it unclassified means its tests join the " +
+            "blocking gate by accident (#3622).",
+            string.Join(", ", unclassified));
+    }
+
+    [Fact]
+    public void ExcludedAndAllowed_DoNotOverlap()
+    {
+        // An overlap would make the intent ambiguous and the next reader's fix a coin flip.
+        ExcludedFromFastGate.Intersect(AllowedInFastGate, StringComparer.Ordinal)
+            .Should().BeEmpty("a category is either excluded from the fast gate or allowed in it");
+    }
+
+    /// <summary>
+    /// Every distinct <c>Category</c> value declared on a test class in this assembly.
+    ///
+    /// Read through <see cref="CustomAttributeData"/> rather than <c>GetCustomAttributes</c>:
+    /// xUnit's <c>TraitAttribute</c> exposes no public properties, so the value is only reachable
+    /// as a constructor argument. Matching on the attribute's simple name also keeps this working
+    /// for traits declared via the <c>TestCategories</c> constants, which compile down to the same
+    /// literal.
+    /// </summary>
+    private static IEnumerable<string> CategoriesInUse() =>
+        typeof(TestCategoryGateArchitectureTests).Assembly
+            .GetTypes()
+            .SelectMany(t => t.GetCustomAttributesData())
+            .Where(a => a.AttributeType.Name == "TraitAttribute" && a.ConstructorArguments.Count == 2)
+            .Where(a => (a.ConstructorArguments[0].Value as string) == "Category")
+            .Select(a => a.ConstructorArguments[1].Value as string)
+            .Where(v => !string.IsNullOrWhiteSpace(v))
+            .Select(v => v!)
+            .Distinct(StringComparer.Ordinal);
+}

--- a/apps/api/tests/Api.Tests/Integration/DevTools/DevToolsEndpointsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DevTools/DevToolsEndpointsIntegrationTests.cs
@@ -3,10 +3,12 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Http.Json;
 using System.Threading.Tasks;
+using System.Linq;
 using Api.DevTools;
 using Api.Infrastructure;
 using Api.Services;
 using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -34,7 +36,13 @@ namespace Api.Tests.Integration.DevTools;
 /// They are grouped in a collection to enforce sequential execution, since the
 /// MockToggleStateProvider singleton is shared across tests.
 /// </summary>
+// Issue #3622: la classe era priva di [Trait("Category", …)] e quindi non veniva eseguita da
+// NESSUN gate — né da `Category=Unit` né da `Category=Integration`. È così che il suo host è
+// potuto restare rotto senza che nulla lo segnalasse. Integration e non Unit perché avvia
+// l'host completo via WebApplicationFactory (~13s per test): troppo lento per il gate veloce.
 [Collection("DevToolsEndpoints")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "DevTools")]
 public class DevToolsEndpointsIntegrationTests
     : IClassFixture<DevToolsEndpointsTestFactory>
 {
@@ -198,6 +206,18 @@ public sealed class DevToolsEndpointsTestFactory : WebApplicationFactory<Program
             // DomainEventCollector is only registered in non-Testing path of
             // InfrastructureServiceExtensions.AddDatabaseServices(); add it manually.
             services.AddScoped<IDomainEventCollector, DomainEventCollector>();
+
+            // Issue #3622: drop every IHostedService. Several of them (HybridCacheInvalidationSubscriber,
+            // ProviderCacheInvalidationSubscriber, …) call _redis.GetSubscriber() in StartAsync; the mock
+            // above only stubs GetDatabase, so they get null and the host dies with a
+            // NullReferenceException before a single route is reachable. That is precisely why these
+            // tests were red — unnoticed, because the class carried no Category trait and no gate ran it.
+            //
+            // Removed wholesale rather than one by one: deep-stubbing is not an option
+            // (ChannelMessageQueue is sealed), and an allow-list would silently break again the next
+            // time someone registers a Redis-backed background service. These four tests exercise three
+            // synchronous /dev/toggles routes — no hosted service takes part in that.
+            services.RemoveAll(typeof(IHostedService));
 
             // Wire DevTools services manually (guarded by #if DEBUG + IsDevelopment in Program.cs)
             DevToolsServiceCollectionExtensions.AddMeepleDevTools(services);


### PR DESCRIPTION
Chiude #3622.

## Il problema

Ogni gate backend selezionava i test per **inclusione** (`Category=Unit` / `Category=Integration`). Un test che non dichiara il trait non finiva in alcun filtro e **non veniva eseguito da nessun workflow**: non falliva, non risultava saltato con un motivo — semplicemente non esisteva per la CI. Misurati **1326 test in 82 file**.

La dimenticanza era silenziosa in entrambe le direzioni: chi scriveva un test nuovo non riceveva alcun segnale che non sarebbe mai stato eseguito.

## ⚠️ La direzione dell'issue è giusta, il filtro proposto no

L'issue proponeva `--filter "Category!=Integration"`. **Eseguito: 52 test rossi.**

Le categorie in uso non sono due ma **otto** (`Unit`, `Integration`, `E2E`, `Performance`, `Security`, `Manual`, `PDF`, `Contract`, `CrossContext`), in parte dichiarate via costanti `TestCategories.*`. `!=Integration` tira dentro E2E, Performance e Manual — cioè proprio i test che richiedono Testcontainers.

Serve una **deny-list**, che preserva comunque l'obiettivo: un test privo di trait non è in nessuna categoria esclusa, quindi viene eseguito.

```
Category!=Integration&Category!=E2E&Category!=Performance&Category!=Manual&Category!=Slow
```

`PDF` e `CrossContext` non sono elencate perché portano **sempre** anche `Integration`. `Contract` resta nel gate veloce: usa un WireMock in-process, nessuna rete.

## Un test rotto da mesi, trovato dal cambio

`DevToolsEndpointsIntegrationTests` non aveva trait → nessun gate lo eseguiva → **era rosso e nessuno lo sapeva**. È la tesi dell'issue, verificata sul campo.

Causa: due `IHostedService` (`HybridCacheInvalidationSubscriber`, `ProviderCacheInvalidationSubscriber`) chiamano `_redis.GetSubscriber()` in `StartAsync`, ma il mock stubba solo `GetDatabase` → `null` → `NullReferenceException` all'avvio dell'host, prima che una singola route sia raggiungibile.

Rimuovo **tutti** gli `IHostedService` dalla factory invece del singolo colpevole: ho provato la rimozione mirata e ne è emerso subito un secondo, e un allow-list si romperebbe di nuovo al prossimo servizio Redis-backed (deep-stubbing non è un'opzione: `ChannelMessageQueue` è sealed). Quei quattro test esercitano tre route sincrone. Marcata `Integration`: avvia l'host completo, ~13s per test.

## Il guard

La deny-list è una stringa letterale in due workflow. Al primo `Category` inedito — poniamo `Chaos` — i suoi test entrerebbero **in silenzio** nel gate bloccante, e se richiedessero Docker romperebbero ogni PR.

`TestCategoryGateArchitectureTests` enumera via reflection ogni `Category` in uso e fallisce su qualunque valore non classificato. Non decide se una categoria appartenga al gate veloce — quella è una scelta umana; garantisce solo che venga fatta una volta, deliberatamente, invece di essere ereditata per caso. Verificato **in negativo**: con una categoria fittizia il guard fallisce.

## Criteri di accettazione

| AC | Esito |
|---|---|
| 1. Un test senza trait viene eseguito dal gate bloccante | ✅ |
| 2. I gate coprono l'assembly meno gli skip espliciti | ⚠️ vedi sotto |
| 3. Il gate veloce resta entro l'SLO di 3 minuti | ✅ **1m55s** |
| 4. Nessun test che richiede infrastruttura nel gate veloce | ✅ 22589 test, 0 falliti |

Gate bloccante: **21 505 → 22 589 test (+1084)**.

## Follow-up: AC2 non è pienamente soddisfatto (pre-esistente)

I **58 test `Category=Performance` non sono eseguiti da nessun workflow**. Non è una regressione di questa PR — li escludeva anche `Category=Unit` — ma è lo stesso difetto di copertura su un altro asse, e ora che è misurato vale la pena tracciarlo. Includerli nel gate veloce non è la risposta: 10-30s per test violerebbe l'SLO.

`Category=E2E` (222 test) è invece coperto da `backend-e2e-tests.yml`, e `Manual` (3) è manuale per definizione.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
