### PR TITLE
release: promozione main-dev → main-staging (2026-08-11, notte)

### DIFF
--- a/.github/workflows/backend-e2e-tests.yml
+++ b/.github/workflows/backend-e2e-tests.yml
@@ -1,5 +1,22 @@
 name: Backend E2E Tests
 
+# RUNNER — #3662: questi job girano su `ubuntu-latest` FISSO, deliberatamente, e non
+# sull'indirezione `${{ vars.RUNNER && fromJSON(vars.RUNNER) || 'ubuntu-latest' }}` usata
+# altrove nel repo.
+#
+# `vars.RUNNER` puntava al runner self-hosted CO-LOCATO sul VPS di staging
+# (`self-hosted,linux,ARM64`), dove questo build competeva per la RAM con i servizi in
+# esecuzione. Il 2026-06-22 lo step *Build Solution* è morto con
+# `System.OutOfMemoryException` dentro l'analyzer Roslyn, e quel run è rimasto l'ULTIMO
+# per sette settimane. #3331 ha poi ritirato quel runner («co-located CI runner is the
+# structural disk/RAM driver»), e da allora il build passa in ~6 min su GitHub-hosted.
+#
+# Il README documenta però una «Rollback Procedure» per re-introdurre il self-hosted
+# ricreando la variabile `RUNNER`. Se qualcuno la esegue per i workflow di DEPLOY --
+# che quel runner ce l'hanno per un motivo, ci deployano sopra -- un workflow di TEST
+# come questo lo seguirebbe silenziosamente e l'OOM tornerebbe identico.
+# Un gate di test non ha ragione di girare sul runner di deploy: qui il legame è tagliato.
+
 on:
   pull_request:
     # Scope to prod-promotion only (main-staging → main). Real-API E2E checks
@@ -8,7 +25,10 @@ on:
     branches: [main]
     paths:
       - 'apps/api/**'
-      - 'tests/Api.Tests/E2E/**'
+      # #3662: era `tests/Api.Tests/E2E/**`, che NON esiste -- i test E2E stanno sotto
+      # `apps/api/tests/`. Innocuo solo perché `apps/api/**` copre già tutto, ma un
+      # filtro che non corrisponde a nulla è indistinguibile da uno che funziona.
+      - 'apps/api/tests/Api.Tests/E2E/**'
   workflow_dispatch:
 
 # Cancel in-progress runs for same PR/branch
@@ -27,7 +47,7 @@ jobs:
   # Quick path filtering
   changes:
     name: Detect Changes
-    runs-on: ${{ vars.RUNNER && fromJSON(vars.RUNNER) || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest  # NON usare vars.RUNNER qui -- vedi commento in testa al file (#3662)
     outputs:
       e2e-needed: ${{ steps.filter.outputs.e2e }}
     steps:
@@ -39,13 +59,13 @@ jobs:
           filters: |
             e2e:
               - 'apps/api/**'
-              - 'tests/Api.Tests/E2E/**'
+              - 'apps/api/tests/Api.Tests/E2E/**'  # #3662: era `tests/…`, path inesistente
               - '.github/workflows/backend-e2e-tests.yml'
 
   # Backend E2E Tests with Testcontainers
   backend-e2e-tests:
     name: Backend E2E Tests
-    runs-on: ${{ vars.RUNNER && fromJSON(vars.RUNNER) || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest  # NON usare vars.RUNNER qui -- vedi commento in testa al file (#3662)
     needs: changes
     if: needs.changes.outputs.e2e-needed == 'true' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 20
@@ -113,7 +133,7 @@ jobs:
   # Quality Gate
   backend-e2e-quality-gate:
     name: Backend E2E Quality Gate
-    runs-on: ${{ vars.RUNNER && fromJSON(vars.RUNNER) || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest  # NON usare vars.RUNNER qui -- vedi commento in testa al file (#3662)
     needs: backend-e2e-tests
     if: always()
     steps:

--- a/apps/api/src/Api/BoundedContexts/Administration/Domain/Entities/BatchJob.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Domain/Entities/BatchJob.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.Administration.Domain.Enums;
+using Api.Middleware.Exceptions;
 
 namespace Api.BoundedContexts.Administration.Domain.Entities;
 
@@ -80,17 +81,26 @@ public sealed class BatchJob
         if (StartedAt.HasValue) DurationSeconds = (int)(CompletedAt.Value - StartedAt.Value).TotalSeconds;
     }
 
+    // #3662: erano `InvalidOperationException`, che il middleware non mappa e che quindi
+    // usciva come 500. Annullare un job già completato o riprovarne uno in coda sono
+    // operazioni legittime ma non ammesse nello stato corrente: la risposta corretta è un
+    // 409, non un errore server. È il pitfall #2568 (ConflictException 409 /
+    // NotFoundException 404, mai InvalidOperationException) e lo stesso pattern già usato
+    // da User, ProcessingJob, GameSession e GameNightEvent.
+    //
+    // Emerso solo ora perché i test E2E che lo coprivano non venivano eseguiti da
+    // nessun gate dal 2026-06-22.
     public void Cancel()
     {
         if (Status == JobStatus.Completed || Status == JobStatus.Failed)
-            throw new InvalidOperationException("Cannot cancel completed or failed jobs");
+            throw new ConflictException("Cannot cancel completed or failed jobs");
         Status = JobStatus.Cancelled;
         CompletedAt = DateTime.UtcNow;
     }
 
     public void Retry()
     {
-        if (Status != JobStatus.Failed) throw new InvalidOperationException("Only failed jobs can be retried");
+        if (Status != JobStatus.Failed) throw new ConflictException("Only failed jobs can be retried");
         Status = JobStatus.Queued;
         Progress = 0;
         StartedAt = null;

--- a/apps/api/src/Api/Routing/BatchJobEndpoints.cs
+++ b/apps/api/src/Api/Routing/BatchJobEndpoints.cs
@@ -39,7 +39,7 @@ internal static class BatchJobEndpoints
             .WithName("CreateBatchJob")
             .WithSummary("Create a new batch job")
             .Produces<CreateBatchJobResponse>(StatusCodes.Status201Created)
-            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status409Conflict)  // #3662: stato non valido -> 409, non 400
             .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status403Forbidden);
 
@@ -49,7 +49,7 @@ internal static class BatchJobEndpoints
             .WithSummary("Cancel a running or queued batch job")
             .Produces(StatusCodes.Status204NoContent)
             .Produces(StatusCodes.Status404NotFound)
-            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status409Conflict)  // #3662: stato non valido -> 409, non 400
             .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status403Forbidden);
 

--- a/apps/api/tests/Api.Tests/Architecture/ConstantTimeComparisonArchitectureTests.cs
+++ b/apps/api/tests/Api.Tests/Architecture/ConstantTimeComparisonArchitectureTests.cs
@@ -1,0 +1,169 @@
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Architecture;
+
+/// <summary>
+/// Issue #3657 — i confronti di segreti passano da <c>CryptographicOperations.FixedTimeEquals</c>.
+///
+/// <para>
+/// <b>Perché strutturale e non cronometrico.</b> La suite originale
+/// (<c>TimingAttackSecurityTests</c>) misurava tempi di parete: 5 test su 8 erano
+/// <c>[Fact(Skip = "Timing tests are inherently flaky in CI environments")]</c>, e la motivazione
+/// era corretta — JIT, scheduling, carico e GC rendono la misura inaffidabile. Ma la garanzia che
+/// quei test volevano dare non è «i tempi sono simili»: è <b>«il confronto non termina in anticipo
+/// sul primo byte diverso»</b>, e quella dipende interamente dalla primitiva usata. È verificabile
+/// leggendo il codice, senza cronometri e senza varianza.
+/// </para>
+/// <para>
+/// Un test che misura il tempo può fallire per il rumore della macchina e passare su un confronto
+/// vulnerabile che per caso ha impiegato lo stesso tempo. Questo non può: se qualcuno sostituisce
+/// <c>FixedTimeEquals</c> con <c>SequenceEqual</c> o <c>==</c>, diventa rosso in modo deterministico.
+/// </para>
+/// <para>
+/// Segue il pattern a scansione del sorgente già usato da
+/// <c>EgressHttpClientPinArchitectureTests</c> e <c>NonCriticalHealthCheckStatusArchitectureTests</c>.
+/// </para>
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("Category", TestCategories.Security)]
+[Trait("BoundedContext", "Architecture")]
+[Trait("OWASP", "A07-Authentication")]
+public class ConstantTimeComparisonArchitectureTests
+{
+    /// <summary>
+    /// I confronti che devono essere a tempo costante, con il segreto che proteggono.
+    /// Aggiungendo un nuovo confronto di segreti, registralo qui: il test
+    /// <see cref="EverySiteUsingFixedTimeEquals_IsRegisteredInTheInventory"/> fallisce finché non lo fai,
+    /// così l'inventario non può divergere dal codice in silenzio.
+    /// </summary>
+    private static readonly (string RelativePath, string Secret)[] ConstantTimeSites =
+    [
+        ("Services/PasswordHashingService.cs", "hash PBKDF2 della password"),
+        ("BoundedContexts/Authentication/Domain/ValueObjects/PasswordHash.cs", "hash PBKDF2 della password (value object)"),
+        ("BoundedContexts/Authentication/Application/Commands/Registration/RegisterCommandHandler.cs", "codice di invito"),
+        ("BoundedContexts/UserNotifications/Infrastructure/Slack/SlackSignatureValidator.cs", "firma HMAC del webhook Slack"),
+    ];
+
+    private const string ConstantTimeCall = "CryptographicOperations.FixedTimeEquals";
+
+    [Fact]
+    public void SecretComparisons_UseFixedTimeEquals()
+    {
+        var apiSrc = LocateApiSrc();
+
+        var missing = ConstantTimeSites
+            .Where(site => !ReadSource(apiSrc, site.RelativePath).Contains(ConstantTimeCall, StringComparison.Ordinal))
+            .Select(site => $"{site.RelativePath} — protegge: {site.Secret}")
+            .ToList();
+
+        missing.Should().BeEmpty(
+            $"un confronto di segreti che non passa da {ConstantTimeCall} termina al primo byte "
+            + "diverso, e il tempo di risposta rivela quanti byte iniziali erano corretti — è il "
+            + "presupposto di un attacco a forza bruta byte per byte (OWASP A07:2021). "
+            + "Siti senza confronto a tempo costante:\n" + string.Join('\n', missing));
+    }
+
+    [Fact]
+    public void SecretComparisons_DoNotUseVariableTimeEquality()
+    {
+        var apiSrc = LocateApiSrc();
+
+        var offenders = new List<string>();
+
+        foreach (var site in ConstantTimeSites)
+        {
+            var text = ReadSource(apiSrc, site.RelativePath);
+
+            // SequenceEqual è la sostituzione plausibile: stessa firma d'uso su byte[], ma esce
+            // al primo elemento diverso. `==` su byte[] confronta i riferimenti, quindi non è un
+            // rischio di timing ma un bug funzionale che altri test coglierebbero.
+            foreach (var (line, number) in NumberedLines(text))
+            {
+                if (line.Contains(".SequenceEqual(", StringComparison.Ordinal))
+                {
+                    offenders.Add($"{site.RelativePath}:{number}  {line.Trim()}");
+                }
+            }
+        }
+
+        offenders.Should().BeEmpty(
+            "SequenceEqual esce al primo byte diverso: usato su un segreto reintroduce esattamente "
+            + "la perdita di tempo che FixedTimeEquals esiste per evitare. Occorrenze:\n"
+            + string.Join('\n', offenders));
+    }
+
+    [Fact]
+    public void EverySiteUsingFixedTimeEquals_IsRegisteredInTheInventory()
+    {
+        var apiSrc = LocateApiSrc();
+        var registered = ConstantTimeSites
+            .Select(site => site.RelativePath)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var unregistered = new List<string>();
+
+        foreach (var path in Directory.EnumerateFiles(apiSrc, "*.cs", SearchOption.AllDirectories))
+        {
+            var relative = Path.GetRelativePath(apiSrc, path).Replace('\\', '/');
+            if (relative.StartsWith("bin/", StringComparison.Ordinal)
+                || relative.StartsWith("obj/", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (File.ReadAllText(path).Contains(ConstantTimeCall, StringComparison.Ordinal)
+                && !registered.Contains(relative))
+            {
+                unregistered.Add(relative);
+            }
+        }
+
+        unregistered.Should().BeEmpty(
+            "un nuovo confronto a tempo costante è comparso senza essere registrato in "
+            + $"{nameof(ConstantTimeSites)}. Aggiungilo con il segreto che protegge: l'inventario è "
+            + "ciò che rende gli altri due test capaci di accorgersi di una rimozione. "
+            + "Non registrati:\n" + string.Join('\n', unregistered));
+    }
+
+    // -----------------------------------------------------------------------
+    // Source scanning
+    // -----------------------------------------------------------------------
+
+    private static string ReadSource(string apiSrc, string relativePath)
+    {
+        var path = Path.Combine(apiSrc, relativePath.Replace('/', Path.DirectorySeparatorChar));
+        File.Exists(path).Should().BeTrue(
+            $"il sito registrato in {nameof(ConstantTimeSites)} deve esistere: {relativePath}. "
+            + "Se il file è stato spostato, aggiorna l'inventario invece di rimuoverlo.");
+
+        return File.ReadAllText(path);
+    }
+
+    private static IEnumerable<(string Line, int Number)> NumberedLines(string text)
+        => text.Split('\n').Select((line, index) => (line, index + 1));
+
+    private static string LocateApiSrc()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+
+        // In un git worktree `.git` è un file, non una directory: accettare entrambi fa fermare
+        // la risalita alla root giusta invece di proseguire verso il checkout principale.
+        while (dir is not null)
+        {
+            var git = Path.Combine(dir.FullName, ".git");
+            if (Directory.Exists(git) || File.Exists(git))
+            {
+                break;
+            }
+
+            dir = dir.Parent;
+        }
+
+        dir.Should().NotBeNull("the test binary must live inside the meepleai-monorepo repo");
+        var apiSrc = Path.Combine(dir!.FullName, "apps", "api", "src", "Api");
+        Directory.Exists(apiSrc).Should().BeTrue($"Api source must exist at {apiSrc}");
+        return apiSrc;
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Security/TimingAttackSecurityTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Security/TimingAttackSecurityTests.cs
@@ -12,10 +12,31 @@ namespace Api.Tests.BoundedContexts.Authentication.Security;
 /// OWASP Reference: A07:2021 - Identification and Authentication Failures
 /// </summary>
 /// <remarks>
+/// <para>
 /// Timing attacks exploit response time differences to extract secrets:
 /// - If "wrong first character" returns faster than "wrong last character",
 ///   attacker can brute-force character-by-character.
 /// - PBKDF2 with FixedTimeEquals prevents this by ensuring constant-time comparison.
+/// </para>
+/// <para>
+/// <b>#3657 — dove vive la garanzia.</b> Questa classe dichiarava 8 test, di cui <b>5 skippati</b>
+/// («timing tests are inherently flaky in CI»). La motivazione era corretta e i 3 rimasti usavano
+/// la stessa tecnica: quali girassero dipendeva dall'ordine in cui qualcuno aveva spento i rossi,
+/// non da un criterio. Un file chiamato <c>TimingAttackSecurityTests</c> con 8 metodi annotati
+/// <c>SECURITY TEST</c> comunicava una garanzia che per il 62% nessuno esercitava.
+/// </para>
+/// <para>
+/// I 5 cronometrici sono stati rimossi. Ciò che volevano garantire — <i>«il confronto non termina
+/// in anticipo sul primo byte diverso»</i> — non dipende dai tempi misurati ma dalla primitiva
+/// usata, ed è ora verificato in modo deterministico da
+/// <c>Architecture/ConstantTimeComparisonArchitectureTests</c>: se qualcuno sostituisce
+/// <c>FixedTimeEquals</c> con <c>SequenceEqual</c>, quel test diventa rosso senza varianza.
+/// </para>
+/// <para>
+/// I 3 che restano <b>girano davvero</b> e misurano proprietà più grossolane e stabili (nessuna
+/// uscita anticipata su hash malformati, costo di PBKDF2 indipendente dall'input). Restano perché
+/// passano, non perché siano l'unica prova: la prova è quella strutturale.
+/// </para>
 /// </remarks>
 [Trait("Category", TestCategories.Security)]
 [Trait("Category", TestCategories.Unit)]
@@ -35,215 +56,7 @@ public class TimingAttackSecurityTests
         _passwordHashingService = new PasswordHashingService();
     }
 
-    #region Password Timing Attack Tests
-
-    /// <summary>
-    /// SECURITY TEST: Password verification should use constant-time comparison.
-    /// Timing difference between correct and incorrect passwords should be minimal.
-    /// </summary>
-    /// <remarks>
-    /// This test is skipped in CI because timing measurements are inherently unreliable
-    /// due to JIT compilation, CPU scheduling, system load, and GC pauses.
-    /// The underlying PBKDF2 + FixedTimeEquals implementation is secure by design.
-    /// </remarks>
-    [Fact(Skip = "Timing tests are inherently flaky in CI environments due to system variance")]
-    public void PasswordVerification_ValidVsInvalid_ShouldBeConstantTime()
-    {
-        // Arrange
-        var password = "Secure@UnusualPwd123!";
-        var storedHash = _passwordHashingService.HashSecret(password);
-
-        var validTimings = new List<long>();
-        var invalidTimings = new List<long>();
-
-        // Warm-up to reduce JIT impact
-        for (int i = 0; i < 10; i++)
-        {
-            _passwordHashingService.VerifySecret(password, storedHash);
-            _passwordHashingService.VerifySecret("WrongPassword", storedHash);
-        }
-
-        // Act - Measure timing for valid vs invalid passwords
-        for (int i = 0; i < SampleSize; i++)
-        {
-            // Valid password timing
-            var sw1 = Stopwatch.StartNew();
-            var validResult = _passwordHashingService.VerifySecret(password, storedHash);
-            sw1.Stop();
-            if (validResult) validTimings.Add(sw1.ElapsedTicks);
-
-            // Invalid password timing
-            var sw2 = Stopwatch.StartNew();
-            var invalidResult = _passwordHashingService.VerifySecret("CompletelyWrongPassword!", storedHash);
-            sw2.Stop();
-            if (!invalidResult) invalidTimings.Add(sw2.ElapsedTicks);
-        }
-
-        // Assert - Statistical analysis
-        var validAvg = validTimings.Average();
-        var invalidAvg = invalidTimings.Average();
-        var timingDifference = Math.Abs(validAvg - invalidAvg) / Math.Max(validAvg, invalidAvg);
-
-        // OWASP: Timing variance should be minimal for constant-time comparison
-        (timingDifference < MaxTimingVariancePercent).Should().BeTrue($"Timing difference {timingDifference:P2} exceeds threshold {MaxTimingVariancePercent:P2}. " +
-            $"Valid avg: {validAvg:F2} ticks, Invalid avg: {invalidAvg:F2} ticks");
-    }
-
-    /// <summary>
-    /// SECURITY TEST: Password verification should not leak info via "closeness" to correct value.
-    /// "Almost correct" passwords should take same time as completely wrong ones.
-    /// </summary>
-    /// <remarks>
-    /// This test is skipped in CI because timing measurements are inherently unreliable
-    /// due to JIT compilation, CPU scheduling, system load, and GC pauses.
-    /// The underlying PBKDF2 + FixedTimeEquals implementation is secure by design.
-    /// </remarks>
-    [Fact(Skip = "Timing tests are inherently flaky in CI environments due to system variance")]
-    public void PasswordVerification_CloseVsFar_ShouldNotLeakInformation()
-    {
-        // Arrange
-        var password = "Secure@UnusualPwd123!";
-        var storedHash = _passwordHashingService.HashSecret(password);
-
-        // "Close" passwords (differ by 1 char) vs "far" passwords (completely different)
-        var closePassword = "Secure@Password123?"; // Off by 1 char
-        var farPassword = "XXXXXXXXXXXXXXXXXXX"; // Completely different
-
-        var closeTimings = new List<long>();
-        var farTimings = new List<long>();
-
-        // Warm-up
-        for (int i = 0; i < 10; i++)
-        {
-            _passwordHashingService.VerifySecret(closePassword, storedHash);
-            _passwordHashingService.VerifySecret(farPassword, storedHash);
-        }
-
-        // Act
-        for (int i = 0; i < SampleSize; i++)
-        {
-            var sw1 = Stopwatch.StartNew();
-            _passwordHashingService.VerifySecret(closePassword, storedHash);
-            sw1.Stop();
-            closeTimings.Add(sw1.ElapsedTicks);
-
-            var sw2 = Stopwatch.StartNew();
-            _passwordHashingService.VerifySecret(farPassword, storedHash);
-            sw2.Stop();
-            farTimings.Add(sw2.ElapsedTicks);
-        }
-
-        // Assert
-        var closeAvg = closeTimings.Average();
-        var farAvg = farTimings.Average();
-        var timingDifference = Math.Abs(closeAvg - farAvg) / Math.Max(closeAvg, farAvg);
-
-        (timingDifference < MaxTimingVariancePercent).Should().BeTrue($"Timing reveals password similarity. Close: {closeAvg:F2}, Far: {farAvg:F2}, Diff: {timingDifference:P2}");
-    }
-
-    /// <summary>
-    /// SECURITY TEST: Different password lengths should not affect verification timing.
-    /// Short incorrect passwords should take same time as long incorrect ones.
-    /// </summary>
-    /// <remarks>
-    /// This test is skipped in CI because timing measurements are inherently unreliable
-    /// due to JIT compilation, CPU scheduling, system load, and GC pauses.
-    /// The underlying PBKDF2 + FixedTimeEquals implementation is secure by design.
-    /// </remarks>
-    [Fact(Skip = "Timing tests are inherently flaky in CI environments due to system variance")]
-    public void PasswordVerification_DifferentLengths_ShouldBeConstantTime()
-    {
-        // Arrange
-        var password = "Secure@UnusualPwd123!";
-        var storedHash = _passwordHashingService.HashSecret(password);
-
-        var shortPassword = "x";
-        var longPassword = new string('x', 1000);
-
-        var shortTimings = new List<long>();
-        var longTimings = new List<long>();
-
-        // Warm-up
-        for (int i = 0; i < 10; i++)
-        {
-            _passwordHashingService.VerifySecret(shortPassword, storedHash);
-            _passwordHashingService.VerifySecret(longPassword, storedHash);
-        }
-
-        // Act
-        for (int i = 0; i < SampleSize; i++)
-        {
-            var sw1 = Stopwatch.StartNew();
-            _passwordHashingService.VerifySecret(shortPassword, storedHash);
-            sw1.Stop();
-            shortTimings.Add(sw1.ElapsedTicks);
-
-            var sw2 = Stopwatch.StartNew();
-            _passwordHashingService.VerifySecret(longPassword, storedHash);
-            sw2.Stop();
-            longTimings.Add(sw2.ElapsedTicks);
-        }
-
-        // Assert
-        var shortAvg = shortTimings.Average();
-        var longAvg = longTimings.Average();
-        var timingDifference = Math.Abs(shortAvg - longAvg) / Math.Max(shortAvg, longAvg);
-
-        (timingDifference < MaxTimingVariancePercent).Should().BeTrue($"Timing reveals password length. Short: {shortAvg:F2}, Long: {longAvg:F2}, Diff: {timingDifference:P2}");
-    }
-
-    #endregion
-
     #region API Key Timing Attack Tests
-
-    /// <summary>
-    /// SECURITY TEST: API key verification should use constant-time comparison.
-    /// Uses same PBKDF2/FixedTimeEquals mechanism as password verification.
-    /// </summary>
-    /// <remarks>
-    /// This test is skipped in CI because timing measurements are inherently unreliable
-    /// due to JIT compilation, CPU scheduling, system load, and GC pauses.
-    /// The underlying PBKDF2 + FixedTimeEquals implementation is secure by design.
-    /// </remarks>
-    [Fact(Skip = "Timing tests are inherently flaky in CI environments due to system variance")]
-    public void ApiKeyVerification_ValidVsInvalid_ShouldBeConstantTime()
-    {
-        // Arrange - API keys use same hashing service
-        var apiKey = "mpl_live_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijk";
-        var storedHash = _passwordHashingService.HashSecret(apiKey);
-
-        var validTimings = new List<long>();
-        var invalidTimings = new List<long>();
-
-        // Warm-up
-        for (int i = 0; i < 10; i++)
-        {
-            _passwordHashingService.VerifySecret(apiKey, storedHash);
-            _passwordHashingService.VerifySecret("mpl_live_WRONGKEYWRONGKEYWRONGKEY", storedHash);
-        }
-
-        // Act
-        for (int i = 0; i < SampleSize; i++)
-        {
-            var sw1 = Stopwatch.StartNew();
-            _passwordHashingService.VerifySecret(apiKey, storedHash);
-            sw1.Stop();
-            validTimings.Add(sw1.ElapsedTicks);
-
-            var sw2 = Stopwatch.StartNew();
-            _passwordHashingService.VerifySecret("mpl_live_InvalidKeyInvalidKeyInvalid", storedHash);
-            sw2.Stop();
-            invalidTimings.Add(sw2.ElapsedTicks);
-        }
-
-        // Assert
-        var validAvg = validTimings.Average();
-        var invalidAvg = invalidTimings.Average();
-        var timingDifference = Math.Abs(validAvg - invalidAvg) / Math.Max(validAvg, invalidAvg);
-
-        (timingDifference < MaxTimingVariancePercent).Should().BeTrue($"API key timing difference {timingDifference:P2} exceeds threshold. " +
-            $"Valid: {validAvg:F2}, Invalid: {invalidAvg:F2}");
-    }
 
     /// <summary>
     /// SECURITY TEST: API key prefix matching should not leak timing information.
@@ -342,61 +155,6 @@ public class TimingAttackSecurityTests
         validHashTimings.Should().NotBeEmpty();
         // Just ensure no crashes - malformed hash timing is expected to differ
         // as PBKDF2 computation is skipped
-    }
-
-    /// <summary>
-    /// SECURITY TEST: Verify FixedTimeEquals is actually being used.
-    /// Statistical analysis should show consistent timing regardless of match position.
-    /// </summary>
-    /// <remarks>
-    /// This test is skipped in CI because timing measurements are inherently unreliable
-    /// due to JIT compilation, CPU scheduling, system load, and GC pauses.
-    /// The underlying PBKDF2 + FixedTimeEquals implementation is secure by design.
-    /// </remarks>
-    [Fact(Skip = "Timing tests are inherently flaky in CI environments due to system variance")]
-    public void HashVerification_FixedTimeEquals_StatisticalConsistency()
-    {
-        // Arrange
-        var secret = "TestSecret";
-        var hash = _passwordHashingService.HashSecret(secret);
-
-        // Different wrong secrets that would fail at different byte positions
-        // if naive comparison was used
-        var wrongSecrets = new[]
-        {
-            "TestSecreT", // Differs at end
-            "TTestSecret", // Differs at start (extra char)
-            "XestSecret", // Differs at start
-            "TestXecret", // Differs in middle
-            "ZZZZZZZZZZ" // Completely different
-        };
-
-        var timingsPerSecret = new Dictionary<string, List<long>>();
-        foreach (var ws in wrongSecrets)
-        {
-            timingsPerSecret[ws] = new List<long>();
-        }
-
-        // Act
-        for (int i = 0; i < SampleSize / wrongSecrets.Length; i++)
-        {
-            foreach (var ws in wrongSecrets)
-            {
-                var sw = Stopwatch.StartNew();
-                _passwordHashingService.VerifySecret(ws, hash);
-                sw.Stop();
-                timingsPerSecret[ws].Add(sw.ElapsedTicks);
-            }
-        }
-
-        // Assert - All timings should be statistically similar
-        var averages = timingsPerSecret.ToDictionary(kv => kv.Key, kv => kv.Value.Average());
-        var minAvg = averages.Values.Min();
-        var maxAvg = averages.Values.Max();
-        var maxVariance = (maxAvg - minAvg) / maxAvg;
-
-        (maxVariance < MaxTimingVariancePercent).Should().BeTrue($"Timing variance between different-position failures: {maxVariance:P2}. " +
-            $"This could indicate non-constant-time comparison.");
     }
 
     #endregion

--- a/apps/api/tests/Api.Tests/E2E/Administration/BatchJobE2ETests.cs
+++ b/apps/api/tests/Api.Tests/E2E/Administration/BatchJobE2ETests.cs
@@ -36,7 +36,11 @@ public sealed class BatchJobE2ETests : E2ETestBase
             await DbContext.SaveChangesAsync();
         }
 
-        Client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+        // #3662: l'API autentica a sessione con cookie (`meepleai_session`), non con Bearer.
+        // L'header Bearer non veniva semplicemente ignorato: faceva fallire l'autenticazione
+        // con 401 anche quando il cookie di sessione era presente. Si usa l'helper della base
+        // class, che è il meccanismo che gli altri test E2E già usano.
+        SetSessionCookie(token);
     }
 
     #region Create Batch Job Tests
@@ -52,7 +56,7 @@ public sealed class BatchJobE2ETests : E2ETestBase
         };
 
         // Act
-        var response = await Client.PostAsJsonAsync("/api/v1/admin/batch-jobs", payload);
+        var response = await Client.PostAsJsonAsync("/api/v1/admin/operations/batch-jobs", payload);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -82,7 +86,7 @@ public sealed class BatchJobE2ETests : E2ETestBase
         };
 
         // Act
-        var response = await Client.PostAsJsonAsync("/api/v1/admin/batch-jobs", payload);
+        var response = await Client.PostAsJsonAsync("/api/v1/admin/operations/batch-jobs", payload);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -99,14 +103,14 @@ public sealed class BatchJobE2ETests : E2ETestBase
         };
 
         // Act
-        var response = await Client.PostAsJsonAsync("/api/v1/admin/batch-jobs", payload);
+        var response = await Client.PostAsJsonAsync("/api/v1/admin/operations/batch-jobs", payload);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
     [Fact]
-    public async Task CreateBatchJob_WithEmptyParameters_ReturnsBadRequest()
+    public async Task CreateBatchJob_WithEmptyParameters_ReturnsUnprocessableEntity()
     {
         // Arrange
         var payload = new
@@ -116,10 +120,12 @@ public sealed class BatchJobE2ETests : E2ETestBase
         };
 
         // Act
-        var response = await Client.PostAsJsonAsync("/api/v1/admin/batch-jobs", payload);
+        var response = await Client.PostAsJsonAsync("/api/v1/admin/operations/batch-jobs", payload);
 
-        // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // Assert — #3662: FluentValidation mappa a 422 per design
+        // (ApiExceptionHandlerMiddleware.cs:179), non a 400. Il nome del test è stato
+        // allineato: si chiamava ...ReturnsBadRequest e asseriva un contratto mai esistito.
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
     }
 
     #endregion
@@ -134,7 +140,7 @@ public sealed class BatchJobE2ETests : E2ETestBase
         await CreateTestJobAsync(JobType.CostAnalysis);
 
         // Act
-        var response = await Client.GetAsync("/api/v1/admin/batch-jobs");
+        var response = await Client.GetAsync("/api/v1/admin/operations/batch-jobs");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -158,7 +164,7 @@ public sealed class BatchJobE2ETests : E2ETestBase
         await DbContext.SaveChangesAsync();
 
         // Act
-        var response = await Client.GetAsync("/api/v1/admin/batch-jobs?status=Queued");
+        var response = await Client.GetAsync("/api/v1/admin/operations/batch-jobs?status=Queued");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -178,8 +184,8 @@ public sealed class BatchJobE2ETests : E2ETestBase
         }
 
         // Act
-        var page1Response = await Client.GetAsync("/api/v1/admin/batch-jobs?page=1&pageSize=2");
-        var page2Response = await Client.GetAsync("/api/v1/admin/batch-jobs?page=2&pageSize=2");
+        var page1Response = await Client.GetAsync("/api/v1/admin/operations/batch-jobs?page=1&pageSize=2");
+        var page2Response = await Client.GetAsync("/api/v1/admin/operations/batch-jobs?page=2&pageSize=2");
 
         // Assert
         page1Response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -204,7 +210,7 @@ public sealed class BatchJobE2ETests : E2ETestBase
         var jobId = await CreateTestJobAsync(JobType.DataCleanup);
 
         // Act
-        var response = await Client.GetAsync($"/api/v1/admin/batch-jobs/{jobId}");
+        var response = await Client.GetAsync($"/api/v1/admin/operations/batch-jobs/{jobId}");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -222,7 +228,7 @@ public sealed class BatchJobE2ETests : E2ETestBase
         var nonExistentId = Guid.NewGuid();
 
         // Act
-        var response = await Client.GetAsync($"/api/v1/admin/batch-jobs/{nonExistentId}");
+        var response = await Client.GetAsync($"/api/v1/admin/operations/batch-jobs/{nonExistentId}");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
@@ -239,10 +245,10 @@ public sealed class BatchJobE2ETests : E2ETestBase
         var jobId = await CreateTestJobAsync(JobType.ResourceForecast);
 
         // Act
-        var response = await Client.PostAsync($"/api/v1/admin/batch-jobs/{jobId}/cancel", null);
+        var response = await Client.PutAsync($"/api/v1/admin/operations/batch-jobs/{jobId}/cancel", null);
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);  // #3662: il contratto dichiara 204 NoContent
 
         // Verify in database
         var job = await DbContext.BatchJobs.FindAsync(jobId);
@@ -261,7 +267,7 @@ public sealed class BatchJobE2ETests : E2ETestBase
         await DbContext.SaveChangesAsync();
 
         // Act
-        var response = await Client.PostAsync($"/api/v1/admin/batch-jobs/{jobId}/cancel", null);
+        var response = await Client.PutAsync($"/api/v1/admin/operations/batch-jobs/{jobId}/cancel", null);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Conflict);
@@ -274,7 +280,7 @@ public sealed class BatchJobE2ETests : E2ETestBase
         var nonExistentId = Guid.NewGuid();
 
         // Act
-        var response = await Client.PostAsync($"/api/v1/admin/batch-jobs/{nonExistentId}/cancel", null);
+        var response = await Client.PutAsync($"/api/v1/admin/operations/batch-jobs/{nonExistentId}/cancel", null);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
@@ -295,10 +301,16 @@ public sealed class BatchJobE2ETests : E2ETestBase
         await DbContext.SaveChangesAsync();
 
         // Act
-        var response = await Client.PostAsync($"/api/v1/admin/batch-jobs/{jobId}/retry", null);
+        var response = await Client.PutAsync($"/api/v1/admin/operations/batch-jobs/{jobId}/retry", null);
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);  // #3662: il contratto dichiara 204 NoContent
+        // #3662: l'API scrive su un ALTRO DbContext (gira dentro la WebApplicationFactory).
+        // Senza svuotare il change tracker, FindAsync restituisce l'istanza già tracciata da
+        // questo contesto -- lo stato pre-chiamata -- e l'assert fallisce pur essendo la riga
+        // aggiornata sul database.
+        DbContext.ChangeTracker.Clear();
+
 
         // Verify in database
         var retrieved = await DbContext.BatchJobs.FindAsync(jobId);
@@ -315,7 +327,7 @@ public sealed class BatchJobE2ETests : E2ETestBase
         var jobId = await CreateTestJobAsync(JobType.BggSync);
 
         // Act
-        var response = await Client.PostAsync($"/api/v1/admin/batch-jobs/{jobId}/retry", null);
+        var response = await Client.PutAsync($"/api/v1/admin/operations/batch-jobs/{jobId}/retry", null);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Conflict);
@@ -332,7 +344,7 @@ public sealed class BatchJobE2ETests : E2ETestBase
         var jobId = await CreateTestJobAsync(JobType.ResourceForecast);
 
         // Act
-        var response = await Client.DeleteAsync($"/api/v1/admin/batch-jobs/{jobId}");
+        var response = await Client.DeleteAsync($"/api/v1/admin/operations/batch-jobs/{jobId}");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NoContent);
@@ -349,7 +361,7 @@ public sealed class BatchJobE2ETests : E2ETestBase
         var nonExistentId = Guid.NewGuid();
 
         // Act
-        var response = await Client.DeleteAsync($"/api/v1/admin/batch-jobs/{nonExistentId}");
+        var response = await Client.DeleteAsync($"/api/v1/admin/operations/batch-jobs/{nonExistentId}");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
@@ -368,7 +380,7 @@ public sealed class BatchJobE2ETests : E2ETestBase
             type = "ResourceForecast",
             parameters = "{\"days\":30}"
         };
-        var createResponse = await Client.PostAsJsonAsync("/api/v1/admin/batch-jobs", createPayload);
+        var createResponse = await Client.PostAsJsonAsync("/api/v1/admin/operations/batch-jobs", createPayload);
         createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
         var createResult = await createResponse.Content.ReadFromJsonAsync<CreateBatchJobResponse>();
         var jobId = createResult!.JobId;
@@ -377,7 +389,7 @@ public sealed class BatchJobE2ETests : E2ETestBase
         await Task.Delay(100);
 
         // Act - Get job details
-        var getResponse = await Client.GetAsync($"/api/v1/admin/batch-jobs/{jobId}");
+        var getResponse = await Client.GetAsync($"/api/v1/admin/operations/batch-jobs/{jobId}");
 
         // Assert
         getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -394,11 +406,11 @@ public sealed class BatchJobE2ETests : E2ETestBase
         var jobId = await CreateTestJobAsync(JobType.CostAnalysis);
 
         // Act - Cancel job
-        var cancelResponse = await Client.PostAsync($"/api/v1/admin/batch-jobs/{jobId}/cancel", null);
-        cancelResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var cancelResponse = await Client.PutAsync($"/api/v1/admin/operations/batch-jobs/{jobId}/cancel", null);
+        cancelResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);  // #3662: il contratto dichiara 204 NoContent
 
         // Act - Delete job
-        var deleteResponse = await Client.DeleteAsync($"/api/v1/admin/batch-jobs/{jobId}");
+        var deleteResponse = await Client.DeleteAsync($"/api/v1/admin/operations/batch-jobs/{jobId}");
 
         // Assert
         deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
@@ -419,12 +431,18 @@ public sealed class BatchJobE2ETests : E2ETestBase
         await DbContext.SaveChangesAsync();
 
         // Act - Retry job
-        var retryResponse = await Client.PostAsync($"/api/v1/admin/batch-jobs/{jobId}/retry", null);
+        var retryResponse = await Client.PutAsync($"/api/v1/admin/operations/batch-jobs/{jobId}/retry", null);
 
         // Assert
-        retryResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        retryResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);  // #3662: il contratto dichiara 204 NoContent
 
         // Verify requeued
+        // #3662: l'API scrive su un ALTRO DbContext (gira dentro la WebApplicationFactory).
+        // Senza svuotare il change tracker, FindAsync restituisce l'istanza già tracciata da
+        // questo contesto -- lo stato pre-chiamata -- e l'assert fallisce pur essendo la riga
+        // aggiornata sul database.
+        DbContext.ChangeTracker.Clear();
+
         var retrieved = await DbContext.BatchJobs.FindAsync(jobId);
         retrieved.Should().NotBeNull();
         retrieved!.Status.Should().Be(JobStatus.Queued);
@@ -439,10 +457,10 @@ public sealed class BatchJobE2ETests : E2ETestBase
     public async Task GetAllBatchJobs_WithoutAuthentication_ReturnsUnauthorized()
     {
         // Arrange - Clear authentication
-        Client.DefaultRequestHeaders.Authorization = null;
+        ClearAuthentication();  // #3662: la sessione è nel cookie, non nell'header Authorization
 
         // Act
-        var response = await Client.GetAsync("/api/v1/admin/batch-jobs");
+        var response = await Client.GetAsync("/api/v1/admin/operations/batch-jobs");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
@@ -452,7 +470,7 @@ public sealed class BatchJobE2ETests : E2ETestBase
     public async Task CreateBatchJob_WithoutAuthentication_ReturnsUnauthorized()
     {
         // Arrange
-        Client.DefaultRequestHeaders.Authorization = null;
+        ClearAuthentication();  // #3662: la sessione è nel cookie, non nell'header Authorization
         var payload = new
         {
             type = "ResourceForecast",
@@ -460,7 +478,7 @@ public sealed class BatchJobE2ETests : E2ETestBase
         };
 
         // Act
-        var response = await Client.PostAsJsonAsync("/api/v1/admin/batch-jobs", payload);
+        var response = await Client.PostAsJsonAsync("/api/v1/admin/operations/batch-jobs", payload);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
@@ -478,7 +496,7 @@ public sealed class BatchJobE2ETests : E2ETestBase
             parameters = "{}"
         };
 
-        var response = await Client.PostAsJsonAsync("/api/v1/admin/batch-jobs", payload);
+        var response = await Client.PostAsJsonAsync("/api/v1/admin/operations/batch-jobs", payload);
         response.EnsureSuccessStatusCode();
         var result = await response.Content.ReadFromJsonAsync<CreateBatchJobResponse>();
         return result!.JobId;

--- a/apps/api/tests/Api.Tests/E2E/KnowledgeBase/ArbitroAgentE2ETests.cs
+++ b/apps/api/tests/Api.Tests/E2E/KnowledgeBase/ArbitroAgentE2ETests.cs
@@ -73,10 +73,10 @@ public sealed class ArbitroAgentE2ETests : E2ETestBase
 
         var validatePayload = new
         {
-            gameId = _testGameId,
-            sessionId = _testSessionId,
-            move = "e4", // Standard chess opening
-            gameState = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1" // Starting position (FEN)
+            gameSessionId = _testSessionId,
+            playerName = "E2E Player",
+            action = "e4", // Standard chess opening
+            position = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR" // Starting position (FEN)
         };
 
         // Act
@@ -108,10 +108,10 @@ public sealed class ArbitroAgentE2ETests : E2ETestBase
 
         var validatePayload = new
         {
-            gameId = _testGameId,
-            sessionId = _testSessionId,
-            move = "Zz9", // Invalid - no Z piece, no 9 rank
-            gameState = "{}"
+            gameSessionId = _testSessionId,
+            playerName = "E2E Player",
+            action = "Zz9", // Invalid - no Z piece, no 9 rank
+            position = "{}"
         };
 
         // Act
@@ -143,10 +143,10 @@ public sealed class ArbitroAgentE2ETests : E2ETestBase
 
         var validatePayload = new
         {
-            gameId = _testGameId,
-            sessionId = _testSessionId,
-            move = "Nf3", // Knight move
-            gameState = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+            gameSessionId = _testSessionId,
+            playerName = "E2E Player",
+            action = "Nf3", // Knight move
+            position = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR"
         };
 
         // Act
@@ -184,8 +184,8 @@ public sealed class ArbitroAgentE2ETests : E2ETestBase
         // Step 1: Query Tutor agent for setup help
         var tutorPayload = new
         {
-            gameId = _testGameId,
-            sessionId = _testSessionId,
+            gameSessionId = _testSessionId,
+            playerName = "E2E Player",
             query = "How do I set up the chess board?"
         };
 
@@ -204,10 +204,10 @@ public sealed class ArbitroAgentE2ETests : E2ETestBase
         // Step 2: Validate a move with Arbitro agent (same session context)
         var arbitroPayload = new
         {
-            gameId = _testGameId,
-            sessionId = _testSessionId,
-            move = "e4",
-            gameState = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+            gameSessionId = _testSessionId,
+            playerName = "E2E Player",
+            action = "e4",
+            position = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR"
         };
 
         var arbitroResponse = await Client.PostAsJsonAsync("/api/v1/agents/arbitro/validate", arbitroPayload);
@@ -235,15 +235,15 @@ public sealed class ArbitroAgentE2ETests : E2ETestBase
         var (sessionToken, _) = await RegisterUserAsync(email, "ValidUnusualPwd123!");
         SetSessionCookie(sessionToken);
 
-        var startingPosition = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+        var startingPosition = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR";
 
         // Turn 1: Validate opening move
         var move1Payload = new
         {
-            gameId = _testGameId,
-            sessionId = _testSessionId,
-            move = "e4",
-            gameState = startingPosition
+            gameSessionId = _testSessionId,
+            playerName = "E2E Player",
+            action = "e4",
+            position = startingPosition
         };
 
         var response1 = await Client.PostAsJsonAsync("/api/v1/agents/arbitro/validate", move1Payload);
@@ -257,10 +257,10 @@ public sealed class ArbitroAgentE2ETests : E2ETestBase
         // Turn 2: Validate response move (same session)
         var move2Payload = new
         {
-            gameId = _testGameId,
-            sessionId = _testSessionId,
-            move = "e5", // Black's response
-            gameState = "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1"
+            gameSessionId = _testSessionId,
+            playerName = "E2E Player",
+            action = "e5", // Black's response
+            position = "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR"
         };
 
         var response2 = await Client.PostAsJsonAsync("/api/v1/agents/arbitro/validate", move2Payload);
@@ -289,10 +289,10 @@ public sealed class ArbitroAgentE2ETests : E2ETestBase
 
         var validatePayload = new
         {
-            gameId = _testGameId,
-            sessionId = _testSessionId,
-            move = "Nf3",
-            gameState = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+            gameSessionId = _testSessionId,
+            playerName = "E2E Player",
+            action = "Nf3",
+            position = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR"
         };
 
         // Act
@@ -327,10 +327,10 @@ public sealed class ArbitroAgentE2ETests : E2ETestBase
 
         var validatePayload = new
         {
-            gameId = _testGameId,
-            sessionId = _testSessionId,
-            move = "e4",
-            gameState = "{}"
+            gameSessionId = _testSessionId,
+            playerName = "E2E Player",
+            action = "e4",
+            position = "{}"
         };
 
         // Act
@@ -350,10 +350,10 @@ public sealed class ArbitroAgentE2ETests : E2ETestBase
 
         var validatePayload = new
         {
-            gameId = _testGameId,
-            sessionId = _testSessionId,
-            move = "e4",
-            gameState = "INVALID_FEN_STRING"
+            gameSessionId = _testSessionId,
+            playerName = "E2E Player",
+            action = "e4",
+            position = "INVALID_FEN_STRING"
         };
 
         // Act
@@ -384,10 +384,10 @@ public sealed class ArbitroAgentE2ETests : E2ETestBase
 
         var validatePayload = new
         {
-            gameId = _testGameId,
-            sessionId = _testSessionId,
-            move = "e4",
-            gameState = "{}"
+            gameSessionId = _testSessionId,
+            playerName = "E2E Player",
+            action = "e4",
+            position = "{}"
         };
 
         // Act

--- a/apps/api/tests/Api.Tests/Unit/Administration/Domain/BatchJobTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/Administration/Domain/BatchJobTests.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.Administration.Domain.Entities;
+using Api.Middleware.Exceptions;
 using Api.BoundedContexts.Administration.Domain.Enums;
 using Api.Tests.Constants;
 using FluentAssertions;
@@ -359,7 +360,7 @@ public sealed class BatchJobTests
     }
 
     [Fact]
-    public void Cancel_WhenCompleted_ShouldThrowInvalidOperationException()
+    public void Cancel_WhenCompleted_ShouldThrowConflictException()
     {
         // Arrange
         var job = BatchJob.Create(JobType.CostAnalysis, "{}", TestUserId);
@@ -370,12 +371,12 @@ public sealed class BatchJobTests
         var act = () => job.Cancel();
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
+        act.Should().Throw<ConflictException>()
             .WithMessage("Cannot cancel completed or failed jobs");
     }
 
     [Fact]
-    public void Cancel_WhenFailed_ShouldThrowInvalidOperationException()
+    public void Cancel_WhenFailed_ShouldThrowConflictException()
     {
         // Arrange
         var job = BatchJob.Create(JobType.DataCleanup, "{}", TestUserId);
@@ -386,7 +387,7 @@ public sealed class BatchJobTests
         var act = () => job.Cancel();
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
+        act.Should().Throw<ConflictException>()
             .WithMessage("Cannot cancel completed or failed jobs");
     }
 
@@ -417,7 +418,7 @@ public sealed class BatchJobTests
     }
 
     [Fact]
-    public void Retry_WhenQueued_ShouldThrowInvalidOperationException()
+    public void Retry_WhenQueued_ShouldThrowConflictException()
     {
         // Arrange
         var job = BatchJob.Create(JobType.ResourceForecast, "{}", TestUserId);
@@ -426,12 +427,12 @@ public sealed class BatchJobTests
         var act = () => job.Retry();
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
+        act.Should().Throw<ConflictException>()
             .WithMessage("Only failed jobs can be retried");
     }
 
     [Fact]
-    public void Retry_WhenRunning_ShouldThrowInvalidOperationException()
+    public void Retry_WhenRunning_ShouldThrowConflictException()
     {
         // Arrange
         var job = BatchJob.Create(JobType.CostAnalysis, "{}", TestUserId);
@@ -441,12 +442,12 @@ public sealed class BatchJobTests
         var act = () => job.Retry();
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
+        act.Should().Throw<ConflictException>()
             .WithMessage("Only failed jobs can be retried");
     }
 
     [Fact]
-    public void Retry_WhenCompleted_ShouldThrowInvalidOperationException()
+    public void Retry_WhenCompleted_ShouldThrowConflictException()
     {
         // Arrange
         var job = BatchJob.Create(JobType.DataCleanup, "{}", TestUserId);
@@ -457,12 +458,12 @@ public sealed class BatchJobTests
         var act = () => job.Retry();
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
+        act.Should().Throw<ConflictException>()
             .WithMessage("Only failed jobs can be retried");
     }
 
     [Fact]
-    public void Retry_WhenCancelled_ShouldThrowInvalidOperationException()
+    public void Retry_WhenCancelled_ShouldThrowConflictException()
     {
         // Arrange
         var job = BatchJob.Create(JobType.BggSync, "{}", TestUserId);
@@ -472,7 +473,7 @@ public sealed class BatchJobTests
         var act = () => job.Retry();
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
+        act.Should().Throw<ConflictException>()
             .WithMessage("Only failed jobs can be retried");
     }
 


### PR DESCRIPTION
Due commit da `main-dev`, entrambi sul tema «test che nessuno eseguiva».

## #3676 — E2E batch-jobs (#3662)

`BatchJobE2ETests` passa da **0/24 a 24/24**. Le cause erano quattro, tutte accumulate nelle sette settimane in cui il gate `Backend E2E` non ha girato: la route aveva guadagnato un segmento (`/admin/batch-jobs` → `/admin/operations/batch-jobs`), cancel e retry sono `PUT` mentre i test usavano `POST`, l'autenticazione usava un header `Bearer` invece del cookie di sessione, e alcuni assert leggevano 200 dove il contratto dichiara 204.

**Contiene una correzione di produzione**: `BatchJob.Cancel()` e `Retry()` sollevavano `InvalidOperationException`, quindi annullare un job già completato restituiva **500** invece di un 4xx (pitfall #2568). Ora `ConflictException` → 409, con `Produces(409)` allineato nell'OpenAPI.

Inoltre `backend-e2e-tests.yml` non usa più l'indirezione `vars.RUNNER`: quella variabile puntava al runner co-locato sul VPS di staging, dove il build competeva per la RAM — l'`OutOfMemoryException` del 2026-06-22. Il runner è stato ritirato da #3331, ma il README documenta una procedura di rollback che lo ri-crea per i workflow di deploy; un workflow di test l'avrebbe seguita in silenzio.

## #3675 — timing attack verificabili (#3657)

Da una sessione parallela.

## Stato dei gate

Nessuna regressione attesa. Restano 22 test E2E rossi su `AdminGameCreationJourney`, `GameManagement` e `ArbitroAgent` — debito preesistente, cause già caratterizzate in #3662, non introdotto qui.
