### PR TITLE
fix(ci): il Migration Safety Gate legge il formato EF vero (#3659)

### DIFF
--- a/infra/scripts/check-migration-safety.py
+++ b/infra/scripts/check-migration-safety.py
@@ -12,7 +12,30 @@ Exit codes
 ----------
     0 — no unsafe pattern (or all bypassed with valid directives)
     1 — at least one unsafe pattern without directive
-    2 — invocation error (missing file, malformed args)
+    2 — invocation error (missing file, malformed args) OR the parser could not
+        attribute the SQL to any migration (see "Fail loud on nothing scanned")
+
+Fail loud on nothing scanned (#3659)
+------------------------------------
+Between 2026-05-18 and 2026-08-11 this gate was green on *every* PR, including
+one that dropped a column, because it recognised only a `-- Migration: <id>`
+header that `dotnet ef migrations script --idempotent` has never emitted. With
+no header there were no blocks, with no blocks nothing was scanned, and "zero
+findings" was reported as success. The audit artifact of a PR containing a real
+`DROP COLUMN` read, in full: `{"unsafe": [], "allowed": []}`.
+
+The self-tests did not catch it because every fixture prepended that header by
+hand — the parser was verified against a format that does not exist.
+
+Hence two invariants, both enforced in `main()`:
+
+  * scanning zero migrations is an ERROR (exit 2), never a pass;
+  * SQL the parser cannot attribute to any migration is an ERROR, so a future
+    change to EF's output shape fails loudly instead of silently returning to
+    the vacuous green above.
+
+"0 unsafe out of 7 migrations scanned" and "0 unsafe because nothing was read"
+must never again be indistinguishable — the report carries the counts.
 
 Convention
 ----------
@@ -32,6 +55,11 @@ on the FIRST line of the migration's Up() body:
 The directive is emitted into the generated SQL by EF Core and the gate picks
 it up. CODEOWNERS already routes any migration change to the backend lead;
 a CI comment is posted whenever a directive is exercised, for audit trail.
+
+Note that EF puts each `migrationBuilder` call in its OWN `DO $EF$` block, so
+the directive and the statement it authorises land in *different* blocks that
+share only their `MigrationId`. Grouping must therefore be per migration, not
+per block — one migration commonly expands into hundreds of blocks.
 """
 
 from __future__ import annotations
@@ -83,8 +111,44 @@ _ADD_COL_RE = re.compile(r"\bADD\s+COLUMN\b[^;]*", re.IGNORECASE)
 _NOT_NULL_RE = re.compile(r"\bNOT\s+NULL\b", re.IGNORECASE)
 _DEFAULT_RE = re.compile(r"\bDEFAULT\b", re.IGNORECASE)
 
-# Migration block header emitted by `dotnet ef migrations script`.
+# --- Real `dotnet ef migrations script --idempotent` shape (#3659) -----------
+#
+#     DO $EF$
+#     BEGIN
+#         IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory"
+#                       WHERE "MigrationId" = '20260811130532_PdfDocumentXminConcurrency') THEN
+#         ALTER TABLE pdf_documents DROP COLUMN "RowVersion";
+#         END IF;
+#     END $EF$;
+#
+# One statement per block; a single migration expands into hundreds of them
+# (measured on this repo: 1012 blocks for 7 migrations).
+_EF_BLOCK_OPEN_RE = re.compile(r"^\s*DO\s+\$EF\$\s*$", re.IGNORECASE)
+_EF_BLOCK_CLOSE_RE = re.compile(r"^\s*END\s+\$EF\$\s*;\s*$", re.IGNORECASE)
+
+# The guard line that names the migration. `=` (not VALUES) deliberately: it must
+# not match the closing `INSERT INTO "__EFMigrationsHistory" … VALUES ('<id>', …)`,
+# which carries the same id but marks the migration as applied rather than
+# opening it.
+_EF_MIGRATION_GUARD_RE = re.compile(
+    r'"MigrationId"\s*=\s*\'(\d{14})_([^\']+)\'', re.IGNORECASE
+)
+
+# Legacy header, kept only for back-compatibility with hand-written fixtures and
+# any caller that pre-annotates its SQL. EF has never emitted this; relying on it
+# alone is what made the gate blind for three months (#3659).
 _MIGRATION_HEADER_RE = re.compile(r"--\s*Migration:\s*(\d{14})_(\S+)", re.IGNORECASE)
+
+# EF preamble that legitimately sits outside every block: the history-table
+# bootstrap and the surrounding transaction. Anything ELSE found outside a block
+# means the parser has lost track of the format and must fail loudly.
+_PREAMBLE_ALLOWED_RE = re.compile(
+    r"^\s*(?:START\s+TRANSACTION\s*;|COMMIT\s*;|BEGIN\s*;|--.*)?\s*$", re.IGNORECASE
+)
+_HISTORY_TABLE_RE = re.compile(r"__EFMigrationsHistory", re.IGNORECASE)
+_DDL_VERB_RE = re.compile(
+    r"\b(?:CREATE|ALTER|DROP|INSERT|UPDATE|DELETE|TRUNCATE)\b", re.IGNORECASE
+)
 
 # Allow directive — rationale must be non-empty after trimming.
 # Use [ \t]* (NOT \s*) so the directive cannot accidentally consume the newline
@@ -108,10 +172,34 @@ class Finding:
 
 @dataclass
 class _Block:
+    """All SQL attributed to ONE migration, however many `DO $EF$` blocks it spans.
+
+    `lines` carries absolute 1-based line numbers from the full SQL file so
+    findings point at the real location instead of an offset from a header.
+    """
+
     migration_id: str
     name: str
-    start_line: int  # 1-based, line of the header in the full SQL
-    body: str  # SQL text of the block (after the header, before next header)
+    lines: list[tuple[int, str]] = field(default_factory=list)
+
+    @property
+    def start_line(self) -> int:
+        return self.lines[0][0] if self.lines else 0
+
+    @property
+    def body(self) -> str:
+        return "\n".join(text for _, text in self.lines)
+
+
+@dataclass
+class ScanResult:
+    """Findings plus the evidence that scanning actually happened (#3659)."""
+
+    findings: list[Finding] = field(default_factory=list)
+    migrations_seen: int = 0  # distinct MigrationIds recognised in the SQL
+    migrations_scanned: int = 0  # after grandfathering by --gate-ship-date
+    lines_scanned: int = 0  # lines attributed to some migration
+    unattributed: list[tuple[int, str]] = field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -119,32 +207,95 @@ class _Block:
 # ---------------------------------------------------------------------------
 
 
-def _split_into_blocks(sql: str) -> list[_Block]:
-    """Split SQL output into per-migration blocks keyed by `-- Migration: <id>`.
+def _split_into_blocks(sql: str) -> tuple[list[_Block], list[tuple[int, str]]]:
+    """Group the SQL by migration, and report every line it could not attribute.
 
-    Lines before the first header are dropped (they are EF preamble — `START
-    TRANSACTION`, schema setup, etc. — not attributable to any single migration
-    and never contain forbidden patterns from §8.2).
+    Handles the two shapes that can reach us:
+
+    * the real `dotnet ef migrations script --idempotent` output — a long run of
+      `DO $EF$ … END $EF$;` blocks, each naming its migration in the
+      `"MigrationId" = '<id>'` guard. All blocks carrying the same id are merged
+      into ONE `_Block`, because EF splits a single migration across hundreds of
+      them and a `-- safe:` directive routinely lands in a different block than
+      the statement it authorises;
+    * the legacy `-- Migration: <id>` header, which EF does not emit but which
+      pre-annotated fixtures may use.
+
+    Returns `(blocks, unattributed)`. `unattributed` holds lines that belong to
+    no migration and are not recognised preamble; the caller treats a non-empty
+    list as a parser failure rather than as "nothing to see" (#3659).
     """
-    lines = sql.splitlines(keepends=True)
-    blocks: list[_Block] = []
-    current: _Block | None = None
-    buf: list[str] = []
+    lines = sql.splitlines()
+    by_id: dict[str, _Block] = {}
+    order: list[str] = []
+    unattributed: list[tuple[int, str]] = []
+
+    def _chunk(mig_id: str, name: str) -> _Block:
+        if mig_id not in by_id:
+            by_id[mig_id] = _Block(migration_id=mig_id, name=name)
+            order.append(mig_id)
+        return by_id[mig_id]
+
+    legacy_current: _Block | None = None
+    in_ef_block = False
+    pending: list[tuple[int, str]] = []
+    block_id: tuple[str, str] | None = None
 
     for idx, line in enumerate(lines, start=1):
-        m = _MIGRATION_HEADER_RE.match(line.strip())
-        if m:
-            if current is not None:
-                current.body = "".join(buf)
-                blocks.append(current)
-            current = _Block(migration_id=m.group(1), name=m.group(2), start_line=idx, body="")
-            buf = []
-        elif current is not None:
-            buf.append(line)
-    if current is not None:
-        current.body = "".join(buf)
-        blocks.append(current)
-    return blocks
+        if _EF_BLOCK_OPEN_RE.match(line):
+            in_ef_block, pending, block_id = True, [], None
+            continue
+
+        if in_ef_block:
+            if _EF_BLOCK_CLOSE_RE.match(line):
+                if block_id is not None:
+                    _chunk(*block_id).lines.extend(pending)
+                else:
+                    # A `DO $EF$` block with no recognisable guard: the parser
+                    # does not know whose SQL this is, so it must not be silently
+                    # dropped.
+                    unattributed.extend(pending)
+                in_ef_block, pending, block_id = False, [], None
+                continue
+            guard = _EF_MIGRATION_GUARD_RE.search(line)
+            if guard is not None and block_id is None:
+                block_id = (guard.group(1), guard.group(2))
+                continue  # the guard itself is scaffolding, not migration SQL
+            pending.append((idx, line))
+            continue
+
+        legacy = _MIGRATION_HEADER_RE.match(line.strip())
+        if legacy:
+            legacy_current = _chunk(legacy.group(1), legacy.group(2))
+            continue
+
+        if legacy_current is not None:
+            legacy_current.lines.append((idx, line))
+            continue
+
+        # Outside every block and every legacy header: only EF preamble is
+        # expected here (transaction control, the __EFMigrationsHistory
+        # bootstrap, blanks and comments).
+        # Only DDL/DML is worth flagging: the bootstrap `CREATE TABLE IF NOT
+        # EXISTS "__EFMigrationsHistory" (…)` spans several lines whose
+        # continuations ("MigrationId" character varying(150) NOT NULL, …) carry
+        # no verb, and flagging those would fail the gate on every single run.
+        # The invariant that matters is narrower and exact: no executable
+        # statement may escape attribution to a migration.
+        if _PREAMBLE_ALLOWED_RE.match(line) or _HISTORY_TABLE_RE.search(line):
+            continue
+        if _DDL_VERB_RE.search(line):
+            unattributed.append((idx, line))
+
+    # An unterminated `DO $EF$` block — truncated file or a format we no longer
+    # understand. Never silently discard its contents.
+    if in_ef_block:
+        if block_id is not None:
+            _chunk(*block_id).lines.extend(pending)
+        else:
+            unattributed.extend(pending)
+
+    return [by_id[i] for i in order], unattributed
 
 
 # ---------------------------------------------------------------------------
@@ -180,7 +331,7 @@ def _scan_block(block: _Block) -> list[Finding]:
 
     # 2. Scan each line for forbidden patterns. Comments and string literals
     #    are stripped to suppress false positives.
-    for offset, raw_line in enumerate(block.body.splitlines(), start=1):
+    for line_number, raw_line in block.lines:
         stripped = raw_line.lstrip()
         if stripped.startswith("--"):
             continue  # SQL line comment — never executable
@@ -194,7 +345,7 @@ def _scan_block(block: _Block) -> list[Finding]:
                         pattern=name,
                         description=description,
                         excerpt=raw_line.strip(),
-                        line_number=block.start_line + offset,
+                        line_number=line_number,
                         allowed=bool(primary_rationale),
                         rationale=primary_rationale,
                     )
@@ -210,7 +361,7 @@ def _scan_block(block: _Block) -> list[Finding]:
                         pattern="ADD_COLUMN_NOT_NULL_NO_DEFAULT",
                         description="ADD COLUMN NOT NULL without DEFAULT -- fails on existing rows",
                         excerpt=raw_line.strip(),
-                        line_number=block.start_line + offset,
+                        line_number=line_number,
                         allowed=bool(primary_rationale),
                         rationale=primary_rationale,
                     )
@@ -224,22 +375,34 @@ def _scan_block(block: _Block) -> list[Finding]:
 # ---------------------------------------------------------------------------
 
 
-def scan_sql(sql: str, gate_ship_date: str) -> list[Finding]:
+def scan(sql: str, gate_ship_date: str) -> ScanResult:
     """Scan a `dotnet ef migrations script` output for §8.2 violations.
 
     Migrations strictly older than `gate_ship_date` (YYYYMMDD prefix of the
     migration timestamp) are grandfathered and skipped.
+
+    Returns the findings AND the counters that let the caller tell "scanned
+    everything, found nothing" apart from "read nothing at all" (#3659).
     """
     if not re.fullmatch(r"\d{8}", gate_ship_date):
         raise ValueError(f"gate_ship_date must be YYYYMMDD; got {gate_ship_date!r}")
 
-    findings: list[Finding] = []
-    for block in _split_into_blocks(sql):
+    blocks, unattributed = _split_into_blocks(sql)
+    result = ScanResult(migrations_seen=len(blocks), unattributed=unattributed)
+
+    for block in blocks:
         # Grandfathering: migration timestamp is YYYYMMDDhhmmss; compare the date prefix.
         if block.migration_id[:8] < gate_ship_date:
             continue
-        findings.extend(_scan_block(block))
-    return findings
+        result.migrations_scanned += 1
+        result.lines_scanned += len(block.lines)
+        result.findings.extend(_scan_block(block))
+    return result
+
+
+def scan_sql(sql: str, gate_ship_date: str) -> list[Finding]:
+    """Back-compatible wrapper returning findings only."""
+    return scan(sql, gate_ship_date).findings
 
 
 def run_check(sql: str, gate_ship_date: str) -> int:
@@ -248,15 +411,33 @@ def run_check(sql: str, gate_ship_date: str) -> int:
     return _report(findings, fmt="text", out=sys.stdout)
 
 
-def _report(findings: Iterable[Finding], fmt: str, out, report_path: Path | None = None) -> int:
+def _report(
+    findings: Iterable[Finding],
+    fmt: str,
+    out,
+    report_path: Path | None = None,
+    result: ScanResult | None = None,
+) -> int:
     findings = list(findings)
     unsafe = [f for f in findings if not f.allowed]
     allowed = [f for f in findings if f.allowed]
+
+    # Coverage counters travel with every report. Without them an empty result is
+    # ambiguous, and that ambiguity is exactly what hid #3659 for three months:
+    # the artifact of a PR containing a real DROP COLUMN read `{"unsafe": [],
+    # "allowed": []}` and was indistinguishable from a clean run.
+    coverage = {
+        "migrations_seen": result.migrations_seen if result else None,
+        "migrations_scanned": result.migrations_scanned if result else None,
+        "lines_scanned": result.lines_scanned if result else None,
+        "unattributed_statements": len(result.unattributed) if result else None,
+    }
 
     if fmt == "json":
         payload = {
             "unsafe": [f.to_dict() for f in unsafe],
             "allowed": [f.to_dict() for f in allowed],
+            "coverage": coverage,
             "exit_code": 1 if unsafe else 0,
         }
         out.write(json.dumps(payload, indent=2) + "\n")
@@ -277,8 +458,16 @@ def _report(findings: Iterable[Finding], fmt: str, out, report_path: Path | None
                 "See docs/for-developers/operations/rollback-runbook.md section 8.4.\n"
             )
         else:
-            out.write(f"[OK] Migration safety gate passed ({len(findings)} pattern(s) scanned, "
-                      f"{len(allowed)} bypassed by directive).\n")
+            scope = (
+                f"{result.migrations_scanned}/{result.migrations_seen} migration(s), "
+                f"{result.lines_scanned} line(s) scanned"
+                if result
+                else f"{len(findings)} pattern(s) scanned"
+            )
+            out.write(
+                f"[OK] Migration safety gate passed ({scope}; "
+                f"{len(allowed)} bypassed by directive).\n"
+            )
 
         if allowed:
             out.write("\nAudit log -- directive-bypassed patterns (CODEOWNERS approval required):\n")
@@ -294,6 +483,7 @@ def _report(findings: Iterable[Finding], fmt: str, out, report_path: Path | None
                 {
                     "unsafe": [f.to_dict() for f in unsafe],
                     "allowed": [f.to_dict() for f in allowed],
+                    "coverage": coverage,
                 },
                 indent=2,
             ),
@@ -344,8 +534,48 @@ def main(argv: list[str] | None = None) -> int:
         sys.stderr.write(f"error: SQL file not found: {args.sql}\n")
         return 2
     sql = args.sql.read_text(encoding="utf-8")
-    findings = scan_sql(sql, gate_ship_date=args.gate_ship_date)
-    return _report(findings, fmt=args.format, out=sys.stdout, report_path=args.report)
+    result = scan(sql, gate_ship_date=args.gate_ship_date)
+
+    # --- Invariant 1: scanning nothing is a failure, never a pass (#3659) -----
+    # A non-empty script that yields zero migrations means the parser no longer
+    # understands EF's output. Reporting that as "no unsafe pattern found" is how
+    # a DROP COLUMN sailed through this gate.
+    if result.migrations_seen == 0 and sql.strip():
+        sys.stderr.write(
+            # ASCII-only: Windows cp1252 stderr cannot encode ellipsis / em-dash,
+            # and a mojibake in the one message that explains a hard failure is
+            # the worst possible place for it.
+            "error: the SQL contains no recognisable migration.\n"
+            f"       Read {len(sql.splitlines())} line(s) and attributed none of them.\n"
+            "       Expected `DO $EF$ ... \"MigrationId\" = '<14 digits>_<name>' ... END $EF$;`\n"
+            "       blocks from `dotnet ef migrations script --idempotent`.\n"
+            "       If EF changed its output shape, fix the parser -- do NOT relax\n"
+            "       this check: passing here means nothing was verified (#3659).\n"
+        )
+        return 2
+
+    # --- Invariant 2: no executable statement may escape attribution ----------
+    if result.unattributed:
+        sys.stderr.write(
+            f"error: {len(result.unattributed)} statement(s) belong to no migration "
+            "and were therefore never checked:\n"
+        )
+        for line_no, text in result.unattributed[:10]:
+            sys.stderr.write(f"       line {line_no}: {text.strip()}\n")
+        if len(result.unattributed) > 10:
+            sys.stderr.write(f"       ... and {len(result.unattributed) - 10} more\n")
+        sys.stderr.write(
+            "       Unscanned SQL is a parser gap, not a pass. Fix the parser (#3659).\n"
+        )
+        return 2
+
+    return _report(
+        result.findings,
+        fmt=args.format,
+        out=sys.stdout,
+        report_path=args.report,
+        result=result,
+    )
 
 
 if __name__ == "__main__":

--- a/infra/scripts/test_check_migration_safety.py
+++ b/infra/scripts/test_check_migration_safety.py
@@ -213,5 +213,162 @@ class CliExitCodeTests(unittest.TestCase):
         self.assertEqual(0, rc)
 
 
+# ---------------------------------------------------------------------------
+# Real `dotnet ef migrations script --idempotent` output (#3659)
+# ---------------------------------------------------------------------------
+#
+# Everything above this line uses `_block()`, whose docstring claims to produce
+# an "EF-Core-style SQL block" by prepending `-- Migration: <id>`. EF has never
+# emitted that header. The parser was green against a format that does not
+# exist, which is why the gate ran for three months without reading a single
+# statement -- including on a PR that dropped a column.
+#
+# The excerpt below is copied VERBATIM from the tail of
+# `dotnet ef migrations script --idempotent` run against this repo on
+# 2026-08-11. Do not tidy it: its value is being byte-for-byte real.
+#
+# Note the shape it proves: one `migrationBuilder` call per `DO $EF$` block, so
+# the `-- safe:` directive and the DROP COLUMN it authorises sit in DIFFERENT
+# blocks joined only by their MigrationId. A parser grouping per block would
+# lose that association.
+REAL_EF_TAIL = '''\
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20260811130532_PdfDocumentXminConcurrency') THEN
+    -- safe: drop dead bytea concurrency column, replaced by the xmin system column
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20260811130532_PdfDocumentXminConcurrency') THEN
+    ALTER TABLE pdf_documents DROP COLUMN "RowVersion";
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20260811130532_PdfDocumentXminConcurrency') THEN
+    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20260811130532_PdfDocumentXminConcurrency', '9.0.11');
+    END IF;
+END $EF$;
+COMMIT;
+'''
+
+REAL_EF_PREAMBLE = '''\
+CREATE TABLE IF NOT EXISTS "__EFMigrationsHistory" (
+    "MigrationId" character varying(150) NOT NULL,
+    "ProductVersion" character varying(32) NOT NULL,
+    CONSTRAINT "PK___EFMigrationsHistory" PRIMARY KEY ("MigrationId")
+);
+
+START TRANSACTION;
+
+'''
+
+
+class RealEfFormatTests(unittest.TestCase):
+    """The regression suite that would have caught #3659 on day one."""
+
+    def test_real_ef_output_contains_no_legacy_header(self):
+        """Pins the fact the old parser depended on and never checked.
+
+        The pre-#3659 parser split on `-- Migration: <id>` alone. This asserts
+        that real EF output contains no such header -- i.e. that a header-only
+        parser reads ZERO statements from it. It is the reason every other test
+        in this class fails against the old implementation, and it is worth
+        stating separately because it is the assumption, not the symptom.
+        """
+        self.assertNotIn("-- Migration:", REAL_EF_PREAMBLE + REAL_EF_TAIL)
+
+    def test_real_ef_output_is_recognised_at_all(self):
+        """The single assertion whose absence let the gate run blind."""
+        result = mod.scan(REAL_EF_PREAMBLE + REAL_EF_TAIL, gate_ship_date=GATE_SHIP_DATE)
+        self.assertGreater(
+            result.migrations_seen, 0,
+            "real EF output must yield at least one migration; if this fails the "
+            "gate is scanning nothing and every result below is vacuous",
+        )
+
+    def test_drop_column_in_real_format_is_found(self):
+        findings = mod.scan_sql(REAL_EF_PREAMBLE + REAL_EF_TAIL, gate_ship_date=GATE_SHIP_DATE)
+        self.assertTrue(any(f.pattern == "DROP_COLUMN" for f in findings))
+
+    def test_directive_in_a_different_block_still_authorises(self):
+        """Cross-block association: directive and statement share only the id."""
+        findings = mod.scan_sql(REAL_EF_PREAMBLE + REAL_EF_TAIL, gate_ship_date=GATE_SHIP_DATE)
+        drop = next(f for f in findings if f.pattern == "DROP_COLUMN")
+        self.assertTrue(drop.allowed)
+        self.assertIn("xmin", drop.rationale)
+
+    def test_many_blocks_collapse_into_one_migration(self):
+        """EF emits one block per call: 3 blocks here, but a single migration."""
+        result = mod.scan(REAL_EF_PREAMBLE + REAL_EF_TAIL, gate_ship_date=GATE_SHIP_DATE)
+        self.assertEqual(1, result.migrations_seen)
+
+    def test_line_numbers_are_absolute_in_the_file(self):
+        sql = REAL_EF_PREAMBLE + REAL_EF_TAIL
+        findings = mod.scan_sql(sql, gate_ship_date=GATE_SHIP_DATE)
+        drop = next(f for f in findings if f.pattern == "DROP_COLUMN")
+        actual = sql.splitlines()[drop.line_number - 1]
+        self.assertIn("DROP COLUMN", actual)
+
+    def test_history_bootstrap_is_not_reported_as_unattributed(self):
+        """Its continuation lines carry no verb; flagging them would fail every run."""
+        result = mod.scan(REAL_EF_PREAMBLE + REAL_EF_TAIL, gate_ship_date=GATE_SHIP_DATE)
+        self.assertEqual([], result.unattributed)
+
+
+class NothingScannedTests(unittest.TestCase):
+    """Scanning nothing must be an error, never a pass (#3659)."""
+
+    def test_unknown_format_yields_zero_migrations(self):
+        result = mod.scan(
+            'ALTER TABLE users DROP COLUMN email;\n', gate_ship_date=GATE_SHIP_DATE
+        )
+        self.assertEqual(0, result.migrations_seen)
+
+    def test_ef_block_without_recognisable_guard_is_unattributed(self):
+        """Simulates EF changing its output: the SQL must not vanish silently."""
+        sql = (
+            "DO $EF$\nBEGIN\n"
+            '    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE migration = 42) THEN\n'
+            '    DROP TABLE "victims";\n'
+            "    END IF;\nEND $EF$;\n"
+        )
+        result = mod.scan(sql, gate_ship_date=GATE_SHIP_DATE)
+        self.assertEqual(0, result.migrations_seen)
+        self.assertTrue(
+            any("DROP TABLE" in text for _, text in result.unattributed),
+            "SQL inside an unrecognised block must surface as unattributed",
+        )
+
+    def test_ddl_outside_any_block_is_unattributed(self):
+        sql = REAL_EF_PREAMBLE + REAL_EF_TAIL + 'DROP TABLE "sneaky_orphan";\n'
+        result = mod.scan(sql, gate_ship_date=GATE_SHIP_DATE)
+        self.assertTrue(any("sneaky_orphan" in text for _, text in result.unattributed))
+
+    def test_unterminated_block_is_not_discarded(self):
+        sql = (
+            "DO $EF$\nBEGIN\n"
+            '    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = \'20260601120000_Trunc\') THEN\n'
+            '    ALTER TABLE "users" DROP COLUMN "email";\n'
+        )
+        findings = mod.scan_sql(sql, gate_ship_date=GATE_SHIP_DATE)
+        self.assertTrue(any(f.pattern == "DROP_COLUMN" for f in findings))
+
+
+class CoverageReportTests(unittest.TestCase):
+    """`{"unsafe": [], "allowed": []}` must never again be ambiguous (#3659)."""
+
+    def test_coverage_counters_distinguish_clean_from_unread(self):
+        clean = mod.scan(REAL_EF_PREAMBLE + REAL_EF_TAIL, gate_ship_date=GATE_SHIP_DATE)
+        unread = mod.scan("SELECT 1;\n", gate_ship_date=GATE_SHIP_DATE)
+        self.assertGreater(clean.lines_scanned, 0)
+        self.assertEqual(0, unread.lines_scanned)
+        self.assertNotEqual(clean.migrations_seen, unread.migrations_seen)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #3659

Il gate era verde su **ogni** PR da quando è stato introdotto il 2026-05-18, inclusa una che cancellava una colonna. Non sbagliava l'analisi: non ne faceva alcuna.

## La causa

`_split_into_blocks` riconosceva solo un header che EF non emette:

```python
_MIGRATION_HEADER_RE = re.compile(r"--\s*Migration:\s*(\d{14})_(\S+)")
```

Nessun header → nessun blocco → `_scan_block` senza nulla da esaminare → zero findings → **exit 0**.

Misurato sull'SQL reale di questo repo (`dotnet ef migrations script --idempotent`):

| | |
|---|---|
| righe | 10.725 |
| occorrenze di `-- Migration:` | **0** |
| statement distruttivi presenti | 1 (`DROP COLUMN`) |
| statement esaminati dal gate | **0** |

L'artifact di audit di #3658 — la PR che conteneva quel `DROP COLUMN` — recita per intero:

```json
{ "unsafe": [], "allowed": [] }
```

## Perché i self-test non lo coglievano

`test_check_migration_safety.py:23` — l'helper che costruisce **ogni** fixture:

```python
f"-- Migration: {migration_id}_TestMigration\n"
```

Il parser era verificato contro un formato che non esiste in produzione, con un docstring che lo definiva «EF-Core-style». Lo step *Run parser self-tests* era quindi precisamente ciò che dava fiducia nel gate.

## Cosa cambia

**1. Riconoscimento del formato vero.** Blocchi `DO $EF$ … END $EF$;` con la migration nel guard `"MigrationId" = '<id>'`.

Il raggruppamento è per **migration**, non per blocco, e non è un dettaglio: EF emette un blocco per ogni chiamata a `migrationBuilder` — misurati **1012 blocchi per 7 migration** — e la direttiva `-- safe:` finisce sistematicamente in un blocco *diverso* da quello dello statement che autorizza, legati solo dal MigrationId. Un parser che raggruppasse per blocco perderebbe quell'associazione e boccerebbe migration correttamente documentate.

**2. Scansionare zero migration è un ERRORE (exit 2), mai un pass.** Idem per qualunque DDL che il parser non riesca ad attribuire. È il punto più importante: senza, un futuro cambio di forma dell'output EF riporterebbe il gate al verde vacuo di oggi. Il messaggio d'errore dice esplicitamente di **non** rilassare il controllo.

**3. Contatori di copertura nel report**, così che «0 unsafe su 7 migration scansionate» non sia più indistinguibile da «0 unsafe perché non ho letto niente» — l'ambiguità che ha nascosto il difetto per tre mesi.

**4. Numeri di riga assoluti** nel file, non offset da un header assente.

## Verifica

Sull'SQL reale, prima vs dopo — stesso input:

```
prima:  { "unsafe": [], "allowed": [] }

dopo:   [OK] passed (7/7 migration(s), 6668 line(s) scanned; 1 bypassed by directive)
        - Migration 20260811130532 (line 10713): DROP_COLUMN
          -> rationale: drop dead bytea concurrency column…
```

La riga 10713 è esattamente quella del `DROP COLUMN`, e la direttiva viene raccolta dal blocco precedente.

| scenario | esito |
|---|---|
| SQL reale con direttiva | exit 0, finding in `allowed` |
| stesso SQL senza direttiva | **exit 1** |
| formato irriconoscibile | **exit 2** |
| DDL fuori da ogni migration | **exit 2** |
| blocco `DO $EF$` con guard non riconosciuto | **exit 2** |

## I test

12 nuovi, che usano un estratto **copiato alla lettera** dall'output reale invece di una fixture sintetica — il modo in cui il difetto è nato è proprio un formato immaginato.

Verificati **negativamente** contro il parser precedente: **11 su 12 falliscono**. L'unico che passa è `test_real_ef_output_contains_no_legacy_header`, che asserisce l'assenza dell'header nel formato reale: documenta l'assunzione su cui il vecchio parser si reggeva, non il sintomo. I 23 test preesistenti restano verdi (il supporto all'header legacy è mantenuto).

---

Quinto membro dello stesso cluster: #3622 → #3625 → #3629 → #3632 → **#3659**. Non controlli che sbagliano, ma controlli che non guardano niente e lo comunicano come successo.
