### PR TITLE
test(auth): la resistenza ai timing attack diventa verificabile (#3657)

### DIFF
--- a/apps/api/tests/Api.Tests/Architecture/ConstantTimeComparisonArchitectureTests.cs
+++ b/apps/api/tests/Api.Tests/Architecture/ConstantTimeComparisonArchitectureTests.cs
@@ -1,0 +1,169 @@
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Architecture;
+
+/// <summary>
+/// Issue #3657 — i confronti di segreti passano da <c>CryptographicOperations.FixedTimeEquals</c>.
+///
+/// <para>
+/// <b>Perché strutturale e non cronometrico.</b> La suite originale
+/// (<c>TimingAttackSecurityTests</c>) misurava tempi di parete: 5 test su 8 erano
+/// <c>[Fact(Skip = "Timing tests are inherently flaky in CI environments")]</c>, e la motivazione
+/// era corretta — JIT, scheduling, carico e GC rendono la misura inaffidabile. Ma la garanzia che
+/// quei test volevano dare non è «i tempi sono simili»: è <b>«il confronto non termina in anticipo
+/// sul primo byte diverso»</b>, e quella dipende interamente dalla primitiva usata. È verificabile
+/// leggendo il codice, senza cronometri e senza varianza.
+/// </para>
+/// <para>
+/// Un test che misura il tempo può fallire per il rumore della macchina e passare su un confronto
+/// vulnerabile che per caso ha impiegato lo stesso tempo. Questo non può: se qualcuno sostituisce
+/// <c>FixedTimeEquals</c> con <c>SequenceEqual</c> o <c>==</c>, diventa rosso in modo deterministico.
+/// </para>
+/// <para>
+/// Segue il pattern a scansione del sorgente già usato da
+/// <c>EgressHttpClientPinArchitectureTests</c> e <c>NonCriticalHealthCheckStatusArchitectureTests</c>.
+/// </para>
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("Category", TestCategories.Security)]
+[Trait("BoundedContext", "Architecture")]
+[Trait("OWASP", "A07-Authentication")]
+public class ConstantTimeComparisonArchitectureTests
+{
+    /// <summary>
+    /// I confronti che devono essere a tempo costante, con il segreto che proteggono.
+    /// Aggiungendo un nuovo confronto di segreti, registralo qui: il test
+    /// <see cref="EverySiteUsingFixedTimeEquals_IsRegisteredInTheInventory"/> fallisce finché non lo fai,
+    /// così l'inventario non può divergere dal codice in silenzio.
+    /// </summary>
+    private static readonly (string RelativePath, string Secret)[] ConstantTimeSites =
+    [
+        ("Services/PasswordHashingService.cs", "hash PBKDF2 della password"),
+        ("BoundedContexts/Authentication/Domain/ValueObjects/PasswordHash.cs", "hash PBKDF2 della password (value object)"),
+        ("BoundedContexts/Authentication/Application/Commands/Registration/RegisterCommandHandler.cs", "codice di invito"),
+        ("BoundedContexts/UserNotifications/Infrastructure/Slack/SlackSignatureValidator.cs", "firma HMAC del webhook Slack"),
+    ];
+
+    private const string ConstantTimeCall = "CryptographicOperations.FixedTimeEquals";
+
+    [Fact]
+    public void SecretComparisons_UseFixedTimeEquals()
+    {
+        var apiSrc = LocateApiSrc();
+
+        var missing = ConstantTimeSites
+            .Where(site => !ReadSource(apiSrc, site.RelativePath).Contains(ConstantTimeCall, StringComparison.Ordinal))
+            .Select(site => $"{site.RelativePath} — protegge: {site.Secret}")
+            .ToList();
+
+        missing.Should().BeEmpty(
+            $"un confronto di segreti che non passa da {ConstantTimeCall} termina al primo byte "
+            + "diverso, e il tempo di risposta rivela quanti byte iniziali erano corretti — è il "
+            + "presupposto di un attacco a forza bruta byte per byte (OWASP A07:2021). "
+            + "Siti senza confronto a tempo costante:\n" + string.Join('\n', missing));
+    }
+
+    [Fact]
+    public void SecretComparisons_DoNotUseVariableTimeEquality()
+    {
+        var apiSrc = LocateApiSrc();
+
+        var offenders = new List<string>();
+
+        foreach (var site in ConstantTimeSites)
+        {
+            var text = ReadSource(apiSrc, site.RelativePath);
+
+            // SequenceEqual è la sostituzione plausibile: stessa firma d'uso su byte[], ma esce
+            // al primo elemento diverso. `==` su byte[] confronta i riferimenti, quindi non è un
+            // rischio di timing ma un bug funzionale che altri test coglierebbero.
+            foreach (var (line, number) in NumberedLines(text))
+            {
+                if (line.Contains(".SequenceEqual(", StringComparison.Ordinal))
+                {
+                    offenders.Add($"{site.RelativePath}:{number}  {line.Trim()}");
+                }
+            }
+        }
+
+        offenders.Should().BeEmpty(
+            "SequenceEqual esce al primo byte diverso: usato su un segreto reintroduce esattamente "
+            + "la perdita di tempo che FixedTimeEquals esiste per evitare. Occorrenze:\n"
+            + string.Join('\n', offenders));
+    }
+
+    [Fact]
+    public void EverySiteUsingFixedTimeEquals_IsRegisteredInTheInventory()
+    {
+        var apiSrc = LocateApiSrc();
+        var registered = ConstantTimeSites
+            .Select(site => site.RelativePath)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var unregistered = new List<string>();
+
+        foreach (var path in Directory.EnumerateFiles(apiSrc, "*.cs", SearchOption.AllDirectories))
+        {
+            var relative = Path.GetRelativePath(apiSrc, path).Replace('\\', '/');
+            if (relative.StartsWith("bin/", StringComparison.Ordinal)
+                || relative.StartsWith("obj/", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (File.ReadAllText(path).Contains(ConstantTimeCall, StringComparison.Ordinal)
+                && !registered.Contains(relative))
+            {
+                unregistered.Add(relative);
+            }
+        }
+
+        unregistered.Should().BeEmpty(
+            "un nuovo confronto a tempo costante è comparso senza essere registrato in "
+            + $"{nameof(ConstantTimeSites)}. Aggiungilo con il segreto che protegge: l'inventario è "
+            + "ciò che rende gli altri due test capaci di accorgersi di una rimozione. "
+            + "Non registrati:\n" + string.Join('\n', unregistered));
+    }
+
+    // -----------------------------------------------------------------------
+    // Source scanning
+    // -----------------------------------------------------------------------
+
+    private static string ReadSource(string apiSrc, string relativePath)
+    {
+        var path = Path.Combine(apiSrc, relativePath.Replace('/', Path.DirectorySeparatorChar));
+        File.Exists(path).Should().BeTrue(
+            $"il sito registrato in {nameof(ConstantTimeSites)} deve esistere: {relativePath}. "
+            + "Se il file è stato spostato, aggiorna l'inventario invece di rimuoverlo.");
+
+        return File.ReadAllText(path);
+    }
+
+    private static IEnumerable<(string Line, int Number)> NumberedLines(string text)
+        => text.Split('\n').Select((line, index) => (line, index + 1));
+
+    private static string LocateApiSrc()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+
+        // In un git worktree `.git` è un file, non una directory: accettare entrambi fa fermare
+        // la risalita alla root giusta invece di proseguire verso il checkout principale.
+        while (dir is not null)
+        {
+            var git = Path.Combine(dir.FullName, ".git");
+            if (Directory.Exists(git) || File.Exists(git))
+            {
+                break;
+            }
+
+            dir = dir.Parent;
+        }
+
+        dir.Should().NotBeNull("the test binary must live inside the meepleai-monorepo repo");
+        var apiSrc = Path.Combine(dir!.FullName, "apps", "api", "src", "Api");
+        Directory.Exists(apiSrc).Should().BeTrue($"Api source must exist at {apiSrc}");
+        return apiSrc;
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Security/TimingAttackSecurityTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Security/TimingAttackSecurityTests.cs
@@ -12,10 +12,31 @@ namespace Api.Tests.BoundedContexts.Authentication.Security;
 /// OWASP Reference: A07:2021 - Identification and Authentication Failures
 /// </summary>
 /// <remarks>
+/// <para>
 /// Timing attacks exploit response time differences to extract secrets:
 /// - If "wrong first character" returns faster than "wrong last character",
 ///   attacker can brute-force character-by-character.
 /// - PBKDF2 with FixedTimeEquals prevents this by ensuring constant-time comparison.
+/// </para>
+/// <para>
+/// <b>#3657 — dove vive la garanzia.</b> Questa classe dichiarava 8 test, di cui <b>5 skippati</b>
+/// («timing tests are inherently flaky in CI»). La motivazione era corretta e i 3 rimasti usavano
+/// la stessa tecnica: quali girassero dipendeva dall'ordine in cui qualcuno aveva spento i rossi,
+/// non da un criterio. Un file chiamato <c>TimingAttackSecurityTests</c> con 8 metodi annotati
+/// <c>SECURITY TEST</c> comunicava una garanzia che per il 62% nessuno esercitava.
+/// </para>
+/// <para>
+/// I 5 cronometrici sono stati rimossi. Ciò che volevano garantire — <i>«il confronto non termina
+/// in anticipo sul primo byte diverso»</i> — non dipende dai tempi misurati ma dalla primitiva
+/// usata, ed è ora verificato in modo deterministico da
+/// <c>Architecture/ConstantTimeComparisonArchitectureTests</c>: se qualcuno sostituisce
+/// <c>FixedTimeEquals</c> con <c>SequenceEqual</c>, quel test diventa rosso senza varianza.
+/// </para>
+/// <para>
+/// I 3 che restano <b>girano davvero</b> e misurano proprietà più grossolane e stabili (nessuna
+/// uscita anticipata su hash malformati, costo di PBKDF2 indipendente dall'input). Restano perché
+/// passano, non perché siano l'unica prova: la prova è quella strutturale.
+/// </para>
 /// </remarks>
 [Trait("Category", TestCategories.Security)]
 [Trait("Category", TestCategories.Unit)]
@@ -35,215 +56,7 @@ public class TimingAttackSecurityTests
         _passwordHashingService = new PasswordHashingService();
     }
 
-    #region Password Timing Attack Tests
-
-    /// <summary>
-    /// SECURITY TEST: Password verification should use constant-time comparison.
-    /// Timing difference between correct and incorrect passwords should be minimal.
-    /// </summary>
-    /// <remarks>
-    /// This test is skipped in CI because timing measurements are inherently unreliable
-    /// due to JIT compilation, CPU scheduling, system load, and GC pauses.
-    /// The underlying PBKDF2 + FixedTimeEquals implementation is secure by design.
-    /// </remarks>
-    [Fact(Skip = "Timing tests are inherently flaky in CI environments due to system variance")]
-    public void PasswordVerification_ValidVsInvalid_ShouldBeConstantTime()
-    {
-        // Arrange
-        var password = "Secure@UnusualPwd123!";
-        var storedHash = _passwordHashingService.HashSecret(password);
-
-        var validTimings = new List<long>();
-        var invalidTimings = new List<long>();
-
-        // Warm-up to reduce JIT impact
-        for (int i = 0; i < 10; i++)
-        {
-            _passwordHashingService.VerifySecret(password, storedHash);
-            _passwordHashingService.VerifySecret("WrongPassword", storedHash);
-        }
-
-        // Act - Measure timing for valid vs invalid passwords
-        for (int i = 0; i < SampleSize; i++)
-        {
-            // Valid password timing
-            var sw1 = Stopwatch.StartNew();
-            var validResult = _passwordHashingService.VerifySecret(password, storedHash);
-            sw1.Stop();
-            if (validResult) validTimings.Add(sw1.ElapsedTicks);
-
-            // Invalid password timing
-            var sw2 = Stopwatch.StartNew();
-            var invalidResult = _passwordHashingService.VerifySecret("CompletelyWrongPassword!", storedHash);
-            sw2.Stop();
-            if (!invalidResult) invalidTimings.Add(sw2.ElapsedTicks);
-        }
-
-        // Assert - Statistical analysis
-        var validAvg = validTimings.Average();
-        var invalidAvg = invalidTimings.Average();
-        var timingDifference = Math.Abs(validAvg - invalidAvg) / Math.Max(validAvg, invalidAvg);
-
-        // OWASP: Timing variance should be minimal for constant-time comparison
-        (timingDifference < MaxTimingVariancePercent).Should().BeTrue($"Timing difference {timingDifference:P2} exceeds threshold {MaxTimingVariancePercent:P2}. " +
-            $"Valid avg: {validAvg:F2} ticks, Invalid avg: {invalidAvg:F2} ticks");
-    }
-
-    /// <summary>
-    /// SECURITY TEST: Password verification should not leak info via "closeness" to correct value.
-    /// "Almost correct" passwords should take same time as completely wrong ones.
-    /// </summary>
-    /// <remarks>
-    /// This test is skipped in CI because timing measurements are inherently unreliable
-    /// due to JIT compilation, CPU scheduling, system load, and GC pauses.
-    /// The underlying PBKDF2 + FixedTimeEquals implementation is secure by design.
-    /// </remarks>
-    [Fact(Skip = "Timing tests are inherently flaky in CI environments due to system variance")]
-    public void PasswordVerification_CloseVsFar_ShouldNotLeakInformation()
-    {
-        // Arrange
-        var password = "Secure@UnusualPwd123!";
-        var storedHash = _passwordHashingService.HashSecret(password);
-
-        // "Close" passwords (differ by 1 char) vs "far" passwords (completely different)
-        var closePassword = "Secure@Password123?"; // Off by 1 char
-        var farPassword = "XXXXXXXXXXXXXXXXXXX"; // Completely different
-
-        var closeTimings = new List<long>();
-        var farTimings = new List<long>();
-
-        // Warm-up
-        for (int i = 0; i < 10; i++)
-        {
-            _passwordHashingService.VerifySecret(closePassword, storedHash);
-            _passwordHashingService.VerifySecret(farPassword, storedHash);
-        }
-
-        // Act
-        for (int i = 0; i < SampleSize; i++)
-        {
-            var sw1 = Stopwatch.StartNew();
-            _passwordHashingService.VerifySecret(closePassword, storedHash);
-            sw1.Stop();
-            closeTimings.Add(sw1.ElapsedTicks);
-
-            var sw2 = Stopwatch.StartNew();
-            _passwordHashingService.VerifySecret(farPassword, storedHash);
-            sw2.Stop();
-            farTimings.Add(sw2.ElapsedTicks);
-        }
-
-        // Assert
-        var closeAvg = closeTimings.Average();
-        var farAvg = farTimings.Average();
-        var timingDifference = Math.Abs(closeAvg - farAvg) / Math.Max(closeAvg, farAvg);
-
-        (timingDifference < MaxTimingVariancePercent).Should().BeTrue($"Timing reveals password similarity. Close: {closeAvg:F2}, Far: {farAvg:F2}, Diff: {timingDifference:P2}");
-    }
-
-    /// <summary>
-    /// SECURITY TEST: Different password lengths should not affect verification timing.
-    /// Short incorrect passwords should take same time as long incorrect ones.
-    /// </summary>
-    /// <remarks>
-    /// This test is skipped in CI because timing measurements are inherently unreliable
-    /// due to JIT compilation, CPU scheduling, system load, and GC pauses.
-    /// The underlying PBKDF2 + FixedTimeEquals implementation is secure by design.
-    /// </remarks>
-    [Fact(Skip = "Timing tests are inherently flaky in CI environments due to system variance")]
-    public void PasswordVerification_DifferentLengths_ShouldBeConstantTime()
-    {
-        // Arrange
-        var password = "Secure@UnusualPwd123!";
-        var storedHash = _passwordHashingService.HashSecret(password);
-
-        var shortPassword = "x";
-        var longPassword = new string('x', 1000);
-
-        var shortTimings = new List<long>();
-        var longTimings = new List<long>();
-
-        // Warm-up
-        for (int i = 0; i < 10; i++)
-        {
-            _passwordHashingService.VerifySecret(shortPassword, storedHash);
-            _passwordHashingService.VerifySecret(longPassword, storedHash);
-        }
-
-        // Act
-        for (int i = 0; i < SampleSize; i++)
-        {
-            var sw1 = Stopwatch.StartNew();
-            _passwordHashingService.VerifySecret(shortPassword, storedHash);
-            sw1.Stop();
-            shortTimings.Add(sw1.ElapsedTicks);
-
-            var sw2 = Stopwatch.StartNew();
-            _passwordHashingService.VerifySecret(longPassword, storedHash);
-            sw2.Stop();
-            longTimings.Add(sw2.ElapsedTicks);
-        }
-
-        // Assert
-        var shortAvg = shortTimings.Average();
-        var longAvg = longTimings.Average();
-        var timingDifference = Math.Abs(shortAvg - longAvg) / Math.Max(shortAvg, longAvg);
-
-        (timingDifference < MaxTimingVariancePercent).Should().BeTrue($"Timing reveals password length. Short: {shortAvg:F2}, Long: {longAvg:F2}, Diff: {timingDifference:P2}");
-    }
-
-    #endregion
-
     #region API Key Timing Attack Tests
-
-    /// <summary>
-    /// SECURITY TEST: API key verification should use constant-time comparison.
-    /// Uses same PBKDF2/FixedTimeEquals mechanism as password verification.
-    /// </summary>
-    /// <remarks>
-    /// This test is skipped in CI because timing measurements are inherently unreliable
-    /// due to JIT compilation, CPU scheduling, system load, and GC pauses.
-    /// The underlying PBKDF2 + FixedTimeEquals implementation is secure by design.
-    /// </remarks>
-    [Fact(Skip = "Timing tests are inherently flaky in CI environments due to system variance")]
-    public void ApiKeyVerification_ValidVsInvalid_ShouldBeConstantTime()
-    {
-        // Arrange - API keys use same hashing service
-        var apiKey = "mpl_live_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijk";
-        var storedHash = _passwordHashingService.HashSecret(apiKey);
-
-        var validTimings = new List<long>();
-        var invalidTimings = new List<long>();
-
-        // Warm-up
-        for (int i = 0; i < 10; i++)
-        {
-            _passwordHashingService.VerifySecret(apiKey, storedHash);
-            _passwordHashingService.VerifySecret("mpl_live_WRONGKEYWRONGKEYWRONGKEY", storedHash);
-        }
-
-        // Act
-        for (int i = 0; i < SampleSize; i++)
-        {
-            var sw1 = Stopwatch.StartNew();
-            _passwordHashingService.VerifySecret(apiKey, storedHash);
-            sw1.Stop();
-            validTimings.Add(sw1.ElapsedTicks);
-
-            var sw2 = Stopwatch.StartNew();
-            _passwordHashingService.VerifySecret("mpl_live_InvalidKeyInvalidKeyInvalid", storedHash);
-            sw2.Stop();
-            invalidTimings.Add(sw2.ElapsedTicks);
-        }
-
-        // Assert
-        var validAvg = validTimings.Average();
-        var invalidAvg = invalidTimings.Average();
-        var timingDifference = Math.Abs(validAvg - invalidAvg) / Math.Max(validAvg, invalidAvg);
-
-        (timingDifference < MaxTimingVariancePercent).Should().BeTrue($"API key timing difference {timingDifference:P2} exceeds threshold. " +
-            $"Valid: {validAvg:F2}, Invalid: {invalidAvg:F2}");
-    }
 
     /// <summary>
     /// SECURITY TEST: API key prefix matching should not leak timing information.
@@ -342,61 +155,6 @@ public class TimingAttackSecurityTests
         validHashTimings.Should().NotBeEmpty();
         // Just ensure no crashes - malformed hash timing is expected to differ
         // as PBKDF2 computation is skipped
-    }
-
-    /// <summary>
-    /// SECURITY TEST: Verify FixedTimeEquals is actually being used.
-    /// Statistical analysis should show consistent timing regardless of match position.
-    /// </summary>
-    /// <remarks>
-    /// This test is skipped in CI because timing measurements are inherently unreliable
-    /// due to JIT compilation, CPU scheduling, system load, and GC pauses.
-    /// The underlying PBKDF2 + FixedTimeEquals implementation is secure by design.
-    /// </remarks>
-    [Fact(Skip = "Timing tests are inherently flaky in CI environments due to system variance")]
-    public void HashVerification_FixedTimeEquals_StatisticalConsistency()
-    {
-        // Arrange
-        var secret = "TestSecret";
-        var hash = _passwordHashingService.HashSecret(secret);
-
-        // Different wrong secrets that would fail at different byte positions
-        // if naive comparison was used
-        var wrongSecrets = new[]
-        {
-            "TestSecreT", // Differs at end
-            "TTestSecret", // Differs at start (extra char)
-            "XestSecret", // Differs at start
-            "TestXecret", // Differs in middle
-            "ZZZZZZZZZZ" // Completely different
-        };
-
-        var timingsPerSecret = new Dictionary<string, List<long>>();
-        foreach (var ws in wrongSecrets)
-        {
-            timingsPerSecret[ws] = new List<long>();
-        }
-
-        // Act
-        for (int i = 0; i < SampleSize / wrongSecrets.Length; i++)
-        {
-            foreach (var ws in wrongSecrets)
-            {
-                var sw = Stopwatch.StartNew();
-                _passwordHashingService.VerifySecret(ws, hash);
-                sw.Stop();
-                timingsPerSecret[ws].Add(sw.ElapsedTicks);
-            }
-        }
-
-        // Assert - All timings should be statistically similar
-        var averages = timingsPerSecret.ToDictionary(kv => kv.Key, kv => kv.Value.Average());
-        var minAvg = averages.Values.Min();
-        var maxAvg = averages.Values.Max();
-        var maxVariance = (maxAvg - minAvg) / maxAvg;
-
-        (maxVariance < MaxTimingVariancePercent).Should().BeTrue($"Timing variance between different-position failures: {maxVariance:P2}. " +
-            $"This could indicate non-constant-time comparison.");
     }
 
     #endregion


### PR DESCRIPTION
Chiude #3657.

## Il difetto non era il flake

`TimingAttackSecurityTests` dichiarava 8 test annotati `SECURITY TEST`, di cui **5 skippati** con «timing tests are inherently flaky in CI environments». La motivazione è tecnicamente corretta — JIT, scheduling, carico e GC rendono inaffidabile la misura del tempo di parete.

Ma i **3 rimasti attivi usavano la stessa identica tecnica**. Se il metodo è inaffidabile lo è per tutti e otto; se è utilizzabile, lo è anche per i cinque. Quali girassero dipendeva dall'ordine in cui qualcuno aveva spento i rossi, non da un criterio.

Il costo reale: un file chiamato `TimingAttackSecurityTests` con 8 metodi `SECURITY TEST` comunicava una garanzia che per il **62%** nessuno esercitava. In un audit di sicurezza è la differenza fra un controllo e la sua promessa.

## Dove va messa la garanzia

Ciò che quei test volevano garantire non è *«i tempi sono simili»*. È:

> **il confronto non termina in anticipo sul primo byte diverso**

e questo dipende **interamente dalla primitiva usata**, non dai millisecondi misurati. È quindi verificabile leggendo il codice, in modo deterministico e senza varianza.

## Cosa cambia

**Nuovo `Architecture/ConstantTimeComparisonArchitectureTests`** — inventario esplicito dei 4 confronti di segreti, ciascuno col segreto che protegge:

| Sito | Protegge |
|---|---|
| `Services/PasswordHashingService.cs` | hash PBKDF2 della password |
| `Authentication/Domain/ValueObjects/PasswordHash.cs` | hash PBKDF2 (value object) |
| `Authentication/…/Registration/RegisterCommandHandler.cs` | codice di invito |
| `UserNotifications/…/Slack/SlackSignatureValidator.cs` | firma HMAC del webhook Slack |

Tre asserzioni:
1. ogni sito passa da `CryptographicOperations.FixedTimeEquals`;
2. nessuno di essi usa `SequenceEqual` — la sostituzione plausibile, stessa ergonomia su `byte[]` ma esce al primo elemento diverso;
3. **nessun sito nuovo può comparire senza essere registrato** — è questa che impedisce all'inventario di divergere dal codice in silenzio, ed è ciò che rende le prime due capaci di accorgersi di una rimozione.

**I 5 cronometrici mai eseguiti sono rimossi.** **I 3 che restano girano davvero** e misurano proprietà più grossolane e stabili (nessuna uscita anticipata su hash malformati, costo PBKDF2 indipendente dall'input). Nessuno skip residuo: il file è coerente, che era la richiesta della issue.

Segue il pattern a scansione del sorgente già usato da `EgressHttpClientPinArchitectureTests` e `NonCriticalHealthCheckStatusArchitectureTests`, invece di introdurre un approccio nuovo.

## Verifica sul difetto reale

Non un test scritto dopo e osservato passare:

| Passo | Esito |
|---|---|
| `FixedTimeEquals` → `SequenceEqual` in `PasswordHashingService` | **2 test strutturali su 3 rossi** (il terzo, l'inventario, resta verde: il file *è* registrato) |
| Primitiva ripristinata (`git diff` vuoto) | **6/6 verdi, 0 skip** |
| 20 esecuzioni consecutive della suite | **0 fallimenti su 20** |

Vale la pena notare *perché* il test cronometrico non avrebbe colto quella sostituzione: `SequenceEqual` su due hash che differiscono già al primo byte può benissimo impiegare lo stesso tempo misurabile del confronto completo. La misura non distingue il caso pericoloso; la primitiva sì.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
