### PR TITLE
fix(rag-smoke): baseline scaduta non è drift del retrieval (#3645)

### DIFF
--- a/.github/workflows/rag-smoke-dispatch.yml
+++ b/.github/workflows/rag-smoke-dispatch.yml
@@ -174,12 +174,24 @@ jobs:
           SMOKE_EMAIL: bake-admin@meepleai.test
           SMOKE_PASSWORD: BakeSeed1!Admin
         run: |
+          # Espone i due snapshot: il passo che apre la issue deve poter dire QUALE dei due
+          # problemi si è verificato senza che un umano rilegga i log (#3645).
+          echo "baseline_snapshot=$(jq -r '.snapshot // ""' fixtures/rag-golden-baseline.json)" >> "$GITHUB_OUTPUT"
+          echo "current_snapshot=$(cat "$SEED_INDEX_OUT_DIR/.latest" 2>/dev/null || echo '')" >> "$GITHUB_OUTPUT"
+
+          # GitHub esegue i run: con `bash -e`: senza set +e il codice di uscita si perde
+          # prima di poterlo classificare.
+          set +e
           if [ "${{ github.event.inputs.update_baseline }}" = "true" ]; then
             bash scripts/rag-smoke-assert.sh --update-baseline
-            echo "::notice:: baseline updated — download the diff from the job and commit infra/fixtures/rag-golden-baseline.json"
+            rc=$?
+            [ "$rc" -eq 0 ] && echo "::notice:: baseline updated — download the diff from the job and commit infra/fixtures/rag-golden-baseline.json"
           else
             bash scripts/rag-smoke-assert.sh
+            rc=$?
           fi
+          echo "exit_code=$rc" >> "$GITHUB_OUTPUT"
+          exit "$rc"
 
       # NB: the title-health extraction-quality guard was MOVED to its own workflow
       # (.github/workflows/title-health-staging.yml). The CI seed snapshot is baked with the Docnet
@@ -189,7 +201,10 @@ jobs:
       - name: Diagnose smoke failure
         # always() is required: without it GitHub implicitly ANDs the condition
         # with success(), so the step is skipped after the smoke step fails (#2480).
-        if: ${{ always() && steps.ragsmoke.outcome == 'failure' }}
+        # exit_code 3 = baseline scaduta: il corpus è cambiato, non il retrieval. Conteggi di
+        # righe e log dell'API non dicono nulla su quel guasto, e 70 righe di diagnostica
+        # irrilevante sono ciò che ha reso invisibile il problema per tre settimane (#3645).
+        if: ${{ always() && steps.ragsmoke.outcome == 'failure' && steps.ragsmoke.outputs.exit_code != '3' }}
         working-directory: infra
         env:
           API_BASE_URL: http://localhost:8080
@@ -244,9 +259,29 @@ jobs:
         # → this step is skipped and the issue is never opened. The outcome check still scopes
         # it to a real drift (skipped/successful ragsmoke → not 'failure').
         if: ${{ always() && steps.ragsmoke.outcome == 'failure' && github.event.inputs.update_baseline != 'true' }}
+        env:
+          EXIT_CODE: ${{ steps.ragsmoke.outputs.exit_code }}
+          BASELINE_SNAPSHOT: ${{ steps.ragsmoke.outputs.baseline_snapshot }}
+          CURRENT_SNAPSHOT: ${{ steps.ragsmoke.outputs.current_snapshot }}
         uses: actions/github-script@v7
         with:
           script: |
+            // #3645: un solo titolo per due guasti diversi ha mandato la diagnosi fuori strada
+            // per tre settimane. exit 3 = la baseline appartiene a un altro snapshot (re-bake,
+            // atteso, si rigenera); exit 1 = il retrieval è cambiato a parità di corpus (da
+            // indagare). Il titolo deve dire quale dei due, perché è la prima cosa che si legge.
+            const stale = process.env.EXIT_CODE === '3';
+            const run = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const runbook = 'docs/for-developers/operations/rag-smoke-runbook.md';
+
+            const title = stale
+              ? `[RAG SMOKE] baseline scaduta dopo un re-bake — ${new Date().toISOString().slice(0,10)}`
+              : `[RAG SMOKE] retrieval drift — ${new Date().toISOString().slice(0,10)}`;
+
+            const body = stale
+              ? `La golden baseline è stata catturata su uno snapshot diverso da quello in esecuzione: **il retrieval non è regredito**, è cambiato il corpus.\n\n| | |\n|---|---|\n| baseline catturata su | \`${process.env.BASELINE_SNAPSHOT}\` |\n| snapshot in esecuzione | \`${process.env.CURRENT_SNAPSHOT}\` |\n\nRun: ${run}\n\n**Azione**: rigenera la baseline con \`--update-baseline\` (dispatch di questo workflow con \`update_baseline=true\`), scarica l'artifact e committa \`infra/fixtures/rag-golden-baseline.json\` — vedi ${runbook}.\n\n⚠️ Finché questa issue resta aperta il gate non emette altri alert (dedup su label), quindi una regressione autentica resterebbe silenziosa: chiudila appena rigenerata.`
+              : `Canonical RAG queries drifted from the golden baseline, **a parità di snapshot** (\`${process.env.CURRENT_SNAPSHOT || 'sconosciuto'}\`) — quindi è un cambiamento del retrieval, non del corpus.\n\nRun: ${run}\n\nSe il drift è intenzionale (nuovo modello di embedding, nuovo chunker), rigenera via \`--update-baseline\` per ${runbook}. Altrimenti va indagato.`;
+
             const existing = await github.rest.issues.listForRepo({
               owner: context.repo.owner, repo: context.repo.repo,
               labels: 'rag-smoke-failure', state: 'open'
@@ -254,8 +289,6 @@ jobs:
             if (existing.data.length === 0) {
               await github.rest.issues.create({
                 owner: context.repo.owner, repo: context.repo.repo,
-                title: `[RAG SMOKE] retrieval drift — ${new Date().toISOString().slice(0,10)}`,
-                labels: ['bug', 'rag-smoke-failure'],
-                body: `Canonical RAG queries drifted from the golden baseline. See run ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}.\n\nIf the drift is intentional (re-index), regenerate via \`--update-baseline\` per docs/for-developers/operations/rag-smoke-runbook.md.`
+                title, labels: ['bug', 'rag-smoke-failure'], body
               });
             }

--- a/docs/for-developers/operations/rag-smoke-runbook.md
+++ b/docs/for-developers/operations/rag-smoke-runbook.md
@@ -18,6 +18,30 @@ The fixture top-level `language` (`"en"`) is the **default**. Each query MAY set
 
 A query with **no golden-baseline entry** reports `SKIP` (via a `::notice::`), not `FAIL`, and does **not** fail the gate. This lets new queries (e.g. the IT set) land *before* the ops `--update-baseline` capture without redding the weekly cron. Real drift and no-citations still `FAIL`. The summary reports `N passed, N failed, N skipped (pending baseline)`; exit is non-zero only on a real `FAIL`.
 
+### Baseline scaduta ≠ retrieval regredito (exit 3, #3645)
+
+Prima di eseguire le query l'harness confronta il campo `snapshot` della baseline con lo snapshot caricato (`$SEED_INDEX_OUT_DIR/.latest`). Se differiscono **esce 3 senza eseguire alcuna query**:
+
+```
+::error:: baseline scaduta — non è una regressione del retrieval
+  baseline catturata su: meepleai_seed_20260729T070620Z_..._9101176e9
+  snapshot in esecuzione: meepleai_seed_20260809T060634Z_..._dc83e1a4e
+```
+
+**Perché esiste**: la baseline fissa i chunk `{source,page}` di un corpus preciso. Su un corpus diverso *ogni* query risulta "drifted" — dal 2026-07-20 al 2026-08-10 il gate ha riportato `0 passed, 11 failed` per tre settimane, aprendo una issue intitolata «retrieval drift» che descriveva un guasto mai avvenuto. Un rosso che significa sempre la stessa cosa smette di essere letto, e in quelle tre settimane una regressione autentica sarebbe passata inosservata.
+
+**Cosa fare**: rigenerare la baseline (§ *Capturing the EN + IT baseline via CI dispatch*). Non è un bug da indagare — è la conseguenza attesa di un re-bake.
+
+| Exit | Significato | Azione |
+|---|---|---|
+| `0` | tutte le query combaciano (o baseline aggiornata) | — |
+| `1` | drift reale **a parità di snapshot**, o nessuna citation | indagare |
+| `3` | baseline catturata su un altro snapshot | rigenerare la baseline |
+
+La guardia confronta solo quando **entrambi** i lati sono noti: senza `.latest` (esecuzione contro un'API remota) o con una baseline priva del campo `snapshot`, non blocca. Uno stato non conoscibile non va trasformato in un fallimento.
+
+⚠️ L'auto-opener deduplica sulla label `rag-smoke-failure`: **finché una issue resta aperta non ne viene emessa un'altra**. Una issue di baseline scaduta lasciata aperta silenzia gli alert successivi, inclusi quelli di un drift vero.
+
 ## Capturing / updating the golden baseline
 
 The baseline must be captured against a **fresh, compatible snapshot** (`snapshot-verify.sh` exit 0). Do this:

--- a/infra/scripts/rag-smoke-assert.sh
+++ b/infra/scripts/rag-smoke-assert.sh
@@ -13,7 +13,8 @@
 #   bash scripts/rag-smoke-assert.sh --update-baseline  # capture the baseline from current retrieval
 #   API_BASE_URL=http://localhost:8080 SMOKE_EMAIL=... SMOKE_PASSWORD=... bash scripts/rag-smoke-assert.sh
 #
-# Exit: 0 = all queries match baseline (or baseline updated); 1 = a query drifted / no citations.
+# Exit: 0 = all queries match baseline (or baseline updated); 1 = a query drifted / no citations;
+#       3 = baseline stale (captured against a different snapshot — nothing to compare).
 set -uo pipefail
 
 BASE_URL="${API_BASE_URL:-http://localhost:8080}"
@@ -24,6 +25,9 @@ UPDATE_BASELINE=false
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"   # infra/
 QUERIES="$DIR/fixtures/rag-canonical-queries.json"
 BASELINE="$DIR/fixtures/rag-golden-baseline.json"
+# Stessa convenzione di snapshot-verify.sh / snapshot-restore.sh / seed-index-publish.sh:
+# il percorso degli snapshot è configurabile, non dedotto dalla posizione dello script.
+OUT_DIR="${SEED_INDEX_OUT_DIR:-$DIR/../data/snapshots}"
 
 for arg in "$@"; do
   case "$arg" in
@@ -44,6 +48,29 @@ command -v curl >/dev/null || fail "curl is required"
 ENDPOINT=$(jq -r '.endpoint' "$QUERIES")
 TOPK=$(jq -r '.topK' "$QUERIES")
 LANG=$(jq -r '.language' "$QUERIES")
+
+# --- guardia: la baseline appartiene allo snapshot in esecuzione? (#3645) ---
+# La baseline fissa i chunk {source,page} di un corpus preciso. Su un corpus diverso il
+# confronto non produce informazione: ogni query "drifta" e il gate riporta una regressione
+# di retrieval che non è avvenuta. È successo dal 2026-07-20 al 2026-08-10 — tre settimane di
+# rosso settimanale in cui una regressione autentica sarebbe passata inosservata.
+#
+# Confrontiamo solo quando entrambi i lati sono noti: eseguire contro un'API remota senza
+# snapshot locale, o con una baseline anteriore all'introduzione del campo, resta legittimo.
+if [ "$UPDATE_BASELINE" = false ]; then
+  baseline_snap=$(jq -r '.snapshot // empty' "$BASELINE")
+  current_snap=$(cat "$OUT_DIR/.latest" 2>/dev/null || true)
+
+  if [ -n "$baseline_snap" ] && [ -n "$current_snap" ] && [ "$baseline_snap" != "$current_snap" ]; then
+    echo "::error:: baseline scaduta — non è una regressione del retrieval" >&2
+    echo "  baseline catturata su: $baseline_snap" >&2
+    echo "  snapshot in esecuzione: $current_snap" >&2
+    echo "  Confrontare il retrieval fra corpus diversi non è significativo. Rigenera la" >&2
+    echo "  baseline (--update-baseline) o esegui contro lo snapshot della baseline —" >&2
+    echo "  docs/for-developers/operations/rag-smoke-runbook.md" >&2
+    exit 3
+  fi
+fi
 
 COOKIE=$(mktemp); trap 'rm -f "$COOKIE" "${TMP_BASELINE:-}"' EXIT
 
@@ -118,8 +145,8 @@ if [ "$UPDATE_BASELINE" = true ]; then
   # Never write a partial baseline: a query that returned no citations would be
   # silently omitted and later assert runs would blame the operator. Fail loudly.
   [ "$FAIL" -eq 0 ] || fail "$FAIL query(ies) returned no citations — baseline NOT written (fix retrieval/auth first)"
-  snap=$(cat "$DIR/../data/snapshots/.latest" 2>/dev/null || echo "unknown")
-  model=$(jq -r '.embedding_model // "unknown"' "$DIR/../data/snapshots/$snap.meta.json" 2>/dev/null || echo "unknown")
+  snap=$(cat "$OUT_DIR/.latest" 2>/dev/null || echo "unknown")
+  model=$(jq -r '.embedding_model // "unknown"' "$OUT_DIR/$snap.meta.json" 2>/dev/null || echo "unknown")
   ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
   jq --slurpfile b "$TMP_BASELINE" --arg snap "$snap" --arg model "$model" --arg ts "$ts" \
      '.baseline=$b[0] | .snapshot=$snap | .embeddingModel=$model | .capturedAt=$ts' \

--- a/infra/scripts/tests/rag-smoke-assert.bats
+++ b/infra/scripts/tests/rag-smoke-assert.bats
@@ -1,0 +1,122 @@
+#!/usr/bin/env bats
+# Unit tests for rag-smoke-assert.sh — riconoscimento della baseline scaduta (#3645).
+#
+# Run with: bats infra/scripts/tests/rag-smoke-assert.bats
+# (requires bats-core: https://github.com/bats-core/bats-core)
+#
+# Perché esistono: il gate settimanale è stato rosso dal 2026-07-20 al 2026-08-10 con
+# `0 passed, 11 failed`, e l'issue che apriva da solo diceva «retrieval drift». Non lo era:
+# la baseline era stata catturata sullo snapshot 20260729T070620Z e il run girava su
+# 20260809T060634Z. L'harness scriveva `snapshot` nella baseline senza mai rileggerlo, quindi
+# non poteva distinguere un re-bake legittimo da una regressione — e chiamava il primo col
+# nome della seconda.
+#
+# I test montano una copia dello script in una gerarchia temporanea (infra/scripts + infra/fixtures
+# + data/snapshots) così da esercitare il percorso reale di risoluzione dei path senza toccare
+# le fixture del repo.
+
+setup() {
+    TMP=$(mktemp -d)
+    mkdir -p "$TMP/infra/scripts" "$TMP/infra/fixtures" "$TMP/data/snapshots"
+    cp "$BATS_TEST_DIRNAME/../rag-smoke-assert.sh" "$TMP/infra/scripts/rag-smoke-assert.sh"
+    SCRIPT="$TMP/infra/scripts/rag-smoke-assert.sh"
+
+    cat > "$TMP/infra/fixtures/rag-canonical-queries.json" <<'JSON'
+{
+  "endpoint": "/api/v1/knowledge-base/ask/global",
+  "topK": 3,
+  "language": "en",
+  "queries": [
+    { "queryId": "catan-setup", "query": "How do you set up Catan?" }
+  ]
+}
+JSON
+
+    # Porta chiusa: se lo script supera la guardia arriva alla curl e fallisce subito,
+    # senza attese di rete. È così che distinguiamo "bloccato dalla guardia" da "proseguito".
+    export API_BASE_URL="http://127.0.0.1:9"
+}
+
+teardown() {
+    rm -rf "$TMP"
+}
+
+# $1 = snapshot registrato nella baseline (stringa vuota = campo assente)
+write_baseline() {
+    if [ -z "$1" ]; then
+        cat > "$TMP/infra/fixtures/rag-golden-baseline.json" <<'JSON'
+{ "schemaVersion": 1, "baseline": { "catan-setup": [ { "source": "catan.pdf", "page": 1 } ] } }
+JSON
+    else
+        cat > "$TMP/infra/fixtures/rag-golden-baseline.json" <<JSON
+{ "schemaVersion": 1, "snapshot": "$1",
+  "baseline": { "catan-setup": [ { "source": "catan.pdf", "page": 1 } ] } }
+JSON
+    fi
+}
+
+# $1 = snapshot attualmente caricato (nessuna chiamata = .latest assente)
+write_latest() {
+    echo "$1" > "$TMP/data/snapshots/.latest"
+}
+
+@test "exit 3 quando la baseline è stata catturata su un altro snapshot" {
+    write_baseline "meepleai_seed_20260729T070620Z_intfloat_multilingual-e5-base_9101176e9"
+    write_latest   "meepleai_seed_20260809T060634Z_intfloat_multilingual-e5-base_dc83e1a4e"
+
+    run bash "$SCRIPT"
+
+    [ "$status" -eq 3 ]
+}
+
+@test "il messaggio di baseline scaduta nomina entrambi gli snapshot" {
+    write_baseline "meepleai_seed_20260729T070620Z_intfloat_multilingual-e5-base_9101176e9"
+    write_latest   "meepleai_seed_20260809T060634Z_intfloat_multilingual-e5-base_dc83e1a4e"
+
+    run bash "$SCRIPT"
+
+    # Chi legge deve poter decidere senza aprire i log: quale baseline, quale snapshot.
+    [[ "$output" == *"20260729T070620Z"* ]]
+    [[ "$output" == *"20260809T060634Z"* ]]
+}
+
+@test "una baseline scaduta non esegue le query" {
+    write_baseline "meepleai_seed_20260729T070620Z_intfloat_multilingual-e5-base_9101176e9"
+    write_latest   "meepleai_seed_20260809T060634Z_intfloat_multilingual-e5-base_dc83e1a4e"
+
+    run bash "$SCRIPT"
+
+    # Undici FAIL su undici erano il sintomo che ha sviato la diagnosi: confrontare
+    # retrieval contro un corpus diverso non produce informazione, solo rumore.
+    [[ "$output" != *"FAIL  catan-setup"* ]]
+}
+
+@test "snapshot coincidente: la guardia non blocca" {
+    write_baseline "meepleai_seed_20260809T060634Z_intfloat_multilingual-e5-base_dc83e1a4e"
+    write_latest   "meepleai_seed_20260809T060634Z_intfloat_multilingual-e5-base_dc83e1a4e"
+
+    run bash "$SCRIPT"
+
+    # Prosegue fino alle query (che falliscono: nessuna API in ascolto) → exit 1, non 3.
+    [ "$status" -eq 1 ]
+}
+
+@test ".latest assente: la guardia non blocca" {
+    write_baseline "meepleai_seed_20260729T070620Z_intfloat_multilingual-e5-base_9101176e9"
+
+    run bash "$SCRIPT"
+
+    # Eseguire contro un'API remota senza snapshot locale è legittimo: uno stato non
+    # conoscibile non va trasformato in un fallimento.
+    [ "$status" -eq 1 ]
+}
+
+@test "baseline senza campo snapshot: la guardia non blocca" {
+    write_baseline ""
+    write_latest   "meepleai_seed_20260809T060634Z_intfloat_multilingual-e5-base_dc83e1a4e"
+
+    run bash "$SCRIPT"
+
+    # Baseline anteriori all'introduzione del campo non devono diventare rosse.
+    [ "$status" -eq 1 ]
+}


### PR DESCRIPTION
Chiude #3645.

## La diagnosi nell'issue era sbagliata

L'issue — auto-generata dal workflow — diceva «retrieval drift». Non lo era.

| | |
|---|---|
| Gate rosso da | **2026-07-20** (7 run falliti su 8) |
| Ultimo esito | **`0 passed, 11 failed`** — tutte le query, EN e IT |
| Baseline catturata su | `meepleai_seed_**20260729T070620Z**_intfloat_multilingual-e5-base_9101176e9` |
| Run girato su | `meepleai_seed_**20260809T060634Z**_intfloat_multilingual-e5-base_dc83e1a4e` |
| Modello di embedding | identico |

Quando fallisce il 100% delle query non è ranking, è **corpus**. L'unico run verde — 2026-07-29 — è il dispatch che ha *catturato* la baseline.

## Il difetto

`rag-smoke-assert.sh` **scriveva** `snapshot` nella baseline (riga 125) e **non lo rileggeva mai**. L'harness non poteva quindi distinguere un re-bake legittimo da una regressione del retrieval — e chiamava il primo col nome della seconda, propagando l'errore fino al titolo della issue che apriva da solo.

**Il costo non era il rosso**: era che per tre settimane una regressione autentica sarebbe passata inosservata. Aggravato dal fatto che l'auto-opener deduplica sulla label `rag-smoke-failure` — finché #3645 restava aperta, **nessun altro alert veniva emesso**.

## Cosa cambia

**Nell'harness** — la guardia confronta `baseline.snapshot` con `.latest` e, se differiscono, esce **3** senza eseguire alcuna query:

```
::error:: baseline scaduta — non è una regressione del retrieval
  baseline catturata su: meepleai_seed_20260729T070620Z_..._9101176e9
  snapshot in esecuzione: meepleai_seed_20260809T060634Z_..._dc83e1a4e
```

Confronta **solo quando entrambi i lati sono noti**: senza `.latest` (esecuzione contro un'API remota) o con una baseline priva del campo, non blocca. Uno stato non conoscibile non va trasformato in un fallimento.

**Nel workflow** — l'esito viene classificato:

| Exit | Titolo della issue aperta | Diagnostica DB/log |
|---|---|---|
| `3` | «baseline scaduta dopo un re-bake», coi due snapshot in tabella e l'azione da fare | saltata |
| `1` | «retrieval drift», con l'aggiunta esplicita **«a parità di snapshot»** | eseguita |

Su exit 3 i 70 righe di conteggi tabella e log dell'API non dicono nulla su un cambio di corpus: erano parte di ciò che rendeva il rosso illeggibile.

**Effetto collaterale corretto** — lo script ora onora `SEED_INDEX_OUT_DIR` come tutti gli script fratelli (`snapshot-verify`, `snapshot-restore`, `seed-index-publish`) invece di dedurre il percorso dalla propria posizione. In CI i due valori coincidono, ma una divergenza produrrebbe un falso «baseline scaduta» — cioè il difetto opposto a quello che questa PR chiude.

## Verifica

Red-green reale su `infra/scripts/tests/rag-smoke-assert.bats` (6 test, harness bats già presente nel repo):

| | senza guardia | con guardia |
|---|---|---|
| `exit 3 quando la baseline è di un altro snapshot` | ❌ | ✅ |
| `il messaggio nomina entrambi gli snapshot` | ❌ | ✅ |
| `una baseline scaduta non esegue le query` | ❌ | ✅ |
| `snapshot coincidente: non blocca` | ✅ | ✅ |
| `.latest assente: non blocca` | ✅ | ✅ |
| `baseline senza campo snapshot: non blocca` | ✅ | ✅ |

I tre di non-blocco passano in entrambi gli stati: è il loro scopo: proteggono dal fixare troppo.

La logica del `github-script` è stata **eseguita fuori da GitHub** con entrambi i codici di uscita, per non dare per scontato il branching:

```
=== STALE (exit 3) ===  TITLE: [RAG SMOKE] baseline scaduta dopo un re-bake — 2026-08-11
=== DRIFT (exit 1) ===  TITLE: [RAG SMOKE] retrieval drift — 2026-08-11
```

`bash -n` pulito, YAML del workflow validato strutturalmente.

## Due cose che ho trovato e non ho toccato

1. **`snapshot-verify.bats` ha 1 fallimento preesistente** («exit 0 when all fields match»), verificato eseguendolo su un albero senza queste modifiche. Non è una regressione di questa PR.
2. **Nessun workflow esegue la suite bats.** `ci.yml` lancia i pytest degli script Python ma non i bats, e non si attiva su PR verso `main-dev`; `dev-fast.yml` non ha `infra/**` fra i suoi `paths`. Una PR solo-infra come questa oggi non ha praticamente CI. Meritano un follow-up: sono la stessa famiglia del problema che questa PR chiude — un controllo che esiste e non guarda nessuno.

## Cosa resta da fare per chiudere il rosso

Questa PR rende il guasto **leggibile**; non rigenera la baseline. Il gate torna verde dopo un dispatch con `update_baseline=true` e il commit dell'artifact — è la procedura del runbook, ora documentata anche nel nuovo § *Baseline scaduta ≠ retrieval regredito*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
