### PR TITLE
test(infra): la suite bats entra in CI e il ramo exit 5 non è più cieco (#3665)

### DIFF
--- a/.github/workflows/dev-fast.yml
+++ b/.github/workflows/dev-fast.yml
@@ -340,9 +340,19 @@ jobs:
     # was hard to fix, but because nobody executed it.
     name: Infra Scripts (bats)
     runs-on: ubuntu-latest
-    # The four suites finish in seconds; the budget covers npx fetching bats on
-    # a cold npm cache, not the tests themselves.
-    timeout-minutes: 10
+    # Measured on the first run (PR #3677): checkout 9m39s, bats 6s, total
+    # 9m49s. Nearly all of it is `actions/checkout` on a large monorepo, NOT
+    # the suites — so the budget has to cover checkout variance, and a 10m
+    # budget cleared it by 11 seconds. Left at 20m (same as migration-safety)
+    # so a slower-than-usual checkout reports a slow gate instead of a red one;
+    # a gate that goes red without anything being broken is how this suite got
+    # ignored in the first place.
+    #
+    # Sparse-checking out only infra/ would cut this to seconds but was
+    # rejected: snapshot-verify.sh reads apps/api/... at lines 37 and 106 with
+    # `2>/dev/null` fallbacks, so a partial tree would silently empty those
+    # values and the checks would stop asserting without failing.
+    timeout-minutes: 20
     needs: changes
     if: needs.changes.outputs.infra == 'true' || github.event_name == 'workflow_dispatch'
     permissions:

--- a/.github/workflows/dev-fast.yml
+++ b/.github/workflows/dev-fast.yml
@@ -22,7 +22,6 @@ on:
       - '.github/actions/**'
       - 'infra/scripts/**'
       - 'infra/seed-schema.version'
-      - 'infra/fixtures/**'
   workflow_dispatch:
 
 concurrency:
@@ -85,12 +84,15 @@ jobs:
               # PR touching only infra/ had practically no CI, and
               # snapshot-verify.bats stayed red for two months unnoticed.
               # Scope is infra/scripts/** (not infra/**) so docker-compose,
-              # monitoring and secrets templates don't wake the hot path: the
-              # bats suites assert on scripts, their fixtures and the seed
-              # schema counter, and nothing else.
+              # monitoring and secrets templates don't wake the hot path.
+              # infra/fixtures/** is deliberately NOT here: rag-smoke-assert.bats
+              # writes its own copies of the canonical-queries and golden-baseline
+              # files into a temp tree (lines 20-51) rather than reading the repo
+              # ones, so a PR editing infra/fixtures/ would boot a gate that
+              # cannot observe the change. infra/seed-schema.version IS here —
+              # snapshot-verify.bats reads the live counter.
               - 'infra/scripts/**'
               - 'infra/seed-schema.version'
-              - 'infra/fixtures/**'
               - '.github/workflows/dev-fast.yml'
 
   # Sharding strategy (incident #1115): the apps/web Vitest suite runs >15min

--- a/.github/workflows/dev-fast.yml
+++ b/.github/workflows/dev-fast.yml
@@ -20,7 +20,9 @@ on:
       - 'global.json'
       - '.github/workflows/dev-fast.yml'
       - '.github/actions/**'
-      - 'infra/scripts/check-migration-safety.py'
+      - 'infra/scripts/**'
+      - 'infra/seed-schema.version'
+      - 'infra/fixtures/**'
   workflow_dispatch:
 
 concurrency:
@@ -40,6 +42,7 @@ jobs:
       backend: ${{ steps.filter.outputs.backend }}
       orchestration: ${{ steps.filter.outputs.orchestration }}
       migrations: ${{ steps.filter.outputs.migrations }}
+      infra: ${{ steps.filter.outputs.infra }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4
@@ -74,6 +77,20 @@ jobs:
               - 'apps/api/src/Api/Infrastructure/Migrations/**/*.cs'
               - 'infra/scripts/check-migration-safety.py'
               - 'infra/scripts/test_check_migration_safety.py'
+              - '.github/workflows/dev-fast.yml'
+            infra:
+              # Issue #3665: the bats suites under infra/scripts/tests/ ran in
+              # NO workflow. ci.yml covers only the Python script tests, and it
+              # triggers on PRs to main/main-staging — not main-dev. Result: a
+              # PR touching only infra/ had practically no CI, and
+              # snapshot-verify.bats stayed red for two months unnoticed.
+              # Scope is infra/scripts/** (not infra/**) so docker-compose,
+              # monitoring and secrets templates don't wake the hot path: the
+              # bats suites assert on scripts, their fixtures and the seed
+              # schema counter, and nothing else.
+              - 'infra/scripts/**'
+              - 'infra/seed-schema.version'
+              - 'infra/fixtures/**'
               - '.github/workflows/dev-fast.yml'
 
   # Sharding strategy (incident #1115): the apps/web Vitest suite runs >15min
@@ -316,3 +333,45 @@ jobs:
           name: migration-safety-report
           path: ${{ runner.temp }}/migration-safety-report.json
           retention-days: 90  # Aligned with audit/compliance retention window.
+
+  infra-scripts:
+    # Issue #3665: infra/scripts/tests/ holds four bats suites that no workflow
+    # ran. snapshot-verify.bats had been red since 2026-06-11 — not because it
+    # was hard to fix, but because nobody executed it.
+    name: Infra Scripts (bats)
+    runs-on: ubuntu-latest
+    # The four suites finish in seconds; the budget covers npx fetching bats on
+    # a cold npm cache, not the tests themselves.
+    timeout-minutes: 10
+    needs: changes
+    if: needs.changes.outputs.infra == 'true' || github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Verify the suite is non-empty
+        # Deliberate guard, not ceremony: `bats` on a directory with no .bats
+        # file prints "1..0" and exits 0. A moved or renamed tests/ directory
+        # would leave this gate green while examining nothing — the same failure
+        # mode as #3622/#3629/#3632, where a green check stopped meaning
+        # "passed" and started meaning "ran nothing". Fail when there is
+        # nothing to examine.
+        run: |
+          if [ ! -d infra/scripts/tests ]; then
+            echo "::error:: infra/scripts/tests/ does not exist — the suite was moved or deleted; point this gate at its new home"
+            exit 1
+          fi
+          count=$(find infra/scripts/tests -name '*.bats' -type f | wc -l)
+          echo "Discovered ${count} .bats suite(s) under infra/scripts/tests/"
+          if [ "$count" -eq 0 ]; then
+            echo "::error:: no .bats suite found — this gate would report success while checking nothing"
+            exit 1
+          fi
+
+      - name: Run bats suites
+        # Version pinned so a bats major bump cannot silently change semantics.
+        # jq and bash are preinstalled on ubuntu-latest; both scripts need them.
+        # --print-output-on-failure surfaces the failing script's stderr in the
+        # job log, so a red check is diagnosable without a local repro.
+        run: npx --yes bats@1.13.0 --print-output-on-failure infra/scripts/tests/

--- a/.github/workflows/dev-fast.yml
+++ b/.github/workflows/dev-fast.yml
@@ -340,13 +340,15 @@ jobs:
     # was hard to fix, but because nobody executed it.
     name: Infra Scripts (bats)
     runs-on: ubuntu-latest
-    # Measured on the first run (PR #3677): checkout 9m39s, bats 6s, total
-    # 9m49s. Nearly all of it is `actions/checkout` on a large monorepo, NOT
-    # the suites — so the budget has to cover checkout variance, and a 10m
-    # budget cleared it by 11 seconds. Left at 20m (same as migration-safety)
-    # so a slower-than-usual checkout reports a slow gate instead of a red one;
-    # a gate that goes red without anything being broken is how this suite got
-    # ignored in the first place.
+    # Two measurements on PR #3677, back to back:
+    #   run 1 — checkout 9m39s, bats  6s, total 9m49s
+    #   run 2 — checkout   29s, bats  8s, total    39s
+    # The suites are never the cost; `actions/checkout` on this monorepo is,
+    # and it swings ~20x between runs. The typical job is under a minute — the
+    # budget exists for the tail, not the median. A 10m budget cleared run 1 by
+    # 11 seconds, which means the next bad-runner day would have turned this
+    # gate red with nothing broken; a red that doesn't mean a defect is exactly
+    # how this suite stopped being read. 20m, same as migration-safety.
     #
     # Sparse-checking out only infra/ would cut this to seconds but was
     # rejected: snapshot-verify.sh reads apps/api/... at lines 37 and 106 with

--- a/infra/scripts/tests/fixtures/meta-good.json
+++ b/infra/scripts/tests/fixtures/meta-good.json
@@ -1,6 +1,7 @@
 {
   "schema_version": "20260401_AddSearchVector",
   "ef_migration_head": "20260401_AddSearchVector",
+  "seed_table_schema_version": 1,
   "embedding_model": "sentence-transformers/all-MiniLM-L6-v2",
   "embedding_dim": 384,
   "app_commit": "test0000",

--- a/infra/scripts/tests/snapshot-verify.bats
+++ b/infra/scripts/tests/snapshot-verify.bats
@@ -8,7 +8,18 @@ setup() {
     SCRIPT_DIR="$BATS_TEST_DIRNAME/.."
     FIXTURES="$BATS_TEST_DIRNAME/fixtures"
     TMPDIR=$(mktemp -d)
+    META="$TMPDIR/meepleai_seed_test.meta.json"
     export SEED_INDEX_OUT_DIR="$TMPDIR"
+
+    # snapshot-verify.sh resolves infra/seed-schema.version RELATIVE TO CWD
+    # (lines 126-131: infra/… → ../infra/… → seed-schema.version) and falls back
+    # to 0 in silence when none matches. Run from infra/scripts/ the counter is
+    # unreachable, and "exit 5 on seed-table schema-version drift" then fails in
+    # the dangerous direction: expected 0 == current 0, the branch is never
+    # taken, and the test asserting the branch is reachable stops reaching it.
+    # Pin the CWD so the suite tests the script's real resolution path instead
+    # of whichever directory the caller happened to stand in.
+    cd "$BATS_TEST_DIRNAME/../../.." || return 1
 }
 
 teardown() {
@@ -17,7 +28,7 @@ teardown() {
 
 install_fixture() {
     local name=$1
-    cp "$FIXTURES/$name.json" "$TMPDIR/meepleai_seed_test.meta.json"
+    cp "$FIXTURES/$name.json" "$META"
     echo "meepleai_seed_test" > "$TMPDIR/.latest"
 }
 
@@ -27,10 +38,11 @@ set_expected_env() {
     export EXPECTED_EMBEDDING_DIM=384
 }
 
-META_FILE() { echo "$TMPDIR/meepleai_seed_test.meta.json"; }
-
 patch_meta() {
-    jq "$1" "$(META_FILE)" > "$TMPDIR/meta.patched" && mv "$TMPDIR/meta.patched" "$(META_FILE)"
+    # Scratch file lives outside SEED_INDEX_OUT_DIR: the script only reads
+    # .latest and $BASENAME.meta.json today, but a future glob over the
+    # snapshot dir shouldn't trip over our temporaries.
+    jq "$1" "$META" > "$BATS_TEST_TMPDIR/meta.patched" && mv "$BATS_TEST_TMPDIR/meta.patched" "$META"
 }
 
 # infra/seed-schema.version is a counter bumped by any PR that renames a seeded
@@ -40,6 +52,12 @@ patch_meta() {
 sync_seed_schema_version() {
     local live
     live=$(tr -d '[:space:]' <"$BATS_TEST_DIRNAME/../../seed-schema.version")
+    # Without this the malformed value reaches jq as a filter fragment and the
+    # failure surfaces as a parse error that names neither the file nor why.
+    [[ "$live" =~ ^[0-9]+$ ]] || {
+        echo "seed-schema.version is not a counter: '$live'" >&2
+        return 1
+    }
     patch_meta ".seed_table_schema_version = $live"
 }
 
@@ -64,6 +82,10 @@ sync_seed_schema_version() {
     patch_meta 'del(.seed_table_schema_version)'
     run bash "$SCRIPT_DIR/snapshot-verify.sh"
     [ "$status" -eq 5 ]
+    # Assert the reason, not just the number: exit 5 must come from THIS gate.
+    # Without it the test could go green off an unrelated future exit 5, or red
+    # with no hint that the counter simply wasn't found.
+    [[ "$output" == *"seed-table schema-version drift"* ]]
 }
 
 @test "exit 2 on migration drift" {

--- a/infra/scripts/tests/snapshot-verify.bats
+++ b/infra/scripts/tests/snapshot-verify.bats
@@ -27,11 +27,43 @@ set_expected_env() {
     export EXPECTED_EMBEDDING_DIM=384
 }
 
+META_FILE() { echo "$TMPDIR/meepleai_seed_test.meta.json"; }
+
+patch_meta() {
+    jq "$1" "$(META_FILE)" > "$TMPDIR/meta.patched" && mv "$TMPDIR/meta.patched" "$(META_FILE)"
+}
+
+# infra/seed-schema.version is a counter bumped by any PR that renames a seeded
+# table (#2126 D9). A fixture pinning the literal would go red on the next bump
+# with nothing actually broken — the same "test rots until nobody reads it"
+# trap this suite exists to catch (#3665). Read the live counter instead.
+sync_seed_schema_version() {
+    local live
+    live=$(tr -d '[:space:]' <"$BATS_TEST_DIRNAME/../../seed-schema.version")
+    patch_meta ".seed_table_schema_version = $live"
+}
+
 @test "exit 0 when all fields match" {
     install_fixture meta-good
+    sync_seed_schema_version
     set_expected_env
     run bash "$SCRIPT_DIR/snapshot-verify.sh"
     [ "$status" -eq 0 ]
+}
+
+@test "exit 5 on seed-table schema-version drift" {
+    install_fixture meta-good
+    set_expected_env
+    # A sidecar baked before the field existed — snapshot-verify.sh treats the
+    # missing field as version 0, so it drifts from any bumped counter while
+    # every other field still matches.
+    #
+    # This branch shipped in #2134 with no test at all: until #3665 the only
+    # fixture that reached it was meta-good, which reached it by accident and
+    # was asserting exit 0. Breaking the branch deliberately ran green.
+    patch_meta 'del(.seed_table_schema_version)'
+    run bash "$SCRIPT_DIR/snapshot-verify.sh"
+    [ "$status" -eq 5 ]
 }
 
 @test "exit 2 on migration drift" {


### PR DESCRIPTION
## Cosa cambia

Le 4 suite bats sotto `infra/scripts/tests/` non venivano eseguite da **nessun** workflow. Questa PR le mette in CI, corregge la fixture che era rossa da due mesi e chiude un buco di copertura emerso durante la verifica.

## Tre fatti, in ordine di scoperta

**1. Il nome del campo nella issue è sbagliato.**
#3665 dice che manca `"seed_schema_version": 1`. Il campo effettivamente letto da `jq` in `snapshot-verify.sh:124` è **`seed_table_schema_version`**. Seguire la issue alla lettera avrebbe lasciato il test rosso. Corretta `meta-good.json` con il nome vero, nella posizione e nel tipo che usa il produttore (`seed-index-dump.sh:120`, `--argjson` → numero).

**2. Correggere la fixture ha scoperto un gate senza test.**
Con `meta-good` di nuovo valido, **nessun test raggiunge più il ramo `exit 5`**. Verificato: rompendo deliberatamente quel ramo (`exit 5` → `exit 99`) la suite resta **tutta verde, exit 0**.

Il gate seed-table schema-version — quello che decide se uno snapshot è ancora ricostruibile dalla shape corrente — è arrivato in #2134 **senza alcun test**. L'unica fixture che lo raggiungeva era `meta-good`, che ci arrivava per sbaglio e asseriva l'esito sbagliato.

Aggiunto `exit 5 on seed-table schema-version drift`. La stessa rottura deliberata ora fallisce.

**3. La fixture non pinna più il counter.**
`infra/seed-schema.version` viene bumpato da ogni PR che rinomina una tabella seedata. Una fixture con il letterale sarebbe diventata rossa al prossimo bump **senza che nulla fosse rotto** — la stessa trappola di manutenzione che questa issue esiste per chiudere. Ora il valore si legge dal file vivo.

## Il job

`Infra Scripts (bats)` in `dev-fast.yml`, con `infra/scripts/**` fra i `paths` e un filtro `infra` corrispondente (obbligatorio: senza, per il commento a riga 49-53, ogni job salterebbe).

Scope `infra/scripts/**` e non `infra/**`: le suite asseriscono su script, fixture e counter di schema, non su docker-compose o monitoring. L'hot path resta stretto (SLO < 3 min).

**Guardia sul conteggio suite.** Non è cerimonia — verificato che `bats` su una directory senza `.bats` stampa `1..0` ed **esce 0**. Una `tests/` spostata renderebbe questo gate verde senza esaminare nulla, cioè lo stesso modo di guastarsi di #3622/#3629/#3632.

## Verifiche eseguite (non assunte)

| Verifica | Esito |
|---|---|
| Baseline pre-fix | 25/26, rosso su `exit 0 when all fields match` |
| Suite post-fix | **27/27**, exit 0 |
| Rottura su ramo coperto (`exit 2`→`22`) | exit 1, `not ok 22 exit 2 on migration drift` |
| Rottura su `exit 5`→`99` **prima** del nuovo test | exit 0 — **non rilevata** |
| Rottura su `exit 5`→`99` **dopo** il nuovo test | exit 1, `not ok 22 exit 5 on seed-table schema-version drift` |
| `bats` su directory vuota | `1..0`, exit 0 → giustifica la guardia |
| Counter bumpato a 2 | suite ancora verde (fixture robusta) |
| **Primo run in CI** | `Infra Scripts (bats)` **pass** — checkout 9m39s, bats 6s, totale 9m49s |

### Il budget del job è stato corretto dopo la misura

Il primo run è passato con **11 secondi di margine** su un budget di 10 minuti, e il costo si è rivelato quasi tutto `actions/checkout`, non `npx` come dichiarava il mio commento iniziale. Con quel margine il gate sarebbe diventato rosso a caso — il meccanismo per cui questa suite aveva smesso di essere letta. Budget portato a 20m (secondo commit).

Sparse-checkout della sola `infra/` valutato e **scartato**: `snapshot-verify.sh:37,106` legge `apps/api/...` con fallback `2>/dev/null`, quindi un albero parziale svuoterebbe quei valori in silenzio e i controlli smetterebbero di asserire senza fallire.

### Sul rosso frontend di questa PR

Non è una regressione: il diff non contiene un solo file frontend. I job FE si sono svegliati perché `dev-fast.yml` compare nel filtro `frontend`. Il log dice **504 file e 6265 test passati, 0 rossi**; l'exit 1 viene da `EnvironmentTeardownError: Closing rpc while "onUserConsoleLog" was pending` in `AlertsTab.test.tsx` — il flaky di teardown già noto.

## DoD #3665

- [x] PR che tocca `infra/scripts/**` verso `main-dev` → il check esegue le suite bats e compare fra i check
- [x] Suite verde in CI — 27/27 (erano 26 + 1 test nuovo)
- [x] Rompendo uno script infra il check diventa rosso — verificato con rottura deliberata su **due** rami (`exit 2` e `exit 5`), non assunto. ⚠️ Verificato **in locale** col comando identico a quello del job (`npx bats@1.13.0 --print-output-on-failure infra/scripts/tests/`, exit 1). In CI è provato che il job parte ed esegue le suite; non è stato pushato un commit rotto apposta per vederlo rosso su GitHub
- [x] Gate schema-version: il caso «tutto combacia» torna exit 0

## Esito della code review (4° commit)

**Il test aggiunto contro i gate ciechi era a sua volta cieco in una condizione plausibile.** `snapshot-verify.sh:126-131` risolve `infra/seed-schema.version` **relativamente alla CWD**, con fallback silenzioso a 0; l'helper del test lo leggeva per path assoluto. Lanciando da `infra/scripts/` la suite dava **5/7** — e il test `exit 5` falliva nella direzione pericolosa: cancella il campo per ottenere `expected=0`, ma se anche `current` è 0 perché il counter non si trova, il ramo **non viene preso**, l'esecuzione prosegue fino all'invariante chunk/embedding ed esce 0. Il test che prova la raggiungibilità del ramo smetteva di raggiungerlo.

Corretto con CWD fissata in `setup()` e con l'asserzione sul **messaggio** oltre allo status, così `exit 5` deve provenire da quel gate. Verificato **7/7 da root, `infra/` e `infra/scripts/`** (prima 7/7, 7/7, **5/7**).

**`infra/fixtures/**` rimosso** da `on.paths` e dal filtro: nessuna suite legge quelle fixture — `rag-smoke-assert.bats:20-51` scrive le proprie copie in un albero temporaneo. Il commento che affermava il contrario era falso e avrebbe fatto partire un gate incapace di osservare il cambiamento.

Aggiunte anche: validazione numerica del counter, `META` come variabile (il basename era duplicato), scratch di `patch_meta` fuori da `SEED_INDEX_OUT_DIR`.

**Follow-up aperto: #3680** — `db-snapshot-common.Tests.ps1` (14 KB, Pester) sta nella stessa directory e non gira in nessun workflow (`grep` sui workflow: zero hit). Stesso difetto di questa issue, stessa cartella. Un verde su `Infra Scripts (bats)` si legge come «la directory è coperta», e circa un terzo non lo è.

**Non applicato**: `npx bats@1.13.0` invece di una action pinnata per SHA. npm vieta il ripubblish, quindi il tarball è di fatto immutabile, ma il repo pinna le action di terze parti per SHA e ha un check apposta — è una scelta di postura che vale oltre questa PR.

## Nota per chi rivede

`Infra Scripts (bats)` **non** è un required check. Se lo si vuole bloccante, va aggiunto alla branch protection di `main-dev` separatamente — altrimenti resta informativo, che è meglio di prima ma non è ancora un gate.

Closes #3665

🤖 Generated with [Claude Code](https://claude.com/claude-code)
