### PR TITLE
test(docprocessing,kb): retry da Pending, seed FK, filtro jsonb (#3633)

### DIFF
--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetPdfCleanupPreview/Integration/GetPdfCleanupPreviewQueryHandlerIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetPdfCleanupPreview/Integration/GetPdfCleanupPreviewQueryHandlerIntegrationTests.cs
@@ -71,6 +71,16 @@ public sealed class GetPdfCleanupPreviewQueryHandlerIntegrationTests : IAsyncLif
 
         _dbContext.Users.Add(CreateUser(userId));
 
+        // #3633: le RaptorSummaries seedate più sotto hanno una FK verso shared_games
+        // (FK_RaptorSummaries_shared_games_GameId), ma il gioco non veniva mai creato: il
+        // SaveChanges falliva con 23503 prima ancora di arrivare alle assert. Va inserito qui,
+        // prima delle righe che lo referenziano.
+        _dbContext.SharedGames.Add(new Api.Infrastructure.Entities.SharedGameCatalog.SharedGameEntity
+        {
+            Id = gameId,
+            Title = "Cleanup Preview Test Game",
+        });
+
         _dbContext.PdfDocuments.AddRange(
             CreatePdfDocument(targetPdfId, userId, fileSize),
             CreatePdfDocument(unrelatedPdfId, userId, 999L));

--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/PdfIndexingFlowKbFlagIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/PdfIndexingFlowKbFlagIntegrationTests.cs
@@ -500,23 +500,28 @@ public sealed class PdfIndexingFlowKbFlagIntegrationTests : IAsyncLifetime
         // outbox row schema does not store an AggregateId column, so the test filters
         // on the serialised event body. Acceptable in test scope because the only PDF in
         // play is the one this test seeded.
+        // #3633: il filtro sul payload va fatto in memoria. `PayloadJson` è mappato a jsonb, e un
+        // `.Contains(...)` dentro l'espressione LINQ viene tradotto in `LIKE`, che per Postgres non
+        // esiste su quel tipo: la query moriva con `42883: operator does not exist: jsonb ~~ jsonb`
+        // prima di qualunque assert. Il filtro su `EventType` (text) resta invece nel database.
         var pdfIdString = pdfDocId.ToString();
-        var pdfStateChangedCount = await _dbContext.DomainEventOutbox
+        var outboxRows = await _dbContext.DomainEventOutbox
             .AsNoTracking()
-            .CountAsync(
-                e => e.EventType.Contains("PdfStateChanged") && e.PayloadJson.Contains(pdfIdString),
-                TestCancellationToken);
+            .Select(e => new { e.EventType, e.PayloadJson })
+            .ToListAsync(TestCancellationToken);
+
+        var pdfStateChangedCount = outboxRows.Count(
+            e => e.EventType.Contains("PdfStateChanged", StringComparison.Ordinal)
+                 && e.PayloadJson.Contains(pdfIdString, StringComparison.Ordinal));
         pdfStateChangedCount.Should().Be(6,
             "pipeline must raise PdfStateChangedEvent for EVERY state transition " +
             "(Pending→Uploading + Uploading→Extracting + Extracting→Chunking + " +
             "Chunking→Embedding + Embedding→Indexing + Indexing→Ready). " +
             "If this counts 1, the bridge-save shortcut from PR #2295 has regressed.");
 
-        var kbDocIndexedCount = await _dbContext.DomainEventOutbox
-            .AsNoTracking()
-            .CountAsync(
-                e => e.EventType.Contains("KbDocIndexed") && e.PayloadJson.Contains(pdfIdString),
-                TestCancellationToken);
+        var kbDocIndexedCount = outboxRows.Count(
+            e => e.EventType.Contains("KbDocIndexed", StringComparison.Ordinal)
+                 && e.PayloadJson.Contains(pdfIdString, StringComparison.Ordinal));
         kbDocIndexedCount.Should().Be(1,
             "KbDocIndexedEvent must fire exactly once per upload, raised by " +
             "PdfDocument.TransitionTo(Ready) (PdfDocument.cs:435-442).");

--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/PdfMetricsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/PdfMetricsIntegrationTests.cs
@@ -296,6 +296,18 @@ public sealed class PdfMetricsIntegrationTests : IAsyncLifetime
         pdf.Retry();
         pdf.RetryCount.Should().Be(1);
 
+        // #3633: `Retry()` riporta a Pending, non allo stato in cui si era fallito. È deliberato
+        // (#3269, bug-hunt B11): la pipeline non ha un resume a metà — `ProcessAsync` riparte
+        // sempre da Extract — e solo un PDF Pending è reclamabile da `TryClaimPendingAsync`, quindi
+        // il vecchio «resume from FailedAtState ?? Extracting» lasciava il documento in uno stato
+        // che nessun binario runtime poteva prendere in carico e il retry non riprocessava mai.
+        //
+        // Il test proseguiva da Chunking come se il retry riprendesse da Extracting, e falliva con
+        // «Invalid state transition: Pending → Chunking». Ora ripercorre il ciclo dall'inizio, che
+        // è ciò che accade davvero in produzione dopo un retry.
+        pdf.TransitionTo(PdfProcessingState.Uploading);
+        pdf.TransitionTo(PdfProcessingState.Extracting);
+
         // Complete successfully
         pdf.TransitionTo(PdfProcessingState.Chunking);
         pdf.TransitionTo(PdfProcessingState.Embedding);


### PR DESCRIPTION
Terzo lotto del triage di #3633: **3 test**, tre cause distinte. Verificati in locale sopra `main-dev` aggiornato dopo il merge di #3652.

---

## 1. `FullPipeline_RetryOverhead_IncludedInMetrics`

Il test proseguiva da `Chunking` dopo `Retry()`, come se il retry riprendesse dallo stato in cui si era fallito, e moriva con `Invalid state transition: Pending → Chunking. Allowed: Uploading, Failed`.

`Retry()` riporta **deliberatamente** a `Pending` (#3269, bug-hunt B11), e la motivazione è scritta accanto al codice: la pipeline non ha un resume a metà — `ProcessAsync` riparte sempre da Extract — e solo un PDF `Pending` è reclamabile da `TryClaimPendingAsync`. Il vecchio «resume from FailedAtState ?? Extracting» lasciava il documento in uno stato che nessun binario runtime poteva prendere in carico, quindi il retry non riprocessava mai.

Il codice ha ragione: era il test a descrivere il comportamento precedente. Ora ripercorre il ciclo dall'inizio, che è ciò che accade in produzione dopo un retry.

## 2. `Handle_RealPostgres_CountsChunksAndRaptorScopedPerPdf`

Il test generava un `gameId` con `Guid.NewGuid()` e lo usava nelle `RaptorSummaries` senza mai inserire la `SharedGameEntity` corrispondente. Il `SaveChanges` falliva con `Npgsql 23503` — violazione di `FK_RaptorSummaries_shared_games_GameId` — prima di arrivare alle assert.

Stesso pattern di #2620: le entità dipendenti vanno seedate per prime.

## 3. `UploadPdf_OnSuccessfulIndexing_SetsHasKnowledgeBaseTrue_OnSharedGame` — parziale

Il test filtrava `PayloadJson` dentro l'espressione LINQ. Quella colonna è mappata a `jsonb` e EF traduceva `.Contains(...)` in `LIKE`, che Postgres non ha per quel tipo:

```
42883: operator does not exist: jsonb ~~ jsonb
```

La query moriva prima di qualunque assert. Ora il filtro su `EventType` (colonna `text`) resta nel database e quello sul payload avviene in memoria.

⚠️ **Il test NON è verde.** Superata la query, l'assert sul conteggio trova **0** eventi `PdfStateChanged` invece di 6, mentre gli assert precedenti sul flag `HasKnowledgeBase` passano — quindi la pipeline gira davvero ma gli eventi non finiscono nell'outbox. **Non** è la regressione di PR #2295 che il commento del test paventava: quella darebbe 1, non 0. Causa non isolata, resta in #3633.

Il fix è comunque corretto e necessario: senza, la query è SQL invalido e il test non può arrivare a misurare nulla.

---

## Nota sul recupero

Questi tre commit erano stati scritti sul branch `feature/issue-3633-remaining-failures`, il cui push era fallito con `remote end hung up`. Nel frattempo una sessione parallela ha mergiato #3652, fatto checkout su `main-dev` ed eliminato quel branch: i commit sono rimasti per qualche minuto solo come oggetti dangling. Recuperati dal reflog e cherry-picked qui sopra `main-dev` aggiornato, poi riverificati (2/2 verdi sui test completabili).

## Stato del triage

**46 dei 57.** Restano ~11: ~5 bloccati da **#3651** (concorrenza ottimistica inefficace su 10 entità — bug di produzione), `UploadPdf` e `PdfCover` con cause non isolate, più i singoli non ancora esaminati.