### PR TITLE
fix(rag-eval): sandbox dei dataset path negli endpoint admin (#3438)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Evaluation/Services/EvalDatasetPathResolver.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Evaluation/Services/EvalDatasetPathResolver.cs
@@ -1,0 +1,161 @@
+using Microsoft.Extensions.Configuration;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Evaluation.Services;
+
+/// <summary>Why a requested evaluation dataset path was refused.</summary>
+internal enum EvalDatasetPathError
+{
+    /// <summary>No dataset root is configured: the subsystem is unavailable, not the request invalid.</summary>
+    RootNotConfigured,
+
+    /// <summary>Empty or whitespace.</summary>
+    Empty,
+
+    /// <summary>Absolute/rooted path, or a path that escapes the root (<c>..</c>, drive-qualified, UNC).</summary>
+    OutsideRoot,
+
+    /// <summary>Not a <c>.json</c> file.</summary>
+    NotJson,
+}
+
+/// <summary>Outcome of resolving a caller-supplied dataset path against the configured root.</summary>
+internal readonly record struct EvalDatasetPathResult(string? FullPath, EvalDatasetPathError? Error)
+{
+    public bool IsSuccess => Error is null;
+
+    public static EvalDatasetPathResult Ok(string fullPath) => new(fullPath, null);
+
+    public static EvalDatasetPathResult Fail(EvalDatasetPathError error) => new(null, error);
+}
+
+/// <summary>
+/// Issue #3438 — resolves a caller-supplied evaluation dataset name against a fixed root, so the
+/// admin eval endpoints can never read or write outside it.
+/// </summary>
+internal interface IEvalDatasetPathResolver
+{
+    /// <summary>Resolves a path for READING. The file must exist inside the root.</summary>
+    EvalDatasetPathResult ResolveForRead(string? requestedPath);
+
+    /// <summary>
+    /// Resolves a path for WRITING. Identical containment rules, but the file need not exist yet —
+    /// merge-labels legitimately targets a new file.
+    /// </summary>
+    EvalDatasetPathResult ResolveForWrite(string? requestedPath);
+}
+
+/// <summary>
+/// Issue #3438 — sandboxes the evaluation dataset paths accepted by the admin eval endpoints.
+///
+/// <para>
+/// Before this, <c>datasetPath</c> reached <c>File.ReadAllTextAsync</c> unfiltered and
+/// <c>outputPath</c> reached the writer: an admin session — or a stolen one, or a CSRF — could read
+/// any file the process could read (<c>appsettings.json</c>, mounted secrets) and, through
+/// merge-labels, WRITE to an arbitrary path. Admin-gating narrows who can do it; it does not make
+/// the capability acceptable.
+/// </para>
+/// <para>
+/// <b>Fail-closed.</b> With no configured root every request is refused. The alternative — guessing
+/// a default like the repo's <c>tests/evaluation-datasets/</c> — would hand back an implicit
+/// sandbox that nobody chose and that silently differs per environment. Refusing until an operator
+/// states where datasets live is the safe direction, and the issue's blocking question («where do
+/// evaluation datasets live in production?») stops being a prerequisite: it becomes configuration.
+/// </para>
+/// <para>
+/// Configuration key <c>Evaluation:DatasetRoot</c> (env <c>Evaluation__DatasetRoot</c>), with
+/// <c>EVAL_DATASET_ROOT</c> accepted as a flat alias for parity with the other service URLs.
+/// </para>
+/// </summary>
+internal sealed class EvalDatasetPathResolver : IEvalDatasetPathResolver
+{
+    internal const string RootConfigKey = "Evaluation:DatasetRoot";
+    internal const string RootEnvAlias = "EVAL_DATASET_ROOT";
+
+    private readonly string? _rootFullPath;
+
+    public EvalDatasetPathResolver(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        var configured = configuration[RootConfigKey];
+        if (string.IsNullOrWhiteSpace(configured))
+        {
+            configured = configuration[RootEnvAlias];
+        }
+
+        // Normalised once at construction: every later comparison is against a canonical, trailing
+        // separator-terminated absolute path, so prefix matching cannot be fooled by a sibling
+        // directory whose name merely starts with the root's ("/data/evalX" vs "/data/eval").
+        _rootFullPath = string.IsNullOrWhiteSpace(configured)
+            ? null
+            : EnsureTrailingSeparator(Path.GetFullPath(configured));
+    }
+
+    public EvalDatasetPathResult ResolveForRead(string? requestedPath)
+    {
+        var resolved = Resolve(requestedPath);
+        if (!resolved.IsSuccess)
+        {
+            return resolved;
+        }
+
+        // Existence is checked by the caller (404 vs 400 is an HTTP concern). Deliberately NOT
+        // checked here: doing so would turn this resolver into a file-existence oracle for paths
+        // it just refused, which is the leak the sandbox exists to prevent.
+        return resolved;
+    }
+
+    public EvalDatasetPathResult ResolveForWrite(string? requestedPath) => Resolve(requestedPath);
+
+    private EvalDatasetPathResult Resolve(string? requestedPath)
+    {
+        if (_rootFullPath is null)
+        {
+            return EvalDatasetPathResult.Fail(EvalDatasetPathError.RootNotConfigured);
+        }
+
+        if (string.IsNullOrWhiteSpace(requestedPath))
+        {
+            return EvalDatasetPathResult.Fail(EvalDatasetPathError.Empty);
+        }
+
+        // Rooted paths are refused outright rather than combined: Path.Combine(root, "/etc/passwd")
+        // returns "/etc/passwd", silently discarding the root. On Windows this also covers
+        // "C:\..." and UNC "\\server\share".
+        if (Path.IsPathRooted(requestedPath))
+        {
+            return EvalDatasetPathResult.Fail(EvalDatasetPathError.OutsideRoot);
+        }
+
+        string candidate;
+        try
+        {
+            candidate = Path.GetFullPath(Path.Combine(_rootFullPath, requestedPath));
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            // Malformed input (invalid characters, over-length) is a refusal, never a 500.
+            return EvalDatasetPathResult.Fail(EvalDatasetPathError.OutsideRoot);
+        }
+
+        // Containment is decided AFTER normalisation, so "a/../../etc/passwd" is caught by where it
+        // actually lands rather than by pattern-matching "..", which misses encodings and rejects
+        // harmless names.
+        if (!candidate.StartsWith(_rootFullPath, StringComparison.Ordinal))
+        {
+            return EvalDatasetPathResult.Fail(EvalDatasetPathError.OutsideRoot);
+        }
+
+        // Datasets are JSON. Narrowing the extension keeps the sandbox from doubling as a reader
+        // for whatever else happens to sit under the root.
+        if (!candidate.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+        {
+            return EvalDatasetPathResult.Fail(EvalDatasetPathError.NotJson);
+        }
+
+        return EvalDatasetPathResult.Ok(candidate);
+    }
+
+    private static string EnsureTrailingSeparator(string path) =>
+        path.EndsWith(Path.DirectorySeparatorChar) ? path : path + Path.DirectorySeparatorChar;
+}

--- a/apps/api/src/Api/Extensions/ApplicationServiceExtensions.cs
+++ b/apps/api/src/Api/Extensions/ApplicationServiceExtensions.cs
@@ -7,14 +7,15 @@ using Api.BoundedContexts.EntityRelationships.Infrastructure.DependencyInjection
 using Api.BoundedContexts.GameManagement.Infrastructure.DependencyInjection;
 using Api.BoundedContexts.GameToolbox.Infrastructure.DependencyInjection;
 using Api.BoundedContexts.GameToolkit.Infrastructure.DependencyInjection;
+using Api.BoundedContexts.KnowledgeBase.Application.Evaluation.Services;
 using Api.BoundedContexts.KnowledgeBase.Infrastructure.DependencyInjection;
 using Api.BoundedContexts.KnowledgeBase.Infrastructure.EmbeddingProviders;
 using Api.Helpers;
 using Api.Infrastructure;
-using Api.Services;
+using Api.Observability;
 using Api.Services.Pdf;
 using Api.Services.Rag;
-using Api.Observability;
+using Api.Services;
 using Api.SharedKernel.Application;
 using FluentValidation;
 
@@ -95,6 +96,11 @@ internal static class ApplicationServiceExtensions
 
         // AI-06: RAG offline evaluation service
         services.AddScoped<IRagEvaluationService, RagEvaluationService>();
+
+        // #3438: sandboxes the dataset paths accepted by the admin eval endpoints against a
+        // configured root. Singleton — it only normalises the root once from IConfiguration and
+        // holds no per-request state.
+        services.AddSingleton<IEvalDatasetPathResolver, EvalDatasetPathResolver>();
 
         // AI-07: Prompt versioning and management service
 

--- a/apps/api/src/Api/Routing/KnowledgeBase/AdminEvalEndpoints.cs
+++ b/apps/api/src/Api/Routing/KnowledgeBase/AdminEvalEndpoints.cs
@@ -40,24 +40,25 @@ internal static class AdminEvalEndpoints
     private static async Task<IResult> HandleRunRetrievalEvaluation(
         RunRetrievalEvaluationRequest request,
         IMediator mediator,
+        IEvalDatasetPathResolver pathResolver,
         CancellationToken ct)
     {
-        // NOTE: this only rejects a missing/non-existent datasetPath with a 4xx before
-        // dispatching any command. Full path sandboxing (restricting datasetPath to an
-        // allowlisted root directory) is tracked in issue #3438.
-        var pathError = ValidateDatasetPath(request.DatasetPath);
+        // #3438: datasetPath is resolved against the configured root BEFORE any command sees it.
+        // Commands downstream call File.ReadAllTextAsync on whatever they are given, so this
+        // endpoint is the trust boundary: everything past it works on an already-sandboxed path.
+        var (datasetPath, pathError) = ResolveDatasetForRead(pathResolver, request.DatasetPath);
         if (pathError is not null)
         {
             return pathError;
         }
 
         var dataset = await mediator.Send(
-            new LoadDatasetCommand { FilePath = request.DatasetPath }, ct).ConfigureAwait(false);
+            new LoadDatasetCommand { FilePath = datasetPath! }, ct).ConfigureAwait(false);
 
         var result = await mediator.Send(
             new RunEvaluationCommand
             {
-                DatasetPath = request.DatasetPath,
+                DatasetPath = datasetPath!,
                 MaxSamples = request.MaxSamples,
                 Enhancements = request.Enhancements
             },
@@ -72,19 +73,17 @@ internal static class AdminEvalEndpoints
     private static async Task<IResult> HandleGenerateLabelingCandidates(
         GenerateLabelingCandidatesRequest request,
         IMediator mediator,
+        IEvalDatasetPathResolver pathResolver,
         CancellationToken ct)
     {
-        // NOTE: this only rejects a missing/non-existent datasetPath with a 4xx before
-        // dispatching any command. Full path sandboxing (restricting datasetPath to an
-        // allowlisted root directory) is tracked in issue #3438.
-        var pathError = ValidateDatasetPath(request.DatasetPath);
+        var (datasetPath, pathError) = ResolveDatasetForRead(pathResolver, request.DatasetPath);
         if (pathError is not null)
         {
             return pathError;
         }
 
         var review = await mediator.Send(
-            new GenerateLabelingCandidatesCommand(request.DatasetPath, request.TopN ?? 10),
+            new GenerateLabelingCandidatesCommand(datasetPath!, request.TopN ?? 10),
             ct).ConfigureAwait(false);
 
         return Results.Ok(review);
@@ -93,12 +92,10 @@ internal static class AdminEvalEndpoints
     private static async Task<IResult> HandleMergeLabels(
         MergeLabelsRequest request,
         IMediator mediator,
+        IEvalDatasetPathResolver pathResolver,
         CancellationToken ct)
     {
-        // NOTE: this only rejects a missing/non-existent datasetPath with a 4xx before
-        // dispatching any command. Full path sandboxing (restricting datasetPath to an
-        // allowlisted root directory) is tracked in issue #3438.
-        var pathError = ValidateDatasetPath(request.DatasetPath);
+        var (datasetPath, pathError) = ResolveDatasetForRead(pathResolver, request.DatasetPath);
         if (pathError is not null)
         {
             return pathError;
@@ -111,29 +108,82 @@ internal static class AdminEvalEndpoints
             return Results.BadRequest(new { error = "review with items is required" });
         }
 
-        // OutputPath defaults to the source dataset (apply labels in-place); callers may target a
-        // separate file. Path sandboxing of the output path is deferred to #3438 alongside datasetPath.
+        // #3438: outputPath is the WRITE side and the more dangerous of the two — an unfiltered
+        // value here means writing an attacker-shaped JSON document anywhere the process can write.
+        // Sandboxed against the same root; unlike the read side the file need not already exist,
+        // since targeting a new labelled dataset is the normal use.
+        string outputPath;
+        if (request.OutputPath is null)
+        {
+            // Defaults to applying labels in place, which is already inside the root.
+            outputPath = datasetPath!;
+        }
+        else
+        {
+            var resolvedOutput = pathResolver.ResolveForWrite(request.OutputPath);
+            if (!resolvedOutput.IsSuccess)
+            {
+                return PathErrorResult(resolvedOutput.Error!.Value, "outputPath");
+            }
+
+            outputPath = resolvedOutput.FullPath!;
+        }
+
         var merged = await mediator.Send(
-            new MergeLabelsCommand(request.DatasetPath, request.Review, request.OutputPath ?? request.DatasetPath),
+            new MergeLabelsCommand(datasetPath!, request.Review, outputPath),
             ct).ConfigureAwait(false);
 
         return Results.Text(merged.ToJson(), "application/json");
     }
 
-    private static IResult? ValidateDatasetPath(string? datasetPath)
+    /// <summary>
+    /// Resolves a read path against the sandbox root and maps the failure to an HTTP result.
+    /// Existence is checked here rather than in the resolver so that a 404 can only ever be
+    /// returned for a path already proven to be inside the root — otherwise the endpoint would
+    /// answer "does this file exist?" for arbitrary paths, which is half the leak it is closing.
+    /// </summary>
+    private static (string? Path, IResult? Error) ResolveDatasetForRead(
+        IEvalDatasetPathResolver resolver,
+        string? requestedPath)
     {
-        if (string.IsNullOrWhiteSpace(datasetPath))
+        var resolved = resolver.ResolveForRead(requestedPath);
+        if (!resolved.IsSuccess)
         {
-            return Results.BadRequest(new { error = "datasetPath is required" });
+            return (null, PathErrorResult(resolved.Error!.Value, "datasetPath"));
         }
 
-        if (!File.Exists(datasetPath))
+        if (!File.Exists(resolved.FullPath))
         {
-            return Results.NotFound(new { error = $"dataset not found: {datasetPath}" });
+            return (null, Results.NotFound(new { error = $"dataset not found: {requestedPath}" }));
         }
 
-        return null;
+        return (resolved.FullPath, null);
     }
+
+    /// <summary>
+    /// Maps a refusal to a response. The message never echoes the resolved absolute path: it would
+    /// disclose the server's layout to a caller who just tried to escape it.
+    /// </summary>
+    private static IResult PathErrorResult(EvalDatasetPathError error, string field) => error switch
+    {
+        // Server misconfiguration, not a bad request: the subsystem is unavailable until an
+        // operator declares where datasets live.
+        EvalDatasetPathError.RootNotConfigured => Results.Problem(
+            detail: $"Evaluation dataset root is not configured. Set '{EvalDatasetPathResolver.RootConfigKey}' " +
+                    $"(or {EvalDatasetPathResolver.RootEnvAlias}) to enable the evaluation endpoints.",
+            statusCode: StatusCodes.Status503ServiceUnavailable),
+
+        EvalDatasetPathError.Empty => Results.BadRequest(new { error = $"{field} is required" }),
+
+        EvalDatasetPathError.OutsideRoot => Results.BadRequest(new
+        {
+            error = $"{field} must be a relative path inside the configured evaluation dataset root"
+        }),
+
+        EvalDatasetPathError.NotJson => Results.BadRequest(new { error = $"{field} must be a .json file" }),
+
+        _ => Results.BadRequest(new { error = $"{field} is invalid" }),
+    };
 }
 
 // #3390 Slice 4 Step 1: Enhancements null → legacy hybrid eval; non-null (incl. empty) → grounded seam

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Endpoints/AdminEvalEndpointsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Endpoints/AdminEvalEndpointsIntegrationTests.cs
@@ -12,6 +12,7 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Moq;
@@ -46,6 +47,7 @@ public sealed class AdminEvalEndpointsIntegrationTests : IAsyncLifetime
     private string _userSessionToken = null!;
     private string _datasetPath = null!;
     private string _mergeOutputPath = null!;
+    private string _datasetRoot = null!;
 
     public AdminEvalEndpointsIntegrationTests(SharedTestcontainersFixture fixture)
     {
@@ -71,10 +73,22 @@ public sealed class AdminEvalEndpointsIntegrationTests : IAsyncLifetime
                 snippets: [new Snippet(text: "Setup rules...", source: "chunk-1", page: 3, line: 1, score: 0.9f)],
                 confidence: 0.8));
 
+        // #3438: the endpoints now resolve datasetPath against a configured root and refuse
+        // anything outside it. The tests get their own throwaway root, so they exercise the
+        // sandboxed behaviour instead of the absolute temp paths they used before.
+        _datasetRoot = Path.Combine(Path.GetTempPath(), $"eval-root-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_datasetRoot);
+
         _factory = IntegrationWebApplicationFactory
             .Create(connectionString)
             .WithWebHostBuilder(builder =>
             {
+                builder.ConfigureAppConfiguration((_, cfg) => cfg.AddInMemoryCollection(
+                    new Dictionary<string, string?>
+                    {
+                        ["Evaluation:DatasetRoot"] = _datasetRoot
+                    }));
+
                 builder.ConfigureTestServices(services =>
                 {
                     services.RemoveAll<IRagService>();
@@ -104,10 +118,11 @@ public sealed class AdminEvalEndpointsIntegrationTests : IAsyncLifetime
             Language = "en"
         });
 
-        _datasetPath = Path.Combine(Path.GetTempPath(), $"eval-dataset-{Guid.NewGuid():N}.json");
-        await File.WriteAllTextAsync(_datasetPath, dataset.ToJson());
+        // Names are now RELATIVE to the configured root — that is what the API accepts.
+        _datasetPath = $"eval-dataset-{Guid.NewGuid():N}.json";
+        await File.WriteAllTextAsync(Path.Combine(_datasetRoot, _datasetPath), dataset.ToJson());
 
-        _mergeOutputPath = Path.Combine(Path.GetTempPath(), $"eval-merged-{Guid.NewGuid():N}.json");
+        _mergeOutputPath = $"eval-merged-{Guid.NewGuid():N}.json";
     }
 
     public async ValueTask DisposeAsync()
@@ -116,14 +131,9 @@ public sealed class AdminEvalEndpointsIntegrationTests : IAsyncLifetime
         await _factory.DisposeAsync();
         await _fixture.DropIsolatedDatabaseAsync(_testDbName);
 
-        if (File.Exists(_datasetPath))
+        if (Directory.Exists(_datasetRoot))
         {
-            File.Delete(_datasetPath);
-        }
-
-        if (File.Exists(_mergeOutputPath))
-        {
-            File.Delete(_mergeOutputPath);
+            Directory.Delete(_datasetRoot, recursive: true);
         }
     }
 
@@ -189,7 +199,8 @@ public sealed class AdminEvalEndpointsIntegrationTests : IAsyncLifetime
     public async Task RunRetrievalEvaluation_WithNonExistentDatasetPath_Returns404()
     {
         // Arrange
-        var missingDatasetPath = Path.Combine(Path.GetTempPath(), $"missing-dataset-{Guid.NewGuid():N}.json");
+        // Relativo e dentro la root: prova il 404 "non esiste", non il 400 "fuori dal sandbox".
+        var missingDatasetPath = $"missing-dataset-{Guid.NewGuid():N}.json";
         var request = TestSessionHelper.CreateAuthenticatedRequest(
             HttpMethod.Post,
             RetrievalEndpoint,
@@ -251,8 +262,9 @@ public sealed class AdminEvalEndpointsIntegrationTests : IAsyncLifetime
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        File.Exists(_mergeOutputPath).Should().BeTrue("the endpoint persists the merged dataset to the output path");
-        var persisted = EvaluationDataset.FromJson(await File.ReadAllTextAsync(_mergeOutputPath));
+        var mergeOutputFullPath = Path.Combine(_datasetRoot, _mergeOutputPath);
+        File.Exists(mergeOutputFullPath).Should().BeTrue("the endpoint persists the merged dataset to the output path");
+        var persisted = EvaluationDataset.FromJson(await File.ReadAllTextAsync(mergeOutputFullPath));
         persisted.Samples.Should().ContainSingle()
             .Which.RelevantChunkIds.Should().BeEquivalentTo(new[] { "chunk-1" });
     }
@@ -261,7 +273,8 @@ public sealed class AdminEvalEndpointsIntegrationTests : IAsyncLifetime
     public async Task MergeLabels_WithNonExistentDatasetPath_Returns404()
     {
         // Arrange
-        var missingDatasetPath = Path.Combine(Path.GetTempPath(), $"missing-dataset-{Guid.NewGuid():N}.json");
+        // Relativo e dentro la root: prova il 404 "non esiste", non il 400 "fuori dal sandbox".
+        var missingDatasetPath = $"missing-dataset-{Guid.NewGuid():N}.json";
         var request = TestSessionHelper.CreateAuthenticatedRequest(
             HttpMethod.Post,
             MergeLabelsEndpoint,
@@ -324,5 +337,69 @@ public sealed class AdminEvalEndpointsIntegrationTests : IAsyncLifetime
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    // ── #3438: the sandbox, proven from the attacker's side ──────────────────────────────
+    //
+    // The unit tests pin the resolver; these pin that the ENDPOINTS actually go through it. An
+    // authenticated admin is the threat model here: admin-gating narrows who can try, it does not
+    // make arbitrary file read/write acceptable.
+
+    [Theory]
+    [InlineData("../../../etc/passwd.json")]
+    [InlineData("subdir/../../../../secrets.json")]
+    public async Task RunRetrievalEvaluation_WithTraversalPath_Returns400AndNeverReads(string traversalPath)
+    {
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            RetrievalEndpoint,
+            _adminSessionToken,
+            new { datasetPath = traversalPath });
+
+        var response = await _client.SendAsync(request);
+
+        // 400, not 404: a 404 would confirm whether the target exists, turning the endpoint into a
+        // file-existence oracle for paths outside the root.
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().NotContain("passwd", "the error must not echo back the attacker's path");
+    }
+
+    [Fact]
+    public async Task RunRetrievalEvaluation_WithAbsolutePath_Returns400()
+    {
+        // The dataset genuinely exists — but by absolute path, which the sandbox refuses. Proves
+        // the refusal is about containment, not about the file being missing.
+        var absolutePath = Path.Combine(_datasetRoot, _datasetPath);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            RetrievalEndpoint,
+            _adminSessionToken,
+            new { datasetPath = absolutePath });
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task MergeLabels_WithOutputPathOutsideRoot_Returns400AndWritesNothing()
+    {
+        // The write side is the more dangerous one: an unfiltered outputPath means dropping an
+        // attacker-shaped JSON document anywhere the process can write.
+        var escapeTarget = Path.Combine(Path.GetTempPath(), $"pwned-{Guid.NewGuid():N}.json");
+        var relativeEscape = $"../{Path.GetFileName(escapeTarget)}";
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            MergeLabelsEndpoint,
+            _adminSessionToken,
+            BuildMergeReviewBody(_datasetPath, relativeEscape));
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        File.Exists(escapeTarget).Should().BeFalse("nothing may be written outside the dataset root");
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Evaluation/EvalDatasetPathResolverTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Evaluation/EvalDatasetPathResolverTests.cs
@@ -1,0 +1,167 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Evaluation.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Evaluation;
+
+/// <summary>
+/// Issue #3438 — the sandbox that keeps the admin eval endpoints from reading, or writing, outside
+/// the configured dataset root.
+///
+/// <para>
+/// Before this, <c>datasetPath</c> reached <c>File.ReadAllTextAsync</c> unfiltered and
+/// <c>outputPath</c> reached the writer: an admin session (or a stolen one, or a CSRF) could read
+/// any file readable by the process and write an attacker-shaped JSON document anywhere writable.
+/// Admin-gating narrows who can try; it does not make the capability acceptable.
+/// </para>
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Issue", "3438")]
+public sealed class EvalDatasetPathResolverTests : IDisposable
+{
+    private readonly string _root;
+
+    public EvalDatasetPathResolverTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), $"eval-root-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+    }
+
+    private EvalDatasetPathResolver CreateResolver(string? root) =>
+        new(new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [EvalDatasetPathResolver.RootConfigKey] = root
+            })
+            .Build());
+
+    [Fact]
+    public void RelativeJsonInsideRoot_Resolves()
+    {
+        var result = CreateResolver(_root).ResolveForRead("golden/catan.json");
+
+        result.IsSuccess.Should().BeTrue();
+        result.FullPath.Should().Be(Path.Combine(_root, "golden", "catan.json"));
+    }
+
+    [Theory]
+    // Classic traversal, and one that only escapes after normalisation — the reason containment is
+    // decided on the resolved path rather than by pattern-matching "..".
+    [InlineData("../../../etc/passwd.json")]
+    [InlineData("golden/../../../etc/passwd.json")]
+    [InlineData("a/b/../../../outside.json")]
+    public void TraversalOutsideRoot_IsRefused(string requested)
+    {
+        var result = CreateResolver(_root).ResolveForRead(requested);
+
+        result.Error.Should().Be(EvalDatasetPathError.OutsideRoot);
+        result.FullPath.Should().BeNull();
+    }
+
+    [Fact]
+    public void AbsolutePath_IsRefused()
+    {
+        // Path.Combine(root, "/etc/passwd") returns "/etc/passwd" — the root is silently discarded.
+        // Rooted input therefore has to be rejected before any combining happens.
+        var absolute = Path.Combine(Path.GetTempPath(), "elsewhere.json");
+
+        var result = CreateResolver(_root).ResolveForRead(absolute);
+
+        result.Error.Should().Be(EvalDatasetPathError.OutsideRoot);
+    }
+
+    [Fact]
+    public void SiblingDirectorySharingTheRootPrefix_IsRefused()
+    {
+        // "…/eval-root-XYZevil/x.json" starts with the root STRING but is a different directory.
+        // Guarded by normalising the root with a trailing separator.
+        var result = CreateResolver(_root).ResolveForRead($"../{Path.GetFileName(_root)}evil/x.json");
+
+        result.Error.Should().Be(EvalDatasetPathError.OutsideRoot);
+    }
+
+    [Theory]
+    [InlineData("appsettings.Production")]
+    [InlineData("secrets.env")]
+    [InlineData("dataset.json.bak")]
+    public void NonJsonExtension_IsRefused(string requested)
+    {
+        var result = CreateResolver(_root).ResolveForRead(requested);
+
+        result.Error.Should().Be(EvalDatasetPathError.NotJson);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void EmptyPath_IsRefused(string? requested)
+    {
+        CreateResolver(_root).ResolveForRead(requested).Error.Should().Be(EvalDatasetPathError.Empty);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void WithoutAConfiguredRoot_EverythingIsRefused(string? root)
+    {
+        // Fail-closed. Guessing a default would hand back an implicit sandbox nobody chose, and one
+        // that silently differs between environments.
+        var resolver = CreateResolver(root);
+
+        resolver.ResolveForRead("golden/catan.json").Error.Should().Be(EvalDatasetPathError.RootNotConfigured);
+        resolver.ResolveForWrite("golden/catan.json").Error.Should().Be(EvalDatasetPathError.RootNotConfigured);
+    }
+
+    [Fact]
+    public void ResolveForWrite_TargetNeedNotExist()
+    {
+        // merge-labels legitimately writes a brand-new labelled dataset.
+        var result = CreateResolver(_root).ResolveForWrite("labelled/new-output.json");
+
+        result.IsSuccess.Should().BeTrue();
+        File.Exists(result.FullPath).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ResolveForWrite_AppliesTheSameContainmentAsRead()
+    {
+        // The write side is the more dangerous of the two: it must not be laxer.
+        CreateResolver(_root).ResolveForWrite("../../evil.json").Error
+            .Should().Be(EvalDatasetPathError.OutsideRoot);
+    }
+
+    [Fact]
+    public void ResolveForRead_DoesNotProbeTheFileSystem()
+    {
+        // Existence is the endpoint's business. If the resolver reported it, a caller could use
+        // refusals-vs-404s to probe for files outside the root — the very leak being closed.
+        var result = CreateResolver(_root).ResolveForRead("definitely-missing.json");
+
+        result.IsSuccess.Should().BeTrue();
+        File.Exists(result.FullPath).Should().BeFalse();
+    }
+
+    [Fact]
+    public void EnvAlias_IsAccepted()
+    {
+        var resolver = new EvalDatasetPathResolver(new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [EvalDatasetPathResolver.RootEnvAlias] = _root
+            })
+            .Build());
+
+        resolver.ResolveForRead("catan.json").IsSuccess.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
Chiude #3438.

## Il finding

`datasetPath` arrivava a `File.ReadAllTextAsync` senza filtro, e `outputPath` raggiungeva il writer. Una sessione admin — o una rubata, o una CSRF — poteva **leggere** qualunque file leggibile dal processo (`appsettings.json`, secret montati) e, via `/merge-labels`, **scrivere** un JSON arbitrario ovunque il processo potesse scrivere.

Il gate admin restringe *chi* può provarci; non rende accettabile la capacità.

> L'issue citava solo la lettura. Il vettore di **scrittura** (`outputPath`) non era elencato ed è il più grave dei due: è coperto qui.

## Il prerequisito che bloccava l'issue non era davvero bloccante

L'issue si dichiarava in attesa di «decidere dove vivono i dataset in produzione». Rendendo la root **configurazione** (`Evaluation:DatasetRoot`, env `Evaluation__DatasetRoot`, alias piatto `EVAL_DATASET_ROOT`), quella decisione smette di essere un prerequisito del fix di sicurezza: si prende quando si deploya, non prima.

**Fail-closed**: senza root configurata ogni richiesta è rifiutata con 503. Indovinare un default — per esempio `tests/evaluation-datasets/` — restituirebbe un sandbox implicito che nessuno ha scelto e che cambia silenziosamente da un ambiente all'altro.

## Le quattro trappole del containment, e come sono chiuse

| Trappola | Difesa |
|---|---|
| `Path.Combine(root, "/etc/passwd")` restituisce `/etc/passwd`, scartando la root | i path rooted sono rifiutati **prima** di combinare (copre anche `C:\…` e UNC) |
| `a/../../etc/passwd` non contiene `..` in testa | il containment è deciso **dopo** `GetFullPath`, cioè da dove il path atterra, non da un pattern |
| `/data/evalEVIL` inizia con la stringa `/data/eval` | la root è normalizzata con separatore finale |
| leggere `appsettings.json` che *sta* dentro la root | estensione ristretta a `.json`… che qui non basterebbe da sola, quindi resta un limite noto: la root deve contenere solo dataset |

## Il 404 come oracolo

L'esistenza del file è verificata **nell'endpoint**, non nel resolver, di proposito: così un 404 può essere restituito solo per un path già provato dentro la root. Altrimenti l'endpoint risponderebbe «questo file esiste?» per path arbitrari — metà della falla che sta chiudendo. Anche i messaggi d'errore non riecheggiano mai il path risolto.

## Test

- **18 unit** sul resolver: traversal (3 forme), path assoluto, directory sorella col prefisso condiviso, estensione, vuoto/null, root non configurata, write che non richiede esistenza, alias env, e la prova che il resolver **non** tocchi il filesystem.
- **4 di integrazione HTTP** dal lato attaccante: traversal → 400 (non 404) e senza echo del path; path assoluto di un file **realmente esistente** → 400, così la refusal è provata essere sul containment e non sull'assenza; `outputPath` fuori root → 400 **e nessun file scritto**.

I 9 test preesistenti sono stati portati a nomi relativi: prima usavano path assoluti in `GetTempPath()`, cioè esattamente ciò che ora è vietato. 13/13 verdi.

## Nota di deploy

Gli endpoint restano inattivi finché non si configura `Evaluation:DatasetRoot` — coerente con lo stato dell'issue («esecuzione deferita, non ancora invocata in prod»). Chi li abiliterà dovrà puntare la root a una directory che contenga **solo** dataset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
