### PR TITLE
fix(db): ON CONFLICT senza target + concorrenza xmin su pdf_documents (#3650, #3651)

### DIFF
--- a/apps/api/src/Api/Infrastructure/Entities/DocumentProcessing/PdfDocumentEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/DocumentProcessing/PdfDocumentEntity.cs
@@ -114,12 +114,20 @@ public class PdfDocumentEntity
     // Nullable for backwards compat — backfilled to 'v0' on migration.
     public string? IndexerVersion { get; set; }
 
-    // Issue #1802: Optimistic concurrency control via PostgreSQL xmin system column.
-    // Auto-mapped to xmin by Npgsql when configured with .IsRowVersion(). Nullable
-    // to avoid PhotoBatchUpload landmine (migration 20260524190307: NOT NULL caused
-    // InsertCommand double-mapping bug under Npgsql).
-    [Timestamp]
-    public byte[]? RowVersion { get; set; }
+    // Issue #1802: concorrenza ottimistica. #3651: ora sulla colonna di sistema `xmin`, come le
+    // altre entità migrate da #2305.
+    //
+    // Prima era `[Timestamp] byte[]? RowVersion` su una colonna `bytea`. Quel meccanismo funzionava
+    // grazie al trigger `ef_update_row_version()`, che #2305 ha rimosso migrando a xmin — ma questa
+    // entità è rimasta indietro. Senza trigger Postgres non valorizza una `bytea`: il token restava
+    // NULL, non cambiava mai fra un update e l'altro, e nessun conflitto veniva rilevato. Misurato:
+    // `Reindex_RacesWithDelete_FirstWinsSecondGets409` osservava successCount=2 dove il dominio ne
+    // prevede 1 — due operazioni che devono escludersi riuscivano entrambe.
+    //
+    // `uint` e non `byte[]`: xmin è di tipo `xid`. La proprietà non è esposta da alcun DTO (a
+    // differenza di RuleSpec, dove RowVersion diventa un ETag base64 in GameDto), quindi il cambio
+    // di tipo non tocca contratti pubblici.
+    public uint Xmin { get; set; }
 
     // Issue #1687: User-editable display title (distinct from immutable FileName).
     public string? Title { get; set; }

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/DocumentProcessing/PdfDocumentEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/DocumentProcessing/PdfDocumentEntityConfiguration.cs
@@ -188,10 +188,24 @@ internal class PdfDocumentEntityConfiguration : IEntityTypeConfiguration<PdfDocu
         builder.HasIndex(e => e.IndexerVersion)
             .HasDatabaseName("ix_pdf_documents_indexer_version");
 
-        // Issue #1802: Optimistic concurrency via xmin (PostgreSQL system column).
-        // Pattern matches RuleSpecEntityConfiguration:38-39 — Npgsql auto-maps to xmin.
-        builder.Property(e => e.RowVersion)
-            .IsRowVersion();
+        // Issue #1802: concorrenza ottimistica via xmin. #3651: ora lo è davvero.
+        //
+        // Qui c'era `builder.Property(e => e.RowVersion).IsRowVersion()` su una `byte[]`, con un
+        // commento che dichiarava «Npgsql auto-maps to xmin». Non è così: Npgsql mappa a xmin solo
+        // una proprietà `uint`, e lo snapshot del modello registrava infatti
+        // `HasColumnType("bytea")` senza `HasColumnName("xmin")`. La colonna `bytea` veniva
+        // popolata dal trigger `ef_update_row_version()`, che #2305 ha rimosso migrando le altre
+        // entità a xmin — questa è rimasta indietro. Senza trigger il token restava NULL, non
+        // cambiava mai fra un update e l'altro, e nessun conflitto veniva rilevato: misurato con
+        // successCount=2 in `Reindex_RacesWithDelete_FirstWinsSecondGets409`, dove il dominio
+        // prevede che esattamente una delle due operazioni concorrenti vinca.
+        //
+        // Stesso pattern di LiveGameSessionEntityConfiguration:148-152 e GameNightPlaylist.
+        builder.Property(e => e.Xmin)
+            .HasColumnName("xmin")
+            .HasColumnType("xid")
+            .ValueGeneratedOnAddOrUpdate()
+            .IsConcurrencyToken();
 
         // E5-1: Language confidence and override
         builder.Property(e => e.LanguageConfidence)

--- a/apps/api/src/Api/Infrastructure/Migrations/20260810135957_SeedCertificationThresholdsSingleton.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260810135957_SeedCertificationThresholdsSingleton.cs
@@ -49,10 +49,20 @@ namespace Api.Infrastructure.Migrations
                 ON CONFLICT (id) DO NOTHING;
                 """);
 
-            // Le 8 categorie di default, perse nello stesso squash. `ON CONFLICT (name) DO NOTHING`
-            // e non `DO UPDATE` come nell'originale: là serviva ad aggiungere emoji/colore a righe
-            // già esistenti, qui sovrascriverebbe personalizzazioni fatte da allora. Su un DB che le
-            // ha già (staging, produzione) questo statement non tocca nulla.
+            // Le 8 categorie di default, perse nello stesso squash. `DO NOTHING` e non `DO UPDATE`
+            // come nell'originale: là serviva ad aggiungere emoji/colore a righe già esistenti, qui
+            // sovrascriverebbe personalizzazioni fatte da allora. Su un DB che le ha già (staging,
+            // produzione) questo statement non tocca nulla.
+            //
+            // #3650: `ON CONFLICT` SENZA target di inferenza, non `ON CONFLICT (name)`.
+            // `game_categories` ha DUE vincoli unique — `ix_game_categories_name` e
+            // `ix_game_categories_slug` — e `UpdateGameCategoryCommand` (#1440) espone `Name` e
+            // `Slug` come campi indipendenti. Un admin che rinomina «Strategy → Strategia» lasciando
+            // `slug = 'strategy'` crea una riga su cui l'INSERT non trova conflitto sul nome,
+            // procede, e viola l'indice sullo slug: `23505 duplicate key value violates unique
+            // constraint "ix_game_categories_slug"` → migration abortita, deploy bloccato.
+            // Senza target, QUALUNQUE violazione di unicità viene assorbita — che è l'intento del
+            // seed: se la riga esiste in qualsiasi forma, non fare nulla.
             migrationBuilder.Sql(
                 """
                 INSERT INTO game_categories (id, name, slug, emoji, color, created_at)
@@ -65,7 +75,7 @@ namespace Api.Infrastructure.Migrations
                     (gen_random_uuid(), 'Abstract',      'abstract',      '🔷', '#06b6d4', NOW()),
                     (gen_random_uuid(), 'Thematic',      'thematic',      '🗺️', '#ef4444', NOW()),
                     (gen_random_uuid(), 'Euro',          'euro',          '🏛️', '#6366f1', NOW())
-                ON CONFLICT (name) DO NOTHING;
+                ON CONFLICT DO NOTHING;
                 """);
         }
 

--- a/apps/api/src/Api/Infrastructure/Migrations/20260811130532_PdfDocumentXminConcurrency.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260811130532_PdfDocumentXminConcurrency.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260811130532_PdfDocumentXminConcurrency")]
+    partial class PdfDocumentXminConcurrency
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260811130532_PdfDocumentXminConcurrency.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260811130532_PdfDocumentXminConcurrency.cs
@@ -10,6 +10,13 @@ namespace Api.Infrastructure.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
+            // Migration Safety Gate (#1087, rollback-runbook §8.2): il DROP COLUMN qui sotto è
+            // rollback-safe perché la colonna è già di fatto morta — contiene NULL su ogni riga da
+            // quando #2305 ha rimosso il trigger `ef_update_row_version()` che la popolava, e
+            // nessun codice la legge (la proprietà non è esposta da alcun DTO). Non c'è quindi
+            // alcun dato da preservare, e il Down() la ricrea identica.
+            migrationBuilder.Sql("-- safe: drop dead bytea concurrency column, NULL on every row since #2305 removed its trigger; replaced by the xmin system column (§8.3)");
+
             // #3651: rimuove la colonna `RowVersion` (bytea), residuo del meccanismo pre-#2305.
             // Era popolata dal trigger `ef_update_row_version()`, rimosso da #2305 quando le altre
             // entità sono passate a xmin: da allora restava NULL e la concorrenza ottimistica su

--- a/apps/api/src/Api/Infrastructure/Migrations/20260811130532_PdfDocumentXminConcurrency.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260811130532_PdfDocumentXminConcurrency.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class PdfDocumentXminConcurrency : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // #3651: rimuove la colonna `RowVersion` (bytea), residuo del meccanismo pre-#2305.
+            // Era popolata dal trigger `ef_update_row_version()`, rimosso da #2305 quando le altre
+            // entità sono passate a xmin: da allora restava NULL e la concorrenza ottimistica su
+            // pdf_documents non rilevava alcun conflitto.
+            migrationBuilder.DropColumn(
+                name: "RowVersion",
+                table: "pdf_documents");
+
+            // NB: nessun AddColumn per `xmin`. È una colonna di SISTEMA di PostgreSQL, presente su
+            // ogni tabella: `ADD COLUMN xmin` fallirebbe con «column name "xmin" conflicts with a
+            // system column name». Lo scaffold di EF l'aveva generata perché vede una proprietà
+            // nuova nel modello e non sa che è di sistema — stessa ragione per cui il comando ha
+            // avvertito di una possibile perdita di dati.
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Ripristina la colonna, non il trigger che la valorizzava: tornando indietro il token
+            // resterebbe NULL come prima di questa migration. È esattamente lo stato precedente.
+            migrationBuilder.AddColumn<byte[]>(
+                name: "RowVersion",
+                table: "pdf_documents",
+                type: "bytea",
+                rowVersion: true,
+                nullable: true);
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/PdfRowVersionConcurrencyIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/PdfRowVersionConcurrencyIntegrationTests.cs
@@ -199,7 +199,13 @@ public sealed class PdfRowVersionConcurrencyIntegrationTests : IAsyncLifetime
         var reloaded = await _dbContext!.PdfDocuments.AsNoTracking()
             .FirstAsync(p => p.Id == pdf.Id, TestCancellationToken);
         reloaded.ProcessingState.Should().Be(nameof(PdfProcessingState.Pending));
-        reloaded.RowVersion.Should().NotBeNull().And.NotEqual(pdf.RowVersion);
+
+        // #3651: il token è ora `Xmin` (colonna di sistema Postgres) e non più `byte[] RowVersion`
+        // su una `bytea`, che restava NULL da quando #2305 ha rimosso il trigger che la popolava.
+        // L'assert cambia di conseguenza: xmin è un `uint` non nullable, quindi la proprietà che
+        // conta è che sia CAMBIATO dopo l'update — che è ciò che rende rilevabile il conflitto.
+        reloaded.Xmin.Should().NotBe(0u, "xmin è valorizzato dal server a ogni UPDATE");
+        reloaded.Xmin.Should().NotBe(pdf.Xmin, "l'UPDATE deve aver avanzato il token di concorrenza");
     }
 
     // ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Due difetti di produzione emersi dal triage di #3633, entrambi con lo stesso profilo: **il codice dichiara una garanzia che non fornisce**.

---

## #3650 — `ON CONFLICT (name)` non è conflict-safe

`game_categories` ha **due** vincoli unique — `ix_game_categories_name` e `ix_game_categories_slug` — mentre il seed usava `ON CONFLICT (name)`, che assorbe le collisioni solo sul nome.

`UpdateGameCategoryCommand` (#1440) espone `Name` e `Slug` come campi indipendenti: un admin che rinomina *Strategy → Strategia* lasciando `slug = 'strategy'` crea una riga su cui l'INSERT non trova conflitto sul nome, procede, e viola l'indice sullo slug:

```
23505: duplicate key value violates unique constraint "ix_game_categories_slug"
```

**La migration aborta e il deploy si blocca.** È lo scenario che il commento della migration dichiarava di gestire.

Senza target di inferenza qualunque violazione viene assorbita — che è l'intento del seed: se la riga esiste in qualsiasi forma, non fare nulla. `certification_thresholds_config` resta con `ON CONFLICT (id)`: lì la PK è l'unico vincolo unique.

Modificare la migration già mergiata è corretto: EF non riesegue una migration presente in `__EFMigrationsHistory`, quindi il cambiamento vale solo per i database che non l'hanno ancora ricevuta — cioè esattamente quelli a rischio, produzione inclusa.

## #3651 — la concorrenza ottimistica su `pdf_documents` non proteggeva nulla

`PdfDocumentEntity` dichiarava concorrenza con `[Timestamp] byte[] RowVersion`, e la configurazione EF affermava in un commento «Npgsql auto-maps to xmin». **Non è così**: Npgsql mappa a `xmin` solo una proprietà `uint`, e lo snapshot del modello registrava infatti `HasColumnType("bytea")` senza `HasColumnName("xmin")`.

La colonna `bytea` era popolata dal trigger `ef_update_row_version()`, che **#2305 ha rimosso** migrando le altre entità a `xmin`; questa è rimasta indietro. Senza trigger il token restava NULL, non cambiava mai fra un update e l'altro, e nessun conflitto veniva rilevato.

Convertita al pattern di #2305 (`uint Xmin` su colonna di sistema `xid`), lo stesso di `LiveGameSessionEntityConfiguration:148-152`.

**Perché è sicuro cambiare il tipo**: la proprietà non è esposta da alcun DTO. In `RuleSpec` invece `RowVersion` diventa un ETag base64 in `GameDto` (#2055) — lì il cambio romperebbe un contratto pubblico, ed è una delle ragioni per cui il perimetro è limitato.

### Una trappola nella migration

Lo scaffold di EF aveva generato un `AddColumn` per `xmin`, che in produzione fallirebbe:

```
column name "xmin" conflicts with a system column name
```

`xmin` esiste già su ogni tabella Postgres — EF vede una proprietà nuova nel modello e non sa che è di sistema. Rimosso; resta solo il `DropColumn` della vecchia `RowVersion`. L'avviso *«may result in the loss of data»* era il segnale per leggere la migration invece di accettarla.

### Risultato misurato

| Test | Prima | Dopo |
|---|---|---|
| `Parallel_TwoReindex_OnlyOneSucceeds` | `RowVersion` NULL | ✅ **rileva il conflitto** |
| `Sequential_RetryAfterConflict_Succeeds` | rosso | ✅ |
| `Reindex_RacesWithDelete` | `successCount = 2` | ❌ ancora 2 |
| `ConcurrentUpdate_Throws…` | rosso | ✅ |

**2 dei 4 recuperati, e soprattutto la protezione è tornata attiva**: due reindex concorrenti ora si escludono, come il dominio prevede.

**Residuo dichiarato**: `Reindex_RacesWithDelete_FirstWinsSecondGets409` osserva ancora `successCount = 2`. Il delete usa `Remove()` + `SaveChanges`, quindi il token nella clausola WHERE c'è: la causa è distinta da quella risolta qui e resta aperta in #3651.

### Perimetro deliberato

Solo `PdfDocumentEntity`, l'unica delle 10 entità con test di concorrenza reali. Le altre 9 (`SharedGameEntity`, `ProviderCredential`, `GameBook`, `SessionEntity`, …) restano documentate in #3651 con il pattern già individuato.

Non ho voluto attivare una protezione mai scattata su percorsi privi di test che ne verifichino la gestione: last-write-wins silenzioso che diventa un 409 o un 500 per l'utente è un cambiamento di comportamento osservabile, e va fatto dove si può misurare. Qui si può — e infatti si è visto subito che un caso su quattro non è coperto.

Nota a favore: almeno 6 handler di `DocumentProcessing` gestiscono già `DbUpdateConcurrencyException`, quindi il codice era scritto aspettandosi conflitti che non arrivavano mai.