### PR TITLE
fix(kb): il golden dataset torna generabile, 28 test riattivati (#3655)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -241,6 +241,11 @@ tests/llm-eval/ocr-validation/manuals/*
 # Golden set contractor CSV uploads (before JSONL conversion)
 tests/llm-eval/golden-set/*.csv
 
+# Golden dataset RAG: generato da tools/golden-dataset-generator, non committato (#3655).
+# tests/data/README.md lo dichiarava già "git-ignored", ma la regola non esisteva: il file
+# era committabile per sbaglio (26.658 righe rigenerabili in due secondi).
+tests/data/golden_dataset.json
+
 # Page catalog (generated screenshots and static site)
 docs/pages/screenshots/
 docs/pages/dist/

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Services/GoldenDatasetLoaderTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Services/GoldenDatasetLoaderTests.cs
@@ -5,26 +5,475 @@ using Moq;
 using Xunit;
 using Api.Tests.Constants;
 
-#pragma warning disable S3261 // Empty namespace - tests disabled in Issue #2577, kept for future re-enablement
 namespace Api.Tests.BoundedContexts.KnowledgeBase.Domain.Services;
-#pragma warning restore S3261
 
 /// <summary>
-/// Unit tests for GoldenDatasetLoader - DISABLED
+/// Unit tests for GoldenDatasetLoader.
 /// BGAI-059: Golden dataset loading, filtering, and sampling logic validation.
-/// 
-/// Issue #2577 CI Fix: Test data removed in PR #2569 (f65edfe3).
-/// - tests/data/golden_dataset.json deleted (26,658 lines)
-/// - All 21 test methods fail with "Could not find golden_dataset.json"
-/// - Tests disabled until test data is restored or tests are updated to use alternative data
-/// 
-/// To re-enable: Restore tests/data/golden_dataset.json or update tests to use embedded resources
 /// </summary>
-/*
+/// <remarks>
+/// <para>
+/// <b>Storia (#3655).</b> Questi 21 test sono stati svuotati il 2026-01-18 (<c>56a950f92</c>), il
+/// giorno dopo che <c>1806fcd0a</c> aveva cancellato <c>tests/data/golden_dataset.json</c> e
+/// spostato <c>tests/rulebook</c> → <c>data/rulebook</c>. Il guscio rimasto rimandava a «Issue
+/// #2577» e «PR #2569», riferimenti che non portano a quel lavoro. Sono recuperati alla lettera
+/// da <c>aef08f51b</c>, non riscritti.
+/// </para>
+/// <para>
+/// <b>Il dataset è generato, non committato</b> — così dice <c>tests/data/README.md</c>. Se manca,
+/// questi test si <b>saltano dicendo come produrlo</b>, invece di fallire o di essere disattivati
+/// a mano: è la disattivazione manuale ad averli fatti sparire per sette mesi senza che nessuno
+/// se ne accorgesse.
+/// </para>
+/// </remarks>
 [Trait("Category", TestCategories.Unit)]
 public class GoldenDatasetLoaderTests
 {
-    // Test class commented out - see class summary for details
-    // 21 test methods skipped
+    private const string GenerateCommand =
+        "dotnet run --project tools/golden-dataset-generator/GenerateGoldenDatasetSimple.csproj";
+
+    private readonly Mock<ILogger<GoldenDatasetLoader>> _mockLogger;
+
+    public GoldenDatasetLoaderTests()
+    {
+        Assert.SkipUnless(
+            DatasetIsPresent(),
+            $"tests/data/golden_dataset.json non trovato. Generalo dalla root del repository:\n"
+                + $"    {GenerateCommand}\n"
+                + "Il dataset è deliberatamente non committato (tests/data/README.md).");
+
+        _mockLogger = new Mock<ILogger<GoldenDatasetLoader>>();
+    }
+
+    /// <summary>
+    /// Risale dalla directory dei binari di test fino alla root del repository, come fa
+    /// <see cref="GoldenDatasetLoader"/> stesso. Cercare il file invece di fidarsi di un percorso
+    /// relativo fisso è ciò che rende il salto affidabile sia in locale sia in CI.
+    /// </summary>
+    private static bool DatasetIsPresent()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "tests", "data", "golden_dataset.json")))
+            {
+                return true;
+            }
+
+            dir = dir.Parent;
+        }
+
+        return false;
+    }
+
+    [Fact]
+    public async Task LoadAllAsync_WithValidDataset_ReturnsTestCases()
+    {
+        // Arrange
+        var logMessages = new List<string>();
+        Exception? capturedException = null;
+        _mockLogger.Setup(x => x.Log(
+            It.IsAny<LogLevel>(),
+            It.IsAny<EventId>(),
+            It.IsAny<It.IsAnyType>(),
+            It.IsAny<Exception?>(),
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()))
+            .Callback(new InvocationAction(invocation =>
+            {
+                var logLevel = (LogLevel)invocation.Arguments[0];
+                var exception = invocation.Arguments[3] as Exception;
+                var formatter = invocation.Arguments[4] as Delegate;
+                var message = formatter?.DynamicInvoke(invocation.Arguments[2], invocation.Arguments[3])?.ToString() ?? "";
+                logMessages.Add($"[{logLevel}] {message}");
+                if (exception != null)
+                {
+                    capturedException = exception;
+                    logMessages.Add($"  Exception: {exception.GetType().Name}: {exception.Message}");
+                }
+            }));
+
+        var loader = new GoldenDatasetLoader(_mockLogger.Object, FindGoldenDatasetPath());
+
+        // Act
+        var testCases = await loader.LoadAllAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(testCases);
+
+        // Debug: If test fails, this will show the logs
+        var debugInfo = $"Expected at least 3 test cases, got {testCases.Count}.\n" +
+                       $"Logs:\n{string.Join("\n", logMessages)}";
+
+        Assert.True(testCases.Count >= 3, debugInfo);
+    }
+
+    [Fact]
+    public async Task LoadAllAsync_CachesResults_OnSecondCall()
+    {
+        // Arrange
+        var loader = new GoldenDatasetLoader(_mockLogger.Object, FindGoldenDatasetPath());
+
+        // Act
+        var firstCall = await loader.LoadAllAsync(TestContext.Current.CancellationToken);
+        var secondCall = await loader.LoadAllAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Same(firstCall, secondCall); // Should return same instance (cached)
+        Assert.Equal(firstCall.Count, secondCall.Count);
+    }
+
+    [Fact]
+    public async Task LoadByGameAsync_WithValidGameId_ReturnsFilteredCases()
+    {
+        // Arrange
+        var loader = new GoldenDatasetLoader(_mockLogger.Object, FindGoldenDatasetPath());
+
+        // Act
+        var testCases = await loader.LoadByGameAsync("terraforming-mars", TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(testCases);
+        Assert.NotEmpty(testCases);
+        Assert.All(testCases, tc => Assert.Equal("terraforming-mars", tc.GameId));
+    }
+
+    [Fact]
+    public async Task LoadByGameAsync_WithNonExistentGame_ReturnsEmpty()
+    {
+        // Arrange
+        var loader = new GoldenDatasetLoader(_mockLogger.Object, FindGoldenDatasetPath());
+
+        // Act
+        var testCases = await loader.LoadByGameAsync("non-existent-game", TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(testCases);
+        Assert.Empty(testCases);
+    }
+
+    [Fact]
+    public async Task LoadByGameAsync_WithEmptyGameId_ThrowsArgumentException()
+    {
+        // Arrange
+        var loader = new GoldenDatasetLoader(_mockLogger.Object, FindGoldenDatasetPath());
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => loader.LoadByGameAsync(string.Empty, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task LoadByDifficultyAsync_WithValidDifficulty_ReturnsFilteredCases()
+    {
+        // Arrange
+        var loader = new GoldenDatasetLoader(_mockLogger.Object, FindGoldenDatasetPath());
+
+        // Act
+        var testCases = await loader.LoadByDifficultyAsync("easy", TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(testCases);
+        Assert.NotEmpty(testCases);
+        Assert.All(testCases, tc => Assert.Equal("easy", tc.Difficulty));
+    }
+
+    [Fact]
+    public async Task LoadByDifficultyAsync_WithMediumDifficulty_ReturnsFilteredCases()
+    {
+        // Arrange
+        var loader = new GoldenDatasetLoader(_mockLogger.Object, FindGoldenDatasetPath());
+
+        // Act
+        var testCases = await loader.LoadByDifficultyAsync("medium", TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(testCases);
+        // May be empty if no medium cases in current dataset
+        Assert.All(testCases, tc => Assert.Equal("medium", tc.Difficulty));
+    }
+
+    [Fact]
+    public async Task LoadByDifficultyAsync_WithEmptyDifficulty_ThrowsArgumentException()
+    {
+        // Arrange
+        var loader = new GoldenDatasetLoader(_mockLogger.Object, FindGoldenDatasetPath());
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => loader.LoadByDifficultyAsync(string.Empty, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task LoadByCategoryAsync_WithValidCategory_ReturnsFilteredCases()
+    {
+        // Arrange
+        var loader = new GoldenDatasetLoader(_mockLogger.Object, FindGoldenDatasetPath());
+
+        // Act
+        var testCases = await loader.LoadByCategoryAsync("gameplay", TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(testCases);
+        // May be empty if no gameplay cases in current dataset
+        Assert.All(testCases, tc => Assert.Equal("gameplay", tc.Category));
+    }
+
+    [Fact]
+    public async Task LoadByCategoryAsync_WithEmptyCategory_ThrowsArgumentException()
+    {
+        // Arrange
+        var loader = new GoldenDatasetLoader(_mockLogger.Object, FindGoldenDatasetPath());
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => loader.LoadByCategoryAsync(string.Empty, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task SampleAsync_WithCountLargerThanTotal_ReturnsAll()
+    {
+        // Arrange
+        var loader = new GoldenDatasetLoader(_mockLogger.Object, FindGoldenDatasetPath());
+        var allCases = await loader.LoadAllAsync(TestContext.Current.CancellationToken);
+
+        // Act
+        var sampled = await loader.SampleAsync(allCases.Count + 100, stratified: true, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(allCases.Count, sampled.Count);
+    }
+
+    [Fact]
+    public async Task SampleAsync_WithStratifiedTrue_ReturnsSampledCases()
+    {
+        // Arrange
+        var loader = new GoldenDatasetLoader(_mockLogger.Object, FindGoldenDatasetPath());
+        var sampleSize = 2;
+
+        // Act
+        var sampled = await loader.SampleAsync(sampleSize, stratified: true, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(sampled);
+        Assert.True(sampled.Count <= sampleSize); // May be less if not enough cases
+    }
+
+    [Fact]
+    public async Task SampleAsync_WithStratifiedFalse_ReturnsRandomSample()
+    {
+        // Arrange
+        var loader = new GoldenDatasetLoader(_mockLogger.Object, FindGoldenDatasetPath());
+        var sampleSize = 2;
+
+        // Act
+        var sampled = await loader.SampleAsync(sampleSize, stratified: false, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(sampled);
+        Assert.True(sampled.Count <= sampleSize);
+    }
+
+    [Fact]
+    public async Task SampleAsync_WithZeroCount_ThrowsArgumentException()
+    {
+        // Arrange
+        var loader = new GoldenDatasetLoader(_mockLogger.Object, FindGoldenDatasetPath());
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => loader.SampleAsync(0, true, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task SampleAsync_WithNegativeCount_ThrowsArgumentException()
+    {
+        // Arrange
+        var loader = new GoldenDatasetLoader(_mockLogger.Object, FindGoldenDatasetPath());
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => loader.SampleAsync(-1, true, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task LoadAllAsync_WithNonExistentFile_ReturnsEmpty()
+    {
+        // Arrange
+        var loader = new GoldenDatasetLoader(_mockLogger.Object, "/nonexistent/path.json");
+
+        // Act
+        var testCases = await loader.LoadAllAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(testCases);
+        Assert.Empty(testCases);
+    }
+
+
+    /// <summary>
+    /// BGAI-060 (Issue #1000): Test loading expert-annotated test cases by excluding template-generated
+    /// </summary>
+    [Fact]
+    public async Task LoadByAnnotatorAsync_ExcludeTemplateGenerated_ReturnsExpertAnnotatedOnly()
+    {
+        // Arrange
+        var datasetPath = FindGoldenDatasetPath();
+        var loader = new GoldenDatasetLoader(_mockLogger.Object, datasetPath);
+
+        // Act - Exclude template_generator_alpha (should return only expert-annotated)
+        var expertCases = await loader.LoadByAnnotatorAsync(
+            annotator: "template_generator_alpha",
+            exclude: true,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(expertCases);
+
+        if (expertCases.Count == 0)
+        {
+            // If no expert cases yet, skip test (dataset may be empty in test environment)
+            return;
+        }
+
+        // All cases should NOT be from template_generator_alpha
+        Assert.All(expertCases, tc =>
+            Assert.NotEqual("template_generator_alpha", tc.AnnotatedBy, StringComparer.OrdinalIgnoreCase));
+
+        // Expected: 50 expert-annotated (20 TM + 15 Wingspan + 15 Azul)
+        // But accept any non-zero count for test flexibility
+        Assert.True(expertCases.Count >= 0);
+    }
+
+    /// <summary>
+    /// BGAI-060: Test loading template-generated test cases by including specific annotator
+    /// </summary>
+    [Fact]
+    public async Task LoadByAnnotatorAsync_IncludeTemplateGenerated_ReturnsTemplateOnly()
+    {
+        // Arrange
+        var datasetPath = FindGoldenDatasetPath();
+        var loader = new GoldenDatasetLoader(_mockLogger.Object, datasetPath);
+
+        // Act - Include only template_generator_alpha
+        var templateCases = await loader.LoadByAnnotatorAsync(
+            annotator: "template_generator_alpha",
+            exclude: false, // Include, not exclude
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(templateCases);
+
+        if (templateCases.Count == 0)
+        {
+            // If no template cases, skip test (dataset may be empty in test environment)
+            return;
+        }
+
+        // All cases should be from template_generator_alpha
+        Assert.All(templateCases, tc =>
+            Assert.Equal("template_generator_alpha", tc.AnnotatedBy, StringComparer.OrdinalIgnoreCase));
+
+        // Accept any count >= 0 for test flexibility
+        Assert.True(templateCases.Count >= 0);
+    }
+
+    /// <summary>
+    /// BGAI-060: Test that LoadByAnnotatorAsync validates input
+    /// </summary>
+    [Fact]
+    public async Task LoadByAnnotatorAsync_WithEmptyAnnotator_ThrowsArgumentException()
+    {
+        // Arrange
+        var datasetPath = FindGoldenDatasetPath();
+        var loader = new GoldenDatasetLoader(_mockLogger.Object, datasetPath);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(async () =>
+            await loader.LoadByAnnotatorAsync("", exclude: false, TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
+    /// BGAI-060: Test that LoadByAnnotatorAsync handles non-existent annotator
+    /// </summary>
+    [Fact]
+    public async Task LoadByAnnotatorAsync_WithNonExistentAnnotator_ReturnsEmpty()
+    {
+        // Arrange
+        var datasetPath = FindGoldenDatasetPath();
+        var loader = new GoldenDatasetLoader(_mockLogger.Object, datasetPath);
+
+        // Act
+        var cases = await loader.LoadByAnnotatorAsync(
+            annotator: "non_existent_annotator_xyz",
+            exclude: false,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(cases);
+        Assert.Empty(cases);
+    }
+
+
+    /// <summary>
+    /// Helper to find golden dataset path from repository root
+    /// </summary>
+    private static string FindGoldenDatasetPath()
+    {
+        // Start from current directory and walk up to find .git
+        var currentDir = Directory.GetCurrentDirectory();
+        var repoRoot = FindRepositoryRoot(currentDir);
+
+        if (repoRoot != null)
+        {
+            var path = Path.Combine(repoRoot, "tests", "data", "golden_dataset.json");
+            if (File.Exists(path))
+                return path;
+        }
+
+        // Fallback: Try multiple levels up to find the file
+        for (int levels = 1; levels <= 10; levels++)
+        {
+            var upPath = string.Join(Path.DirectorySeparatorChar.ToString(),
+                Enumerable.Repeat("..", levels));
+            var testPath = Path.GetFullPath(Path.Combine(currentDir, upPath, "tests", "data", "golden_dataset.json"));
+
+            if (File.Exists(testPath))
+                return testPath;
+        }
+
+        throw new InvalidOperationException(
+            $"Could not find golden_dataset.json searching up from: {currentDir}");
+    }
+
+    /// <summary>
+    /// Find repository root by looking for .git directory
+    /// </summary>
+    private static string? FindRepositoryRoot(string startPath)
+    {
+        var current = new DirectoryInfo(startPath);
+
+        // Walk up maximum 10 levels to prevent infinite loops
+        int maxLevels = 10;
+        int level = 0;
+
+        while (current != null && level < maxLevels)
+        {
+            var gitPath = Path.Combine(current.FullName, ".git");
+            if (Directory.Exists(gitPath))
+                return current.FullName;
+
+            current = current.Parent;
+            level++;
+        }
+
+        return null;
+    }
+
+    [Fact]
+    public void Constructor_WithNullLogger_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new GoldenDatasetLoader(null!));
+    }
 }
-*/

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Integration/FirstAccuracyBaselineTest.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Integration/FirstAccuracyBaselineTest.cs
@@ -137,7 +137,7 @@ public class FirstAccuracyBaselineTest
     /// Use this when not all games are indexed (e.g., Terraforming Mars PDF too large)
     /// Target: Accuracy ≥80%
     /// </summary>
-    [Fact(Skip = "Requires golden_dataset.json generation (Issue #1797) and running API", Timeout = 600000)] // 10 min timeout
+    [Fact(Skip = "Richiede un'API in esecuzione + il dataset generato: dotnet run --project tools/golden-dataset-generator/GenerateGoldenDatasetSimple.csproj (#3655)", Timeout = 600000)] // 10 min timeout
     public async Task RunPartialAccuracyBaseline_IndexedGamesOnly_MeetsThreshold()
     {
         // Arrange - Verify API is available
@@ -262,7 +262,7 @@ public class FirstAccuracyBaselineTest
     /// Cost estimate: ~$0.50-0.75 (OpenRouter API calls)
     /// Execution time: ~15-20 minutes
     /// </remarks>
-    [Fact(Skip = "Requires golden_dataset.json generation (Issue #1797) and running API", Timeout = 1200000)] // 20 min timeout for 110 questions
+    [Fact(Skip = "Richiede un'API in esecuzione + il dataset generato: dotnet run --project tools/golden-dataset-generator/GenerateGoldenDatasetSimple.csproj (#3655)", Timeout = 1200000)] // 20 min timeout for 110 questions
     [Trait("Issue", "1019")]
     [Trait("Category", "Manual")]
     [Trait("BoundedContext", "KnowledgeBase")]

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Integration/GoldenDatasetAccuracyIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Integration/GoldenDatasetAccuracyIntegrationTests.cs
@@ -38,16 +38,28 @@ public class GoldenDatasetAccuracyIntegrationTests
 
     public GoldenDatasetAccuracyIntegrationTests()
     {
+        // #3655: il dataset è generato e non committato (tests/data/README.md). Se manca, questi
+        // test si saltano dicendo come produrlo — prima erano disattivati con uno `Skip` fisso che
+        // rimandava alla «Issue #1797», che è una PR su PlayerStatistics senza rapporto con questo
+        // lavoro. Uno skip che non dice cosa fare equivale a un test cancellato.
+        var datasetPath = FindGoldenDatasetPath();
+        Assert.SkipUnless(
+            datasetPath is not null,
+            "tests/data/golden_dataset.json non trovato. Generalo dalla root del repository:\n"
+                + "    dotnet run --project tools/golden-dataset-generator/GenerateGoldenDatasetSimple.csproj");
+
         _mockLoaderLogger = new Mock<ILogger<GoldenDatasetLoader>>();
         _mockEvaluatorLogger = new Mock<ILogger<RagAccuracyEvaluator>>();
-        _loader = new GoldenDatasetLoader(_mockLoaderLogger.Object, FindGoldenDatasetPath());
+        _loader = new GoldenDatasetLoader(_mockLoaderLogger.Object, datasetPath!);
         _evaluator = new RagAccuracyEvaluator(_mockEvaluatorLogger.Object);
     }
 
     /// <summary>
-    /// Helper to find golden dataset path from repository root
+    /// Helper to find golden dataset path from repository root.
+    /// Restituisce <c>null</c> se il dataset non c'è: l'assenza è uno stato previsto (file
+    /// generato), non un errore, e il costruttore la traduce in uno skip.
     /// </summary>
-    private static string FindGoldenDatasetPath()
+    private static string? FindGoldenDatasetPath()
     {
         // Start from current directory and walk up to find .git
         var currentDir = Directory.GetCurrentDirectory();
@@ -71,8 +83,7 @@ public class GoldenDatasetAccuracyIntegrationTests
                 return testPath;
         }
 
-        throw new InvalidOperationException(
-            $"Could not find golden_dataset.json searching up from: {currentDir}");
+        return null;
     }
 
     /// <summary>
@@ -88,8 +99,11 @@ public class GoldenDatasetAccuracyIntegrationTests
 
         while (current != null && level < maxLevels)
         {
+            // In un git worktree `.git` è un FILE che punta al repository comune, non una
+            // directory: controllare solo Directory.Exists faceva fallire sempre il percorso
+            // primario e reggeva tutto il fallback a risalita. Il repo usa i worktree di routine.
             var gitPath = Path.Combine(current.FullName, ".git");
-            if (Directory.Exists(gitPath))
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
                 return current.FullName;
 
             current = current.Parent;
@@ -103,7 +117,7 @@ public class GoldenDatasetAccuracyIntegrationTests
     /// Test 1: Perfect accuracy scenario - all answers correct
     /// Simulates RAG responses that match all expected criteria
     /// </summary>
-    [Fact(Skip = "Requires golden_dataset.json generation (Issue #1797)", Timeout = 30000)]
+    [Fact(Timeout = 30000)]
     public async Task PerfectScenario_AllAnswersCorrect_MeetsThreshold()
     {
         // Arrange
@@ -133,7 +147,7 @@ public class GoldenDatasetAccuracyIntegrationTests
     /// Test 2: 80% accuracy scenario - exactly at threshold
     /// Simulates 80% correct responses (minimum acceptable)
     /// </summary>
-    [Fact(Skip = "Requires golden_dataset.json generation (Issue #1797)", Timeout = 30000)]
+    [Fact(Timeout = 30000)]
     public async Task ThresholdScenario_80PercentCorrect_MeetsThreshold()
     {
         // Arrange
@@ -166,7 +180,7 @@ public class GoldenDatasetAccuracyIntegrationTests
     /// Test 3: Below threshold scenario - 60% accuracy
     /// Simulates insufficient accuracy (should fail threshold)
     /// </summary>
-    [Fact(Skip = "Requires golden_dataset.json generation (Issue #1797)", Timeout = 30000)]
+    [Fact(Timeout = 30000)]
     public async Task BelowThresholdScenario_60PercentCorrect_FailsThreshold()
     {
         // Arrange
@@ -199,7 +213,7 @@ public class GoldenDatasetAccuracyIntegrationTests
     /// Test 4: Stratified sampling - 50 cases with proportional difficulty distribution
     /// Tests sampling logic maintains difficulty distribution
     /// </summary>
-    [Fact(Skip = "Requires golden_dataset.json generation (Issue #1797)", Timeout = 30000)]
+    [Fact(Timeout = 30000)]
     public async Task StratifiedSample_50Cases_MaintainsDifficultyDistribution()
     {
         // Arrange
@@ -231,7 +245,7 @@ public class GoldenDatasetAccuracyIntegrationTests
     /// Test 5: Accuracy by difficulty - verify metrics grouping
     /// Tests that accuracy can be broken down by difficulty level
     /// </summary>
-    [Fact(Skip = "Requires golden_dataset.json generation (Issue #1797)", Timeout = 30000)]
+    [Fact(Timeout = 30000)]
     public async Task AccuracyByDifficulty_GroupsCorrectly()
     {
         // Arrange
@@ -284,7 +298,7 @@ public class GoldenDatasetAccuracyIntegrationTests
     /// Test 6: Forbidden keywords detection
     /// Verifies hallucination detection through forbidden keywords
     /// </summary>
-    [Fact(Skip = "Requires golden_dataset.json generation (Issue #1797)", Timeout = 30000)]
+    [Fact(Timeout = 30000)]
     public async Task ForbiddenKeywords_DetectedCorrectly()
     {
         // Arrange
@@ -316,7 +330,7 @@ public class GoldenDatasetAccuracyIntegrationTests
     /// Test 7: Citation validation
     /// Verifies citation page number matching
     /// </summary>
-    [Fact(Skip = "Requires golden_dataset.json generation (Issue #1797)", Timeout = 30000)]
+    [Fact(Timeout = 30000)]
     public async Task CitationValidation_CorrectPageNumbers_PassesValidation()
     {
         // Arrange

--- a/tests/data/README.md
+++ b/tests/data/README.md
@@ -7,6 +7,23 @@ Output directory for the **golden evaluation dataset**.
 - `tools/run-golden-dataset-evaluation.ps1` → reads `tests/data/golden_dataset.json`
 - `tools/golden-dataset-generator/` → produces it
 
+## Come generarlo
+
+Dalla **root del repository**:
+
+```bash
+dotnet run --project tools/golden-dataset-generator/GenerateGoldenDatasetSimple.csproj
+```
+
+Produce 1000 Q&A pairs su 10 giochi. Senza questo file i test del golden dataset
+(`GoldenDatasetLoaderTests`, `GoldenDatasetAccuracyIntegrationTests`) si **saltano** riportando
+questo stesso comando — non falliscono e non vanno disattivati a mano.
+
+> Storia (#3655): fino al 2026-08-11 il generatore abortiva con «Run from repository root!» anche
+> quando *eri* nella root, perché cercava `tests/rulebook`, spostata in `data/rulebook` sette mesi
+> prima. La via documentata qui non era percorribile, e i 30 test che dipendono dal dataset erano
+> stati disattivati a mano invece che risolti.
+
 ## Generators (moved out of `tests/`)
 
 The dataset generators are tooling, not tests, and now live under

--- a/tools/golden-dataset-generator/GenerateGoldenDatasetSimple.cs
+++ b/tools/golden-dataset-generator/GenerateGoldenDatasetSimple.cs
@@ -22,15 +22,26 @@ var games = new[]
 
 Console.WriteLine("=== MeepleAI Golden Dataset Generator (Template-Based) ===\n");
 
-// Find repo root
+// Find repo root.
+//
+// #3655: il marcatore era `tests/rulebook`, spostata in `data/rulebook` dal commit 1806fcd0a
+// (2026-01-17) insieme alla cancellazione del dataset. Da allora il generatore abortiva
+// ANCHE se lanciato dalla root, accusando l'utente di stare nella cartella sbagliata — e la
+// via documentata dal README («il dataset è generato, non committato») non era percorribile.
+//
+// Ora il marcatore è la directory di output. È l'unica precondizione di cui il generatore ha
+// davvero bisogno, ed è tenuta tracciata apposta: `tests/data/README.md` esiste testualmente
+// «to keep the folder tracked so the generated output path stays stable». I 132 PDF in
+// `data/rulebook` non li legge nessuno: questo generatore è template-based.
 var repoRoot = Directory.GetCurrentDirectory();
-if (!Directory.Exists(Path.Combine(repoRoot, "tests", "rulebook")))
+var outputDir = Path.Combine(repoRoot, "tests", "data");
+if (!Directory.Exists(outputDir))
 {
-    Console.Error.WriteLine("❌ Run from repository root!");
+    Console.Error.WriteLine($"❌ '{outputDir}' non trovata — esegui dalla root del repository.");
     return 1;
 }
 
-var outputPath = Path.Combine(repoRoot, "tests", "data", "golden_dataset.json");
+var outputPath = Path.Combine(outputDir, "golden_dataset.json");
 
 // Generate dataset
 var dataset = new


### PR DESCRIPTION
Chiude #3655.

## La causa non era la cancellazione del dataset

Il commit `1806fcd0a` (2026-01-17, *«test(shared-catalog): Add comprehensive tests for Background Rulebook Analysis»*) ha fatto **due** cose insieme:

1. cancellato `tests/data/golden_dataset.json`;
2. spostato `tests/rulebook` → `data/rulebook` (132 PDF).

Il secondo punto è quello che nessuno aveva collegato. `GenerateGoldenDatasetSimple.cs` usava `tests/rulebook` **solo come marcatore di root** — è un generatore template-based, quei PDF non li apre. Da allora abortiva **anche quando lo lanciavi dalla root**, con un messaggio che accusa l'utente:

```
$ dotnet run --project tools/golden-dataset-generator/GenerateGoldenDatasetSimple.csproj
=== MeepleAI Golden Dataset Generator (Template-Based) ===
❌ Run from repository root!
```

Quindi la via documentata dal README — *«il dataset è generato, non committato»* — **non era percorribile da sette mesi**. Il giorno dopo (`56a950f92`) i 21 test del loader sono stati svuotati: non commentati, **cancellati**, lasciando un guscio da 30 righe che rimanda a «Issue #2577» e «PR #2569», riferimenti che non portano a quel lavoro. Altri 9 restavano `Skip` su «Issue #1797» — una PR su `PlayerStatistics`.

## Cosa cambia

| | |
|---|---|
| **Marcatore di root** | la directory di **output**, unica precondizione reale del generatore, tenuta tracciata apposta (`tests/data/README.md` esiste testualmente *«to keep the folder tracked so the generated output path stays stable»*) |
| **21 test del loader** | ripristinati **alla lettera** da `aef08f51b`, non riscritti — coprono `LoadAllAsync`, `LoadByGame/Difficulty/Category/Annotator`, `SampleAsync`, la cache |
| **Dataset assente** | `SKIP` che riporta il comando di generazione, non `Skip` fisso né classe commentata |
| **`FindGoldenDatasetPath`** | non lancia più: l'assenza di un file *generato* è uno stato previsto, e nel costruttore un'eccezione darebbe 7 **errori** invece di 7 skip |
| **`FindRepositoryRoot`** | riconosce anche il `.git` **file** dei worktree — cercando solo la directory il percorso primario falliva sempre, e reggeva tutto il fallback a risalita |
| **`.gitignore`** | copre finalmente `tests/data/golden_dataset.json`: il README lo dichiarava git-ignored ma **la regola non esisteva** |

Il punto di metodo: la disattivazione manuale è ciò che ha fatto sparire 30 test per sette mesi senza che nessuno se ne accorgesse. Lo skip dinamico è l'antidoto — dice cosa manca e come rimediare, e si riattiva da solo quando la precondizione c'è.

## Verifica, entrambi i rami

| Stato | Risultato |
|---|---|
| dataset presente | **51 passati, 3 saltati, 0 falliti** |
| dataset assente | **28 saltati, 0 falliti** (21 loader + 7 accuracy) |

I 3 skip residui richiedono un'API in esecuzione o l'indicizzazione di Terraforming Mars — precondizioni vere, che il messaggio ora nomina invece di rimandare a una issue inesistente.

`dotnet format --verify-no-changes` pulito sui file toccati.

## Nota

`tools/run-golden-dataset-evaluation.ps1` e `GenerateGoldenDatasetWithPDF` (PDF-based, richiede `OPENROUTER_API_KEY`) non sono stati toccati: fuori dallo scope di questa issue, che era rendere percorribile la via documentata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
