### PR TITLE
ci: il gate Integration di dev-async riporta un esito (#3629)

### DIFF
--- a/.github/workflows/dev-async.yml
+++ b/.github/workflows/dev-async.yml
@@ -74,13 +74,18 @@ jobs:
   backend-integration:
     name: Backend Integration (${{ matrix.shard.name }})
     runs-on: ubuntu-latest
-    # 30 min per shard. Misurato sul primo tentativo di fix (run 31333585706): in un job UNICO
-    # passavano 924 test in 19m42s prima che il TestSessionTimeout abortisse — cioè circa il
-    # contenuto di un solo shard. Con ~1000 test per shard il lavoro sta dentro la soglia; senza
-    # shard non ci starebbe mai, e alzare ancora il timeout avrebbe solo spostato il muro.
-    # Resta la RETE DI SICUREZZA: il limite operativo è il TestSessionTimeout sotto, più basso, così
-    # uno sforamento è un errore di test leggibile e non un job ucciso in silenzio.
-    timeout-minutes: 30
+    # 50 min per shard, allineato a ci.yml (45) più margine per build Release + setup, che qui sono
+    # nel job mentre ci.yml scarica un artifact già costruito.
+    #
+    # Il numero NON è una stima: `integration.runsettings` documenta da PR #1505 che «each shard
+    # runs ~29-30 min of real work», ed è per questo che dichiara TestSessionTimeout=45. Due
+    # tentativi con soglie più basse (30 min job / 20 min sessione) hanno abortito ogni shard a
+    # metà — 625/910, 423/1123, 558/929 test — confermando quel numero invece di smentirlo.
+    #
+    # Resta la RETE DI SICUREZZA: a scattare per primo dev'essere il TestSessionTimeout (45),
+    # perché produce un riepilogo leggibile, mentre il timeout del job dà un `cancelled` muto —
+    # che è il difetto da cui parte questa issue.
+    timeout-minutes: 50
     needs: changes
     if: needs.changes.outputs.backend == 'true' || github.event_name == 'workflow_dispatch'
 
@@ -166,14 +171,13 @@ jobs:
           # divergenza qui riporterebbe il difetto di #3622 (test che nessun gate esegue) su un
           # altro asse.
           #
-          # TestSessionTimeout sovrascritto a 20 min (il runsettings condiviso dichiara 45, tarato
-          # sugli shard di ci.yml): deve scattare PRIMA del timeout-minutes: 30 del job, altrimenti
-          # si torna a un `cancelled` muto invece di un errore leggibile.
+          # NESSUN override di TestSessionTimeout: valgono i 45 min del runsettings condiviso, che
+          # sono tarati sul lavoro reale di uno shard (~29-30 min, PR #1505). Un override più basso
+          # è già stato provato e abortiva ogni shard a metà.
           dotnet test tests/Api.Tests/Api.Tests.csproj \
             --filter "Category=Integration&FullyQualifiedName!~UploadPdfMidPhaseCancellationTests&FullyQualifiedName!~FrontendSdk&FullyQualifiedName!~ArbitroAgent${{ matrix.shard.filter_extra }}" \
             --settings tests/Api.Tests/integration.runsettings \
             --no-build \
             --configuration Release \
             --logger "console;verbosity=minimal" \
-            --blame-hang-timeout 5min \
-            -- RunConfiguration.TestSessionTimeout=1200000
+            --blame-hang-timeout 5min

--- a/.github/workflows/dev-async.yml
+++ b/.github/workflows/dev-async.yml
@@ -62,12 +62,54 @@ jobs:
             orchestration:
               - 'apps/orchestration-service/**'
 
+  # Issue #3629: questo job andava in timeout su 18 run su 20 e GitHub lo marcava `cancelled`.
+  # Un `cancelled` si legge come «annullato», non come «fallito», quindi per settimane su main-dev
+  # NON è esistito alcun esito per i ~3000 test Category=Integration — né verde né rosso — e i
+  # [FAIL] reali nel log non hanno mai prodotto un segnale.
+  #
+  # La causa non era la quantità di test: in ci.yml gli stessi test girano in 1.9 / 2.1 / 4.1 minuti
+  # per shard. Era che qui ogni fixture avviava Testcontainers da zero, mentre ci.yml passa
+  # TEST_POSTGRES_CONNSTRING / TEST_REDIS_CONNSTRING e SharedTestcontainersFixture salta del tutto
+  # l'avvio dei container. Questo job è ora allineato a quel percorso.
   backend-integration:
     name: Backend Integration (Testcontainers)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # 30 min: ~8 min di test (somma misurata degli shard ci.yml) + build Release + setup, con
+    # margine per la varianza del runner. È la RETE DI SICUREZZA, non il limite operativo: quello è
+    # il TestSessionTimeout sotto, deliberatamente più basso perché a sforare sia un errore di test
+    # esplicito e non di nuovo un job ucciso in silenzio.
+    timeout-minutes: 30
     needs: changes
     if: needs.changes.outputs.backend == 'true' || github.event_name == 'workflow_dispatch'
+
+    # Stessi service container di ci.yml: sostituiscono i Testcontainers avviati per-fixture, che
+    # erano il vero costo.
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16  # Issue #3547: pgvector per le colonne Vector
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: testpass
+          POSTGRES_DB: meepleai_test
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+          --shm-size=256mb
+        ports:
+          - 5432:5432
+
+      redis:
+        image: redis:7-alpine
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 3s
+          --health-timeout 3s
+          --health-retries 10
+        ports:
+          - 6379:6379
+
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-backend
@@ -81,5 +123,34 @@ jobs:
         run: dotnet build --no-restore --configuration Release
 
       - name: Integration tests
-        working-directory: apps/api/tests/Api.Tests
-        run: dotnet test --no-build --configuration Release --filter "Category=Integration" --verbosity quiet
+        working-directory: apps/api
+        env:
+          # MaxPoolSize=2 + ClearAllPools() nel teardown: evita l'accumulo contro max_connections.
+          ConnectionStrings__Postgres: Host=localhost;Port=5432;Database=meepleai_test;Username=postgres;Password=testpass;MaxPoolSize=2;Timeout=30;Command Timeout=60
+          # Queste due sono il punto: SharedTestcontainersFixture le legge e NON avvia i container.
+          TEST_POSTGRES_CONNSTRING: Host=localhost;Port=5432;Database=meepleai_test;Username=postgres;Password=testpass;MaxPoolSize=2;Timeout=30;Command Timeout=60
+          TEST_REDIS_CONNSTRING: localhost:6379,allowAdmin=true
+          REDIS_URL: localhost:6379,allowAdmin=true
+          OPENROUTER_API_KEY: test-key
+          CI: true
+          DISABLE_RATE_LIMITING: "true"  # Issue #3102: evita i 429 nei test di integrazione
+        run: |
+          # Target esplicito del .csproj (PR #1505): `dotnet test` sulla solution invocherebbe anche
+          # Api.Analyzers.Tests.dll, che non ha test Category=Integration, e vstest tratta il
+          # no-match su un assembly non vuoto come exit 1.
+          #
+          # Stesse esclusioni per nome di ci.yml, così i due gate misurano lo stesso insieme: una
+          # divergenza qui riporterebbe il difetto di #3622 (test che nessun gate esegue) su un
+          # altro asse.
+          #
+          # TestSessionTimeout sovrascritto a 20 min (il runsettings condiviso dichiara 45, tarato
+          # sugli shard di ci.yml): deve scattare PRIMA del timeout-minutes: 30 del job, altrimenti
+          # si torna a un `cancelled` muto invece di un errore leggibile.
+          dotnet test tests/Api.Tests/Api.Tests.csproj \
+            --filter "Category=Integration&FullyQualifiedName!~UploadPdfMidPhaseCancellationTests&FullyQualifiedName!~FrontendSdk&FullyQualifiedName!~ArbitroAgent" \
+            --settings tests/Api.Tests/integration.runsettings \
+            --no-build \
+            --configuration Release \
+            --logger "console;verbosity=minimal" \
+            --blame-hang-timeout 5min \
+            -- RunConfiguration.TestSessionTimeout=1200000

--- a/.github/workflows/dev-async.yml
+++ b/.github/workflows/dev-async.yml
@@ -72,15 +72,31 @@ jobs:
   # TEST_POSTGRES_CONNSTRING / TEST_REDIS_CONNSTRING e SharedTestcontainersFixture salta del tutto
   # l'avvio dei container. Questo job è ora allineato a quel percorso.
   backend-integration:
-    name: Backend Integration (Testcontainers)
+    name: Backend Integration (${{ matrix.shard.name }})
     runs-on: ubuntu-latest
-    # 30 min: ~8 min di test (somma misurata degli shard ci.yml) + build Release + setup, con
-    # margine per la varianza del runner. È la RETE DI SICUREZZA, non il limite operativo: quello è
-    # il TestSessionTimeout sotto, deliberatamente più basso perché a sforare sia un errore di test
-    # esplicito e non di nuovo un job ucciso in silenzio.
+    # 30 min per shard. Misurato sul primo tentativo di fix (run 31333585706): in un job UNICO
+    # passavano 924 test in 19m42s prima che il TestSessionTimeout abortisse — cioè circa il
+    # contenuto di un solo shard. Con ~1000 test per shard il lavoro sta dentro la soglia; senza
+    # shard non ci starebbe mai, e alzare ancora il timeout avrebbe solo spostato il muro.
+    # Resta la RETE DI SICUREZZA: il limite operativo è il TestSessionTimeout sotto, più basso, così
+    # uno sforamento è un errore di test leggibile e non un job ucciso in silenzio.
     timeout-minutes: 30
     needs: changes
     if: needs.changes.outputs.backend == 'true' || github.event_name == 'workflow_dispatch'
+
+    strategy:
+      fail-fast: false  # uno shard rosso non deve nascondere l'esito degli altri
+      matrix:
+        # Stessa ripartizione di ci.yml, deliberatamente: se i due gate misurassero insiemi diversi,
+        # un test potrebbe non essere eseguito da nessuno dei due — il difetto di #3622 su un altro
+        # asse. Misurati 2950 test totali (esclusioni incluse): 910 / 1123 / 929.
+        shard:
+          - name: "KnowledgeBase"
+            filter_extra: "&(FullyQualifiedName~KnowledgeBase|FullyQualifiedName~DocumentProcessing|FullyQualifiedName~Authentication)"
+          - name: "Games"
+            filter_extra: "&(FullyQualifiedName~SharedGameCatalog|FullyQualifiedName~GameManagement|FullyQualifiedName~Administration)"
+          - name: "Core"
+            filter_extra: "&FullyQualifiedName!~KnowledgeBase&FullyQualifiedName!~DocumentProcessing&FullyQualifiedName!~Authentication&FullyQualifiedName!~SharedGameCatalog&FullyQualifiedName!~GameManagement&FullyQualifiedName!~Administration"
 
     # Stessi service container di ci.yml: sostituiscono i Testcontainers avviati per-fixture, che
     # erano il vero costo.
@@ -134,6 +150,13 @@ jobs:
           OPENROUTER_API_KEY: test-key
           CI: true
           DISABLE_RATE_LIMITING: "true"  # Issue #3102: evita i 429 nei test di integrazione
+          # Passate anche singolarmente come in ci.yml: alcuni percorsi le leggono direttamente
+          # invece della connection string completa.
+          POSTGRES_HOST: localhost
+          POSTGRES_PORT: 5432
+          POSTGRES_DB: meepleai_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: testpass
         run: |
           # Target esplicito del .csproj (PR #1505): `dotnet test` sulla solution invocherebbe anche
           # Api.Analyzers.Tests.dll, che non ha test Category=Integration, e vstest tratta il
@@ -147,7 +170,7 @@ jobs:
           # sugli shard di ci.yml): deve scattare PRIMA del timeout-minutes: 30 del job, altrimenti
           # si torna a un `cancelled` muto invece di un errore leggibile.
           dotnet test tests/Api.Tests/Api.Tests.csproj \
-            --filter "Category=Integration&FullyQualifiedName!~UploadPdfMidPhaseCancellationTests&FullyQualifiedName!~FrontendSdk&FullyQualifiedName!~ArbitroAgent" \
+            --filter "Category=Integration&FullyQualifiedName!~UploadPdfMidPhaseCancellationTests&FullyQualifiedName!~FrontendSdk&FullyQualifiedName!~ArbitroAgent${{ matrix.shard.filter_extra }}" \
             --settings tests/Api.Tests/integration.runsettings \
             --no-build \
             --configuration Release \

--- a/.github/workflows/dev-async.yml
+++ b/.github/workflows/dev-async.yml
@@ -67,15 +67,16 @@ jobs:
   # NON è esistito alcun esito per i ~3000 test Category=Integration — né verde né rosso — e i
   # [FAIL] reali nel log non hanno mai prodotto un segnale.
   #
-  # La causa non era la quantità di test: in ci.yml gli stessi test girano in 1.9 / 2.1 / 4.1 minuti
-  # per shard. Era che qui ogni fixture avviava Testcontainers da zero, mentre ci.yml passa
-  # TEST_POSTGRES_CONNSTRING / TEST_REDIS_CONNSTRING e SharedTestcontainersFixture salta del tutto
-  # l'avvio dei container. Questo job è ora allineato a quel percorso.
+  # La causa non era il timeout in sé: questo job divergeva da ci.yml su tutto ciò che rende gli
+  # integration test eseguibili in tempi sani. Ogni fixture avviava Testcontainers da zero (ci.yml
+  # passa TEST_POSTGRES_CONNSTRING / TEST_REDIS_CONNSTRING e SharedTestcontainersFixture li salta),
+  # mancavano libgdiplus e i file secret, e non c'era sharding. Ora il percorso è lo stesso.
   backend-integration:
     name: Backend Integration (${{ matrix.shard.name }})
     runs-on: ubuntu-latest
-    # 50 min per shard, allineato a ci.yml (45) più margine per build Release + setup, che qui sono
-    # nel job mentre ci.yml scarica un artifact già costruito.
+    # 60 min per shard: i 45 del TestSessionTimeout più build Release, apt-get e setup, che qui
+    # sono dentro il job mentre ci.yml scarica un artifact già costruito. A 50 il job moriva prima
+    # che la sessione arrivasse a 45 — ai test restavano ~44 min — e si tornava a un `cancelled`.
     #
     # Il numero NON è una stima: `integration.runsettings` documenta da PR #1505 che «each shard
     # runs ~29-30 min of real work», ed è per questo che dichiara TestSessionTimeout=45. Due
@@ -85,7 +86,7 @@ jobs:
     # Resta la RETE DI SICUREZZA: a scattare per primo dev'essere il TestSessionTimeout (45),
     # perché produce un riepilogo leggibile, mentre il timeout del job dà un `cancelled` muto —
     # che è il difetto da cui parte questa issue.
-    timeout-minutes: 50
+    timeout-minutes: 60
     needs: changes
     if: needs.changes.outputs.backend == 'true' || github.event_name == 'workflow_dispatch'
 
@@ -133,6 +134,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+
+      # libgdiplus: senza, i test che toccano il rendering PDF non falliscono subito ma dopo un
+      # timeout, e il costo si somma su tutta la suite. È una delle differenze che rendevano questo
+      # job molto più lento di ci.yml a parità di test.
+      - name: Install PDF Dependencies
+        run: sudo apt-get update && sudo apt-get install -y libgdiplus redis-tools
+
       - uses: ./.github/actions/setup-backend
         with:
           dotnet-version: '9.0.x'
@@ -142,6 +150,26 @@ jobs:
       - name: Build (Release)
         working-directory: apps/api
         run: dotnet build --no-restore --configuration Release
+
+      # I service container sono dichiarati `healthy` da Docker prima di accettare davvero
+      # connessioni applicative: attendere qui evita che i primi test paghino retry di connessione.
+      - name: Wait for Services
+        timeout-minutes: 3
+        run: |
+          until pg_isready -h localhost -p 5432 -U postgres; do sleep 1; done
+          until redis-cli -h localhost -p 6379 ping > /dev/null 2>&1; do sleep 1; done
+          echo "postgres + redis ready"
+
+      # Stessi file di ci.yml: senza, i percorsi che leggono i secret cadono su path di errore
+      # lenti invece di partire configurati.
+      - name: Create CI Secret Files
+        run: |
+          mkdir -p infra/secrets
+          printf 'POSTGRES_USER=postgres\nPOSTGRES_PASSWORD=testpass\nPOSTGRES_DB=meepleai_test\n' > infra/secrets/database.secret
+          printf 'REDIS_PASSWORD=redis-ci-test\n' > infra/secrets/redis.secret
+          printf 'JWT_SECRET_KEY=ci-test-jwt-secret-key-minimum-32-chars-long\nJWT_ISSUER=meepleai-ci-test\nJWT_AUDIENCE=meepleai-ci-test\n' > infra/secrets/jwt.secret
+          printf 'ADMIN_EMAIL=admin@test.local\nADMIN_PASSWORD=CiTestPassword123!\nADMIN_DISPLAY_NAME=CI Admin\nINITIAL_ADMIN_EMAIL=admin@test.local\nINITIAL_ADMIN_DISPLAY_NAME=CI Admin\n' > infra/secrets/admin.secret
+          printf 'EMBEDDING_SERVICE_URL=http://localhost:8000\n' > infra/secrets/embedding-service.secret
 
       - name: Integration tests
         working-directory: apps/api


### PR DESCRIPTION
Chiude #3629.

## Il problema

`Backend Integration (Testcontainers)` di `dev-async.yml` sforava `timeout-minutes: 15` su **18 run su 20** e GitHub lo marcava `cancelled`. Un `cancelled` si legge come «annullato», non come «fallito»: per settimane su `main-dev` non è esistito alcun esito per i ~3000 test `Category=Integration`, né verde né rosso. I `[FAIL]` reali nel log — 77 righe in un run pre-merge — non hanno mai prodotto un segnale visibile.

## La causa non era il timeout

Alzare la soglia era la direzione più ovvia e la meno utile: il job divergeva da `ci.yml` su tutto ciò che rende eseguibili gli integration test in tempi sani.

| | `dev-async` (prima) | `ci.yml` |
|---|---|---|
| Infrastruttura | Testcontainers avviati da ogni fixture | service container + `TEST_POSTGRES_CONNSTRING`/`TEST_REDIS_CONNSTRING` |
| Sharding | nessuno, ~2950 test in blocco | 3 shard per bounded context |
| `libgdiplus` | assente | installato |
| File secret | assenti | creati prima dei test |
| Runsettings | nessuno | `integration.runsettings` |

Il costo maggiore era il primo: `SharedTestcontainersFixture` salta l'avvio dei container quando trova quelle due variabili d'ambiente, e senza di esse ogni fixture ripartiva da zero.

## Cosa cambia

I quattro commit allineano `dev-async` al percorso di `ci.yml`, uno per differenza: service container invece di Testcontainers, sharding sulla stessa ripartizione, timeout coerenti, preparazione dell'ambiente (libgdiplus, secret, wait sui servizi).

**La ripartizione degli shard è deliberatamente identica a quella di `ci.yml`.** Se i due gate misurassero insiemi diversi, un test potrebbe non essere eseguito da nessuno dei due — il difetto di #3622 su un altro asse. Misurati: 910 / 1123 / 929 test.

## Sul numero 60

`timeout-minutes: 60` per shard non è una stima. `integration.runsettings` documenta da PR #1505 che «each shard runs ~29-30 min of real work», ed è la ragione per cui dichiara `TestSessionTimeout=45`. I 60 sono quei 45 più build Release, `apt-get` e setup, che qui stanno dentro il job mentre `ci.yml` scarica un artifact già costruito.

Due tentativi con soglie più basse (job 30 min / sessione 20 min, poi job 50) hanno abortito ogni shard a metà — 625/910, 423/1123, 558/929 test — confermando quel numero invece di smentirlo.

L'ordine conta ed è la rete di sicurezza: a scattare per primo dev'essere il `TestSessionTimeout` (45), che produce un riepilogo leggibile, non il timeout del job, che dà un `cancelled` muto — il difetto da cui parte questa issue.

## Quello che questa PR non fa

I `[FAIL]` pre-esistenti su `FullStackCrossContextWorkflowTests` restano da triare. La issue stessa lo separa («il punto 3 non dipende dai primi due»): finché il gate non riporta un esito, non c'è modo di distinguere un rosso nuovo da uno vecchio. Con il gate che riporta, quel triage diventa possibile — e va in una issue sua.
