### PR TITLE
fix(live-sessions,admin): scoring config fixture + 403 sullo stream SSE (#3633)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/Mappers/LiveGameSessionMapper.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/Mappers/LiveGameSessionMapper.cs
@@ -322,7 +322,17 @@ internal static class LiveGameSessionMapper
         var dto = JsonSerializer.Deserialize<ScoringConfigDto>(json, JsonOptions);
         if (dto == null) return SessionScoringConfig.CreateDefault();
 
-        return new SessionScoringConfig(dto.EnabledDimensions, dto.DimensionUnits);
+        // #3633: un JSON sintatticamente valido ma privo di questi campi (una riga scritta da uno
+        // schema precedente, o troncata) deserializza in un DTO con le due proprietà a null, e il
+        // costruttore di SessionScoringConfig fa ArgumentNullException.ThrowIfNull. Attraversando
+        // il middleware quell'eccezione diventa un 400 «Invalid request parameters» su un endpoint
+        // di sola LETTURA — opaco per il chiamante e impossibile da diagnosticare dal solo corpo.
+        //
+        // Le due righe sopra già degradano a CreateDefault() per json vuoto e per dto null: che il
+        // terzo caso lanciasse era un'omissione, non una scelta. Ora la degradazione è coerente.
+        return new SessionScoringConfig(
+            dto.EnabledDimensions ?? SessionScoringConfig.CreateDefault().EnabledDimensions.ToList(),
+            dto.DimensionUnits ?? new Dictionary<string, string>(StringComparer.Ordinal));
     }
 
     /// <summary>

--- a/apps/api/src/Api/Routing/AdminEventsEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminEventsEndpoints.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Http.HttpResults;
 using System.Text.Json;
 using Api.BoundedContexts.Administration.Application.Queries.AdminEvents;
 using Api.Extensions;
@@ -297,8 +298,17 @@ internal static class AdminEventsEndpoints
     /// </remarks>
     private static int ExtractStatusCode(IResult? result)
     {
-        if (result is IStatusCodeHttpResult sc) return sc.StatusCode ?? 401;
-        return 401; // safe default for null or non-status results
+        if (result is IStatusCodeHttpResult sc && sc.StatusCode.HasValue) return sc.StatusCode.Value;
+
+        // #3633: `Results.Forbid()` produce un ForbidHttpResult, che NON implementa
+        // IStatusCodeHttpResult — delega lo status allo schema di autenticazione invece di
+        // dichiararlo. Senza questo ramo cadeva nel default e lo stream rispondeva 401 a un utente
+        // autenticato ma senza i permessi: il chiamante non poteva distinguere «sessione scaduta,
+        // rifai login» da «non hai i permessi», mentre gli altri due endpoint della stessa famiglia
+        // (GET /admin/events e /types, che restituiscono l'IResult direttamente) rispondevano 403.
+        if (result is ForbidHttpResult) return StatusCodes.Status403Forbidden;
+
+        return StatusCodes.Status401Unauthorized; // default per null o risultati senza status
     }
 
     /// <summary>

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Integration/PdfCoverPropagationIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Integration/PdfCoverPropagationIntegrationTests.cs
@@ -9,7 +9,9 @@ using Api.Tests.Constants;
 using Api.Tests.Infrastructure;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
+using Api.Infrastructure.DomainEventOutbox;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace Api.Tests.BoundedContexts.SharedGameCatalog.Integration;
@@ -44,6 +46,17 @@ public sealed class PdfCoverPropagationIntegrationTests : IAsyncLifetime
         var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
 
         var services = IntegrationServiceCollectionBuilder.CreateBase(connectionString);
+
+        // #3633: prerequisito necessario ma NON sufficiente — il test resta rosso anche con questo
+        // override, la causa residua non è ancora stata isolata (vedi #3633).
+        //
+        // Serve comunque: il default DI è OutboxOnly (cutover T9 di #1535), quindi gli eventi vanno
+        // in domain_event_outbox e NON sono pubblicati inline via MediatR — senza l'override
+        // PdfCoverGeneratedEventHandler non verrebbe invocato in nessun caso. È la terza classe
+        // rimasta indietro rispetto al cutover, dopo DomainEventDispatcherIntegrationTests e
+        // FullStackCrossContextWorkflowTests (#3647).
+        services.AddSingleton<IOptions<DomainEventOutboxOptions>>(
+            Options.Create(new DomainEventOutboxOptions { Mode = DomainEventDispatchMode.Hybrid }));
 
         // PdfCoverGeneratedEventHandler depends on ISharedGameRepository, which is not
         // registered in the base builder (it lives in SharedGameCatalogServiceExtensions).

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/LazyCompanionOnSubscribeTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/LazyCompanionOnSubscribeTests.cs
@@ -368,7 +368,16 @@ public sealed class LazyCompanionOnSubscribeTests : IAsyncLifetime
             CurrentPhaseIndex = 0,
             TurnAdvancePolicy = 0,  // Manual
             AgentMode = 0,           // None
-            ScoringConfigJson = """{"type":0,"dimensions":[{"name":"Points","unit":null,"scoreType":0}]}""",
+            // #3633: qui c'era `{"type":0,"dimensions":[…]}`, un formato che l'applicazione non
+            // produce e non ha mai prodotto — `LiveGameSessionMapper.SerializeScoringConfig` scrive
+            // `enabledDimensions` / `dimensionUnits`. Quel JSON deserializzava in un DTO con
+            // entrambi i campi a null e il costruttore di SessionScoringConfig lanciava
+            // ArgumentNullException, che il middleware traduce in 400: tutti e quattro i test di
+            // questa classe fallivano sulla `GET /stream` prima ancora di arrivare alla logica del
+            // companion, con un messaggio («Invalid request parameters») che non diceva nulla.
+            //
+            // Formato reale, prodotto dal serializzatore del mapper:
+            ScoringConfigJson = """{"enabledDimensions":["Points"],"dimensionUnits":{"Points":"pt"}}""",
             TrackingSessionId = trackingSessionId
         };
     }


### PR DESCRIPTION
Secondo lotto del triage di #3633: **5 test**, due cluster. La issue resta aperta come tracking.

---

## 1. Subscribe companion — 4 test

Tutti e quattro fallivano con `400 Invalid request parameters` sulla `GET /live-sessions/{id}/stream`, **prima** di arrivare alla logica del companion che era l'oggetto del test. Il messaggio non conteneva alcun indizio: è servito lo stack per scoprire un `ArgumentNullException` dal costruttore di `SessionScoringConfig`, dentro `LiveGameSessionMapper.ToDomain`.

**Causa** — la fixture scriveva `ScoringConfigJson` come:

```json
{"type":0,"dimensions":[{"name":"Points","unit":null,"scoreType":0}]}
```

un formato che l'applicazione **non produce e non ha mai prodotto**: `SerializeScoringConfig` scrive `enabledDimensions` / `dimensionUnits`. Il JSON deserializzava quindi in un DTO con entrambi i campi a `null`.

**Robustezza** — `DeserializeScoringConfig` degradava già a `CreateDefault()` per JSON vuoto e per DTO nullo, ma sul terzo caso (campi nulli) lasciava lanciare. Un'omissione, non una scelta: trasformava una riga malformata in un 400 opaco su un endpoint di sola lettura. Ora la degradazione è coerente sui tre casi.

## 2. Stream admin SSE — 1 test, bug di produzione

`ExtractStatusCode` leggeva lo status solo da `IStatusCodeHttpResult`:

```csharp
if (result is IStatusCodeHttpResult sc) return sc.StatusCode ?? 401;
return 401;
```

Ma `Results.Forbid()` produce un `ForbidHttpResult`, che **non implementa quell'interfaccia** — delega lo status allo schema di autenticazione invece di dichiararlo. Il ramo di default vinceva sempre.

**Effetto**: sullo stream SSE admin un utente autenticato ma senza permessi riceveva **401 invece di 403**, e il chiamante non poteva distinguere «sessione scaduta, rifai login» da «non hai i permessi». Gli altri due endpoint della stessa famiglia (`GET /admin/events`, `/types`) rispondevano correttamente 403, perché restituiscono l'`IResult` direttamente invece di estrarne lo status.

---

## Cosa NON è stato risolto, e perché

**`PdfCoverGeneratedEvent_PropagatesToSharedGame` resta rosso.** Ho aggiunto l'override `DomainEventDispatchMode.Hybrid` — la terza classe rimasta indietro dal cutover `OutboxOnly` di #1535, dopo le due sistemate in #3647 — ma è un **prerequisito necessario e non sufficiente**: senza, l'handler non partirebbe affatto; con, il test fallisce ancora e la causa residua non è isolata. Il commento nel codice lo dichiara esplicitamente invece di lasciarlo intendere.

**Il gruppo reindex-race (~5 test) è bloccato da un bug di produzione**, aperto come **#3651**: dieci entità dichiarano concorrenza ottimistica con `byte[] RowVersion` su colonna `bytea`, che Postgres non popola mai. Il token resta null, non cambia fra un update e l'altro, e nessun conflitto viene rilevato — `Reindex_RacesWithDelete_FirstWinsSecondGets409` osserva `successCount = 2` dove il dominio ne prevede 1.

Non l'ho corretto contestualmente perché non è una sostituzione meccanica: cambia il tipo delle proprietà (`byte[]?` → `uint`), richiede una migration, e soprattutto **attivare una protezione che non è mai scattata farà emergere `DbUpdateConcurrencyException` su percorsi che oggi non le vedono**, da verificare caso per caso.

## Bilancio del triage

| | Test |
|---|---|
| Risolti (#3647 + questa PR) | **43** su 57 |
| Bloccati da #3651 | ~5 |
| Residui da triagiare | ~9 |

Issue di prodotto emerse dal triage: **#3650** (`ON CONFLICT (name)` non conflict-safe sulle `game_categories`), **#3651** (concorrenza ottimistica inefficace su 10 entità). Nessuna delle due era visibile finché i gate non hanno ripreso a eseguire i test di integrazione (#3629, #3632).
