### PR TITLE
chore(toolkit): ripunta il breadcrumb VersionSemver a #3670 (#564)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Infrastructure/Persistence/GameToolkitRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Infrastructure/Persistence/GameToolkitRepository.cs
@@ -310,7 +310,7 @@ internal class GameToolkitRepository : RepositoryBase, IGameToolkitRepository
             Version = toolkit.Version,
 #pragma warning restore CS0618
 #pragma warning disable S1135 // TODO: architectural breadcrumb — mitigated footgun: see comment below.
-            // TODO(#1458): VersionSemver already has a real producer.
+            // TODO(#3670): VersionSemver already has a real producer.
             // PublishToolkitVersionCommandHandler.cs:137 writes the user-input
             // semver and DELIBERATELY bypasses GameToolkitRepository.UpdateAsync
             // (see handler comment at lines 131-136) precisely because this
@@ -319,8 +319,8 @@ internal class GameToolkitRepository : RepositoryBase, IGameToolkitRepository
             // AddAsync (brand-new toolkit → seed "0.1.0"): UpdateAsync now excludes
             // VersionSemver (and Description/License) from the Update() so no
             // non-publish update path clobbers the published marketplace pointer.
-            // Full fix: surface VersionSemver on the domain aggregate (separate
-            // epic — original paired-write context shipped in #1144 2026-05-14)
+            // Full fix: surface VersionSemver on the domain aggregate (#3670 —
+            // original paired-write context shipped in #1144 2026-05-14)
             // so MapToPersistence can read it directly and the synthesis goes away.
             VersionSemver = $"0.{toolkit.Version}.0",
 #pragma warning restore S1135


### PR DESCRIPTION
Esito del ciclo di triage TODO/FIXME di #564 ([report completo](https://github.com/meepleAi-app/meepleai-monorepo/issues/564#issuecomment-5256002833)).

## Il cambiamento

Una riga di commento. `GameToolkitRepository.cs:313` rimandava a **#1458**, che è chiusa — ed era «chore: drift audit 2026-05-23», non il lavoro che il breadcrumb descrive. Chi seguiva il riferimento non trovava il fix promesso, trovava un audit concluso: peggio di un TODO senza numero, perché fa credere che la storia sia già stata letta.

Ora punta a **#3670**, aperta in questo ciclo con il fix descritto (esporre `VersionSemver` sull'aggregato ed eliminare la sintesi in `MapToPersistence`).

## Perché il commento resta

Documenta un footgun reale: `MapToPersistence` sintetizza `VersionSemver` da un intero legacy, e `PublishToolkitVersionCommandHandler` deve deliberatamente scavalcare `GameToolkitRepository.UpdateAsync` per non farsi sovrascrivere il valore inserito dall'utente. Chi tocca `UpdateAsync` senza saperlo azzera il puntatore di versione pubblicata sul marketplace. Il breadcrumb va tenuto finché il fix non arriva — mancava solo la issue che dichiarava di avere.

Nessun cambiamento di comportamento: due commenti, zero codice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)