### PR TITLE
test: due fallimenti di integrazione con la stessa firma — un handler assente sembra un handler inerte (#3633)

### DIFF
--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Integration/PdfCoverPropagationIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Integration/PdfCoverPropagationIntegrationTests.cs
@@ -4,6 +4,7 @@ using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Repositories;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
 using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Services;
 using Api.SharedKernel.Application.Services;
 using Api.Tests.Constants;
 using Api.Tests.Infrastructure;
@@ -47,8 +48,8 @@ public sealed class PdfCoverPropagationIntegrationTests : IAsyncLifetime
 
         var services = IntegrationServiceCollectionBuilder.CreateBase(connectionString);
 
-        // #3633: prerequisito necessario ma NON sufficiente — il test resta rosso anche con questo
-        // override, la causa residua non è ancora stata isolata (vedi #3633).
+        // #3633: prerequisito necessario ma non sufficiente — la causa residua era la
+        // registrazione mancante più sotto (ICacheInvalidationRetryPolicy).
         //
         // Serve comunque: il default DI è OutboxOnly (cutover T9 di #1535), quindi gli eventi vanno
         // in domain_event_outbox e NON sono pubblicati inline via MediatR — senza l'override
@@ -62,6 +63,16 @@ public sealed class PdfCoverPropagationIntegrationTests : IAsyncLifetime
         // registered in the base builder (it lives in SharedGameCatalogServiceExtensions).
         // Register the real implementation so handler can load and update the SharedGame aggregate.
         services.AddScoped<ISharedGameRepository, SharedGameRepository>();
+
+        // #3633: seconda dipendenza mancante, ed è quella che teneva rosso il test. Senza,
+        // il DI non riesce ad attivare PdfCoverGeneratedEventHandler e `MediatR.Publish`
+        // solleva `InvalidOperationException: Unable to resolve service for type
+        // 'ICacheInvalidationRetryPolicy'`. L'eccezione non arriva mai al test: il dispatch
+        // inline in MeepleAiDbContext.SaveChangesAsync la cattura (CA1031 soppresso) e la
+        // manda solo nel log, quindi il fallimento si presentava come «PdfCoverR2Key è null»
+        // — un handler che non esiste è indistinguibile da un handler che non fa nulla.
+        // In produzione la registra InfrastructureServiceExtensions.cs:371 come Singleton.
+        services.AddSingleton<ICacheInvalidationRetryPolicy, CacheInvalidationRetryPolicy>();
 
         _serviceProvider = services.BuildServiceProvider();
         _eventCollector = _serviceProvider.GetRequiredService<IDomainEventCollector>();

--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/PdfIndexingFlowKbFlagIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/PdfIndexingFlowKbFlagIntegrationTests.cs
@@ -1,6 +1,7 @@
 using System.Security.Cryptography;
 using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
 using Api.BoundedContexts.DocumentProcessing.Application.Commands;
+using Api.BoundedContexts.DocumentProcessing.Domain.Events;
 using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
 using Api.BoundedContexts.DocumentProcessing.Domain.Services;
 using Api.BoundedContexts.DocumentProcessing.Infrastructure.Configuration;
@@ -8,6 +9,7 @@ using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
 using Api.BoundedContexts.DocumentProcessing.Infrastructure.Persistence;
 using Api.BoundedContexts.DocumentProcessing.Infrastructure.Services;
 using Api.Infrastructure;
+using Api.Infrastructure.DomainEventLog;
 using Api.Infrastructure.Entities;
 using Api.Infrastructure.Entities.SharedGameCatalog;
 using Api.Services;
@@ -504,6 +506,16 @@ public sealed class PdfIndexingFlowKbFlagIntegrationTests : IAsyncLifetime
         // `.Contains(...)` dentro l'espressione LINQ viene tradotto in `LIKE`, che per Postgres non
         // esiste su quel tipo: la query moriva con `42883: operator does not exist: jsonb ~~ jsonb`
         // prima di qualunque assert. Il filtro su `EventType` (text) resta invece nel database.
+        // #3633: gli alias arrivano da EventTypeRegistry, non scritti a mano. La colonna
+        // `EventType` NON contiene il nome CLR: `MeepleAiDbContext.EnqueueOutboxRows` la
+        // popola con `EventTypeRegistry.ResolveOrFullName(...)`, che per questi due eventi
+        // restituisce gli alias stabili «pdf.state.changed» e «kb.doc.indexed» (#661).
+        // I filtri precedenti cercavano «PdfStateChanged» e «KbDocIndexed» e non potevano
+        // matchare nulla: il test contava 0 e 0, e falliva sul primo assert facendo sembrare
+        // regredita la pipeline mentre a essere sbagliata era l'interrogazione.
+        var pdfStateChangedAlias = EventTypeRegistry.AliasByType[typeof(PdfStateChangedEvent)];
+        var kbDocIndexedAlias = EventTypeRegistry.AliasByType[typeof(KbDocIndexedEvent)];
+
         var pdfIdString = pdfDocId.ToString();
         var outboxRows = await _dbContext.DomainEventOutbox
             .AsNoTracking()
@@ -511,7 +523,7 @@ public sealed class PdfIndexingFlowKbFlagIntegrationTests : IAsyncLifetime
             .ToListAsync(TestCancellationToken);
 
         var pdfStateChangedCount = outboxRows.Count(
-            e => e.EventType.Contains("PdfStateChanged", StringComparison.Ordinal)
+            e => string.Equals(e.EventType, pdfStateChangedAlias, StringComparison.Ordinal)
                  && e.PayloadJson.Contains(pdfIdString, StringComparison.Ordinal));
         pdfStateChangedCount.Should().Be(6,
             "pipeline must raise PdfStateChangedEvent for EVERY state transition " +
@@ -520,7 +532,7 @@ public sealed class PdfIndexingFlowKbFlagIntegrationTests : IAsyncLifetime
             "If this counts 1, the bridge-save shortcut from PR #2295 has regressed.");
 
         var kbDocIndexedCount = outboxRows.Count(
-            e => e.EventType.Contains("KbDocIndexed", StringComparison.Ordinal)
+            e => string.Equals(e.EventType, kbDocIndexedAlias, StringComparison.Ordinal)
                  && e.PayloadJson.Contains(pdfIdString, StringComparison.Ordinal));
         kbDocIndexedCount.Should().Be(1,
             "KbDocIndexedEvent must fire exactly once per upload, raised by " +


### PR DESCRIPTION
Parte di #3633. Due test di integrazione, due cause diverse, la **stessa firma**: un assert che riporta un valore mancante e sembra accusare la logica di produzione, mentre a essere rotta è la fixture o l'interrogazione.

---

## 1. `UploadPdf_…_SetsHasKnowledgeBaseTrue_OnSharedGame` — contava 0 eventi invece di 6

Il messaggio di fallimento accusava una regressione della pipeline:

> *"If this counts 1, the bridge-save shortcut from PR #2295 has regressed."*

**La pipeline non era regredita.** La colonna `EventType` dell'outbox non contiene il nome CLR dell'evento: `MeepleAiDbContext.EnqueueOutboxRows` la popola con `EventTypeRegistry.ResolveOrFullName(...)`, che mappa questi eventi sugli alias stabili di #661:

```csharp
[typeof(KbDocIndexedEvent)]     = "kb.doc.indexed",
[typeof(PdfStateChangedEvent)]  = "pdf.state.changed",
```

I filtri cercavano `"PdfStateChanged"` e `"KbDocIndexed"`. Non potevano matchare **per costruzione**: il conteggio era 0 qualunque cosa facesse la pipeline.

Gli alias ora si leggono da `EventTypeRegistry.AliasByType`, così il test segue il registry invece di tornare a contare zero se un alias cambia. Il confronto passa da `Contains` a `string.Equals`: un alias è un identificatore esatto, non un frammento.

**Verifica**: il test passa e conta davvero **6** `PdfStateChangedEvent` e **1** `KbDocIndexedEvent` — il bridge-save shortcut di PR #2295 non è regredito, e ora l'assert lo dimostra.

---

## 2. `PdfCoverGeneratedEvent_PropagatesToSharedGame_OnSaveChanges` — `PdfCoverR2Key` null

`ICacheInvalidationRetryPolicy` non è registrato in `IntegrationServiceCollectionBuilder.CreateBase` (in produzione lo fa `InfrastructureServiceExtensions.cs:371`). Il DI non riesce ad attivare `PdfCoverGeneratedEventHandler` e `MediatR.Publish` solleva:

```
InvalidOperationException: Unable to resolve service for type
'Api.Services.ICacheInvalidationRetryPolicy' while attempting to activate
'PdfCoverGeneratedEventHandler'.
```

Quell'eccezione **non raggiunge mai il test**: il dispatch inline in `MeepleAiDbContext.SaveChangesAsync` la cattura (`CA1031` soppresso) e la scrive solo nel log. Da fuori, un handler che non esiste e un handler che non fa nulla danno lo stesso identico sintomo — ed è il motivo per cui il tentativo precedente si era fermato al solo override della modalità `Hybrid`, necessario ma non sufficiente.

Isolata strumentando la fixture, un'ipotesi alla volta:

| evidenza | esito |
|---|---|
| riga in `domain_event_outbox` | ✅ l'evento raggiunge il `DbContext` |
| `ISharedGameRepository.GetByIdAsync` | ✅ il gioco viene trovato |
| identità del collector | ✅ condiviso col `DbContext` |
| attivazione dell'handler | ❌ **qui** |

**Verifica**: entrambi i test della classe passano.

---

## Nota trasversale

Il `catch` che inghiotte le eccezioni degli handler è deliberato in produzione (un handler che esplode non deve annullare un commit già avvenuto), ma rende i test di integrazione ciechi sulla causa. Non lo cambio qui — è una decisione di design con la sua motivazione — ma vale la pena sapere che **ogni** fallimento «il valore atteso non c'è» su un percorso a eventi può nascondere un errore di DI, non un errore di logica.

Verificato inoltre che nessun altro test fra quelli che toccano `DomainEventOutbox` filtri `EventType` per nome CLR.
