### PR TITLE
ci: alza il TestSessionTimeout a 75 min, i job a 90 (#3634)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -838,7 +838,15 @@ jobs:
         # the suite now actually runs to completion (it used to short-circuit
         # on the first wave of failures at ~25 min). 45 min keeps headroom
         # for transient Testcontainers churn on the GitHub-hosted runner.
-        timeout-minutes: 45
+        #
+        # #3634: 45 → 90. Il TestSessionTimeout del runsettings passa a 75 min perché a 45 la
+        # sessione veniva troncata a metà (2148 test su ~2962, `Test Run Aborted.` su tutti e tre
+        # gli shard). Questo timeout deve restare SOPRA quello della sessione: se scattasse prima,
+        # GitHub marcherebbe il job `cancelled` senza riepilogo — il difetto di #3629.
+        #
+        # Nota: la stima «45 min bastano» di PR #1505 non era verificabile, perché nello stesso
+        # periodo questo job non eseguiva alcun test (#3632).
+        timeout-minutes: 90
         env:
           POSTGRES_HOST: localhost
           POSTGRES_PORT: 5432

--- a/.github/workflows/dev-async.yml
+++ b/.github/workflows/dev-async.yml
@@ -74,19 +74,25 @@ jobs:
   backend-integration:
     name: Backend Integration (${{ matrix.shard.name }})
     runs-on: ubuntu-latest
-    # 60 min per shard: i 45 del TestSessionTimeout più build Release, apt-get e setup, che qui
-    # sono dentro il job mentre ci.yml scarica un artifact già costruito. A 50 il job moriva prima
-    # che la sessione arrivasse a 45 — ai test restavano ~44 min — e si tornava a un `cancelled`.
+    # Il job sta SOPRA il TestSessionTimeout perché qui build Release, apt-get e setup sono dentro
+    # il job, mentre ci.yml scarica un artifact già costruito. Con job a 50 e sessione a 45 il job
+    # moriva prima — ai test restavano ~44 min — e si tornava a un `cancelled`.
     #
-    # Il numero NON è una stima: `integration.runsettings` documenta da PR #1505 che «each shard
-    # runs ~29-30 min of real work», ed è per questo che dichiara TestSessionTimeout=45. Due
-    # tentativi con soglie più basse (30 min job / 20 min sessione) hanno abortito ogni shard a
-    # metà — 625/910, 423/1123, 558/929 test — confermando quel numero invece di smentirlo.
+    # Il numero NON è una stima. Tre tentativi con soglie più basse hanno abortito ogni shard a
+    # metà: 625/910, 423/1123, 558/929 a 30 min di job, e poi 2148/2962 complessivi a 45 min di
+    # sessione. Il riferimento di PR #1505 («each shard runs ~29-30 min of real work») è da
+    # scartare: veniva da ci.yml, che in quel periodo non eseguiva alcun test (#3632).
     #
-    # Resta la RETE DI SICUREZZA: a scattare per primo dev'essere il TestSessionTimeout (45),
-    # perché produce un riepilogo leggibile, mentre il timeout del job dà un `cancelled` muto —
-    # che è il difetto da cui parte questa issue.
-    timeout-minutes: 60
+    # Resta la RETE DI SICUREZZA: a scattare per primo dev'essere il TestSessionTimeout, perché
+    # produce un riepilogo leggibile, mentre il timeout del job dà un `cancelled` muto — che è il
+    # difetto da cui parte questa issue.
+    #
+    # #3634: 60 → 90, di pari passo con il TestSessionTimeout portato da 45 a 75 min. A 45 la
+    # sessione veniva troncata: nel primo run che ha davvero eseguito i test, i tre shard si sono
+    # fermati a ~44m30s con `Test Run Aborted.` lasciando ~800 test non raggiunti. 2148 test in 44
+    # minuti danno ~61 minuti per l'intera selezione; 75 + 90 conserva il margine E l'ordine giusto
+    # fra le due soglie.
+    timeout-minutes: 90
     needs: changes
     if: needs.changes.outputs.backend == 'true' || github.event_name == 'workflow_dispatch'
 
@@ -199,9 +205,9 @@ jobs:
           # divergenza qui riporterebbe il difetto di #3622 (test che nessun gate esegue) su un
           # altro asse.
           #
-          # NESSUN override di TestSessionTimeout: valgono i 45 min del runsettings condiviso, che
-          # sono tarati sul lavoro reale di uno shard (~29-30 min, PR #1505). Un override più basso
-          # è già stato provato e abortiva ogni shard a metà.
+          # NESSUN override di TestSessionTimeout: valgono i 75 min del runsettings condiviso (#3634),
+          # calcolati sul lavoro reale misurato di uno shard. Override più bassi sono già stati
+          # provati due volte e abortivano ogni shard a metà.
           dotnet test tests/Api.Tests/Api.Tests.csproj \
             --filter "Category=Integration&FullyQualifiedName!~UploadPdfMidPhaseCancellationTests&FullyQualifiedName!~FrontendSdk&FullyQualifiedName!~ArbitroAgent${{ matrix.shard.filter_extra }}" \
             --settings tests/Api.Tests/integration.runsettings \

--- a/apps/api/tests/Api.Tests/integration.runsettings
+++ b/apps/api/tests/Api.Tests/integration.runsettings
@@ -8,7 +8,19 @@
          aborted the run with exit 134 ("test run timeout of 1800000 milliseconds
          exceeded") even though every test passed. Kept in sync with the GHA
          step `timeout-minutes: 45` in ci.yml. -->
-    <TestSessionTimeout>2700000</TestSessionTimeout>
+    <!-- #3634: 45 → 75 min. I 45 troncavano la sessione a metà: nel primo run in cui il gate ha
+         davvero eseguito (#3629 + #3632) i tre shard si sono fermati a 44m19s-44m31s con
+         `Test Run Aborted.`, avendo eseguito 2148 test sui ~2962 selezionati — circa 800 non
+         raggiunti, su TUTTI e tre gli shard.
+
+         Il numero è calcolato, non stimato: 2148 test in 44 minuti danno ~61 minuti per l'intera
+         selezione; 75 lascia margine per la varianza del runner senza diventare una soglia che non
+         scatta mai. Il vecchio riferimento di «~29-30 min di lavoro reale per shard» (PR #1505) non
+         è utilizzabile: veniva da `ci.yml`, che in quel periodo non eseguiva alcun test (#3632).
+
+         Resta il principio di #3629: questo timeout deve scattare PRIMA di quello del job, perché
+         produce un riepilogo leggibile mentre il job timeout dà un `cancelled` muto. -->
+    <TestSessionTimeout>4500000</TestSessionTimeout>
 
     <!-- Results directory -->
     <ResultsDirectory>./TestResults</ResultsDirectory>


### PR DESCRIPTION
Closes #3634

## Il problema

I 45 minuti di `TestSessionTimeout` troncavano la sessione a metà. Nel primo run in cui il gate ha **davvero eseguito** i test — cioè dopo #3629 e #3632, che hanno reso visibile l'esito — i tre shard si sono fermati a 44m19s–44m31s con `Test Run Aborted.`, avendo eseguito **2148 test sui ~2962 selezionati**. Circa 800 test non raggiunti, su tutti e tre gli shard.

## Perché il valore era 45

PR #1505 lo aveva alzato a 45 documentando «each shard runs ~29-30 min of real work». Quel numero **non è utilizzabile**: veniva da `ci.yml`, che in quel periodo non eseguiva alcun test (#3632). Era la misura di una suite vuota, ereditata come se fosse una misura di lavoro reale.

## Il nuovo valore

Calcolato, non stimato: 2148 test in 44 minuti danno **~61 minuti** per l'intera selezione. 75 lascia margine per la varianza del runner senza diventare una soglia che non scatta mai.

| | prima | dopo |
|---|---|---|
| `integration.runsettings` → `TestSessionTimeout` | 45 min | **75 min** |
| `ci.yml` → step *Run Integration Tests* | 45 min | **90 min** |
| `dev-async.yml` → job `backend-integration` | 60 min | **90 min** |

## Perché i job salgono a 90 e non a 75

Per conservare **l'ordine fra le due soglie**. A scattare per primo deve restare il `TestSessionTimeout`: produce un riepilogo leggibile ed esce 134, facendo fallire lo step. Se scattasse prima il timeout del job, GitHub marcherebbe tutto `cancelled` — che è esattamente il difetto muto di #3629, dove per settimane su `main-dev` non è esistito alcun esito per i ~3000 test di integrazione.

Sono anche stati riallineati i commenti che citavano i vecchi valori e la misura di PR #1505, che altrimenti avrebbero contraddetto la configurazione.

## Trade-off dichiarato

Il worst case di `ci.yml` sull'integration passa da 45 a 90 minuti. L'alternativa — aumentare gli shard da 3 a 5-6 per tenere il wall-clock sui ~35 min — è un cambio più invasivo: la partizione è un deny-list duplicato fra `ci.yml` e `dev-async.yml`, e sbagliarla reintroduce il difetto di #3622 (test che nessun gate esegue). Qui si sceglie la modifica minima che rende la suite completa; lo sharding resta come ottimizzazione separata, ora che i tempi reali sono finalmente misurabili.

## Verifica

Il segnale è il run stesso: se gli shard arrivano in fondo senza `Test Run Aborted.` ed eseguono ~910 / ~1123 / ~929 test, il troncamento è risolto. Il guard di #3643 continua a coprire il caso opposto (zero test eseguiti).
