### PR TITLE
refactor(toolkit): VersionSemver è stato dell'aggregato, via la sintesi nel mapper (#3670)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/PublishToolkitVersion/PublishToolkitVersionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/PublishToolkitVersion/PublishToolkitVersionCommandHandler.cs
@@ -18,7 +18,7 @@ namespace Api.BoundedContexts.GameToolkit.Application.Commands.PublishToolkitVer
 /// <remarks>
 /// <para>Pipeline (spec-panel §6 Gherkin):</para>
 /// <list type="number">
-///   <item>Load tracked toolkit row — return <c>null</c> if missing (404).</item>
+///   <item>Load the toolkit aggregate through <c>IGameToolkitRepository</c> — <c>null</c> if missing (404).</item>
 ///   <item>Owner check (<c>CreatedByUserId == ViewerId</c>) — throw <c>ForbiddenException</c>.</item>
 ///   <item>Uniqueness check — throw <c>ConflictException</c> if <c>(ToolkitId, VersionNumber)</c> exists
 ///         (covers yanked numbers per §1 — permanently retired).</item>

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/PublishToolkitVersion/PublishToolkitVersionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/PublishToolkitVersion/PublishToolkitVersionCommandHandler.cs
@@ -34,7 +34,7 @@ namespace Api.BoundedContexts.GameToolkit.Application.Commands.PublishToolkitVer
 internal sealed class PublishToolkitVersionCommandHandler
     : ICommandHandler<PublishToolkitVersionCommand, PublishedToolkitVersionResponse?>
 {
-    private readonly MeepleAiDbContext _context;
+    private readonly IGameToolkitRepository _toolkitRepository;
     private readonly IToolkitVersionRepository _versionRepository;
     private readonly IUnitOfWork _unitOfWork;
     private readonly IHybridCacheService _cache;
@@ -42,14 +42,14 @@ internal sealed class PublishToolkitVersionCommandHandler
     private readonly ILogger<PublishToolkitVersionCommandHandler> _logger;
 
     public PublishToolkitVersionCommandHandler(
-        MeepleAiDbContext context,
+        IGameToolkitRepository toolkitRepository,
         IToolkitVersionRepository versionRepository,
         IUnitOfWork unitOfWork,
         IHybridCacheService cache,
         TimeProvider timeProvider,
         ILogger<PublishToolkitVersionCommandHandler> logger)
     {
-        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _toolkitRepository = toolkitRepository ?? throw new ArgumentNullException(nameof(toolkitRepository));
         _versionRepository = versionRepository ?? throw new ArgumentNullException(nameof(versionRepository));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _cache = cache ?? throw new ArgumentNullException(nameof(cache));
@@ -63,11 +63,17 @@ internal sealed class PublishToolkitVersionCommandHandler
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        // 1) Tracked load — we mutate VersionSemver + IsPublished below and
-        //    rely on EF change tracking to emit the UPDATE inside the UnitOfWork
-        //    transaction. AsNoTracking would discard those changes.
-        var toolkit = await _context.GameToolkits
-            .FirstOrDefaultAsync(t => t.Id == request.ToolkitId, cancellationToken)
+        // 1) Load the aggregate through the repository (#3670). This used to be a TRACKED
+        //    load of the EF entity via MeepleAiDbContext, because step 6 mutated the row
+        //    directly to dodge MapToPersistence's VersionSemver synthesis. The aggregate now
+        //    owns VersionSemver, so the normal repository path works.
+        //
+        //    Do NOT reintroduce a tracked load alongside UpdateAsync: GetByIdAsync is
+        //    AsNoTracking, and UpdateAsync calls Set<GameToolkitEntity>().Update() with a
+        //    freshly mapped instance. Two instances of the same key in the change tracker
+        //    would throw ("instance with the same key value is already being tracked").
+        var toolkit = await _toolkitRepository
+            .GetByIdAsync(request.ToolkitId, cancellationToken)
             .ConfigureAwait(false);
 
         if (toolkit is null)
@@ -128,15 +134,13 @@ internal sealed class PublishToolkitVersionCommandHandler
 
         await _versionRepository.AddAsync(version, cancellationToken).ConfigureAwait(false);
 
-        // 6) Mutate parent toolkit DIRECTLY on the tracked EF entity.
-        //    Bypass GameToolkitRepository.UpdateAsync deliberately: its
-        //    MapToPersistence pass synthesises VersionSemver from the legacy
-        //    int Version field (see #1144 follow-up tracker at GameToolkitRepository.cs:308),
-        //    which would overwrite our user-input semver. Direct mutation
-        //    preserves the user-input value through the UPDATE statement.
-        toolkit.VersionSemver = request.VersionNumber;
-        toolkit.IsPublished = true;
-        toolkit.UpdatedAt = now;
+        // 6) Move the parent toolkit's marketplace pointer through the aggregate (#3670).
+        //    Previously this mutated the tracked EF row directly to bypass
+        //    GameToolkitRepository.UpdateAsync, whose MapToPersistence synthesised
+        //    VersionSemver as "0.{Version}.0" and would have overwritten the user's input.
+        //    That synthesis is gone, so the write goes through the repository like any other.
+        toolkit.PublishMarketplaceVersion(request.VersionNumber, now);
+        await _toolkitRepository.UpdateAsync(toolkit, cancellationToken).ConfigureAwait(false);
 
         // 7) Single transaction — IUnitOfWork dispatches domain events post-commit.
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Domain/Entities/GameToolkit.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Domain/Entities/GameToolkit.cs
@@ -34,6 +34,18 @@ internal sealed class GameToolkit : AggregateRoot<Guid>
     /// </remarks>
     public string VersionSemver { get; private set; } = SeedSemver;
 
+    /// <summary>
+    /// Postgres <c>xmin</c> concurrency token (ADR-060). Carried by the aggregate so the
+    /// repository can hand EF the real original value when persisting a detached entity.
+    /// </summary>
+    /// <remarks>
+    /// Without it, <c>UpdateAsync</c> attaches an entity whose <c>Xmin</c> is 0 and EF emits
+    /// <c>WHERE "Id" = @p AND xmin = 0</c>, which matches no live tuple: every update raised
+    /// DbUpdateConcurrencyException on Postgres while the InMemory tests stayed green.
+    /// Same pattern as <c>AlertChannel</c> (#2690).
+    /// </remarks>
+    public uint Xmin { get; private set; }
+
     /// <summary>Semver assigned to a toolkit that has never been published to the marketplace.</summary>
     /// <remarks>
     /// Matches what the old <c>MapToPersistence</c> synthesis produced for a brand-new toolkit
@@ -109,6 +121,11 @@ internal sealed class GameToolkit : AggregateRoot<Guid>
         Name = name.Trim();
         Version = 1;
         VersionSemver = SeedSemver;
+        // A toolkit that has never been persisted has no xmin yet — Postgres assigns it on
+        // INSERT. Stated explicitly rather than left to the type default: the setter is
+        // otherwise only reached by MapToDomain's reflection, and S1144 reads it as dead code
+        // (the analyzer has already had DI constructors deleted out from under it, #2296).
+        Xmin = 0;
         CreatedByUserId = createdByUserId;
         CreatedAt = DateTime.UtcNow;
         UpdatedAt = DateTime.UtcNow;

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Domain/Entities/GameToolkit.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Domain/Entities/GameToolkit.cs
@@ -21,6 +21,25 @@ internal sealed class GameToolkit : AggregateRoot<Guid>
     public Guid? PrivateGameId { get; private set; }
     public string Name { get; private set; }
     public int Version { get; private set; }
+
+    /// <summary>
+    /// Marketplace version pointer, in semver. Issue #3670.
+    /// </summary>
+    /// <remarks>
+    /// Distinct from <see cref="Version"/>, which is a legacy monotonic counter for session
+    /// immutability. This is the user-authored version published to the marketplace, and it
+    /// is the aggregate's own state — before #3670 the aggregate did not carry it, so the
+    /// persistence mapper synthesised <c>"0.{Version}.0"</c> and every write path had to
+    /// defend against that synthesis overwriting the real value.
+    /// </remarks>
+    public string VersionSemver { get; private set; } = SeedSemver;
+
+    /// <summary>Semver assigned to a toolkit that has never been published to the marketplace.</summary>
+    /// <remarks>
+    /// Matches what the old <c>MapToPersistence</c> synthesis produced for a brand-new toolkit
+    /// (<c>Version</c> starts at 1 → <c>"0.1.0"</c>), so existing rows keep their value.
+    /// </remarks>
+    internal const string SeedSemver = "0.1.0";
     public Guid CreatedByUserId { get; private set; }
     public DateTime CreatedAt { get; private set; }
     public DateTime UpdatedAt { get; private set; }
@@ -89,6 +108,7 @@ internal sealed class GameToolkit : AggregateRoot<Guid>
         PrivateGameId = hasPrivateGameId ? privateGameId : null;
         Name = name.Trim();
         Version = 1;
+        VersionSemver = SeedSemver;
         CreatedByUserId = createdByUserId;
         CreatedAt = DateTime.UtcNow;
         UpdatedAt = DateTime.UtcNow;
@@ -140,6 +160,27 @@ internal sealed class GameToolkit : AggregateRoot<Guid>
         Version++;
         UpdatedAt = DateTime.UtcNow;
         AddDomainEvent(new ToolkitPublishedEvent(Id, Version));
+    }
+
+    /// <summary>
+    /// Moves the marketplace pointer to a newly published semver. Issue #3670.
+    /// </summary>
+    /// <remarks>
+    /// Ordering against the currently published version is enforced by
+    /// <c>PublishToolkitVersionCommandHandler</c> against the ToolkitVersion aggregate, which
+    /// owns version history; this method only moves the parent's pointer. It exists so the
+    /// publish path can go through the repository like every other write: before #3670 the
+    /// handler had to mutate the tracked EF entity directly, because persisting the aggregate
+    /// would have overwritten the user's semver with a synthesised one.
+    /// </remarks>
+    public void PublishMarketplaceVersion(string versionSemver, DateTime publishedAt)
+    {
+        if (string.IsNullOrWhiteSpace(versionSemver))
+            throw new ArgumentException("Version semver cannot be empty", nameof(versionSemver));
+
+        VersionSemver = versionSemver.Trim();
+        IsPublished = true;
+        UpdatedAt = publishedAt;
     }
 
     // ========================================================================

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Infrastructure/Persistence/GameToolkitRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Infrastructure/Persistence/GameToolkitRepository.cs
@@ -136,6 +136,14 @@ internal class GameToolkitRepository : RepositoryBase, IGameToolkitRepository
         var entity = MapToPersistence(toolkit);
         var entry = DbContext.Set<GameToolkitEntity>().Update(entity);
 
+        // Hand EF the real xmin as the ORIGINAL value (#3670). MapToPersistence builds a fresh
+        // detached entity, so without this the token's original value is 0 and the statement
+        // becomes `WHERE "Id" = @p AND xmin = 0`, which matches no live tuple: SaveChanges then
+        // raised DbUpdateConcurrencyException for EVERY write in this bounded context on
+        // Postgres — rename, dice tools, presets — while the InMemory tests stayed green
+        // because that provider has no xmin column. Same pattern as AlertChannelRepository:78.
+        entry.Property(e => e.Xmin).OriginalValue = toolkit.Xmin;
+
         // The aggregate still carries no Description/License, so MapToPersistence leaves them
         // null. Update() marks every column Modified, which would null both on every unrelated
         // update. Exclude them so their persisted values survive.
@@ -184,10 +192,13 @@ internal class GameToolkitRepository : RepositoryBase, IGameToolkitRepository
         SetPrivateProperty(toolkit, "Name", entity.Name);
         SetPrivateProperty(toolkit, "CreatedByUserId", entity.CreatedByUserId);
         SetPrivateProperty(toolkit, "Version", entity.Version);
+        SetPrivateProperty(toolkit, "Xmin", entity.Xmin);
         // #3670: MUST be loaded. UpdateAsync now writes VersionSemver from the aggregate, so an
         // aggregate that doesn't know the persisted value would clobber the published marketplace
         // pointer on any unrelated update (a rename, say). Guarded by
         // GameToolkitRepositoryUpdatePreservationTests.
+        // The ?? is defensive only: the column is NOT NULL with default "0.1.0"
+        // (GameToolkitEntityConfiguration:33), so materialisation cannot yield null.
         SetPrivateProperty(toolkit, "VersionSemver", entity.VersionSemver ?? Domain.Entities.GameToolkit.SeedSemver);
         SetPrivateProperty(toolkit, "IsPublished", entity.IsPublished);
         SetPrivateProperty(toolkit, "OverridesTurnOrder", entity.OverridesTurnOrder);
@@ -311,7 +322,10 @@ internal class GameToolkitRepository : RepositoryBase, IGameToolkitRepository
             OverridesTurnOrder = toolkit.OverridesTurnOrder,
             OverridesScoreboard = toolkit.OverridesScoreboard,
             OverridesDiceSet = toolkit.OverridesDiceSet,
-#pragma warning disable CS0618 // Issue #1144 / spec D-5: paired write — legacy int + new semver in same MapToPersistence call.
+#pragma warning disable CS0618 // GameToolkitEntity.Version's setter is [Obsolete], but the column still
+                               // backs the (GameId, Version) / (PrivateGameId, Version) unique indexes,
+                               // so the write cannot be dropped until that column is retired. Not to be
+                               // confused with the #3670 breadcrumb, which is gone.
             Version = toolkit.Version,
 #pragma warning restore CS0618
             // #3670: read from the aggregate. This was synthesised as "0.{Version}.0" until

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Infrastructure/Persistence/GameToolkitRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Infrastructure/Persistence/GameToolkitRepository.cs
@@ -136,14 +136,14 @@ internal class GameToolkitRepository : RepositoryBase, IGameToolkitRepository
         var entity = MapToPersistence(toolkit);
         var entry = DbContext.Set<GameToolkitEntity>().Update(entity);
 
-        // Issue #1458: the domain aggregate carries no VersionSemver/Description/License,
-        // so MapToPersistence cannot reconstruct them — VersionSemver is synthesized as
-        // "0.{Version}.0" and the other two default to null. Update() marks every column
-        // Modified, which would clobber the published marketplace pointer (e.g. reset
-        // "2.3.1" → "0.1.0") and null the description/license on every non-publish update.
-        // Exclude those three columns so their persisted values survive. PublishToolkitVersion
-        // writes VersionSemver on the tracked entity directly, bypassing this method.
-        entry.Property(e => e.VersionSemver).IsModified = false;
+        // The aggregate still carries no Description/License, so MapToPersistence leaves them
+        // null. Update() marks every column Modified, which would null both on every unrelated
+        // update. Exclude them so their persisted values survive.
+        //
+        // VersionSemver was in this list until #3670: it is now real aggregate state, loaded by
+        // MapToDomain and written back here like any other column, so the publish path no longer
+        // has to bypass this method. Re-excluding it would make PublishMarketplaceVersion a
+        // silent no-op — the aggregate would accept the new semver and the UPDATE would drop it.
         entry.Property(e => e.Description).IsModified = false;
         entry.Property(e => e.License).IsModified = false;
 
@@ -184,6 +184,11 @@ internal class GameToolkitRepository : RepositoryBase, IGameToolkitRepository
         SetPrivateProperty(toolkit, "Name", entity.Name);
         SetPrivateProperty(toolkit, "CreatedByUserId", entity.CreatedByUserId);
         SetPrivateProperty(toolkit, "Version", entity.Version);
+        // #3670: MUST be loaded. UpdateAsync now writes VersionSemver from the aggregate, so an
+        // aggregate that doesn't know the persisted value would clobber the published marketplace
+        // pointer on any unrelated update (a rename, say). Guarded by
+        // GameToolkitRepositoryUpdatePreservationTests.
+        SetPrivateProperty(toolkit, "VersionSemver", entity.VersionSemver ?? Domain.Entities.GameToolkit.SeedSemver);
         SetPrivateProperty(toolkit, "IsPublished", entity.IsPublished);
         SetPrivateProperty(toolkit, "OverridesTurnOrder", entity.OverridesTurnOrder);
         SetPrivateProperty(toolkit, "OverridesScoreboard", entity.OverridesScoreboard);
@@ -309,21 +314,10 @@ internal class GameToolkitRepository : RepositoryBase, IGameToolkitRepository
 #pragma warning disable CS0618 // Issue #1144 / spec D-5: paired write — legacy int + new semver in same MapToPersistence call.
             Version = toolkit.Version,
 #pragma warning restore CS0618
-#pragma warning disable S1135 // TODO: architectural breadcrumb — mitigated footgun: see comment below.
-            // TODO(#3670): VersionSemver already has a real producer.
-            // PublishToolkitVersionCommandHandler.cs:137 writes the user-input
-            // semver and DELIBERATELY bypasses GameToolkitRepository.UpdateAsync
-            // (see handler comment at lines 131-136) precisely because this
-            // MapToPersistence synthesis would otherwise overwrite the user
-            // value with "0.{Version}.0". This synthesis is only meaningful for
-            // AddAsync (brand-new toolkit → seed "0.1.0"): UpdateAsync now excludes
-            // VersionSemver (and Description/License) from the Update() so no
-            // non-publish update path clobbers the published marketplace pointer.
-            // Full fix: surface VersionSemver on the domain aggregate (#3670 —
-            // original paired-write context shipped in #1144 2026-05-14)
-            // so MapToPersistence can read it directly and the synthesis goes away.
-            VersionSemver = $"0.{toolkit.Version}.0",
-#pragma warning restore S1135
+            // #3670: read from the aggregate. This was synthesised as "0.{Version}.0" until
+            // the aggregate carried the value, which forced the publish path to bypass
+            // UpdateAsync so the synthesis wouldn't overwrite the user's semver.
+            VersionSemver = toolkit.VersionSemver,
             CreatedByUserId = toolkit.CreatedByUserId,
             IsPublished = toolkit.IsPublished,
             CreatedAt = toolkit.CreatedAt,

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Application/Commands/PublishToolkitVersionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Application/Commands/PublishToolkitVersionCommandHandlerTests.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.GameToolkit.Application.Commands.PublishToolkitVersion
 using Api.BoundedContexts.GameToolkit.Domain.Entities;
 using Api.BoundedContexts.GameToolkit.Domain.Enums;
 using Api.BoundedContexts.GameToolkit.Domain.Repositories;
+using Api.BoundedContexts.GameToolkit.Infrastructure.Persistence;
 using Api.Infrastructure.Entities.GameToolkit;
 using Api.Middleware.Exceptions;
 using Api.Services;
@@ -9,6 +10,7 @@ using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.Constants;
 using Api.Tests.TestHelpers;
 using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
@@ -48,8 +50,16 @@ public class PublishToolkitVersionCommandHandlerTests
         var unitOfWork = new EfCoreUnitOfWork(context);
         var timeProvider = new FakeTimeProvider(Now);
 
+        // Real repository, not a mock (#3670). The handler no longer mutates the tracked EF
+        // row: it loads the aggregate, calls PublishMarketplaceVersion and persists through
+        // UpdateAsync. A mocked repository would stub out exactly the mapping round-trip that
+        // makes this safe — MapToDomain loading VersionSemver so MapToPersistence can write it
+        // back — and the test would still pass if that round-trip broke.
+        var toolkitRepo = new GameToolkitRepository(
+            context, TestDbContextFactory.CreateMockEventCollector().Object);
+
         var handler = new PublishToolkitVersionCommandHandler(
-            context,
+            toolkitRepo,
             versionRepo.Object,
             unitOfWork,
             cache.Object,
@@ -79,6 +89,14 @@ public class PublishToolkitVersionCommandHandlerTests
             UpdatedAt = Now,        };
 #pragma warning restore CS0618
         context.GameToolkits.Add(toolkit);
+        context.SaveChanges();
+
+        // Detach so the act phase starts with an empty change tracker, which is what a request
+        // actually sees: MeepleAiDbContext is scoped, and the handler's only load is
+        // GetByIdAsync (AsNoTracking). Leaving the seeded instance tracked makes UpdateAsync's
+        // Set<>().Update() attach a second instance of the same key and throw — a fixture
+        // artifact, not a product defect, but one that reads exactly like a real bug (#3670).
+        context.Entry(toolkit).State = EntityState.Detached;
         return toolkit;
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Infrastructure/Persistence/GameToolkitRepositoryUpdatePreservationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Infrastructure/Persistence/GameToolkitRepositoryUpdatePreservationTests.cs
@@ -14,17 +14,24 @@ namespace Api.Tests.BoundedContexts.GameToolkit.Infrastructure.Persistence;
 /// Regression tests for <see cref="GameToolkitRepository.UpdateAsync"/> (issue #1458 footgun).
 ///
 /// <para>
-/// <c>MapToPersistence</c> synthesizes <c>VersionSemver = "0.{Version}.0"</c> and omits
-/// <c>Description</c>/<c>License</c> entirely (the domain aggregate has no knowledge of these
-/// three entity-level marketplace columns). Because <c>UpdateAsync</c> calls
+/// <c>MapToPersistence</c> omits <c>Description</c>/<c>License</c> entirely (the domain aggregate
+/// has no knowledge of those entity-level marketplace columns). Because <c>UpdateAsync</c> calls
 /// <c>DbContext.Update(entity)</c>, which marks EVERY scalar column Modified, any non-publish
-/// update path (rename, add/remove tool, override change, …) silently overwrote the published
-/// marketplace pointer: <c>VersionSemver "2.3.1" → "0.1.0"</c> and nulled <c>Description</c>/<c>License</c>.
+/// update path (rename, add/remove tool, override change, …) would null them.
 /// </para>
 ///
-/// InMemory is the correct vehicle: it honors per-property <c>IsModified</c> flags but ignores
-/// the Postgres <c>xmin</c> concurrency token (which would otherwise mask this bug behind a
-/// <c>DbUpdateConcurrencyException</c> on a real database).
+/// <para>
+/// <c>VersionSemver</c> used to be in that list too, synthesized as <c>"0.{Version}.0"</c>, which
+/// silently reset the published marketplace pointer <c>"2.3.1" → "0.1.0"</c>. Since #3670 it is
+/// real aggregate state, loaded by <c>MapToDomain</c> and written back like any other column —
+/// so this test now guards the round-trip rather than an exclusion, and still goes red if the
+/// synthesis returns.
+/// </para>
+///
+/// InMemory honors per-property <c>IsModified</c> flags, which is what this test asserts on. It
+/// has no <c>xmin</c> column, so it says nothing about the Postgres concurrency token — that is
+/// covered by <c>GameToolkitRepositoryPostgresConcurrencyTests</c> (#3670), added after this
+/// provider gap turned out to be hiding a real DbUpdateConcurrencyException on every write.
 /// </summary>
 [Trait("Category", TestCategories.Unit)]
 [Trait("BoundedContext", "GameToolkit")]

--- a/apps/api/tests/Api.Tests/Integration/ToolkitMarketplace/GameToolkitRepositoryPostgresConcurrencyTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/ToolkitMarketplace/GameToolkitRepositoryPostgresConcurrencyTests.cs
@@ -1,0 +1,145 @@
+using Api.BoundedContexts.GameToolkit.Application.Commands;
+using Api.BoundedContexts.GameToolkit.Domain.Enums;
+using Api.BoundedContexts.GameToolkit.Domain.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.GameToolkit;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.ToolkitMarketplace;
+
+/// <summary>
+/// Issue #3670. Exercises <c>GameToolkitRepository.UpdateAsync</c> against a real Postgres.
+/// </summary>
+/// <remarks>
+/// Every other test of this repository runs on the EF InMemory provider, which has no
+/// <c>xmin</c> system column — so it cannot observe what the concurrency token does to the
+/// UPDATE statement. <c>GameToolkitEntityConfiguration</c> declares <c>Xmin</c> as a
+/// concurrency token, and <c>UpdateAsync</c> attaches a freshly mapped (detached) entity whose
+/// <c>Xmin</c> is never assigned. If EF emitted that zero as the original value, the statement
+/// would read <c>WHERE "Id" = @p AND xmin = 0</c>, match no live tuple, and every update in
+/// this bounded context would raise <c>DbUpdateConcurrencyException</c>.
+///
+/// This test exists to answer that empirically rather than by reading EF's source: it is the
+/// difference between "publish is fine" and "renaming a toolkit has been 500ing in production".
+/// </remarks>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "GameToolkit")]
+public sealed class GameToolkitRepositoryPostgresConcurrencyTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+
+    private static readonly Guid OwnerId = Guid.Parse("00000000-0000-0000-0000-000000003670");
+
+    public GameToolkitRepositoryPostgresConcurrencyTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"toolkit_xmin_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        await dbContext.Database.MigrateAsync();
+    }
+
+    public async ValueTask DisposeAsync() => await _factory.DisposeAsync();
+
+    private async Task<Guid> SeedToolkitAsync(string versionSemver)
+    {
+        var toolkitId = Guid.NewGuid();
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+#pragma warning disable CS0618 // legacy int Version — seeding the paired column
+        db.GameToolkits.Add(new GameToolkitEntity
+        {
+            Id = toolkitId,
+            Name = "Original Name",
+            CreatedByUserId = OwnerId,
+            Version = 1,
+            VersionSemver = versionSemver,
+            IsPublished = true,
+            TemplateStatus = (int)TemplateStatus.Approved,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+#pragma warning restore CS0618
+
+        await db.SaveChangesAsync();
+        return toolkitId;
+    }
+
+    [Fact]
+    public async Task UpdateAsync_OnPostgres_SucceedsDespiteDetachedXmin()
+    {
+        var toolkitId = await SeedToolkitAsync("2.3.1");
+
+        // Fresh scope = the change tracker a real request starts with.
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var repository = scope.ServiceProvider.GetRequiredService<IGameToolkitRepository>();
+            var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+
+            var toolkit = await repository.GetByIdAsync(toolkitId);
+            toolkit.Should().NotBeNull();
+
+            toolkit!.UpdateDetails("Renamed Toolkit");
+            await repository.UpdateAsync(toolkit);
+
+            // The assertion that matters: no DbUpdateConcurrencyException.
+            await unitOfWork.SaveChangesAsync();
+        }
+
+        using (var verifyScope = _factory.Services.CreateScope())
+        {
+            var db = verifyScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var reloaded = await db.GameToolkits.AsNoTracking()
+                .FirstAsync(t => t.Id == toolkitId);
+
+            reloaded.Name.Should().Be("Renamed Toolkit");
+            reloaded.VersionSemver.Should().Be("2.3.1",
+                "a non-publish update must not disturb the published marketplace pointer");
+        }
+    }
+
+    [Fact]
+    public async Task PublishMarketplaceVersion_ThroughRepository_PersistsOnPostgres()
+    {
+        var toolkitId = await SeedToolkitAsync("1.0.0");
+        var publishedAt = new DateTime(2026, 8, 12, 10, 0, 0, DateTimeKind.Utc);
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var repository = scope.ServiceProvider.GetRequiredService<IGameToolkitRepository>();
+            var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+
+            var toolkit = await repository.GetByIdAsync(toolkitId);
+            toolkit!.PublishMarketplaceVersion("1.1.0", publishedAt);
+            await repository.UpdateAsync(toolkit);
+            await unitOfWork.SaveChangesAsync();
+        }
+
+        using (var verifyScope = _factory.Services.CreateScope())
+        {
+            var db = verifyScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var reloaded = await db.GameToolkits.AsNoTracking()
+                .FirstAsync(t => t.Id == toolkitId);
+
+            reloaded.VersionSemver.Should().Be("1.1.0");
+            reloaded.IsPublished.Should().BeTrue();
+        }
+    }
+}


### PR DESCRIPTION
> ## 🔴 Questa PR contiene anche un fix P1 pre-esistente
>
> La code review ha alzato un dubbio sul token `xmin`. Verificandolo su **Postgres vero** è emerso che `GameToolkitRepository.UpdateAsync` **è rotto in produzione oggi**, per tutti i ~21 percorsi che lo usano — rename, dice tool, preset: `DbUpdateConcurrencyException` → 500.
>
> **Non è causato da questa PR.** Verificato eseguendo lo stesso test su `main-dev` prima delle mie modifiche (worktree separato su `afd51b770`): fallisce identico.
>
> Ma è **bloccante per questa PR**: il publish era l'unico percorso di scrittura sano, perché faceva un load *tracked* e lo snapshot EF portava l'`xmin` reale. Spostarlo su `UpdateAsync` senza il fix avrebbe trasformato un endpoint funzionante in uno rotto. Dettagli sotto.

## Il problema

`MapToPersistence` **inventava** `VersionSemver` come `"0.{Version}.0"` da un intero legacy, perché l'aggregato non portava il valore. Da quella sintesi discendevano due comportamenti non ovvi, documentati solo in un commento:

- `PublishToolkitVersionCommandHandler` scavalcava `GameToolkitRepository.UpdateAsync`, mutando la riga EF tracked, per non farsi sovrascrivere il semver inserito dall'utente
- `UpdateAsync` escludeva `VersionSemver` dall'`UPDATE` (`IsModified = false`)

Chi toccava `UpdateAsync` senza conoscere entrambi poteva azzerare il puntatore di versione pubblicata sul marketplace. Il breadcrumb esisteva proprio per segnalarlo — ma un commento non è un invariante.

## Il fix

- **`GameToolkit` espone `VersionSemver`**, con `SeedSemver = "0.1.0"` che replica ciò che la vecchia sintesi produceva per un toolkit nuovo (`Version` parte da 1): le righe esistenti mantengono il valore
- **`MapToPersistence` legge** dall'aggregato. Via il breadcrumb e il `#pragma S1135`
- **`MapToDomain` carica** la colonna
- **`PublishMarketplaceVersion()`** sull'aggregato; il handler carica via repository e persiste con `UpdateAsync`, senza più bypass

### Il punto critico non è nel titolo

`MapToDomain` **deve** caricare `VersionSemver`. Prima non lo faceva, e non serviva perché `UpdateAsync` escludeva la colonna. Ora che ci transita, un aggregato ignaro del valore persistito lo azzererebbe a ogni aggiornamento non-publish.

Verificato **in negativo**: reintroducendo la sintesi, `UpdateAsync_RenamingToolkit_PreservesPublishedVersionSemverDescriptionAndLicense` diventa **rosso**. Il guardrail protegge davvero, non è verde per inerzia.

## Doppio tracking EF — c'era, ed è un artefatto del fixture

Spostare il publish su `UpdateAsync` ha fatto esplodere due test con:

> *The instance of entity type 'GameToolkitEntity' cannot be tracked because another instance with the same key value for {'Id'} is already being tracked.*

**Non è un difetto di prodotto.** In produzione `MeepleAiDbContext` è scoped per richiesta e l'unico load del handler è `GetByIdAsync` (`AsNoTracking`): change tracker vuoto, `Update()` attacca senza conflitto. Il fixture invece lasciava l'entità seedata tracked nello **stesso** context. Il seed ora fa `SaveChanges` + `Detach`, che è ciò che una richiesta vede davvero — lo stesso principio che `GameToolkitRepositoryUpdatePreservationTests` applica con due context separati.

Il test del handler usa ora il **repository reale, non un mock**: un mock stubberebbe esattamente il round-trip `MapToDomain`/`MapToPersistence` che rende sicura questa modifica, e resterebbe verde se quel round-trip si rompesse.

## Verifiche prima di toccare il handler

| Controllo | Esito |
|---|---|
| `ToolkitVersionRepository` traccia il parent? | No — **tutte** le letture sono `AsNoTracking` |
| Colonne omesse da `MapToPersistence` (che `Update()` azzererebbe) | 4: `Game`/`PrivateGame` sono navigation, `License` già esclusa, resta `Xmin` |
| Test | **324/324 GameToolkit** (2 su Postgres) · **21552/21552 unit** |

## Follow-up non affrontati in questa PR

- **`VersionDriftPreventionTests` non esamina nulla.** Il suo regex cerca `toolkit.Version =` / `entity.Version =`: zero occorrenze in `apps/api/src`. Le sue stesse note dicono «allargalo quando l'aggregato avrà `VersionSemver`» — è successo oggi, ma allargarlo alla forma nuda catturerebbe solo la factory (già appaiata), mentre la deriva reale è `Version++` in `Publish()`, che nessuna regex su `=` intercetta. Va deciso se i due concetti di versione debbano ancora essere appaiati, ora che sono separati.
- **Le altre entità su `xmin`.** Il fix qui è locale a `GameToolkitRepository`. Ogni altro repository che fa `MapToPersistence` + `Update()` su grafo detached ha lo stesso difetto: il token c'è ma **rifiuta ogni scrittura** invece di non proteggere nulla. È il guasto opposto a quello descritto in #3651, e va cercato con la stessa attenzione.

## Il fix P1: `xmin` (secondo commit)

`GameToolkitEntityConfiguration:60-64` dichiara `Xmin` come concurrency token. EF mette i token nella `WHERE` usando il valore **originale**, ma `MapToPersistence` costruisce un'entità **detached** in cui `Xmin` non viene mai assegnato → `original == current == 0`:

```sql
UPDATE "GameToolkits" SET … WHERE "Id" = @p AND xmin = 0
```

`xmin` non è mai 0 per una tupla viva → 0 righe → `DbUpdateConcurrencyException` → 500.

**Perché era invisibile**: ogni test di questo repository gira su EF InMemory, che la colonna di sistema `xmin` non ce l'ha. Il commento di `GameToolkitRepositoryUpdatePreservationTests` lo diceva pure — *«ignores the Postgres xmin concurrency token»* — senza che nessuno tirasse la conclusione. Stessa famiglia dei gate ciechi di #3665: il verde misurava un ambiente in cui il difetto non può manifestarsi.

**Verifica in tre passaggi** (non dedotta):

| Passo | Esito |
|---|---|
| Branch, Postgres vero | `DbUpdateConcurrencyException` su rename **e** publish |
| `main-dev` pre-PR (`afd51b770`, worktree separato) | Rename fallisce **identico** → pre-esistente |
| Dopo il fix | **2/2 verdi** |

**Il fix** è il pattern che il codebase già usa in `AlertChannelRepository:78`: l'aggregato porta `Xmin`, il repository lo passa come `OriginalValue`. `Xmin` è assegnato esplicitamente anche nella factory perché il setter è altrimenti raggiunto solo dalla riflessione di `MapToDomain`, e `S1144` lo legge come codice morto (con i precedenti di #2296).

**Aggiunti `GameToolkitRepositoryPostgresConcurrencyTests`**: rename e publish contro Postgres via Testcontainers. Erano il buco che rendeva il difetto invisibile — `POST /api/v1/toolkits/{id}/versions` non aveva alcun integration test.

## Da sapere

**Scostamento dal DoD.** Il DoD chiede di rimuovere «i due `#pragma warning disable`». Il `CS0618` **resta**: copre il paired write sulla colonna legacy `int Version`, che `VersionDriftPreventionTests` impone. Toglierlo significa ritirare quella colonna, che è un'altra issue.

## DoD #3670

- [x] `VersionSemver` è proprietà del dominio, non derivata da `Version` in fase di persistenza
- [x] `PublishToolkitVersionCommandHandler` non scavalca più `GameToolkitRepository.UpdateAsync`
- [x] Un aggiornamento non-publish preserva il `VersionSemver` pubblicato — con un test che fallisce se la sintesi torna (verificato)
- [x] Il breadcrumb non c'è più — con il `#pragma S1135`. Il `CS0618` resta per il motivo sopra

Closes #3670

🤖 Generated with [Claude Code](https://claude.com/claude-code)
