### PR TITLE
fix(api,e2e): batch-jobs verdi, un 500 diventato 409, workflow staccato da vars.RUNNER (#3662)

### DIFF
--- a/.github/workflows/backend-e2e-tests.yml
+++ b/.github/workflows/backend-e2e-tests.yml
@@ -1,5 +1,22 @@
 name: Backend E2E Tests
 
+# RUNNER — #3662: questi job girano su `ubuntu-latest` FISSO, deliberatamente, e non
+# sull'indirezione `${{ vars.RUNNER && fromJSON(vars.RUNNER) || 'ubuntu-latest' }}` usata
+# altrove nel repo.
+#
+# `vars.RUNNER` puntava al runner self-hosted CO-LOCATO sul VPS di staging
+# (`self-hosted,linux,ARM64`), dove questo build competeva per la RAM con i servizi in
+# esecuzione. Il 2026-06-22 lo step *Build Solution* è morto con
+# `System.OutOfMemoryException` dentro l'analyzer Roslyn, e quel run è rimasto l'ULTIMO
+# per sette settimane. #3331 ha poi ritirato quel runner («co-located CI runner is the
+# structural disk/RAM driver»), e da allora il build passa in ~6 min su GitHub-hosted.
+#
+# Il README documenta però una «Rollback Procedure» per re-introdurre il self-hosted
+# ricreando la variabile `RUNNER`. Se qualcuno la esegue per i workflow di DEPLOY --
+# che quel runner ce l'hanno per un motivo, ci deployano sopra -- un workflow di TEST
+# come questo lo seguirebbe silenziosamente e l'OOM tornerebbe identico.
+# Un gate di test non ha ragione di girare sul runner di deploy: qui il legame è tagliato.
+
 on:
   pull_request:
     # Scope to prod-promotion only (main-staging → main). Real-API E2E checks
@@ -8,7 +25,10 @@ on:
     branches: [main]
     paths:
       - 'apps/api/**'
-      - 'tests/Api.Tests/E2E/**'
+      # #3662: era `tests/Api.Tests/E2E/**`, che NON esiste -- i test E2E stanno sotto
+      # `apps/api/tests/`. Innocuo solo perché `apps/api/**` copre già tutto, ma un
+      # filtro che non corrisponde a nulla è indistinguibile da uno che funziona.
+      - 'apps/api/tests/Api.Tests/E2E/**'
   workflow_dispatch:
 
 # Cancel in-progress runs for same PR/branch
@@ -27,7 +47,7 @@ jobs:
   # Quick path filtering
   changes:
     name: Detect Changes
-    runs-on: ${{ vars.RUNNER && fromJSON(vars.RUNNER) || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest  # NON usare vars.RUNNER qui -- vedi commento in testa al file (#3662)
     outputs:
       e2e-needed: ${{ steps.filter.outputs.e2e }}
     steps:
@@ -39,13 +59,13 @@ jobs:
           filters: |
             e2e:
               - 'apps/api/**'
-              - 'tests/Api.Tests/E2E/**'
+              - 'apps/api/tests/Api.Tests/E2E/**'  # #3662: era `tests/…`, path inesistente
               - '.github/workflows/backend-e2e-tests.yml'
 
   # Backend E2E Tests with Testcontainers
   backend-e2e-tests:
     name: Backend E2E Tests
-    runs-on: ${{ vars.RUNNER && fromJSON(vars.RUNNER) || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest  # NON usare vars.RUNNER qui -- vedi commento in testa al file (#3662)
     needs: changes
     if: needs.changes.outputs.e2e-needed == 'true' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 20
@@ -113,7 +133,7 @@ jobs:
   # Quality Gate
   backend-e2e-quality-gate:
     name: Backend E2E Quality Gate
-    runs-on: ${{ vars.RUNNER && fromJSON(vars.RUNNER) || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest  # NON usare vars.RUNNER qui -- vedi commento in testa al file (#3662)
     needs: backend-e2e-tests
     if: always()
     steps:

--- a/apps/api/src/Api/BoundedContexts/Administration/Domain/Entities/BatchJob.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Domain/Entities/BatchJob.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.Administration.Domain.Enums;
+using Api.Middleware.Exceptions;
 
 namespace Api.BoundedContexts.Administration.Domain.Entities;
 
@@ -80,17 +81,26 @@ public sealed class BatchJob
         if (StartedAt.HasValue) DurationSeconds = (int)(CompletedAt.Value - StartedAt.Value).TotalSeconds;
     }
 
+    // #3662: erano `InvalidOperationException`, che il middleware non mappa e che quindi
+    // usciva come 500. Annullare un job già completato o riprovarne uno in coda sono
+    // operazioni legittime ma non ammesse nello stato corrente: la risposta corretta è un
+    // 409, non un errore server. È il pitfall #2568 (ConflictException 409 /
+    // NotFoundException 404, mai InvalidOperationException) e lo stesso pattern già usato
+    // da User, ProcessingJob, GameSession e GameNightEvent.
+    //
+    // Emerso solo ora perché i test E2E che lo coprivano non venivano eseguiti da
+    // nessun gate dal 2026-06-22.
     public void Cancel()
     {
         if (Status == JobStatus.Completed || Status == JobStatus.Failed)
-            throw new InvalidOperationException("Cannot cancel completed or failed jobs");
+            throw new ConflictException("Cannot cancel completed or failed jobs");
         Status = JobStatus.Cancelled;
         CompletedAt = DateTime.UtcNow;
     }
 
     public void Retry()
     {
-        if (Status != JobStatus.Failed) throw new InvalidOperationException("Only failed jobs can be retried");
+        if (Status != JobStatus.Failed) throw new ConflictException("Only failed jobs can be retried");
         Status = JobStatus.Queued;
         Progress = 0;
         StartedAt = null;

--- a/apps/api/src/Api/Routing/BatchJobEndpoints.cs
+++ b/apps/api/src/Api/Routing/BatchJobEndpoints.cs
@@ -39,7 +39,7 @@ internal static class BatchJobEndpoints
             .WithName("CreateBatchJob")
             .WithSummary("Create a new batch job")
             .Produces<CreateBatchJobResponse>(StatusCodes.Status201Created)
-            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status409Conflict)  // #3662: stato non valido -> 409, non 400
             .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status403Forbidden);
 
@@ -49,7 +49,7 @@ internal static class BatchJobEndpoints
             .WithSummary("Cancel a running or queued batch job")
             .Produces(StatusCodes.Status204NoContent)
             .Produces(StatusCodes.Status404NotFound)
-            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status409Conflict)  // #3662: stato non valido -> 409, non 400
             .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status403Forbidden);
 

--- a/apps/api/tests/Api.Tests/E2E/Administration/BatchJobE2ETests.cs
+++ b/apps/api/tests/Api.Tests/E2E/Administration/BatchJobE2ETests.cs
@@ -36,7 +36,11 @@ public sealed class BatchJobE2ETests : E2ETestBase
             await DbContext.SaveChangesAsync();
         }
 
-        Client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+        // #3662: l'API autentica a sessione con cookie (`meepleai_session`), non con Bearer.
+        // L'header Bearer non veniva semplicemente ignorato: faceva fallire l'autenticazione
+        // con 401 anche quando il cookie di sessione era presente. Si usa l'helper della base
+        // class, che è il meccanismo che gli altri test E2E già usano.
+        SetSessionCookie(token);
     }
 
     #region Create Batch Job Tests
@@ -52,7 +56,7 @@ public sealed class BatchJobE2ETests : E2ETestBase
         };
 
         // Act
-        var response = await Client.PostAsJsonAsync("/api/v1/admin/batch-jobs", payload);
+        var response = await Client.PostAsJsonAsync("/api/v1/admin/operations/batch-jobs", payload);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -82,7 +86,7 @@ public sealed class BatchJobE2ETests : E2ETestBase
         };
 
         // Act
-        var response = await Client.PostAsJsonAsync("/api/v1/admin/batch-jobs", payload);
+        var response = await Client.PostAsJsonAsync("/api/v1/admin/operations/batch-jobs", payload);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -99,14 +103,14 @@ public sealed class BatchJobE2ETests : E2ETestBase
         };
 
         // Act
-        var response = await Client.PostAsJsonAsync("/api/v1/admin/batch-jobs", payload);
+        var response = await Client.PostAsJsonAsync("/api/v1/admin/operations/batch-jobs", payload);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
     [Fact]
-    public async Task CreateBatchJob_WithEmptyParameters_ReturnsBadRequest()
+    public async Task CreateBatchJob_WithEmptyParameters_ReturnsUnprocessableEntity()
     {
         // Arrange
         var payload = new
@@ -116,10 +120,12 @@ public sealed class BatchJobE2ETests : E2ETestBase
         };
 
         // Act
-        var response = await Client.PostAsJsonAsync("/api/v1/admin/batch-jobs", payload);
+        var response = await Client.PostAsJsonAsync("/api/v1/admin/operations/batch-jobs", payload);
 
-        // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // Assert — #3662: FluentValidation mappa a 422 per design
+        // (ApiExceptionHandlerMiddleware.cs:179), non a 400. Il nome del test è stato
+        // allineato: si chiamava ...ReturnsBadRequest e asseriva un contratto mai esistito.
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
     }
 
     #endregion
@@ -134,7 +140,7 @@ public sealed class BatchJobE2ETests : E2ETestBase
         await CreateTestJobAsync(JobType.CostAnalysis);
 
         // Act
-        var response = await Client.GetAsync("/api/v1/admin/batch-jobs");
+        var response = await Client.GetAsync("/api/v1/admin/operations/batch-jobs");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -158,7 +164,7 @@ public sealed class BatchJobE2ETests : E2ETestBase
         await DbContext.SaveChangesAsync();
 
         // Act
-        var response = await Client.GetAsync("/api/v1/admin/batch-jobs?status=Queued");
+        var response = await Client.GetAsync("/api/v1/admin/operations/batch-jobs?status=Queued");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -178,8 +184,8 @@ public sealed class BatchJobE2ETests : E2ETestBase
         }
 
         // Act
-        var page1Response = await Client.GetAsync("/api/v1/admin/batch-jobs?page=1&pageSize=2");
-        var page2Response = await Client.GetAsync("/api/v1/admin/batch-jobs?page=2&pageSize=2");
+        var page1Response = await Client.GetAsync("/api/v1/admin/operations/batch-jobs?page=1&pageSize=2");
+        var page2Response = await Client.GetAsync("/api/v1/admin/operations/batch-jobs?page=2&pageSize=2");
 
         // Assert
         page1Response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -204,7 +210,7 @@ public sealed class BatchJobE2ETests : E2ETestBase
         var jobId = await CreateTestJobAsync(JobType.DataCleanup);
 
         // Act
-        var response = await Client.GetAsync($"/api/v1/admin/batch-jobs/{jobId}");
+        var response = await Client.GetAsync($"/api/v1/admin/operations/batch-jobs/{jobId}");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -222,7 +228,7 @@ public sealed class BatchJobE2ETests : E2ETestBase
         var nonExistentId = Guid.NewGuid();
 
         // Act
-        var response = await Client.GetAsync($"/api/v1/admin/batch-jobs/{nonExistentId}");
+        var response = await Client.GetAsync($"/api/v1/admin/operations/batch-jobs/{nonExistentId}");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
@@ -239,10 +245,10 @@ public sealed class BatchJobE2ETests : E2ETestBase
         var jobId = await CreateTestJobAsync(JobType.ResourceForecast);
 
         // Act
-        var response = await Client.PostAsync($"/api/v1/admin/batch-jobs/{jobId}/cancel", null);
+        var response = await Client.PutAsync($"/api/v1/admin/operations/batch-jobs/{jobId}/cancel", null);
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);  // #3662: il contratto dichiara 204 NoContent
 
         // Verify in database
         var job = await DbContext.BatchJobs.FindAsync(jobId);
@@ -261,7 +267,7 @@ public sealed class BatchJobE2ETests : E2ETestBase
         await DbContext.SaveChangesAsync();
 
         // Act
-        var response = await Client.PostAsync($"/api/v1/admin/batch-jobs/{jobId}/cancel", null);
+        var response = await Client.PutAsync($"/api/v1/admin/operations/batch-jobs/{jobId}/cancel", null);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Conflict);
@@ -274,7 +280,7 @@ public sealed class BatchJobE2ETests : E2ETestBase
         var nonExistentId = Guid.NewGuid();
 
         // Act
-        var response = await Client.PostAsync($"/api/v1/admin/batch-jobs/{nonExistentId}/cancel", null);
+        var response = await Client.PutAsync($"/api/v1/admin/operations/batch-jobs/{nonExistentId}/cancel", null);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
@@ -295,10 +301,16 @@ public sealed class BatchJobE2ETests : E2ETestBase
         await DbContext.SaveChangesAsync();
 
         // Act
-        var response = await Client.PostAsync($"/api/v1/admin/batch-jobs/{jobId}/retry", null);
+        var response = await Client.PutAsync($"/api/v1/admin/operations/batch-jobs/{jobId}/retry", null);
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);  // #3662: il contratto dichiara 204 NoContent
+        // #3662: l'API scrive su un ALTRO DbContext (gira dentro la WebApplicationFactory).
+        // Senza svuotare il change tracker, FindAsync restituisce l'istanza già tracciata da
+        // questo contesto -- lo stato pre-chiamata -- e l'assert fallisce pur essendo la riga
+        // aggiornata sul database.
+        DbContext.ChangeTracker.Clear();
+
 
         // Verify in database
         var retrieved = await DbContext.BatchJobs.FindAsync(jobId);
@@ -315,7 +327,7 @@ public sealed class BatchJobE2ETests : E2ETestBase
         var jobId = await CreateTestJobAsync(JobType.BggSync);
 
         // Act
-        var response = await Client.PostAsync($"/api/v1/admin/batch-jobs/{jobId}/retry", null);
+        var response = await Client.PutAsync($"/api/v1/admin/operations/batch-jobs/{jobId}/retry", null);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Conflict);
@@ -332,7 +344,7 @@ public sealed class BatchJobE2ETests : E2ETestBase
         var jobId = await CreateTestJobAsync(JobType.ResourceForecast);
 
         // Act
-        var response = await Client.DeleteAsync($"/api/v1/admin/batch-jobs/{jobId}");
+        var response = await Client.DeleteAsync($"/api/v1/admin/operations/batch-jobs/{jobId}");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NoContent);
@@ -349,7 +361,7 @@ public sealed class BatchJobE2ETests : E2ETestBase
         var nonExistentId = Guid.NewGuid();
 
         // Act
-        var response = await Client.DeleteAsync($"/api/v1/admin/batch-jobs/{nonExistentId}");
+        var response = await Client.DeleteAsync($"/api/v1/admin/operations/batch-jobs/{nonExistentId}");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
@@ -368,7 +380,7 @@ public sealed class BatchJobE2ETests : E2ETestBase
             type = "ResourceForecast",
             parameters = "{\"days\":30}"
         };
-        var createResponse = await Client.PostAsJsonAsync("/api/v1/admin/batch-jobs", createPayload);
+        var createResponse = await Client.PostAsJsonAsync("/api/v1/admin/operations/batch-jobs", createPayload);
         createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
         var createResult = await createResponse.Content.ReadFromJsonAsync<CreateBatchJobResponse>();
         var jobId = createResult!.JobId;
@@ -377,7 +389,7 @@ public sealed class BatchJobE2ETests : E2ETestBase
         await Task.Delay(100);
 
         // Act - Get job details
-        var getResponse = await Client.GetAsync($"/api/v1/admin/batch-jobs/{jobId}");
+        var getResponse = await Client.GetAsync($"/api/v1/admin/operations/batch-jobs/{jobId}");
 
         // Assert
         getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -394,11 +406,11 @@ public sealed class BatchJobE2ETests : E2ETestBase
         var jobId = await CreateTestJobAsync(JobType.CostAnalysis);
 
         // Act - Cancel job
-        var cancelResponse = await Client.PostAsync($"/api/v1/admin/batch-jobs/{jobId}/cancel", null);
-        cancelResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var cancelResponse = await Client.PutAsync($"/api/v1/admin/operations/batch-jobs/{jobId}/cancel", null);
+        cancelResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);  // #3662: il contratto dichiara 204 NoContent
 
         // Act - Delete job
-        var deleteResponse = await Client.DeleteAsync($"/api/v1/admin/batch-jobs/{jobId}");
+        var deleteResponse = await Client.DeleteAsync($"/api/v1/admin/operations/batch-jobs/{jobId}");
 
         // Assert
         deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
@@ -419,12 +431,18 @@ public sealed class BatchJobE2ETests : E2ETestBase
         await DbContext.SaveChangesAsync();
 
         // Act - Retry job
-        var retryResponse = await Client.PostAsync($"/api/v1/admin/batch-jobs/{jobId}/retry", null);
+        var retryResponse = await Client.PutAsync($"/api/v1/admin/operations/batch-jobs/{jobId}/retry", null);
 
         // Assert
-        retryResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        retryResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);  // #3662: il contratto dichiara 204 NoContent
 
         // Verify requeued
+        // #3662: l'API scrive su un ALTRO DbContext (gira dentro la WebApplicationFactory).
+        // Senza svuotare il change tracker, FindAsync restituisce l'istanza già tracciata da
+        // questo contesto -- lo stato pre-chiamata -- e l'assert fallisce pur essendo la riga
+        // aggiornata sul database.
+        DbContext.ChangeTracker.Clear();
+
         var retrieved = await DbContext.BatchJobs.FindAsync(jobId);
         retrieved.Should().NotBeNull();
         retrieved!.Status.Should().Be(JobStatus.Queued);
@@ -439,10 +457,10 @@ public sealed class BatchJobE2ETests : E2ETestBase
     public async Task GetAllBatchJobs_WithoutAuthentication_ReturnsUnauthorized()
     {
         // Arrange - Clear authentication
-        Client.DefaultRequestHeaders.Authorization = null;
+        ClearAuthentication();  // #3662: la sessione è nel cookie, non nell'header Authorization
 
         // Act
-        var response = await Client.GetAsync("/api/v1/admin/batch-jobs");
+        var response = await Client.GetAsync("/api/v1/admin/operations/batch-jobs");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
@@ -452,7 +470,7 @@ public sealed class BatchJobE2ETests : E2ETestBase
     public async Task CreateBatchJob_WithoutAuthentication_ReturnsUnauthorized()
     {
         // Arrange
-        Client.DefaultRequestHeaders.Authorization = null;
+        ClearAuthentication();  // #3662: la sessione è nel cookie, non nell'header Authorization
         var payload = new
         {
             type = "ResourceForecast",
@@ -460,7 +478,7 @@ public sealed class BatchJobE2ETests : E2ETestBase
         };
 
         // Act
-        var response = await Client.PostAsJsonAsync("/api/v1/admin/batch-jobs", payload);
+        var response = await Client.PostAsJsonAsync("/api/v1/admin/operations/batch-jobs", payload);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
@@ -478,7 +496,7 @@ public sealed class BatchJobE2ETests : E2ETestBase
             parameters = "{}"
         };
 
-        var response = await Client.PostAsJsonAsync("/api/v1/admin/batch-jobs", payload);
+        var response = await Client.PostAsJsonAsync("/api/v1/admin/operations/batch-jobs", payload);
         response.EnsureSuccessStatusCode();
         var result = await response.Content.ReadFromJsonAsync<CreateBatchJobResponse>();
         return result!.JobId;

--- a/apps/api/tests/Api.Tests/E2E/KnowledgeBase/ArbitroAgentE2ETests.cs
+++ b/apps/api/tests/Api.Tests/E2E/KnowledgeBase/ArbitroAgentE2ETests.cs
@@ -73,10 +73,10 @@ public sealed class ArbitroAgentE2ETests : E2ETestBase
 
         var validatePayload = new
         {
-            gameId = _testGameId,
-            sessionId = _testSessionId,
-            move = "e4", // Standard chess opening
-            gameState = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1" // Starting position (FEN)
+            gameSessionId = _testSessionId,
+            playerName = "E2E Player",
+            action = "e4", // Standard chess opening
+            position = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR" // Starting position (FEN)
         };
 
         // Act
@@ -108,10 +108,10 @@ public sealed class ArbitroAgentE2ETests : E2ETestBase
 
         var validatePayload = new
         {
-            gameId = _testGameId,
-            sessionId = _testSessionId,
-            move = "Zz9", // Invalid - no Z piece, no 9 rank
-            gameState = "{}"
+            gameSessionId = _testSessionId,
+            playerName = "E2E Player",
+            action = "Zz9", // Invalid - no Z piece, no 9 rank
+            position = "{}"
         };
 
         // Act
@@ -143,10 +143,10 @@ public sealed class ArbitroAgentE2ETests : E2ETestBase
 
         var validatePayload = new
         {
-            gameId = _testGameId,
-            sessionId = _testSessionId,
-            move = "Nf3", // Knight move
-            gameState = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+            gameSessionId = _testSessionId,
+            playerName = "E2E Player",
+            action = "Nf3", // Knight move
+            position = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR"
         };
 
         // Act
@@ -184,8 +184,8 @@ public sealed class ArbitroAgentE2ETests : E2ETestBase
         // Step 1: Query Tutor agent for setup help
         var tutorPayload = new
         {
-            gameId = _testGameId,
-            sessionId = _testSessionId,
+            gameSessionId = _testSessionId,
+            playerName = "E2E Player",
             query = "How do I set up the chess board?"
         };
 
@@ -204,10 +204,10 @@ public sealed class ArbitroAgentE2ETests : E2ETestBase
         // Step 2: Validate a move with Arbitro agent (same session context)
         var arbitroPayload = new
         {
-            gameId = _testGameId,
-            sessionId = _testSessionId,
-            move = "e4",
-            gameState = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+            gameSessionId = _testSessionId,
+            playerName = "E2E Player",
+            action = "e4",
+            position = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR"
         };
 
         var arbitroResponse = await Client.PostAsJsonAsync("/api/v1/agents/arbitro/validate", arbitroPayload);
@@ -235,15 +235,15 @@ public sealed class ArbitroAgentE2ETests : E2ETestBase
         var (sessionToken, _) = await RegisterUserAsync(email, "ValidUnusualPwd123!");
         SetSessionCookie(sessionToken);
 
-        var startingPosition = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+        var startingPosition = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR";
 
         // Turn 1: Validate opening move
         var move1Payload = new
         {
-            gameId = _testGameId,
-            sessionId = _testSessionId,
-            move = "e4",
-            gameState = startingPosition
+            gameSessionId = _testSessionId,
+            playerName = "E2E Player",
+            action = "e4",
+            position = startingPosition
         };
 
         var response1 = await Client.PostAsJsonAsync("/api/v1/agents/arbitro/validate", move1Payload);
@@ -257,10 +257,10 @@ public sealed class ArbitroAgentE2ETests : E2ETestBase
         // Turn 2: Validate response move (same session)
         var move2Payload = new
         {
-            gameId = _testGameId,
-            sessionId = _testSessionId,
-            move = "e5", // Black's response
-            gameState = "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1"
+            gameSessionId = _testSessionId,
+            playerName = "E2E Player",
+            action = "e5", // Black's response
+            position = "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR"
         };
 
         var response2 = await Client.PostAsJsonAsync("/api/v1/agents/arbitro/validate", move2Payload);
@@ -289,10 +289,10 @@ public sealed class ArbitroAgentE2ETests : E2ETestBase
 
         var validatePayload = new
         {
-            gameId = _testGameId,
-            sessionId = _testSessionId,
-            move = "Nf3",
-            gameState = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+            gameSessionId = _testSessionId,
+            playerName = "E2E Player",
+            action = "Nf3",
+            position = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR"
         };
 
         // Act
@@ -327,10 +327,10 @@ public sealed class ArbitroAgentE2ETests : E2ETestBase
 
         var validatePayload = new
         {
-            gameId = _testGameId,
-            sessionId = _testSessionId,
-            move = "e4",
-            gameState = "{}"
+            gameSessionId = _testSessionId,
+            playerName = "E2E Player",
+            action = "e4",
+            position = "{}"
         };
 
         // Act
@@ -350,10 +350,10 @@ public sealed class ArbitroAgentE2ETests : E2ETestBase
 
         var validatePayload = new
         {
-            gameId = _testGameId,
-            sessionId = _testSessionId,
-            move = "e4",
-            gameState = "INVALID_FEN_STRING"
+            gameSessionId = _testSessionId,
+            playerName = "E2E Player",
+            action = "e4",
+            position = "INVALID_FEN_STRING"
         };
 
         // Act
@@ -384,10 +384,10 @@ public sealed class ArbitroAgentE2ETests : E2ETestBase
 
         var validatePayload = new
         {
-            gameId = _testGameId,
-            sessionId = _testSessionId,
-            move = "e4",
-            gameState = "{}"
+            gameSessionId = _testSessionId,
+            playerName = "E2E Player",
+            action = "e4",
+            position = "{}"
         };
 
         // Act

--- a/apps/api/tests/Api.Tests/Unit/Administration/Domain/BatchJobTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/Administration/Domain/BatchJobTests.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.Administration.Domain.Entities;
+using Api.Middleware.Exceptions;
 using Api.BoundedContexts.Administration.Domain.Enums;
 using Api.Tests.Constants;
 using FluentAssertions;
@@ -359,7 +360,7 @@ public sealed class BatchJobTests
     }
 
     [Fact]
-    public void Cancel_WhenCompleted_ShouldThrowInvalidOperationException()
+    public void Cancel_WhenCompleted_ShouldThrowConflictException()
     {
         // Arrange
         var job = BatchJob.Create(JobType.CostAnalysis, "{}", TestUserId);
@@ -370,12 +371,12 @@ public sealed class BatchJobTests
         var act = () => job.Cancel();
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
+        act.Should().Throw<ConflictException>()
             .WithMessage("Cannot cancel completed or failed jobs");
     }
 
     [Fact]
-    public void Cancel_WhenFailed_ShouldThrowInvalidOperationException()
+    public void Cancel_WhenFailed_ShouldThrowConflictException()
     {
         // Arrange
         var job = BatchJob.Create(JobType.DataCleanup, "{}", TestUserId);
@@ -386,7 +387,7 @@ public sealed class BatchJobTests
         var act = () => job.Cancel();
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
+        act.Should().Throw<ConflictException>()
             .WithMessage("Cannot cancel completed or failed jobs");
     }
 
@@ -417,7 +418,7 @@ public sealed class BatchJobTests
     }
 
     [Fact]
-    public void Retry_WhenQueued_ShouldThrowInvalidOperationException()
+    public void Retry_WhenQueued_ShouldThrowConflictException()
     {
         // Arrange
         var job = BatchJob.Create(JobType.ResourceForecast, "{}", TestUserId);
@@ -426,12 +427,12 @@ public sealed class BatchJobTests
         var act = () => job.Retry();
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
+        act.Should().Throw<ConflictException>()
             .WithMessage("Only failed jobs can be retried");
     }
 
     [Fact]
-    public void Retry_WhenRunning_ShouldThrowInvalidOperationException()
+    public void Retry_WhenRunning_ShouldThrowConflictException()
     {
         // Arrange
         var job = BatchJob.Create(JobType.CostAnalysis, "{}", TestUserId);
@@ -441,12 +442,12 @@ public sealed class BatchJobTests
         var act = () => job.Retry();
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
+        act.Should().Throw<ConflictException>()
             .WithMessage("Only failed jobs can be retried");
     }
 
     [Fact]
-    public void Retry_WhenCompleted_ShouldThrowInvalidOperationException()
+    public void Retry_WhenCompleted_ShouldThrowConflictException()
     {
         // Arrange
         var job = BatchJob.Create(JobType.DataCleanup, "{}", TestUserId);
@@ -457,12 +458,12 @@ public sealed class BatchJobTests
         var act = () => job.Retry();
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
+        act.Should().Throw<ConflictException>()
             .WithMessage("Only failed jobs can be retried");
     }
 
     [Fact]
-    public void Retry_WhenCancelled_ShouldThrowInvalidOperationException()
+    public void Retry_WhenCancelled_ShouldThrowConflictException()
     {
         // Arrange
         var job = BatchJob.Create(JobType.BggSync, "{}", TestUserId);
@@ -472,7 +473,7 @@ public sealed class BatchJobTests
         var act = () => job.Retry();
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
+        act.Should().Throw<ConflictException>()
             .WithMessage("Only failed jobs can be retried");
     }
 


### PR DESCRIPTION
Parte di #3662. Due cose: staccare il workflow dall'indirezione `vars.RUNNER`, e cominciare ad allineare i 39 test E2E rossi emersi quando il gate è tornato a girare.

## 1. Il workflow non segue più `vars.RUNNER`

`runs-on` passa a `ubuntu-latest` fisso.

Quella variabile puntava al runner self-hosted **co-locato sul VPS di staging** (`self-hosted,linux,ARM64`), dove questo build competeva per la RAM con i servizi in esecuzione: è l'`OutOfMemoryException` del 2026-06-22, e quel run è rimasto l'ultimo per sette settimane. #3331 ha poi ritirato il runner, ma il README documenta una **procedura di rollback** che lo ri-crea. Se qualcuno la esegue per i workflow di *deploy* — che quel runner ce l'hanno per un motivo, ci deployano sopra — un workflow di *test* lo seguirebbe silenziosamente e l'OOM tornerebbe identico.

Corretto anche il path filter `tests/Api.Tests/E2E/**`, che punta a una **directory inesistente** (i test stanno in `apps/api/tests/`). Innocuo solo perché `apps/api/**` copre già tutto, ma un filtro che non corrisponde a nulla è indistinguibile da uno che funziona — lo stesso difetto di forma di #3659.

## 2. `BatchJobE2ETests`: da 0/24 a 24/24

Quattro cause distinte, tutte figlie del fatto che nulla eseguiva questi test dal 2026-06-22:

| | problema | fix |
|---|---|---|
| **route** | i test chiamano `/api/v1/admin/batch-jobs`, la route è `/api/v1/admin/**operations**/batch-jobs` | 25 occorrenze |
| **verbo** | cancel e retry sono `MapPut`, i test usavano `PostAsync` | 7 occorrenze |
| **auth** | header `Authorization: Bearer`, ma l'API autentica a sessione con cookie | `SetSessionCookie()` |
| **contratti** | `Produces(204)` letto come 200; FluentValidation mappa a 422, non 400 | assert allineati |

Sull'autenticazione c'è un corollario che vale la pena isolare: i due test *WithoutAuthentication* si de-autenticavano azzerando `Authorization` — che con il cookie non c'entra nulla — quindi restavano autenticati e ricevevano **200/201 dove si aspettavano 401**. Sembrava che gli endpoint admin fossero aperti. Non lo sono: ogni handler chiama `RequireAdminSession()`. Era il test a non riuscire a de-autenticarsi.

Infine, due test rileggevano l'entità con `FindAsync` dopo la chiamata HTTP e vedevano lo stato *pre-chiamata*: l'API scrive su un altro `DbContext`, quindi serve `ChangeTracker.Clear()` prima della verifica.

## 3. Un bug di produzione, trovato dal gate

`BatchJob.Cancel()` e `Retry()` sollevavano `InvalidOperationException`, che il middleware non mappa: **annullare un job già completato o riprovarne uno in coda restituiva 500** invece di un 4xx.

È esattamente il pitfall #2568 in CLAUDE.md — *«ConflictException (409), NotFoundException (404) — mai InvalidOperationException (500)»* — e lo stesso pattern già usato da `User`, `ProcessingJob`, `GameSession`, `GameNightEvent`. Ora sollevano `ConflictException`, e l'endpoint dichiara `Produces(409)` al posto di `Produces(400)`.

Questo è il valore del gate: non ha solo test da riparare, aveva anche un difetto vero da mostrare.

## 4. Arbitro: progresso parziale, dichiarato

I payload usavano la forma vecchia `{gameId, sessionId, move, gameState}`; il DTO è `ValidateMoveRequest(GameSessionId, PlayerName, Action, Position?, AdditionalContext?)` e `playerName` non veniva inviato affatto. Da qui i 422. (`Position` ha `MaximumLength(50)` mentre la FEN completa è di 56 caratteri: si manda il solo piece-placement.)

**I 422 diventano 404**: la validazione ora passa, ma il seed fa `_testSessionId = Guid.NewGuid()` senza creare alcuna `GameSession`, e l'API attuale quell'id lo risolve davvero. Completarli richiede di seminare l'aggregato con le sue invarianti e FK — lavoro distinto, non incluso qui. Il fix del payload resta necessario comunque: il corpo precedente non poteva funzionare in nessuno scenario.

## Cosa resta

22 test su `AdminGameCreationJourney` (11), `GameManagement` (6) e `ArbitroAgent` (5). Cause eterogenee, già caratterizzate: 404 da seed mancanti, 403 da ruoli, 422 da contratti di validazione. Restano tracciati in #3662.

**Verifica**: `BatchJobE2ETests` 24/24 in locale con Testcontainers. Il gate su questa PR non gira (scatta solo su PR verso `main`), quindi la verifica è locale per costruzione — ed è il motivo per cui #3662 chiede anche un trigger più frequente.
