### PR TITLE
fix(catalog): invalida il crop quando la cover base cambia (#3615)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ApproveGameProposal/ApproveGameProposalCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ApproveGameProposal/ApproveGameProposalCommandHandler.cs
@@ -229,6 +229,16 @@ internal sealed class ApproveGameProposalCommandHandler : ICommandHandler<Approv
         sharedGame.SetPdfCoverR2Key(shareRequest.PendingCoverR2Key);
         _sharedGameRepository.Update(sharedGame);
 
+        // #3615: this branch retargets an EXISTING game's cover, so it can carry a Social crop
+        // rendered from the previous image — stale from here on, with nothing to regenerate it.
+        // Unlike the other regeneration paths this method does not own the transaction (the caller
+        // commits), so the targeted UPDATE lands before that commit: should the commit then fail,
+        // a valid crop is lost and simply falls back to the base cover until reassigned. Preferred
+        // over leaving a crop of an image the game no longer uses.
+        await _sharedGameRepository
+            .InvalidateGeneratedCropsAsync(targetId, CoverAssignmentSource.Pdf, cancellationToken)
+            .ConfigureAwait(false);
+
         return targetId;
     }
 

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommandHandler.cs
@@ -1,4 +1,5 @@
 using Amazon.S3;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Providers;
 using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Resilience;
@@ -293,6 +294,14 @@ internal sealed class EnrichCatalogCoverCommandHandler
             await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
             game = fresh;
         }
+
+        // #3615: the Wikidata base image was replaced, so a Social crop rendered from the previous
+        // one now shows the wrong picture and nothing regenerates it. Clearing the key falls back
+        // to the new base cover. Placed after BOTH persistence paths (first attempt and the
+        // concurrency retry) so it runs exactly once, on a committed change.
+        await _repository
+            .InvalidateGeneratedCropsAsync(game.Id, CoverAssignmentSource.Wikidata, cancellationToken)
+            .ConfigureAwait(false);
 
         // Issue #3138: the cover columns changed — evict the SharedGameCatalog read-model
         // caches so /shared-games (list) and /shared-games/{id} (detail) reflect the new

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RemoveCoverAssignmentCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RemoveCoverAssignmentCommandHandler.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.Middleware.Exceptions;
 using Api.Services;
+using Api.Services.Pdf;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
@@ -22,6 +23,7 @@ internal sealed class RemoveCoverAssignmentCommandHandler : ICommandHandler<Remo
     private readonly IUnitOfWork _unitOfWork;
     private readonly IHybridCacheService _cache;
     private readonly ICacheInvalidationRetryPolicy _cacheRetryPolicy;
+    private readonly IBlobStorageService _blobStorage;
     private readonly ILogger<RemoveCoverAssignmentCommandHandler> _logger;
 
     public RemoveCoverAssignmentCommandHandler(
@@ -29,12 +31,14 @@ internal sealed class RemoveCoverAssignmentCommandHandler : ICommandHandler<Remo
         IUnitOfWork unitOfWork,
         IHybridCacheService cache,
         ICacheInvalidationRetryPolicy cacheRetryPolicy,
+        IBlobStorageService blobStorage,
         ILogger<RemoveCoverAssignmentCommandHandler> logger)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _cache = cache ?? throw new ArgumentNullException(nameof(cache));
         _cacheRetryPolicy = cacheRetryPolicy ?? throw new ArgumentNullException(nameof(cacheRetryPolicy));
+        _blobStorage = blobStorage ?? throw new ArgumentNullException(nameof(blobStorage));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -48,10 +52,33 @@ internal sealed class RemoveCoverAssignmentCommandHandler : ICommandHandler<Remo
             throw new NotFoundException("SharedGame", command.GameId.ToString());
         }
 
+        // #3615: capture the rendered crop's key BEFORE removing the assignment — afterwards the
+        // aggregate no longer knows it existed, and the R2 object would be orphaned with nothing
+        // left pointing at it. Mirrors RevokeManualCoverCommandHandler, which already does this.
+        var cropKeyToDelete = game.CoverAssignments
+            .FirstOrDefault(a => a.Context == command.Context)?.GeneratedR2Key;
+
         game.RemoveCoverAssignment(command.Context);
 
         await _repository.ReconcileCoverAssignmentsAsync(game, cancellationToken).ConfigureAwait(false);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        // Best-effort cleanup AFTER the authoritative DB removal, same ordering as the revoke path:
+        // the removed row is what makes the crop unreachable, so a failed delete leaves only an
+        // unreferenced object rather than a row pointing at a deleted one. Never fails the request.
+        if (!string.IsNullOrWhiteSpace(cropKeyToDelete))
+        {
+            try
+            {
+                await _blobStorage.DeleteRawKeyAsync(cropKeyToDelete, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogWarning(ex,
+                    "Failed to delete rendered crop {Key} for {Context} on game {GameId}; the assignment is already removed",
+                    cropKeyToDelete, command.Context, command.GameId);
+            }
+        }
 
         await CoverCacheInvalidation
             .EvictReadModelAsync(_cache, _cacheRetryPolicy, command.GameId, cancellationToken)

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ReuploadBggCover/ReuploadBggCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ReuploadBggCover/ReuploadBggCoverCommandHandler.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.Middleware.Exceptions;
 using Api.Services;
@@ -85,6 +86,14 @@ internal sealed class ReuploadBggCoverCommandHandler : ICommandHandler<ReuploadB
         game.SetBggCover(r2Key);
         _repository.Update(game);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        // #3615: un crop Social renderizzato dalla vecchia cover BGG resterebbe puntato a
+        // quell'immagine per sempre — niente lo rigenera. Azzerata la chiave, il resolver ricade
+        // sulla cover base nuova. Dopo il save: ExecuteUpdate è immediato, e invalidare prima di
+        // un salvataggio poi fallito butterebbe via un crop ancora valido.
+        await _repository
+            .InvalidateGeneratedCropsAsync(game.Id, CoverAssignmentSource.Bgg, cancellationToken)
+            .ConfigureAwait(false);
 
         // La colonna che il read-model risolve è cambiata → evict lista + dettaglio.
         await CoverCacheInvalidation

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/SetManualCoverCommandHandler.cs
@@ -1,17 +1,18 @@
-using System.Security.Cryptography;
-using System.Text.Json;
 using Api.BoundedContexts.SecurityAudit.Application.Services;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 using Api.Middleware.Exceptions;
 using Api.Observability;
-using Api.Services;
 using Api.Services.Pdf;
+using Api.Services;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Domain.Covers;
 using Api.SharedKernel.Infrastructure.Http;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Microsoft.Extensions.Logging;
+using System.Security.Cryptography;
+using System.Text.Json;
 
 namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands;
 
@@ -144,6 +145,13 @@ internal sealed class SetManualCoverCommandHandler : ICommandHandler<SetManualCo
             }));
 
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        // #3615: replacing the manual image leaves any crop rendered from the previous one stale,
+        // and nothing regenerates it. Clearing the key falls back to the new base cover. Targeted
+        // UPDATE after the save — see ISharedGameRepository.InvalidateGeneratedCropsAsync.
+        await _repository
+            .InvalidateGeneratedCropsAsync(game.Id, CoverAssignmentSource.Manual, cancellationToken)
+            .ConfigureAwait(false);
 
         // The cover columns the read-model resolves changed → evict the list + detail caches (AC-6).
         await CoverCacheInvalidation

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/PdfCoverGeneratedEventHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/PdfCoverGeneratedEventHandler.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.DocumentProcessing.Domain.Events;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.Services;
 using Api.SharedKernel.Infrastructure.Persistence;
@@ -66,6 +67,19 @@ internal sealed class PdfCoverGeneratedEventHandler : INotificationHandler<PdfCo
         game.SetPdfCoverR2Key(notification.CoverR2Key);
         _repository.Update(game);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        // #3615: the base image just changed, so any Social crop rendered from the PDF cover now
+        // shows the OLD picture — nothing regenerates it. Clearing the key makes the resolver fall
+        // back to the new base cover.
+        //
+        // A targeted UPDATE, not a reconcile: reconciliation treats the in-memory collection as the
+        // desired state, so a caller that loaded the aggregate without its assignments would delete
+        // every row. AFTER the save, because ExecuteUpdate runs immediately: invalidating first and
+        // then failing to persist the cover would drop a crop that is still perfectly valid.
+        // Reached only after the real key change (the early returns above are no-ops).
+        await _repository
+            .InvalidateGeneratedCropsAsync(sharedGameId, CoverAssignmentSource.Pdf, cancellationToken)
+            .ConfigureAwait(false);
 
         // Issue #3143: the PDF-extracted cover (which OUTRANKS the Wikidata cover in
         // CoverUrlResolver precedence) changed on an existing game — evict the catalog

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/SharedGame.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/SharedGame.cs
@@ -759,6 +759,7 @@ public sealed class SharedGame : AggregateRoot<Guid>
             return;
 
         _pdfCoverR2Key = coverR2Key;
+        InvalidateCropsDerivedFrom(CoverAssignmentSource.Pdf);
     }
 
     /// <summary>
@@ -780,6 +781,29 @@ public sealed class SharedGame : AggregateRoot<Guid>
             return;
 
         _bggCoverR2Key = coverR2Key;
+        InvalidateCropsDerivedFrom(CoverAssignmentSource.Bgg);
+    }
+
+    /// <summary>
+    /// Issue #3615 — drops the rendered per-context crops pinned to <paramref name="source"/>,
+    /// because the base image they were derived from has just been replaced.
+    ///
+    /// <para>
+    /// Called from the base-cover setters AFTER their idempotency guard, so a re-write of the same
+    /// key changes nothing. Only assignments pinned to that exact source are touched: a Social crop
+    /// of the Wikidata cover is unaffected by the PDF pipeline regenerating its own image.
+    /// </para>
+    /// <para>
+    /// Without this the crop keeps serving the OLD image indefinitely — nothing regenerates it, and
+    /// the staleness is invisible because the assignment row still looks perfectly valid.
+    /// </para>
+    /// </summary>
+    private void InvalidateCropsDerivedFrom(CoverAssignmentSource source)
+    {
+        foreach (var assignment in _coverAssignments.Where(a => a.Source == source))
+        {
+            assignment.InvalidateGeneratedCrop();
+        }
     }
 
     /// <summary>
@@ -874,11 +898,21 @@ public sealed class SharedGame : AggregateRoot<Guid>
         if (string.IsNullOrWhiteSpace(sourceUrl))
             throw new ArgumentException("Source URL cannot be empty.", nameof(sourceUrl));
 
+        // #3615: unlike SetPdfCoverR2Key/SetBggCover this method has no idempotency guard — the
+        // quarterly re-verification calls it with the SAME key just to refresh verifiedAt. Compare
+        // before writing so a no-op re-verification does not throw away a perfectly valid crop.
+        var coverImageChanged = !string.Equals(_wikidataCoverR2Key, r2Key, StringComparison.Ordinal);
+
         _wikidataCoverR2Key = r2Key;
         _wikidataCoverLicense = license;
         _wikidataCoverAttribution = string.IsNullOrWhiteSpace(attribution) ? null : attribution;
         _wikidataCoverSourceUrl = sourceUrl;
         _wikidataQidLastVerifiedAt = verifiedAt;
+
+        if (coverImageChanged)
+        {
+            InvalidateCropsDerivedFrom(CoverAssignmentSource.Wikidata);
+        }
     }
 
     /// <summary>
@@ -908,12 +942,21 @@ public sealed class SharedGame : AggregateRoot<Guid>
         if (attestedBy == Guid.Empty)
             throw new ArgumentException("AttestedBy cannot be empty.", nameof(attestedBy));
 
+        // #3615: as in SetWikidataCover, compare before writing — a re-attestation that keeps the
+        // same image must not discard a crop rendered from it.
+        var coverImageChanged = !string.Equals(_manualCoverR2Key, r2Key, StringComparison.Ordinal);
+
         _manualCoverR2Key = r2Key;
         _manualCoverLicense = license;
         _manualCoverAttribution = string.IsNullOrWhiteSpace(attribution) ? null : attribution;
         _manualCoverSourceUrl = sourceUrl;
         _manualCoverAttestedBy = attestedBy;
         _manualCoverAttestedAt = attestedAt;
+
+        if (coverImageChanged)
+        {
+            InvalidateCropsDerivedFrom(CoverAssignmentSource.Manual);
+        }
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/GameCoverAssignment.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/GameCoverAssignment.cs
@@ -174,6 +174,42 @@ public sealed class GameCoverAssignment : Entity<Guid>
         _updatedAt = DateTime.UtcNow;
     }
 
+    /// <summary>
+    /// Issue #3615 — drops the rendered crop because the BASE cover it was derived from changed
+    /// underneath it (the pipeline regenerated the PDF/BGG/Wikidata image, or an admin replaced the
+    /// manual one).
+    ///
+    /// <para>
+    /// <see cref="ChangeSource"/> and <see cref="SetFocalPoint"/> already cover the «the admin
+    /// changed their mind» case. This covers the opposite direction, where nobody touched the
+    /// assignment at all: without it the crop keeps pointing at the old image indefinitely, since
+    /// nothing regenerates it.
+    /// </para>
+    /// <para>
+    /// Clearing the key is enough — the resolver falls back to the base cover when it is null, so
+    /// the game shows the NEW image uncropped rather than a stale crop of the old one. The R2
+    /// object is deliberately left in place: its key is deterministic
+    /// (<c>covers/crops/{gameId}/social.webp</c>), so the next assignment overwrites it, and while
+    /// unreferenced it costs storage but can never be served.
+    /// </para>
+    /// <para>
+    /// A system operation like <see cref="SetGeneratedKey"/>: stamps the timestamp but leaves
+    /// <see cref="UpdatedBy"/> on the last human change.
+    /// </para>
+    /// </summary>
+    /// <returns><see langword="true"/> when a crop was actually dropped.</returns>
+    internal bool InvalidateGeneratedCrop()
+    {
+        if (_generatedR2Key is null)
+        {
+            return false;
+        }
+
+        _generatedR2Key = null;
+        _updatedAt = DateTime.UtcNow;
+        return true;
+    }
+
     private void Touch(Guid updatedBy)
     {
         _updatedAt = DateTime.UtcNow;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Repositories/ISharedGameRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Repositories/ISharedGameRepository.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
 
 namespace Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
@@ -98,6 +99,29 @@ public interface ISharedGameRepository
     /// <param name="sharedGame">The aggregate whose <c>CoverAssignments</c> are the desired state.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     Task ReconcileCoverAssignmentsAsync(SharedGame sharedGame, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Issue #3615 — clears the rendered per-context crops pinned to <paramref name="source"/> for
+    /// one game, because the base image they were derived from has just been replaced.
+    ///
+    /// <para>
+    /// A targeted UPDATE rather than <see cref="ReconcileCoverAssignmentsAsync"/>: reconciliation
+    /// treats the in-memory collection as the desired state, so calling it from a handler that
+    /// loaded the aggregate WITHOUT its assignments would delete every row. The cover-regeneration
+    /// paths do not all load them, and a silent data loss is a far worse failure than a stale crop.
+    /// </para>
+    /// <para>
+    /// Does NOT call <c>SaveChanges</c> — it executes immediately, server-side, and bypasses the
+    /// change tracker, so an entity already tracked in this context keeps its stale in-memory value
+    /// (harmless in these write-then-finish paths; the aggregate mirrors the same invalidation
+    /// in-memory anyway).
+    /// </para>
+    /// </summary>
+    /// <returns>Number of assignments whose crop was cleared.</returns>
+    Task<int> InvalidateGeneratedCropsAsync(
+        Guid gameId,
+        CoverAssignmentSource source,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Checks if a game with the given BGG ID already exists.

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/SharedGameRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/SharedGameRepository.cs
@@ -281,6 +281,25 @@ internal sealed class SharedGameRepository : RepositoryBase, ISharedGameReposito
         }
     }
 
+    public async Task<int> InvalidateGeneratedCropsAsync(
+        Guid gameId,
+        CoverAssignmentSource source,
+        CancellationToken cancellationToken = default)
+    {
+        // Filtered on GeneratedR2Key != null so the statement is a no-op (0 rows) for the common
+        // case of a game with no rendered crop — which is every game until an admin pins a Social
+        // assignment. Cheaper than loading the collection to find out there was nothing to do.
+        return await DbContext.Set<GameCoverAssignmentEntity>()
+            .Where(a => a.SharedGameId == gameId
+                        && a.Source == source
+                        && a.GeneratedR2Key != null)
+            .ExecuteUpdateAsync(
+                s => s.SetProperty(a => a.GeneratedR2Key, (string?)null)
+                      .SetProperty(a => a.UpdatedAt, DateTime.UtcNow),
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
     public async Task<bool> ExistsByBggIdAsync(int bggId, CancellationToken cancellationToken = default)
     {
         return await DbContext.Set<SharedGameEntity>()

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/AssignCoverCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/AssignCoverCommandHandlerTests.cs
@@ -56,8 +56,11 @@ public sealed class AssignCoverCommandHandlerTests
             _blobStorage.Object,
             NullLogger<AssignCoverCommandHandler>.Instance);
 
+    // #3615: the remove path deletes the removed assignment's rendered crop from R2, so it now
+    // takes the blob storage too (shared with the assign handler above).
     private RemoveCoverAssignmentCommandHandler CreateRemoveHandler() =>
-        new(_repository.Object, _unitOfWork.Object, _cache.Object, _cacheRetryPolicy.Object, NullLogger<RemoveCoverAssignmentCommandHandler>.Instance);
+        new(_repository.Object, _unitOfWork.Object, _cache.Object, _cacheRetryPolicy.Object,
+            _blobStorage.Object, NullLogger<RemoveCoverAssignmentCommandHandler>.Instance);
 
     private static SharedGame NewGame() => SharedGame.Create(
         "Catan", 1995, "desc", 3, 4, 90, 10, 2.5m, 7.8m,
@@ -178,5 +181,63 @@ public sealed class AssignCoverCommandHandlerTests
 
         await act.Should().ThrowAsync<NotFoundException>();
         _cache.Verify(c => c.RemoveByTagAcrossReplicasAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ── #3615: removing an assignment must not orphan its rendered crop ──────────────────
+    //
+    // RevokeManualCoverCommandHandler already deleted the crop objects of the assignments it
+    // removed; this path did not. Since #3611 those crops actually exist, so a removed Social
+    // assignment left `covers/crops/{gameId}/social.webp` behind with nothing referencing it.
+
+    [Fact]
+    public async Task Remove_DeletesTheRenderedCropObject()
+    {
+        var game = NewGame();
+        var assignment = game.AssignCover(CoverContext.Social, CoverAssignmentSource.Wikidata, AdminId);
+        assignment.SetGeneratedKey($"covers/crops/{game.Id}/social.webp");
+        _repository.Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>())).ReturnsAsync(game);
+        var handler = CreateRemoveHandler();
+
+        await handler.Handle(new RemoveCoverAssignmentCommand(game.Id, CoverContext.Social, AdminId), CancellationToken.None);
+
+        _blobStorage.Verify(
+            b => b.DeleteRawKeyAsync($"covers/crops/{game.Id}/social.webp", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Remove_AssignmentWithoutCrop_DeletesNothing()
+    {
+        // Card/Hero are framed client-side and never render a file: a delete call here would be
+        // a pointless round-trip against a key that was never written.
+        var game = NewGame();
+        game.AssignCover(CoverContext.Card, CoverAssignmentSource.Wikidata, AdminId);
+        _repository.Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>())).ReturnsAsync(game);
+        var handler = CreateRemoveHandler();
+
+        await handler.Handle(new RemoveCoverAssignmentCommand(game.Id, CoverContext.Card, AdminId), CancellationToken.None);
+
+        _blobStorage.Verify(b => b.DeleteRawKeyAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Remove_BlobDeleteFails_StillSucceeds()
+    {
+        // The DB removal is authoritative: a failed R2 delete leaves an unreferenced object, which
+        // is a storage cost, not a correctness problem. It must never surface as a failed request.
+        var game = NewGame();
+        var assignment = game.AssignCover(CoverContext.Social, CoverAssignmentSource.Wikidata, AdminId);
+        assignment.SetGeneratedKey($"covers/crops/{game.Id}/social.webp");
+        _repository.Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>())).ReturnsAsync(game);
+        _blobStorage
+            .Setup(b => b.DeleteRawKeyAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("R2 unavailable"));
+        var handler = CreateRemoveHandler();
+
+        var act = () => handler.Handle(
+            new RemoveCoverAssignmentCommand(game.Id, CoverContext.Social, AdminId), CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+        _unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Aggregates/SharedGameCoverAssignmentTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Aggregates/SharedGameCoverAssignmentTests.cs
@@ -162,4 +162,121 @@ public sealed class SharedGameCoverAssignmentTests
         a.GeneratedR2Key.Should().BeNull("moving the focal point invalidates the stale crop");
         a.UpdatedBy.Should().Be(Admin2Id);
     }
+
+    // ── #3615: the base cover changing underneath a rendered crop ────────────────────────
+    //
+    // ChangeSource/SetFocalPoint cover «the admin changed their mind». The opposite direction —
+    // nobody touches the assignment, but the pipeline regenerates the base image — left the crop
+    // pointing at the old picture indefinitely, because nothing regenerates it. Clearing the key
+    // makes the resolver fall back to the NEW base cover instead of serving a stale crop.
+
+    [Fact]
+    public void SetPdfCoverR2Key_NewKey_InvalidatesCropsPinnedToPdf()
+    {
+        var game = NewGame();
+        game.SetPdfCoverR2Key("covers/g/cover-preview");
+        var a = game.AssignCover(CoverContext.Social, CoverAssignmentSource.Pdf, AdminId);
+        a.SetGeneratedKey("covers/crops/g/social.webp");
+
+        game.SetPdfCoverR2Key("covers/g/cover-preview-v2");
+
+        a.GeneratedR2Key.Should().BeNull("the image the crop was rendered from no longer exists");
+    }
+
+    [Fact]
+    public void SetBggCover_NewKey_InvalidatesCropsPinnedToBgg()
+    {
+        var game = NewGame();
+        game.SetBggCover("covers/g/bgg");
+        var a = game.AssignCover(CoverContext.Social, CoverAssignmentSource.Bgg, AdminId);
+        a.SetGeneratedKey("covers/crops/g/social.webp");
+
+        game.SetBggCover("covers/g/bgg-v2");
+
+        a.GeneratedR2Key.Should().BeNull();
+    }
+
+    [Fact]
+    public void SetPdfCoverR2Key_SameKey_KeepsTheCrop()
+    {
+        // Re-writing the identical key is a no-op upstream (the event handler is idempotent):
+        // discarding a valid crop there would degrade the Social rendering for nothing.
+        var game = NewGame();
+        game.SetPdfCoverR2Key("covers/g/cover-preview");
+        var a = game.AssignCover(CoverContext.Social, CoverAssignmentSource.Pdf, AdminId);
+        a.SetGeneratedKey("covers/crops/g/social.webp");
+
+        game.SetPdfCoverR2Key("covers/g/cover-preview");
+
+        a.GeneratedR2Key.Should().Be("covers/crops/g/social.webp");
+    }
+
+    [Fact]
+    public void SetPdfCoverR2Key_DoesNotTouchCropsPinnedToAnotherSource()
+    {
+        // The PDF pipeline regenerating its own image says nothing about a crop rendered from the
+        // Wikidata cover: invalidating it would throw away a perfectly current file.
+        var game = NewGame();
+        game.SetWikidataCover("covers/g/cover", "CC BY-SA 4.0", null, "https://www.wikidata.org/entity/Q1", DateTime.UtcNow);
+        var wikidataCrop = game.AssignCover(CoverContext.Social, CoverAssignmentSource.Wikidata, AdminId);
+        wikidataCrop.SetGeneratedKey("covers/crops/g/social.webp");
+
+        game.SetPdfCoverR2Key("covers/g/cover-preview");
+
+        wikidataCrop.GeneratedR2Key.Should().Be("covers/crops/g/social.webp");
+    }
+
+    [Fact]
+    public void SetWikidataCover_SameImageReVerified_KeepsTheCrop()
+    {
+        // SetWikidataCover has no idempotency guard: the quarterly re-verification calls it with
+        // the same key just to refresh verifiedAt. That must not cost the crop.
+        var game = NewGame();
+        game.SetWikidataCover("covers/g/cover", "CC BY-SA 4.0", null, "https://www.wikidata.org/entity/Q1", DateTime.UtcNow);
+        var a = game.AssignCover(CoverContext.Social, CoverAssignmentSource.Wikidata, AdminId);
+        a.SetGeneratedKey("covers/crops/g/social.webp");
+
+        game.SetWikidataCover("covers/g/cover", "CC BY-SA 4.0", null, "https://www.wikidata.org/entity/Q1", DateTime.UtcNow.AddDays(90));
+
+        a.GeneratedR2Key.Should().Be("covers/crops/g/social.webp", "only a NEW image invalidates the crop");
+    }
+
+    [Fact]
+    public void SetWikidataCover_NewImage_InvalidatesTheCrop()
+    {
+        var game = NewGame();
+        game.SetWikidataCover("covers/g/cover", "CC BY-SA 4.0", null, "https://www.wikidata.org/entity/Q1", DateTime.UtcNow);
+        var a = game.AssignCover(CoverContext.Social, CoverAssignmentSource.Wikidata, AdminId);
+        a.SetGeneratedKey("covers/crops/g/social.webp");
+
+        game.SetWikidataCover("covers/g/cover-v2", "CC BY-SA 4.0", null, "https://www.wikidata.org/entity/Q1", DateTime.UtcNow);
+
+        a.GeneratedR2Key.Should().BeNull();
+    }
+
+    [Fact]
+    public void SetManualCover_NewImage_InvalidatesTheCrop()
+    {
+        var game = NewGame();
+        game.SetManualCover("covers/g/manual", "CC0", null, "https://example.com/a", AdminId, DateTime.UtcNow);
+        var a = game.AssignCover(CoverContext.Social, CoverAssignmentSource.Manual, AdminId);
+        a.SetGeneratedKey("covers/crops/g/social.webp");
+
+        game.SetManualCover("covers/g/manual-v2", "CC0", null, "https://example.com/b", AdminId, DateTime.UtcNow);
+
+        a.GeneratedR2Key.Should().BeNull();
+    }
+
+    [Fact]
+    public void SetManualCover_SameImageReAttested_KeepsTheCrop()
+    {
+        var game = NewGame();
+        game.SetManualCover("covers/g/manual", "CC0", null, "https://example.com/a", AdminId, DateTime.UtcNow);
+        var a = game.AssignCover(CoverContext.Social, CoverAssignmentSource.Manual, AdminId);
+        a.SetGeneratedKey("covers/crops/g/social.webp");
+
+        game.SetManualCover("covers/g/manual", "CC BY 4.0", "Artist", "https://example.com/a", Admin2Id, DateTime.UtcNow);
+
+        a.GeneratedR2Key.Should().Be("covers/crops/g/social.webp");
+    }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/SharedGameCoverAssignmentReconcileIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/SharedGameCoverAssignmentReconcileIntegrationTests.cs
@@ -220,4 +220,56 @@ public sealed class SharedGameCoverAssignmentReconcileIntegrationTests : IAsyncL
         afterRevoke.CoverAssignments.Should().ContainSingle("the Manual pin was cascade-removed; Wikidata survives");
         afterRevoke.CoverAssignments.Single().Source.Should().Be(CoverAssignmentSource.Wikidata);
     }
+
+    /// <summary>
+    /// #3615 — the crop invalidation must reach the DATABASE, not just the in-memory aggregate.
+    ///
+    /// The regeneration paths call <c>Update()</c>, which maps scalars only, so an invalidation
+    /// applied to the child collection would be silently dropped: the domain would look right and
+    /// the stale crop would keep being served. Only a round-trip through real Postgres proves it.
+    /// </summary>
+    [Fact]
+    public async Task InvalidateGeneratedCrops_ClearsOnlyTheMatchingSource_OnPostgres()
+    {
+        var gameId = await SeedGameAsync();
+
+        var g = await _repository.GetByIdAsync(gameId);
+        var pdfPin = g!.AssignCover(CoverContext.Social, CoverAssignmentSource.Pdf, AdminId);
+        pdfPin.SetGeneratedKey($"covers/crops/{gameId}/social.webp");
+        var wikidataPin = g.AssignCover(CoverContext.Card, CoverAssignmentSource.Wikidata, AdminId);
+        wikidataPin.SetGeneratedKey($"covers/crops/{gameId}/card.webp");
+        await _repository.ReconcileCoverAssignmentsAsync(g);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        var cleared = await _repository.InvalidateGeneratedCropsAsync(gameId, CoverAssignmentSource.Pdf);
+
+        // ExecuteUpdate runs server-side and needs no SaveChanges — assert on a fresh read.
+        cleared.Should().Be(1);
+        _dbContext.ChangeTracker.Clear();
+        var after = await _repository.GetByIdAsync(gameId);
+        after!.CoverAssignments.Single(a => a.Source == CoverAssignmentSource.Pdf)
+            .GeneratedR2Key.Should().BeNull("the PDF base image was replaced");
+        after.CoverAssignments.Single(a => a.Source == CoverAssignmentSource.Wikidata)
+            .GeneratedR2Key.Should().Be($"covers/crops/{gameId}/card.webp",
+                "a crop rendered from another source is still current");
+    }
+
+    [Fact]
+    public async Task InvalidateGeneratedCrops_NoCropToClear_IsANoOp_OnPostgres()
+    {
+        // The overwhelmingly common case: a game with no rendered crop at all. The statement is
+        // filtered on GeneratedR2Key != null so it touches zero rows rather than rewriting them
+        // with a fresh UpdatedAt.
+        var gameId = await SeedGameAsync();
+        var g = await _repository.GetByIdAsync(gameId);
+        g!.AssignCover(CoverContext.Social, CoverAssignmentSource.Pdf, AdminId);
+        await _repository.ReconcileCoverAssignmentsAsync(g);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        var cleared = await _repository.InvalidateGeneratedCropsAsync(gameId, CoverAssignmentSource.Pdf);
+
+        cleared.Should().Be(0);
+    }
 }


### PR DESCRIPTION
Chiude #3615.

## Il difetto

Il dominio azzerava `GeneratedR2Key` su `ChangeSource`/`SetFocalPoint`, quindi il caso «l'admin cambia idea» era coperto. Non lo era il caso opposto: **la pipeline rigenera la cover base** (`PdfCoverR2Key`/`BggCoverR2Key`) e il crop Social resta puntato all'immagine vecchia a tempo indeterminato, perché nulla lo rigenera — mentre la riga di assegnazione continua a sembrare perfettamente valida.

L'aggregato ora azzera il crop delle assegnazioni pinnate alla sorgente sostituita; il resolver ricade sulla cover base **nuova** invece di servire un crop di quella vecchia.

## Il punto non ovvio: l'invalidazione di dominio da sola non sarebbe servita a nulla

I 5 path di rigenerazione (`PdfCoverGeneratedEventHandler`, `ReuploadBggCover`, `SetManualCover`, `EnrichCatalogCover`, `ApproveGameProposal`) chiamano `Update()`, che **mappa i soli scalari**, e nessuno di essi riconcilia la collezione figlia. L'azzeramento sarebbe rimasto in memoria e non avrebbe mai raggiunto il database: un fix che sembra corretto in ogni code review e non produce alcun effetto.

Da qui `InvalidateGeneratedCropsAsync`, un **UPDATE mirato** e non un reconcile:

> la riconciliazione tratta la collezione in memoria come stato desiderato, quindi invocarla da un handler che ha caricato l'aggregato *senza* le assegnazioni ne cancellerebbe ogni riga. Una perdita di dati silenziosa è molto peggio di un crop stantio.

È filtrato su `GeneratedR2Key != null`, quindi tocca zero righe nel caso dominante (nessun crop) invece di riscriverle con un `UpdatedAt` nuovo. Eseguito **dopo** il `SaveChanges`: `ExecuteUpdate` è immediato, e invalidare prima di un salvataggio poi fallito butterebbe via un crop ancora valido.

## Idempotenza: due setter si comportano diversamente

`SetPdfCoverR2Key`/`SetBggCover` hanno un guard di idempotenza; `SetWikidataCover` e `SetManualCover` **no** — la re-verifica trimestrale chiama il primo con la stessa chiave solo per aggiornare `verifiedAt`. Invalidare incondizionatamente lì avrebbe distrutto un crop valido a ogni cron. Ora confrontano il valore prima di scrivere, e i test coprono entrambe le direzioni.

## Simmetria mancante (secondo punto dell'issue)

`RemoveCoverAssignmentCommandHandler` non ripuliva il crop generato, mentre `RevokeManualCoverCommandHandler` lo faceva. Da #3611 quei file esistono davvero, quindi rimuovere un'assegnazione Social lasciava un orfano a `covers/crops/{gameId}/social.webp`. Ora lo cancella best-effort, con lo stesso ordinamento del revoke: la rimozione dal DB è autoritativa, un delete fallito lascia solo un oggetto non referenziato e non deve mai far fallire la richiesta.

## Test

- **8 di dominio**: invalidazione per Pdf/Bgg/Wikidata/Manual, non-invalidazione su chiave identica, e la non-interferenza fra sorgenti (il PDF che si rigenera non tocca un crop Wikidata).
- **3 sull'handler**: il crop viene cancellato, un'assegnazione senza crop non produce chiamate, un delete fallito non fa fallire la richiesta.
- **2 di integrazione su Postgres reale**: provano che l'invalidazione **persiste** e che colpisce solo la sorgente giusta. Senza questi il fix sarebbe stato inefficace senza che nulla lo segnalasse.

Non-regressione: 3659 test verdi nell'area Cover/SharedGame.

## Nota su `ApproveGameProposal`

È l'unico dei cinque a non possedere la propria transazione (commit del chiamante), quindi lì l'UPDATE mirato precede il commit: se questo fallisse, un crop valido andrebbe perso e ricadrebbe sulla cover base finché non riassegnato. Preferito al lasciare un crop di un'immagine che il gioco non usa più. È annotato nel codice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
