### PR TITLE
fix(db): xmin su shared_games e provider_credentials (#3651)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,6 +270,14 @@ tests/                    # Api.Tests, k6, api-smoke, llm-eval, fixtures — see
 
 **Baseline currently clean** (0 known failures on `main-dev`). Resolved-triage history (#1349 → #1422 → #1887 → #2270 → #2266): [claude-md-history.md](./docs/for-claude/claude-md-history.md#known-flaky-tests--resolved-history).
 
+**Intermittenti noti** (non contano nella baseline: passano al rerun, ma costano un'indagine a chi li incontra la prima volta):
+
+| Test | Sintomo | Issue |
+|------|---------|-------|
+| `DurationTracking_MultipleStageFallback_RecordsCumulativeTime` | asserzione **wall-clock** (`TotalDurationMs >= 100` su tre `Task.Delay(50)`) in un `Category=Unit`, quindi gira in `Backend Fast`: 1 fallimento su 2 run dello stesso SHA | [#3686](https://github.com/meepleAi-app/meepleai-monorepo/issues/3686) |
+
+Prima di rilassare la soglia di un test di timing, stabilisci **perché** la misura scende: se il cronometro non accumula davvero, il test sta segnalando un difetto vero e la soglia va alzata, non abbassata.
+
 **Policy**: PRs MUST NOT grow the unit-test fail count above baseline (zero). Future regressions: fix the root cause OR skip with `[Trait("Skip", "<issue#>")]` and add a row here in the same PR.
 
 ## AI Assistant Rules

--- a/apps/api/src/Api/BoundedContexts/Administration/Domain/Aggregates/ProviderCredentials/ProviderCredential.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Domain/Aggregates/ProviderCredentials/ProviderCredential.cs
@@ -23,11 +23,26 @@ public sealed class ProviderCredential
     public DateTime RotatedAt { get; private set; }
     public Guid RotatedByUserId { get; private set; }
     public Guid? PreviousCredentialId { get; private set; }
-    // Nullable so the Npgsql provider can omit the store-generated row_version from the
-    // INSERT (a NOT NULL bytea column raised a 23502 violation on the first insert).
-    // Get-only: EF Core populates it via reflection. The token is not populated on this table
-    // (no trigger/xmin), so the 1-active-row guard is the ux_provider_credentials_active_one index.
-    public byte[]? RowVersion { get; }
+    // #3651: token di concorrenza ottimistica sulla colonna di sistema `xmin`, come le entità
+    // migrate da #2305.
+    //
+    // Prima era `byte[]? RowVersion` su una colonna `bytea`, e il commento qui dichiarava che il
+    // token «non è popolato su questa tabella» accettandolo come normale: la protezione era
+    // dichiarata dalla configurazione EF ma non esisteva, perché Postgres non valorizza una
+    // `bytea` da solo e il trigger che lo faceva è stato rimosso da #2305. Restava NULL su ogni
+    // riga, EF confrontava NULL = NULL e ogni update passava.
+    //
+    // L'indice parziale ux_provider_credentials_active_one continua a garantire l'invariante
+    // «una sola riga attiva per provider», ma copre l'INSERT della nuova credenziale, non
+    // l'UPDATE che disattiva la precedente: due rotazioni concorrenti disattivavano entrambe la
+    // stessa riga senza che nulla lo segnalasse.
+    //
+    // `uint` e non `byte[]`: xmin è di tipo `xid`. La proprietà non è esposta da alcun DTO.
+    //
+    // Get-only come lo era RowVersion: il dominio non deve mai assegnarla, la scrive solo EF Core
+    // sul backing field. Un `private set` qui verrebbe segnalato da S1144 come setter inutilizzato,
+    // perché l'unico scrittore è la reflection.
+    public uint Xmin { get; }
 
     public IReadOnlyCollection<INotification> DomainEvents => _domainEvents.AsReadOnly();
     public void ClearDomainEvents() => _domainEvents.Clear();

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/SharedGame.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/SharedGame.cs
@@ -291,6 +291,25 @@ public sealed class SharedGame : AggregateRoot<Guid>
     public DateTime? ModifiedAt => _modifiedAt;
 
     /// <summary>
+    /// Token di concorrenza ottimistica (colonna di sistema PostgreSQL <c>xmin</c>, ADR-060).
+    /// Stesso pattern di <see cref="MechanicCard.XminVersion"/>, <see cref="MechanicAnalysis.XminVersion"/>
+    /// e <see cref="CertificationThresholdsConfig.XminVersion"/>.
+    /// <para>
+    /// Deve attraversare l'aggregato perché <c>SharedGameRepository.Update()</c> persiste un grafo
+    /// <b>detached</b> (<c>MapToEntity</c> + <c>DbSet.Update()</c>): EF non ha una riga tracciata da
+    /// cui ricavare l'<i>original value</i> del token, e usa quello che trova sulla proprietà. Se
+    /// l'aggregato non lo trasportasse, il valore sarebbe <c>0</c> — che non è mai un xid reale —
+    /// e ogni UPDATE emetterebbe <c>WHERE xmin = 0</c>, colpendo 0 righe e sollevando
+    /// <c>DbUpdateConcurrencyException</c> anche <b>senza alcuna concorrenza</b> (#3651).
+    /// </para>
+    /// <para>
+    /// Vale <c>0</c> per un aggregato appena creato con <c>Create()</c>: quel percorso è un INSERT,
+    /// dove il token non viene usato ed è Postgres a valorizzarlo.
+    /// </para>
+    /// </summary>
+    public uint XminVersion { get; private set; }
+
+    /// <summary>
     /// Gets the designers who created this game.
     /// </summary>
     public IReadOnlyCollection<GameDesigner> Designers => _designers.AsReadOnly();
@@ -425,8 +444,10 @@ public sealed class SharedGame : AggregateRoot<Guid>
         string? manualCoverSourceUrl = null,
         Guid? manualCoverAttestedBy = null,
         DateTime? manualCoverAttestedAt = null,
-        string? bggCoverR2Key = null) : base(id)
+        string? bggCoverR2Key = null,
+        uint xminVersion = 0) : base(id)
     {
+        XminVersion = xminVersion;
         _id = id;
         _title = title;
         _yearPublished = yearPublished;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/SharedGameRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/SharedGameRepository.cs
@@ -413,7 +413,13 @@ internal sealed class SharedGameRepository : RepositoryBase, ISharedGameReposito
             manualCoverAttestedAt: entity.ManualCoverAttestedAt,
             // #3590 Slice B — senza questa lettura l'aggregato non conosce la cover BGG, quindi
             // MapToEntity la riscriverebbe come NULL al primo Update() (grafo detached).
-            bggCoverR2Key: entity.BggCoverR2Key);
+            bggCoverR2Key: entity.BggCoverR2Key,
+            // #3651 — il token di concorrenza deve attraversare l'aggregato per la stessa ragione
+            // strutturale delle colonne qui sopra: l'Update() è su grafo detached, quindi EF non ha
+            // una riga tracciata da cui ricavare l'original value e usa quello sulla proprietà.
+            // Senza questa lettura sarebbe 0, e ogni UPDATE emetterebbe `WHERE xmin = 0` — che non
+            // corrisponde mai a un xid reale — fallendo anche senza alcuna concorrenza.
+            xminVersion: entity.Xmin);
 
         // Issue #2035: Hydrate designers from the M:N join — only when the caller
         // eager-loaded the navigation (GetByIdAsync), otherwise the EF Core
@@ -496,7 +502,15 @@ internal sealed class SharedGameRepository : RepositoryBase, ISharedGameReposito
             CreatedAt = game.CreatedAt,
             ModifiedAt = game.ModifiedAt,
             IsDeleted = game.IsDeleted,  // Fix: Use aggregate value, not hardcoded false (Issue #2514 code review)
-            AgentDefinitionId = game.AgentDefinitionId  // Issue #4228
+            AgentDefinitionId = game.AgentDefinitionId,  // Issue #4228
+            // #3651 — token di concorrenza (ADR-060). Su un grafo detached EF non ha una riga
+            // tracciata da cui ricavare l'original value del token e usa quello che trova qui:
+            // omettendolo resterebbe 0, e ogni UPDATE emetterebbe `WHERE xmin = 0` colpendo 0
+            // righe, cioè un DbUpdateConcurrencyException su ogni scrittura anche senza
+            // concorrenza. Con il valore letto in MapToDomain il confronto è quello giusto: la
+            // scrittura passa se la riga non è cambiata, e fallisce con 409 se qualcuno l'ha
+            // modificata nel frattempo.
+            Xmin = game.XminVersion
         };
     }
 

--- a/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/SharedGameEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/SharedGameEntity.cs
@@ -51,10 +51,17 @@ public class SharedGameEntity
     public bool HasKnowledgeBase { get; set; }
 
     /// <summary>
-    /// Optimistic concurrency token. Managed by the database.
-    /// Spec-panel recommendation C-3.
+    /// Token di concorrenza ottimistica, sulla colonna di sistema <c>xmin</c> di PostgreSQL.
+    /// Spec-panel recommendation C-3; #3651 per la conversione.
+    /// <para>
+    /// Prima era <c>byte[]? RowVersion</c> su una colonna <c>bytea</c>. Postgres non popola una
+    /// <c>bytea</c> da solo, e il trigger che lo faceva è stato rimosso da #2305 migrando le altre
+    /// entità a <c>xmin</c>: da allora il token restava NULL, EF confrontava <c>NULL = NULL</c> a
+    /// ogni update e due redattori concorrenti sulla stessa scheda si sovrascrivevano a vicenda in
+    /// silenzio.
+    /// </para>
     /// </summary>
-    public byte[]? RowVersion { get; set; }
+    public uint Xmin { get; set; }
 
     /// <summary>
     /// Issue #1823 (umbrella #1821 L2) — Wikidata/Wikimedia Commons-sourced

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/Administration/ProviderCredentialEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/Administration/ProviderCredentialEntityConfiguration.cs
@@ -48,16 +48,25 @@ internal sealed class ProviderCredentialEntityConfiguration
         builder.Property(e => e.PreviousCredentialId)
             .HasColumnName("previous_credential_id");
 
-        // row_version MUST be nullable: with .IsRowVersion() the Npgsql provider treats it as
-        // store-generated and omits it from INSERT, so a NOT NULL bytea column raised a 23502
-        // not-null violation on the first credential INSERT (breaking rotate-key). Nullable
-        // lets the provider omit it on INSERT. Note: this table has no trigger/xmin populating
-        // the token, so it stays NULL and provides no real optimistic-concurrency detection —
-        // the single-active-row invariant is enforced by the ux_provider_credentials_active_one
-        // unique index. Mirrors the PhotoBatchUpload aggregate (same byte[]? RowVersion pattern).
-        builder.Property(e => e.RowVersion)
-            .HasColumnName("row_version")
-            .IsRowVersion();
+        // #3651: concorrenza ottimistica via `xmin`, la colonna di sistema di PostgreSQL.
+        //
+        // Qui c'era `.Property(e => e.RowVersion).HasColumnName("row_version").IsRowVersion()` su
+        // una `bytea`, con un commento che riconosceva il difetto invece di correggerlo: «this
+        // table has no trigger/xmin populating the token, so it stays NULL and provides no real
+        // optimistic-concurrency detection». Restava quindi una dichiarazione senza effetto — EF
+        // confrontava NULL = NULL a ogni update e nessun conflitto veniva rilevato.
+        //
+        // Anche il vincolo storico che imponeva la colonna nullable sparisce: serviva perché
+        // .IsRowVersion() faceva omettere row_version dall'INSERT, e una `bytea` NOT NULL alzava
+        // un 23502 alla prima credenziale. `xmin` è di sistema: Postgres la valorizza da sé e non
+        // compare mai in un INSERT.
+        //
+        // Stesso pattern di LiveGameSessionEntityConfiguration:148-152 e GameNightPlaylist.
+        builder.Property(e => e.Xmin)
+            .HasColumnName("xmin")
+            .HasColumnType("xid")
+            .ValueGeneratedOnAddOrUpdate()
+            .IsConcurrencyToken();
 
         // Partial unique index: 1 sola row attiva per provider (Postgres filtered index)
         builder.HasIndex(e => e.ProviderName)

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/SharedGameCatalog/SharedGameEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/SharedGameCatalog/SharedGameEntityConfiguration.cs
@@ -122,10 +122,19 @@ internal class SharedGameEntityConfiguration : IEntityTypeConfiguration<SharedGa
             .IsRequired()
             .HasDefaultValue(false);
 
-        // Optimistic concurrency (spec-panel C-3)
-        builder.Property(e => e.RowVersion)
-            .HasColumnName("row_version")
-            .IsRowVersion();
+        // Optimistic concurrency (spec-panel C-3) — #3651: ora sulla colonna di sistema `xmin`.
+        //
+        // Era `.Property(e => e.RowVersion).HasColumnName("row_version").IsRowVersion()` su una
+        // `bytea`: Postgres non la valorizza da sé, e il trigger `ef_update_row_version()` che lo
+        // faceva è stato rimosso da #2305 quando le altre entità sono passate a xmin. Da allora il
+        // token restava NULL su ogni riga e la protezione non scattava mai.
+        //
+        // Stesso pattern di LiveGameSessionEntityConfiguration:148-152 e GameNightPlaylist.
+        builder.Property(e => e.Xmin)
+            .HasColumnName("xmin")
+            .HasColumnType("xid")
+            .ValueGeneratedOnAddOrUpdate()
+            .IsConcurrencyToken();
 
         // Issue #1823 (umbrella #1821 L2) — Wikidata cover columns.
         builder.Property(e => e.WikidataCoverR2Key)

--- a/apps/api/src/Api/Infrastructure/Migrations/20260811224354_SharedGameProviderCredentialXminConcurrency.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260811224354_SharedGameProviderCredentialXminConcurrency.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260811224354_SharedGameProviderCredentialXminConcurrency")]
+    partial class SharedGameProviderCredentialXminConcurrency
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260811224354_SharedGameProviderCredentialXminConcurrency.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260811224354_SharedGameProviderCredentialXminConcurrency.cs
@@ -1,0 +1,63 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class SharedGameProviderCredentialXminConcurrency : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Migration Safety Gate (#1087, rollback-runbook §8.2): i DROP COLUMN qui sotto sono
+            // rollback-safe perché le colonne sono già di fatto morte. Nessun trigger nello schema
+            // le popola — `ef_update_row_version()` è stato rimosso da #2305 e non esiste in alcuna
+            // migration — e Postgres non valorizza una `bytea` da sé, quindi contengono NULL su
+            // ogni riga. Nessun codice le legge: non sono esposte da alcun DTO né dal frontend.
+            // Il Down() le ricrea identiche.
+            migrationBuilder.Sql("-- safe: drop dead bytea concurrency columns, NULL on every row (no trigger populates them since #2305); replaced by the xmin system column (§8.3)");
+
+            // #3651: rimuove le colonne `row_version` (bytea), residuo del meccanismo pre-#2305.
+            // Finché esistevano, EF confrontava NULL = NULL a ogni update e nessun conflitto veniva
+            // rilevato: la concorrenza ottimistica era dichiarata dalla configurazione ma inattiva.
+            // Misurato prima della conversione — due scritture concorrenti riuscivano entrambe:
+            //   SharedGameXminConcurrencyTests.ConcurrentEdits_SecondWriterThrowsConcurrencyException
+            //   ProviderCredentialXminConcurrencyTests.ConcurrentDeactivations_SecondWriterThrowsConcurrencyException
+            migrationBuilder.DropColumn(
+                name: "row_version",
+                table: "shared_games");
+
+            migrationBuilder.DropColumn(
+                name: "row_version",
+                table: "provider_credentials");
+
+            // NB: nessun AddColumn per `xmin`, benché lo scaffold di EF ne avesse generati due.
+            // `xmin` è una colonna di SISTEMA di PostgreSQL, presente su ogni tabella: un
+            // `ADD COLUMN xmin` fallirebbe con «column name "xmin" conflicts with a system column
+            // name». EF la vede come una proprietà nuova del modello e non sa che è di sistema —
+            // stessa ragione per cui il comando ha avvertito di una possibile perdita di dati.
+            // Identico a quanto fatto per pdf_documents in 20260811130532 (#3658).
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Ripristina le colonne, non un meccanismo che le valorizzi: tornando indietro il token
+            // resterebbe NULL come prima di questa migration. È esattamente lo stato precedente.
+            migrationBuilder.AddColumn<byte[]>(
+                name: "row_version",
+                table: "shared_games",
+                type: "bytea",
+                rowVersion: true,
+                nullable: true);
+
+            migrationBuilder.AddColumn<byte[]>(
+                name: "row_version",
+                table: "provider_credentials",
+                type: "bytea",
+                rowVersion: true,
+                nullable: true);
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/SharedGameEntityRowVersionTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/SharedGameEntityRowVersionTests.cs
@@ -5,31 +5,43 @@ using Xunit;
 namespace Api.Tests.BoundedContexts.SharedGameCatalog.Domain;
 
 /// <summary>
-/// Verifica che SharedGameEntity abbia RowVersion per ottimistic concurrency.
-/// Spec-panel recommendation C-3.
+/// Verifica che SharedGameEntity dichiari il token di concorrenza ottimistica nella forma che
+/// PostgreSQL può effettivamente popolare. Spec-panel recommendation C-3; #3651.
+///
+/// Questi test asserivano <c>PropertyType == typeof(byte[])</c> ed erano verdi mentre la
+/// protezione non esisteva: il token `bytea` restava NULL su ogni riga da quando #2305 ha rimosso
+/// il trigger che lo popolava, quindi EF confrontava NULL = NULL e ogni update passava. Un test
+/// che fissa la forma sbagliata certifica il difetto invece di rilevarlo — la verifica di merito
+/// (due scritture concorrenti, la seconda rifiutata) sta in
+/// <c>SharedGameXminConcurrencyTests</c>, che richiede un vero PostgreSQL.
 /// </summary>
 [Trait("Category", "Unit")]
 [Trait("BoundedContext", "SharedGameCatalog")]
 public sealed class SharedGameEntityRowVersionTests
 {
     [Fact]
-    public void SharedGameEntity_HasRowVersionProperty()
+    public void SharedGameEntity_HasXminConcurrencyToken()
     {
         // Arrange & Act
-        var property = typeof(SharedGameEntity).GetProperty("RowVersion");
+        var property = typeof(SharedGameEntity).GetProperty("Xmin");
 
         // Assert
-        property.Should().NotBeNull("SharedGameEntity must have a RowVersion property for optimistic concurrency");
-        property!.PropertyType.Should().Be(typeof(byte[]), "RowVersion must be byte[] for EF Core timestamp token");
+        property.Should().NotBeNull("SharedGameEntity deve esporre il token di concorrenza xmin");
+        property!.PropertyType.Should().Be(
+            typeof(uint),
+            "xmin è di tipo xid: Npgsql lo mappa solo su una proprietà uint. Con byte[] la colonna " +
+            "diventa una bytea che Postgres non valorizza, e la concorrenza ottimistica non scatta");
     }
 
     [Fact]
-    public void SharedGameEntity_RowVersionIsNullableByDefault()
+    public void SharedGameEntity_NoLongerCarriesTheDeadByteArrayToken()
     {
         // Arrange & Act
-        var entity = new SharedGameEntity();
+        var legacy = typeof(SharedGameEntity).GetProperty("RowVersion");
 
         // Assert
-        entity.RowVersion.Should().BeNull("new entity RowVersion is assigned by the database on first save");
+        legacy.Should().BeNull(
+            "il token bytea è stato rimosso da #3651 insieme alla colonna row_version: " +
+            "reintrodurlo riporterebbe una protezione dichiarata ma inesistente");
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/SharedGameRepositoryIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/SharedGameRepositoryIntegrationTests.cs
@@ -147,14 +147,30 @@ public sealed class SharedGameRepositoryIntegrationTests : IAsyncLifetime
     public async Task Update_WithModifiedGame_PersistsChanges()
     {
         // Arrange
-        var game = SharedGame.Create("Ticket to Ride", 2004, "Original description", 2, 5, 60, 8,
+        var created = SharedGame.Create("Ticket to Ride", 2004, "Original description", 2, 5, 60, 8,
             null, null, "https://example.com/ticket.jpg", "https://example.com/ticket-thumb.jpg", null, TestUserId);
-        await _repository.AddAsync(game);
+        await _repository.AddAsync(created);
         await _dbContext.SaveChangesAsync();
         _dbContext.ChangeTracker.Clear(); // Detach entities to simulate separate request
 
+        // #3651 — la rilettura non è cosmetica, è il contratto.
+        //
+        // Prima questo test mutava e ripersisteva la STESSA istanza restituita da Create(), senza
+        // mai rileggerla. Funzionava perché il token di concorrenza era una `bytea` sempre NULL su
+        // ogni riga (nessun trigger la popolava): EF generava `row_version IS NULL`, che
+        // corrispondeva sempre. Cioè funzionava proprio perché la protezione non esisteva — lo
+        // stesso difetto che #3651 corregge.
+        //
+        // Con `xmin` attivo, aggiornare un aggregato mai letto dal DB non è più un'operazione
+        // definibile: non si sa da quale versione si parte, e `XminVersion` vale 0, che non è mai
+        // un xid reale. Tutti i ~30 handler di produzione che scrivono sul catalogo fanno già
+        // read-modify-write (`GetByIdAsync` / `GetGameByFaqIdAsync` / …), quindi questo test si
+        // allinea a loro invece di coprire un percorso che nessuno usa.
+        var game = await _repository.GetByIdAsync(created.Id);
+        game.Should().NotBeNull();
+
         // Act
-        game.UpdateInfo(
+        game!.UpdateInfo(
             title: "Ticket to Ride",
             yearPublished: 2004,
             description: "Updated description - claim railway routes across North America",

--- a/apps/api/tests/Api.Tests/Integration/Administration/ProviderCredentialXminConcurrencyTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Administration/ProviderCredentialXminConcurrencyTests.cs
@@ -1,0 +1,99 @@
+using Api.BoundedContexts.Administration.Domain.Aggregates.ProviderCredentials;
+using Api.Infrastructure;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace Api.Tests.Integration.Administration;
+
+/// <summary>
+/// Prova che <c>provider_credentials</c> rilevi davvero un conflitto di scrittura concorrente.
+///
+/// Prima di #3651 la tabella dichiarava la concorrenza ottimistica con <c>byte[]? RowVersion</c>
+/// su una colonna <c>bytea</c>. Postgres non popola una <c>bytea</c> da solo, e il trigger che lo
+/// faceva è stato rimosso da #2305 nel passaggio a <c>xmin</c> delle altre entità: da allora il
+/// token restava NULL su ogni riga, EF confrontava <c>NULL = NULL</c> a ogni update, e nessun
+/// conflitto veniva mai rilevato. La protezione era dichiarata ma inesistente.
+///
+/// Lo scenario qui è quello che il dominio prevede esplicitamente: due rotazioni di chiave
+/// concorrenti che disattivano la stessa credenziale precedente. L'indice parziale
+/// <c>ux_provider_credentials_active_one</c> protegge l'INSERT della nuova riga attiva, ma non
+/// l'UPDATE che disattiva la vecchia — quello è scoperto, ed è ciò che questo test copre.
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "Administration")]
+public sealed class ProviderCredentialXminConcurrencyTests : IAsyncLifetime
+{
+    private static readonly DateTimeOffset FixedNow = new(2026, 8, 12, 9, 0, 0, TimeSpan.Zero);
+
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = null!;
+    private string _connectionString = null!;
+    private MeepleAiDbContext _dbContext = null!;
+
+    public ProviderCredentialXminConcurrencyTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"provcred_xmin_{Guid.NewGuid():N}";
+        _connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        _dbContext = _fixture.CreateDbContext(_connectionString);
+        await _dbContext.Database.MigrateAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _dbContext.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    [Fact(DisplayName = "Due disattivazioni concorrenti: la seconda solleva DbUpdateConcurrencyException")]
+    public async Task ConcurrentDeactivations_SecondWriterThrowsConcurrencyException()
+    {
+        // ── Arrange: una credenziale attiva, come dopo una prima rotazione ────────
+        var credential = ProviderCredential.Create(
+            ProviderName.Create("openrouter"),
+            "encrypted-ciphertext",
+            KeyFingerprint.FromPlaintext("sk-or-abcd1234"),
+            Guid.NewGuid(),
+            previousCredentialId: null,
+            new FakeTimeProvider(FixedNow));
+        var credentialId = credential.Id;
+
+        await _dbContext.ProviderCredentials.AddAsync(credential);
+        await _dbContext.SaveChangesAsync();
+
+        // ── Due scope indipendenti leggono la stessa riga ─────────────────────────
+        // Change tracker separati: ciascuno tiene il proprio snapshot del token.
+        await using var dbA = _fixture.CreateDbContext(_connectionString);
+        await using var dbB = _fixture.CreateDbContext(_connectionString);
+
+        var credentialA = await dbA.ProviderCredentials.FirstAsync(c => c.Id == credentialId);
+        var credentialB = await dbB.ProviderCredentials.FirstAsync(c => c.Id == credentialId);
+
+        credentialA.Should().NotBeSameAs(credentialB);
+
+        // ── Act: A vince la gara e committa per primo ─────────────────────────────
+        credentialA.Deactivate(new FakeTimeProvider(FixedNow));
+        await dbA.SaveChangesAsync();
+
+        // B ha letto prima del commit di A: il suo original value di IsActive è ancora true,
+        // quindi EF emette comunque l'UPDATE — ma con un token ormai stale, che in Postgres
+        // non corrisponde ad alcuna riga. 0 righe affette ⇒ DbUpdateConcurrencyException.
+        credentialB.Deactivate(new FakeTimeProvider(FixedNow));
+        Func<Task> act = async () => await dbB.SaveChangesAsync();
+
+        // ── Assert ────────────────────────────────────────────────────────────────
+        await act.Should().ThrowAsync<DbUpdateConcurrencyException>(
+            "due rotazioni concorrenti non possono disattivare entrambe la stessa credenziale: " +
+            "la seconda deve vedersi rifiutata invece di sovrascrivere in silenzio");
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/SharedGameCatalog/SharedGameXminConcurrencyTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/SharedGameCatalog/SharedGameXminConcurrencyTests.cs
@@ -1,9 +1,13 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Repositories;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.SharedKernel.Application.Services;
 using Api.Tests.Constants;
 using Api.Tests.Infrastructure;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
+using Moq;
 using Xunit;
 
 namespace Api.Tests.Integration.SharedGameCatalog;
@@ -87,5 +91,107 @@ public sealed class SharedGameXminConcurrencyTests : IAsyncLifetime
         await act.Should().ThrowAsync<DbUpdateConcurrencyException>(
             "lo scope B ha un token stale dopo il commit di A — la seconda scrittura va rifiutata " +
             "invece di sovrascrivere silenziosamente la modifica del primo redattore");
+    }
+
+    // ── Il percorso reale: SharedGameRepository.Update() ──────────────────────────
+    //
+    // I due test qui sotto coprono il repository invece del DbContext, perché è lì che passano i
+    // ~30 handler che scrivono sul catalogo — e perché `Update()` persiste un grafo **detached**
+    // (`MapToEntity` + `DbSet.Update()`), che con un token di concorrenza si comporta in modo
+    // diverso da una riga tracciata: EF non ha un original value da cui partire e usa quello che
+    // trova sulla proprietà.
+    //
+    // Senza il trasporto di `XminVersion` attraverso l'aggregato, quel valore è `0` — mai un xid
+    // reale — quindi ogni UPDATE emette `WHERE xmin = 0`, colpisce 0 righe e solleva
+    // `DbUpdateConcurrencyException` **anche senza concorrenza**: il rovescio esatto del difetto
+    // che #3651 corregge. Il primo test è la regressione di quel guasto, il secondo verifica che
+    // la protezione resti attiva sullo stesso percorso.
+
+    private SharedGameRepository CreateRepository(MeepleAiDbContext dbContext) =>
+        new(dbContext, new Mock<IDomainEventCollector>().Object);
+
+    private static SharedGame NewGame() => SharedGame.Create(
+        "Ticket to Ride", 2004, "Descrizione originale", 2, 5, 60, 8,
+        null, null, "https://example.com/c.jpg", "https://example.com/t.jpg", null, Guid.NewGuid());
+
+    [Fact(DisplayName = "Update() da singolo scrittore riesce: il token non blocca chi non ha rivali")]
+    public async Task RepositoryUpdate_WithNoConcurrentWriter_Succeeds()
+    {
+        // ── Arrange: una scheda salvata, poi il tracker svuotato per simulare una request nuova ──
+        var repository = CreateRepository(_dbContext);
+        var game = NewGame();
+        await repository.AddAsync(game);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        // ── Act: rileggo, modifico e persisto — nessun altro scrittore in gioco ───
+        var loaded = await repository.GetByIdAsync(game.Id);
+        loaded.Should().NotBeNull();
+        loaded!.XminVersion.Should().NotBe(0,
+            "l'aggregato deve trasportare il token letto dal DB: se resta 0 l'UPDATE cercherebbe " +
+            "`WHERE xmin = 0`, che non corrisponde ad alcuna riga");
+
+        loaded.UpdateInfo(
+            title: "Ticket to Ride",
+            yearPublished: 2004,
+            description: "Descrizione aggiornata",
+            minPlayers: 2,
+            maxPlayers: 5,
+            playingTimeMinutes: 60,
+            minAge: 8,
+            complexityRating: null,
+            averageRating: null,
+            imageUrl: "https://example.com/c.jpg",
+            thumbnailUrl: "https://example.com/t.jpg",
+            rules: null,
+            modifiedBy: Guid.NewGuid());
+        repository.Update(loaded);
+
+        Func<Task> act = async () => await _dbContext.SaveChangesAsync();
+
+        // ── Assert ────────────────────────────────────────────────────────────────
+        await act.Should().NotThrowAsync(
+            "senza scritture concorrenti l'update deve passare: un token di concorrenza che " +
+            "rifiuta ogni scrittura non protegge nulla, rompe soltanto");
+
+        _dbContext.ChangeTracker.Clear();
+        var reloaded = await repository.GetByIdAsync(game.Id);
+        reloaded!.Description.Should().Be("Descrizione aggiornata");
+    }
+
+    [Fact(DisplayName = "Update() con token stale è rifiutato: la protezione vale anche sul repository")]
+    public async Task RepositoryUpdate_AfterConcurrentWrite_ThrowsConcurrencyException()
+    {
+        // ── Arrange ───────────────────────────────────────────────────────────────
+        var seedRepository = CreateRepository(_dbContext);
+        var game = NewGame();
+        await seedRepository.AddAsync(game);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        await using var dbA = _fixture.CreateDbContext(_connectionString);
+        await using var dbB = _fixture.CreateDbContext(_connectionString);
+        var repoA = CreateRepository(dbA);
+        var repoB = CreateRepository(dbB);
+
+        var gameA = await repoA.GetByIdAsync(game.Id);
+        var gameB = await repoB.GetByIdAsync(game.Id);
+        gameA!.XminVersion.Should().Be(gameB!.XminVersion, "entrambi hanno letto la stessa riga");
+
+        // ── Act: A committa per primo, B resta con un token vecchio ───────────────
+        gameA.UpdateInfo("Ticket to Ride", 2004, "Modificata da A", 2, 5, 60, 8,
+            null, null, "https://example.com/c.jpg", "https://example.com/t.jpg", null, Guid.NewGuid());
+        repoA.Update(gameA);
+        await dbA.SaveChangesAsync();
+
+        gameB.UpdateInfo("Ticket to Ride", 2004, "Modificata da B", 2, 5, 60, 8,
+            null, null, "https://example.com/c.jpg", "https://example.com/t.jpg", null, Guid.NewGuid());
+        repoB.Update(gameB);
+        Func<Task> act = async () => await dbB.SaveChangesAsync();
+
+        // ── Assert ────────────────────────────────────────────────────────────────
+        await act.Should().ThrowAsync<DbUpdateConcurrencyException>(
+            "il token trasportato da B è quello di prima del commit di A: la seconda scrittura " +
+            "va rifiutata anche passando dal repository, non solo dal DbContext");
     }
 }

--- a/apps/api/tests/Api.Tests/Integration/SharedGameCatalog/SharedGameXminConcurrencyTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/SharedGameCatalog/SharedGameXminConcurrencyTests.cs
@@ -1,0 +1,91 @@
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Api.Tests.Integration.SharedGameCatalog;
+
+/// <summary>
+/// Prova che <c>shared_games</c> rilevi davvero un conflitto di scrittura concorrente.
+///
+/// Prima di #3651 la tabella dichiarava la concorrenza ottimistica con <c>byte[]? RowVersion</c>
+/// su una colonna <c>bytea</c>. Postgres non popola una <c>bytea</c> da solo, e il trigger che lo
+/// faceva è stato rimosso da #2305 nel passaggio a <c>xmin</c> delle altre entità: da allora il
+/// token restava NULL su ogni riga, EF confrontava <c>NULL = NULL</c> a ogni update, e nessun
+/// conflitto veniva mai rilevato. La protezione era dichiarata ma inesistente.
+///
+/// Lo scenario coperto è l'editing concorrente dal catalogo: due redattori aprono la stessa
+/// scheda gioco e salvano modifiche a campi diversi. Senza token la seconda scrittura sovrascrive
+/// la prima in silenzio (last-write-wins), e chi ha salvato per primo non ha modo di accorgersene.
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class SharedGameXminConcurrencyTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = null!;
+    private string _connectionString = null!;
+    private MeepleAiDbContext _dbContext = null!;
+
+    public SharedGameXminConcurrencyTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"sharedgame_xmin_{Guid.NewGuid():N}";
+        _connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        _dbContext = _fixture.CreateDbContext(_connectionString);
+        await _dbContext.Database.MigrateAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _dbContext.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    [Fact(DisplayName = "Editing concorrente della stessa scheda: la seconda scrittura è rifiutata")]
+    public async Task ConcurrentEdits_SecondWriterThrowsConcurrencyException()
+    {
+        // ── Arrange: una scheda pubblicata nel catalogo ───────────────────────────
+        var gameId = Guid.NewGuid();
+        _dbContext.SharedGames.Add(new SharedGameEntity
+        {
+            Id = gameId,
+            Title = "Gloomhaven"
+        });
+        await _dbContext.SaveChangesAsync();
+
+        // ── Due scope indipendenti aprono la stessa scheda ─────────────────────────
+        await using var dbA = _fixture.CreateDbContext(_connectionString);
+        await using var dbB = _fixture.CreateDbContext(_connectionString);
+
+        var gameA = await dbA.SharedGames.FirstAsync(g => g.Id == gameId);
+        var gameB = await dbB.SharedGames.FirstAsync(g => g.Id == gameId);
+
+        gameA.Should().NotBeSameAs(gameB);
+
+        // ── Act: A salva per primo ────────────────────────────────────────────────
+        gameA.Title = "Gloomhaven: Jaws of the Lion";
+        await dbA.SaveChangesAsync();
+
+        // B modifica un campo diverso, quindi non c'è collisione a livello di colonna: senza un
+        // token di concorrenza il suo UPDATE riesce e riporta il Title al valore che A aveva
+        // appena cambiato. È il caso in cui il last-write-wins è più insidioso — non c'è alcun
+        // sintomo, solo una modifica che sparisce.
+        gameB.Description = "Un dungeon crawler cooperativo a campagna.";
+        Func<Task> act = async () => await dbB.SaveChangesAsync();
+
+        // ── Assert ────────────────────────────────────────────────────────────────
+        await act.Should().ThrowAsync<DbUpdateConcurrencyException>(
+            "lo scope B ha un token stale dopo il commit di A — la seconda scrittura va rifiutata " +
+            "invece di sovrascrivere silenziosamente la modifica del primo redattore");
+    }
+}

--- a/docs/for-claude/architecture/adr/adr-060-live-session-persistence.md
+++ b/docs/for-claude/architecture/adr/adr-060-live-session-persistence.md
@@ -210,3 +210,29 @@ Implementation:
 Same migration pattern applied to `GameNightPlaylist` and `MechanicDraft` (issue #2306) which had `bytea NOT NULL row_version` without any trigger — optimistic concurrency was effectively disabled on those tables. The new xmin pattern + integration tests prove the fix.
 
 Pattern reference: `apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicAnalysisEntityConfiguration.cs:101-107`.
+
+## Update 2026-08-12 — il censimento lasciato aperto da #2305 (issue #3651)
+
+L'update del 2026-06-14 ha rimosso il trigger `ef_update_row_version()`, ma la conversione a `xmin` ha coperto solo le entità allora note. **Le altre hanno smesso di essere protette senza che nulla lo segnalasse**: senza trigger Postgres non valorizza una `bytea`, quindi il token restava NULL su ogni riga, EF confrontava `NULL = NULL` a ogni update e nessun conflitto veniva più rilevato. È lo stesso difetto già descritto sopra per `GameNightPlaylist`/`MechanicDraft` — solo, non era stato censito fino in fondo.
+
+Il difetto è **silenzioso per costruzione**: la configurazione EF continua a dichiarare `.IsRowVersion()`, quindi leggendo il codice la protezione sembra esserci. Una configurazione arrivò perfino a documentare la propria inefficacia come se fosse accettabile (`ProviderCredentialEntityConfiguration`: *«this table has no trigger/xmin populating the token, so it stays NULL and provides no real optimistic-concurrency detection»*).
+
+Stato del censimento (verificabile su `MeepleAiDbContextModelSnapshot.cs`):
+
+| | conteggio | come contarle |
+|---|---|---|
+| convertite a `xmin` | **18** | `grep -c 'HasColumnName("xmin")'` |
+| ancora su `bytea` | **7** | `grep -c 'HasColumnName("row_version")'` |
+
+Restano: `AbTestSession` · `BggTosHashEntity` · `CatalogSeedDraftEntity` · `GameBook` · `PhotoBatchUpload` · `SessionEntity` · `ShareRequestEntity`.
+
+**Ordine di lavoro obbligato** (issue #3651, DoD): prima un test di integrazione che fallisce con *«no exception was thrown»* — cioè che dimostra l'assenza di conflitto invece di assumerla — poi la conversione che lo fa passare. Convertire senza il test rosso significa sostituire un'asserzione non verificata con un'altra.
+
+Due trappole ricorrenti, entrambe già incontrate:
+
+1. **Lo scaffold di EF genera un `AddColumn` per `xmin`**, che in produzione fallisce con *«column name "xmin" conflicts with a system column name»*: è una colonna di sistema presente su ogni tabella. Va rimosso a mano dalla migration. L'avviso *«may result in the loss of data»* è il segnale per leggerla invece di accettarla.
+2. **Il `DROP COLUMN row_version` richiede la direttiva `-- safe:`** sulla prima riga di `Up()` (Migration Safety Gate, #1087, rollback-runbook §8.2).
+
+Attivare la protezione fa emergere `DbUpdateConcurrencyException` su percorsi che prima non la vedevano mai. La rete esiste già: `ApiExceptionHandlerMiddleware` la mappa a **409** con `X-Warning-Code: concurrent-edit`, quindi nessun percorso HTTP degrada a 500. Da verificare caso per caso restano i **job in background**, dove un'eccezione non gestita non produce un 409 ma un ciclo perso.
+
+Riferimenti: #2305 (la conversione parziale) · #3658 (`PdfDocument`) · #3651 + PR #3683 (`SharedGame`, `ProviderCredential`).


### PR DESCRIPTION
Secondo lotto della conversione a `xmin` di #3651: **2 entità su 9**, scelte perché il dominio prevede esplicitamente una race su entrambe — editing concorrente dal catalogo e rotazione chiavi.

## Il difetto, misurato

Entrambe dichiaravano la concorrenza ottimistica con `byte[]? RowVersion` su una colonna `bytea`. Postgres non popola una `bytea` da sola, e il trigger `ef_update_row_version()` che lo faceva è stato rimosso da #2305 migrando le altre entità a `xmin`. Da allora il token restava NULL su ogni riga, EF confrontava `NULL = NULL` a ogni update, e nessun conflitto veniva rilevato.

La configurazione di `provider_credentials` lo diceva perfino a chiare lettere, accettandolo come normale invece di correggerlo:

> *this table has no trigger/xmin populating the token, so it stays NULL and provides no real optimistic-concurrency detection*

**I due test aggiunti sono stati scritti prima della conversione e falliti entrambi**, con `no exception was thrown` — cioè per assenza di conflitto, non per errori di setup:

| test | prima | dopo |
|---|---|---|
| `SharedGameXminConcurrencyTests` — due redattori sulla stessa scheda | ❌ nessuna eccezione, la seconda scrittura sovrascrive | ✅ `DbUpdateConcurrencyException` |
| `ProviderCredentialXminConcurrencyTests` — due rotazioni concorrenti | ❌ nessuna eccezione, entrambe disattivano la stessa riga | ✅ `DbUpdateConcurrencyException` |

Su `provider_credentials` l'indice parziale `ux_provider_credentials_active_one` protegge l'INSERT della nuova riga attiva, ma **non** l'UPDATE che disattiva la precedente: era quello il varco.

## Migration

Rimossi i due `AddColumn` per `xmin` generati dallo scaffold: è una colonna di **sistema**, presente su ogni tabella Postgres, e `ADD COLUMN xmin` fallirebbe in produzione con «column name "xmin" conflicts with a system column name». Stessa correzione fatta per `pdf_documents` in #3658 — l'avviso *«may result in the loss of data»* è il segnale per leggere la migration invece di accettarla.

Presente la direttiva `-- safe:` richiesta dal Migration Safety Gate (#1087): le colonne rimosse contengono NULL su ogni riga (nessun trigger nello schema le popola) e non sono lette da alcun DTO né dal frontend — verificato.

## Percorsi di scrittura

Il punto 3 della issue avvertiva che attivare una protezione mai scattata fa emergere eccezioni dove prima non se ne vedevano. Verificati:

- il **middleware globale** mappa già `DbUpdateConcurrencyException` a **409** con `X-Warning-Code: concurrent-edit` — nessun percorso HTTP degrada a 500;
- `VectorDocumentIndexedForKbFlagHandler` è idempotente, e un suo fallimento è **già compensato** da `KbFlagDriftAuditJob` entro 10 minuti (difesa documentata nel codice, non introdotta qui);
- `KbFlagDriftAuditJob` cattura `Exception` per non far sospendere il trigger Quartz: assorbe anche il conflitto e riprova al ciclo dopo;
- `RotateProviderKeyCommandHandler` non cattura: la seconda rotazione concorrente ora prende un **409 esplicito** invece di arrivare a violare l'indice unique.

## Un test che certificava il difetto

`SharedGameEntityRowVersionTests` asseriva `PropertyType == typeof(byte[])` ed era **verde mentre la protezione non esisteva**. Un test che fissa la forma sbagliata certifica il difetto invece di rilevarlo: riscritto sul contratto vero (`uint Xmin` presente, `RowVersion` assente).

## Verifica

- 4/4 verdi: i 2 test di concorrenza + i 2 unit riscritti
- **2650** unit test dei bounded context toccati (SharedGameCatalog + Administration): 0 falliti
- `dotnet format --verify-no-changes` pulito su tutti i file toccati

## Cosa resta

**7 entità**, nessuna con test di concorrenza: `AbTestSession` · `BggTosHashEntity` · `CatalogSeedDraftEntity` · `GameBook` · `PhotoBatchUpload` · `SessionEntity` · `ShareRequestEntity`.

La issue #3651 resta **aperta** e ora porta in corpo la DoD che prima viveva solo in un commento — stesso ordine test-rosso-prima per il lotto successivo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
