### PR TITLE
fix(infra): monitora orchestration quando gira in staging (#3617)

### DIFF
--- a/docs/for-developers/operations/operations-manual.md
+++ b/docs/for-developers/operations/operations-manual.md
@@ -1737,6 +1737,36 @@ cd infra
 docker compose -f docker-compose.yml -f compose.dev.yml --profile monitoring up -d
 ```
 
+### Health checks of opt-in services (#3339, #3617)
+
+**Regola: un servizio opt-in va monitorato quando è attivo, e solo allora.**
+
+Alcuni health check sono registrati condizionalmente, in base alla presenza della URL del servizio
+in configurazione (`HealthCheckServiceExtensions`): `orchestrator` su `ORCHESTRATION_SERVICE_URL`,
+`ollama` su `OLLAMA_URL`. Il motivo è che le due condizioni sbagliate falliscono entrambe, in
+direzioni opposte:
+
+- registrare il check per un servizio **non deployato** produce un Degraded permanente — rumore che
+  insegna a ignorare il report (era #3339);
+- non registrarlo per un servizio **che gira** lascia un servizio non monitorato che sembra
+  monitorato: se degrada durante una sessione, `/health` non lo dice (era #3617).
+
+La condizione corretta non è «quale ambiente» ma «il servizio è attivo». Poiché le env var di
+compose non sono condizionabili per profilo, l'attivazione passa da un file di override applicato
+solo dal target che avvia il profilo.
+
+| Comando | orchestration gira | `ORCHESTRATION_SERVICE_URL` | check `orchestrator` |
+|---|---|---|---|
+| `make staging-minimal` | no | non settata | non registrato |
+| `make staging-with-tutor` | sì | `compose.staging.tutor.yml` | registrato |
+| `make staging-tutor-down` | no (rimosso) | rimossa ricreando `api` | non registrato |
+| dev / prod | sì | `compose.dev.yml` / `compose.prod.yml` | registrato |
+
+> ⚠️ `staging-tutor-down` deve ricreare il container `api`, non solo fermare orchestration: un
+> container avviato con l'override conserva la variabile finché vive, e il check resterebbe
+> registrato su un servizio ormai assente — di nuovo #3339, per giunta in una forma transitoria che
+> non si spiega leggendo `compose.staging.yml`.
+
 ### Prometheus
 
 #### Configuration

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -64,12 +64,22 @@ staging-minimal: ## Deploy staging single-tester profile (~3GB RAM) — edge via
 		--profile ai-essential --profile monitoring-essential up -d
 
 staging-with-tutor: ## Deploy staging single-tester + orchestration-service for tutor agents (~5GB RAM)
-	$(COMPOSE) -f compose.staging.yml \
+	# Issue #3617: compose.staging.tutor.yml valorizza ORCHESTRATION_SERVICE_URL sull'api, così
+	# l'health check `orchestrator` viene registrato quando il servizio gira davvero. Va aggiunto
+	# QUI e non in compose.staging.yml: le env var non sono condizionabili per profilo, e settarla
+	# per lo staging standard (dove orchestration non è deployato) riaprirebbe #3339.
+	$(COMPOSE) -f compose.staging.yml -f compose.staging.tutor.yml \
 		--profile ai-essential --profile monitoring-essential --profile tutor-agents up -d
 
 staging-tutor-down: ## Stop only orchestration-service (keep rest of staging running)
 	$(COMPOSE) -f compose.staging.yml --profile tutor-agents stop orchestration-service
 	$(COMPOSE) -f compose.staging.yml --profile tutor-agents rm -f orchestration-service
+	# Issue #3617: ricrea l'api SENZA l'override del tutor. Senza questo passo il container
+	# conserva ORCHESTRATION_SERVICE_URL dall'avvio precedente: il check resta registrato mentre
+	# orchestration non c'è più → Degraded permanente, cioè #3339 di nuovo, e per giunta in una
+	# forma transitoria che non si spiega leggendo compose.staging.yml.
+	$(COMPOSE) -f compose.staging.yml \
+		--profile ai-essential --profile monitoring-essential up -d --force-recreate api
 
 staging-core: ## (Deprecated, use staging-minimal) Deploy staging core only — no AI services
 	$(COMPOSE) -f compose.staging.yml \

--- a/infra/compose.staging.tutor.yml
+++ b/infra/compose.staging.tutor.yml
@@ -1,0 +1,29 @@
+# Issue #3617 — override staging attivo SOLO insieme al profilo `tutor-agents`.
+#
+# ## Perché un file separato invece di una riga in compose.staging.yml
+#
+# L'health check `orchestrator` viene registrato solo se `ORCHESTRATION_SERVICE_URL` è valorizzata
+# (`HealthCheckServiceExtensions.cs`). È la condizione che ha chiuso #3339: in staging standard
+# orchestration NON è deployato, e registrare il check per un servizio deliberatamente assente
+# produceva un Degraded permanente — rumore che a lungo andare insegna a ignorare il report.
+#
+# Ma le env var di compose non sono condizionabili per profilo: metterla in `compose.staging.yml`
+# la applicherebbe anche allo staging standard, riaprendo esattamente #3339. Da qui l'override, che
+# `make staging-with-tutor` aggiunge e gli altri target no.
+#
+# ## Il requisito che l'issue lasciava aperto
+#
+# «Un servizio opt-in, quando è attivo, deve essere osservabile?» — sì. Un servizio che gira e che
+# può degradare durante una sessione tutor senza che `/health` lo dica è indistinguibile da uno
+# funzionante: è il caso peggiore, perché il monitoraggio sembra esserci. La condizione corretta
+# non è «l'ambiente è staging» ma «il servizio è attivo», ed è ciò che questo file esprime.
+#
+# ## Simmetria obbligatoria
+#
+# `make staging-tutor-down` DEVE ricreare `api` senza questo override. Fermare orchestration
+# lasciando la variabile sul container significa check registrato + servizio assente, cioè di nuovo
+# #3339 — con l'aggravante di essere transitorio e quindi più difficile da diagnosticare.
+services:
+  api:
+    environment:
+      ORCHESTRATION_SERVICE_URL: http://orchestration-service:8004


### PR DESCRIPTION
Chiude #3617.

## Il buco

L'health check `orchestrator` è registrato solo se `ORCHESTRATION_SERVICE_URL` è valorizzata — la condizione che ha chiuso #3339. Ma `compose.staging.yml` non la settava (a differenza di dev e prod), quindi sotto `--profile tutor-agents` **orchestration girava davvero e non era monitorato affatto**: se degradava durante una sessione tutor, `/health` non lo diceva.

## La decisione che l'issue lasciava aperta

> «Un servizio opt-in, quando è attivo, deve essere osservabile?»

**Sì.** Le due condizioni sbagliate falliscono entrambe, in direzioni opposte:

- registrare il check per un servizio **non deployato** → Degraded permanente, cioè rumore che insegna a ignorare il report (#3339);
- non registrarlo per un servizio **che gira** → un servizio non monitorato che *sembra* monitorato, che è il caso peggiore dei due.

La condizione corretta non è «quale ambiente» ma «il servizio è attivo».

## Come, dato il vincolo

Le env var di compose non sono condizionabili per profilo, quindi metterla in `compose.staging.yml` riaprirebbe #3339 per lo staging standard. L'attivazione passa da `compose.staging.tutor.yml`, aggiunto **solo** da `make staging-with-tutor`.

Verificato con `docker compose config`:

| Contesto | `ORCHESTRATION_SERVICE_URL` |
|---|---|
| `compose.staging.yml` + `compose.staging.tutor.yml` | `http://orchestration-service:8004` |
| `compose.staging.yml` da solo (staging standard) | assente |

## Il caso che l'issue non copriva

`make staging-tutor-down` ferma e rimuove orchestration, ma il container `api` era già avviato **con** l'override e conserva la variabile finché vive: il check resterebbe registrato su un servizio ormai assente — di nuovo #3339, per giunta in forma transitoria, quindi non diagnosticabile leggendo `compose.staging.yml`.

Il target ora ricrea `api` senza l'override, chiudendo la simmetria.

## DoD

- [x] Deciso e documentato il requisito di osservabilità per i servizi opt-in attivi
- [x] Orchestration monitorato sotto `tutor-agents` senza reintrodurre rumore in staging standard
- [x] Tabella comportamentale aggiornata — spostata dal corpo della PR #3344 all'`operations-manual.md`, dove un operatore la cerca davvero, con la riga `staging-tutor-down` che prima mancava

## Note

- Il comportamento backend era già coperto da `Orchestration_Is_Registered_Only_When_Url_Is_Set` (#3339); questa PR è infrastrutturale e non aggiunge test .NET.
- **Non deployato**: la modifica ha effetto al prossimo `make staging-with-tutor`. Chi lo esegue si porta dietro anche la ricreazione dell'`api` al `tutor-down`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
