### PR TITLE
test(db): guard sull'inventario dei seed di migration (#3656)

### DIFF
--- a/apps/api/tests/Api.Tests/Infrastructure/MigrationSeedInventoryIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/MigrationSeedInventoryIntegrationTests.cs
@@ -1,0 +1,144 @@
+using Api.Infrastructure;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Api.Tests.Infrastructure;
+
+/// <summary>
+/// Issue #3656 — inventario dei seed che un database creato <b>da zero</b> deve contenere.
+///
+/// <para>
+/// <b>Perché esiste.</b> Il repository ha subito tre squash di migration (<c>eff570a08</c> #2021,
+/// <c>7d9d67c13</c> #2880, <c>414b30230</c> #3518). Le stesse due righe di seed sono state perse
+/// <b>due volte</b>: eliminate da #2021, ripristinate il 2026-07-11 da
+/// <c>RestoreLostThresholdsAndCategorySeeds</c>, rieliminate da #2880, ripristinate di nuovo da
+/// #3648. Nessuno se ne è accorto per mesi perché staging e produzione hanno database preesistenti
+/// agli squash: a nascere vuoto è solo un database creato da zero.
+/// </para>
+/// <para>
+/// <b>La regola che spiega quali seed si perdono.</b> Un seed dichiarato con <c>HasData</c> nel
+/// modello EF vive nello snapshot, quindi ogni <c>InitialCreate</c> rigenerato lo riemette da solo:
+/// è il caso di <c>SystemConfiguration.IncidentBannerState</c>, l'unico sopravvissuto a tutti e tre
+/// gli squash. Un seed scritto come <c>migrationBuilder.Sql(...)</c> vive invece solo nel corpo
+/// della migration: lo squash lo riscrive a mano e può ometterlo senza che nulla protesti.
+/// </para>
+/// <para>
+/// Questa classe è il posto in cui l'omissione protesta. Asserisce sul <b>database</b> via SQL
+/// grezzo, non sulle entità EF, perché ciò che va protetto è l'esito delle migration — non il
+/// mapping del modello, che un refactor può cambiare legittimamente.
+/// </para>
+/// <para>
+/// <b>Se aggiungi un seed</b>, aggiungi qui la riga corrispondente. <b>Se un test qui fallisce dopo
+/// uno squash</b>, il seed non è stato riportato: recuperalo dalla history
+/// (<c>git show &lt;commit&gt;^:&lt;path-migration&gt;</c>) e riprendi i valori alla lettera, non dedurli.
+/// </para>
+/// </summary>
+[Collection("Integration-GroupD")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "Infrastructure")]
+public sealed class MigrationSeedInventoryIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private MeepleAiDbContext _dbContext = null!;
+    private string _databaseName = null!;
+
+    public MigrationSeedInventoryIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_seed_inventory_{Guid.NewGuid():N}";
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        _dbContext = _fixture.CreateDbContext(connectionString);
+        await _dbContext.Database.MigrateAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _dbContext.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    private async Task<int> CountAsync(string sql)
+    {
+        var rows = await _dbContext.Database
+            .SqlQueryRaw<int>(sql)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        return rows.Single();
+    }
+
+    // ============================================================
+    // Seed raw-SQL — quelli che gli squash hanno già perso due volte
+    // ============================================================
+
+    [Fact]
+    public async Task FreshDatabase_HasCertificationThresholdsSingleton()
+    {
+        // La tabella dichiara `ck_certification_thresholds_config_singleton` (id = 1): ammette
+        // esattamente una riga. Senza il seed è in uno stato che il DB considera valido e il
+        // dominio no — ogni lettura delle soglie fallisce.
+        var seeded = await CountAsync(
+            """
+            SELECT COUNT(*)::int AS "Value"
+            FROM certification_thresholds_config
+            WHERE id = 1
+              AND min_coverage_pct = 70
+              AND max_page_tolerance = 10
+              AND min_bgg_match_pct = 80
+              AND min_overall_score = 60
+            """);
+
+        seeded.Should().Be(
+            1,
+            "un database creato da zero deve contenere il singleton delle soglie con i valori di "
+                + "CertificationThresholds.Default() — se manca, uno squash ha perso il seed raw-SQL "
+                + "della migration (storia in #3646 / #3648 / #3656)");
+    }
+
+    [Fact]
+    public async Task FreshDatabase_HasEightDefaultGameCategories()
+    {
+        var seeded = await CountAsync(
+            """
+            SELECT COUNT(*)::int AS "Value"
+            FROM game_categories
+            WHERE slug IN (
+                'strategy', 'party', 'cooperative', 'deck-building',
+                'family', 'abstract', 'thematic', 'euro'
+            )
+            """);
+
+        seeded.Should().Be(
+            8,
+            "un database creato da zero deve contenere le 8 categorie di default — se ne mancano, "
+                + "uno squash ha perso il seed raw-SQL della migration (storia in #3646 / #3648 / #3656)");
+    }
+
+    // ============================================================
+    // Seed dichiarativo — non può regredire con uno squash, ma
+    // l'inventario è utile solo se è completo
+    // ============================================================
+
+    [Fact]
+    public async Task FreshDatabase_HasIncidentBannerStateSingleton()
+    {
+        var seeded = await CountAsync(
+            """
+            SELECT COUNT(*)::int AS "Value"
+            FROM "SystemConfiguration"."IncidentBannerState"
+            WHERE "Id" = '00000000-0000-0000-0000-000000000001'
+            """);
+
+        seeded.Should().Be(
+            1,
+            "il singleton del banner incidenti è dichiarato con HasData nel modello EF, quindi ogni "
+                + "InitialCreate rigenerato lo riemette: se manca, il problema non è uno squash ma la "
+                + "rimozione dell'HasData in IncidentBannerStateEntityConfiguration");
+    }
+}


### PR DESCRIPTION
Chiude #3656.

## L'audit

#3646 aveva lasciato una domanda aperta — *«vale anche la pena verificare se altri seed siano stati persi nello stesso appiattimento»* — e #3648 si era fermato a ripristinarne due. Questa PR fa il confronto sistematico, ispezionando i file di migration nello stato **precedente a ciascuno squash** (`git show <commit>^:<path>`), non l'albero corrente.

**Gli squash sono tre, non due**: `eff570a08` (#2021, 165→3 file), `7d9d67c13` (#2880, 95→3), `414b30230` (#3518, 37→3).

| Statement | Tipo | Perso in | Ripristinato | Oggi |
|---|---|---|---|---|
| `certification_thresholds_config` — singleton | seed statico, raw-SQL | #2021 **e di nuovo** #2880 | 2026-07-11, poi #3648 | ✅ |
| `game_categories` — 8 default | seed statico, raw-SQL | #2021 **e di nuovo** #2880 | 2026-07-11, poi #3648 | ✅ |
| `SystemConfiguration.IncidentBannerState` | seed statico, **`HasData`** | mai | — | ✅ |
| `ToolkitVersions` — backfill | **migrazione dati**, raw-SQL | #2021 | mai | ⚠️ innocuo |

**Nessun seed statico manca oggi.** Nessuna migration di ripristino, quindi.

## Ma il difetto si è già ripetuto

Le due righe ripristinate da #3648 **erano già state ripristinate una volta**, il 2026-07-11, da `20260711091716_RestoreLostThresholdsAndCategorySeeds`. Lo squash #2880 del giorno dopo le ha rimangiate, e #3648 ha riapplicato la stessa correzione un mese più tardi senza che nulla segnalasse la ricaduta.

Il problema non è quali seed manchino oggi: è che la procedura di squash non ha modo di accorgersi di averne persi.

## La regola che dice quali seed sono a rischio

`IncidentBannerState` è l'unico sopravvissuto a tutti e tre gli squash, e non per caso: è dichiarato con `.HasData()` (`IncidentBannerStateEntityConfiguration.cs:58`), quindi vive nello **snapshot del modello** e ogni `InitialCreate` rigenerato lo riemette da solo.

Gli altri sono `migrationBuilder.Sql(...)` nel corpo della migration, che lo squash riscrive a mano.

> Seed raw-SQL = a rischio a ogni squash. Seed `HasData` = immune.

## Il guard

`MigrationSeedInventoryIntegrationTests` asserisce, su un database appena migrato, la presenza di ogni riga di seed attesa. Interroga il **database via SQL grezzo**, non le entità EF: ciò che va protetto è l'esito delle migration, non il mapping del modello, che un refactor può cambiare legittimamente.

Se il prossimo squash perde un seed, il test diventa rosso lo stesso giorno.

## Verifica

Red-green reale, non un test scritto dopo:

| Passo | Esito |
|---|---|
| Seed della migration neutralizzato (simula la perdita da squash) | `FreshDatabase_HasCertificationThresholdsSingleton` **FAIL** (0 invece di 1) · `FreshDatabase_HasEightDefaultGameCategories` **FAIL** (0 invece di 8) · `FreshDatabase_HasIncidentBannerStateSingleton` **PASS** |
| Migration ripristinata byte-identica (`git diff` vuoto) | **3/3 verdi** |

Il fatto che il test `HasData` resti verde in entrambi i passaggi è la conferma sperimentale della regola sopra — non l'ho solo dedotta dalla history.

`dotnet format` sul file nuovo: nessuna modifica richiesta.

## `ToolkitVersions`: perso, ma non va ripristinato

`20260518134809_CreateToolkitVersionsTable_Issue822` conteneva un `INSERT ... SELECT FROM "GameToolkits" WHERE "IsPublished" = TRUE`. Non è un seed ma un **backfill una tantum**: su un database creato da zero `GameToolkits` è vuota quando la migration gira, quindi inserisce zero righe — il comportamento corretto; su staging e produzione la migration originale ha già girato il 2026-05-18. Ripristinarlo aggiungerebbe codice morto.

## Fuori scope

Spostare i seed statici da raw-SQL a `HasData` li renderebbe immuni, ma non è universale: #3648 ha scelto deliberatamente il raw-SQL per `game_categories` perché i database esistenti hanno righe con GUID casuali e un `HasData` a GUID fisso collide su `UNIQUE(name)`. Merita un'issue separata, con quel vincolo in premessa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
