### PR TITLE
test(e2e): il flusso sessione segue il modello GameNight (#3662)

### DIFF
--- a/apps/api/tests/Api.Tests/E2E/GameManagement/GameManagementE2ETests.cs
+++ b/apps/api/tests/Api.Tests/E2E/GameManagement/GameManagementE2ETests.cs
@@ -1,3 +1,4 @@
+using Api.Infrastructure.Entities;
 using Api.Tests.E2E.Infrastructure;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
@@ -50,6 +51,55 @@ public sealed class GameManagementE2ETests : E2ETestBase
         DbContext.SharedGames.Add(game);
         await DbContext.SaveChangesAsync();
         _testGameId = game.Id;
+
+        // #3662: avviare una sessione richiede una knowledge base PRONTA -- altrimenti
+        // CreateSessionCommandHandler risponde 422 `kb_not_ready`. E' una regola di business
+        // aggiunta dopo la scrittura di questi test, e senza di essa nessun test del ciclo di
+        // vita della sessione puo' passare.
+        //
+        // «Pronta» significa, secondo GetKbReadinessQueryHandler: almeno un PdfDocument del
+        // gioco in stato "Ready" E un VectorDocument su quel PDF con IndexingStatus
+        // "completed". Servono entrambi: con il solo PDF lo stato resta non-ready.
+        var kbOwner = new UserEntity
+        {
+            Id = Guid.NewGuid(),
+            Email = $"e2e-kb-owner-{Guid.NewGuid():N}@test.invalid",
+            DisplayName = "E2E KB Owner",
+            PasswordHash = "placeholder.NeverLogsIn",
+            Role = "user",
+            Tier = "free",
+            Status = "Active",
+            EmailVerified = false,
+            CreatedAt = DateTime.UtcNow,
+        };
+        DbContext.Users.Add(kbOwner);
+
+        var pdf = new PdfDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            FileName = "e2e-rulebook.pdf",
+            FilePath = "/tmp/e2e-rulebook.pdf",
+            FileSizeBytes = 1024,
+            ContentType = "application/pdf",
+            UploadedByUserId = kbOwner.Id,
+            SharedGameId = game.Id,
+            ProcessingState = "Ready",
+        };
+        DbContext.PdfDocuments.Add(pdf);
+
+        DbContext.VectorDocuments.Add(new VectorDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            SharedGameId = game.Id,
+            PdfDocumentId = pdf.Id,
+            IndexingStatus = "completed",
+            EmbeddingModel = "e2e-test-model",
+            EmbeddingDimensions = 768,
+            ChunkCount = 1,
+            IndexedAt = DateTime.UtcNow,
+        });
+
+        await DbContext.SaveChangesAsync();
     }
 
     #region Public Game Browsing Tests
@@ -134,23 +184,14 @@ public sealed class GameManagementE2ETests : E2ETestBase
         var (sessionToken, _) = await RegisterUserAsync(email, "ValidUnusualPwd123!");
         SetSessionCookie(sessionToken);
 
-        var createPayload = new
-        {
-            gameId = _testGameId,
-            players = new[]
-            {
-                new { playerName = "Player 1", playerOrder = 1 },
-                new { playerName = "Player 2", playerOrder = 2 }
-            }
-        };
-
-        var createResponse = await Client.PostAsJsonAsync("/api/v1/sessions", createPayload);
-        createResponse.EnsureSuccessStatusCode();
-        var session = await createResponse.Content.ReadFromJsonAsync<GameSessionDto>();
+        // #3662: il vecchio `POST /api/v1/sessions` non esiste piu'. Una Session
+        // appartiene a una GameNight (invariante «GameNight 1..N Session»): si crea
+        // la serata e vi si avvia dentro la sessione.
+        var sessionId = await StartSessionAsync(_testGameId);
 
         // Act - Complete the session
         var completePayload = new { winnerName = "Player 1" };
-        var completeResponse = await Client.PostAsJsonAsync($"/api/v1/sessions/{session!.Id}/complete", completePayload);
+        var completeResponse = await Client.PostAsJsonAsync($"/api/v1/sessions/{sessionId}/complete", completePayload);
 
         // Assert
         completeResponse.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -168,22 +209,13 @@ public sealed class GameManagementE2ETests : E2ETestBase
         var (sessionToken, _) = await RegisterUserAsync(email, "ValidUnusualPwd123!");
         SetSessionCookie(sessionToken);
 
-        var createPayload = new
-        {
-            gameId = _testGameId,
-            players = new[]
-            {
-                new { playerName = "Player 1", playerOrder = 1 },
-                new { playerName = "Player 2", playerOrder = 2 }
-            }
-        };
-
-        var createResponse = await Client.PostAsJsonAsync("/api/v1/sessions", createPayload);
-        createResponse.EnsureSuccessStatusCode();
-        var session = await createResponse.Content.ReadFromJsonAsync<GameSessionDto>();
+        // #3662: il vecchio `POST /api/v1/sessions` non esiste piu'. Una Session
+        // appartiene a una GameNight (invariante «GameNight 1..N Session»): si crea
+        // la serata e vi si avvia dentro la sessione.
+        var sessionId = await StartSessionAsync(_testGameId);
 
         // Act - Abandon the session
-        var abandonResponse = await Client.PostAsJsonAsync($"/api/v1/sessions/{session!.Id}/abandon", new { });
+        var abandonResponse = await Client.PostAsJsonAsync($"/api/v1/sessions/{sessionId}/abandon", new { });
 
         // Assert
         abandonResponse.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -201,29 +233,20 @@ public sealed class GameManagementE2ETests : E2ETestBase
         var (sessionToken, _) = await RegisterUserAsync(email, "ValidUnusualPwd123!");
         SetSessionCookie(sessionToken);
 
-        var createPayload = new
-        {
-            gameId = _testGameId,
-            players = new[]
-            {
-                new { playerName = "Player 1", playerOrder = 1 },
-                new { playerName = "Player 2", playerOrder = 2 }
-            }
-        };
-
-        var createResponse = await Client.PostAsJsonAsync("/api/v1/sessions", createPayload);
-        createResponse.EnsureSuccessStatusCode();
-        var session = await createResponse.Content.ReadFromJsonAsync<GameSessionDto>();
+        // #3662: il vecchio `POST /api/v1/sessions` non esiste piu'. Una Session
+        // appartiene a una GameNight (invariante «GameNight 1..N Session»): si crea
+        // la serata e vi si avvia dentro la sessione.
+        var sessionId = await StartSessionAsync(_testGameId);
 
         // Act - Pause the session
-        var pauseResponse = await Client.PostAsJsonAsync($"/api/v1/sessions/{session!.Id}/pause", new { });
+        var pauseResponse = await Client.PostAsJsonAsync($"/api/v1/sessions/{sessionId}/pause", new { });
         pauseResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var pausedSession = await pauseResponse.Content.ReadFromJsonAsync<GameSessionDto>();
         pausedSession!.Status.Should().Be("Paused");
 
         // Act - Resume the session
-        var resumeResponse = await Client.PostAsJsonAsync($"/api/v1/sessions/{session.Id}/resume", new { });
+        var resumeResponse = await Client.PostAsJsonAsync($"/api/v1/sessions/{sessionId}/resume", new { });
         resumeResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var resumedSession = await resumeResponse.Content.ReadFromJsonAsync<GameSessionDto>();
@@ -255,18 +278,20 @@ public sealed class GameManagementE2ETests : E2ETestBase
         SetSessionCookie(sessionToken);
 
         // Step 4: Start a game session
-        var startPayload = new
-        {
-            gameId = _testGameId,
-            players = new[]
-            {
-                new { playerName = "Alice", playerOrder = 1 },
-                new { playerName = "Bob", playerOrder = 2 },
-                new { playerName = "Charlie", playerOrder = 3 }
-            }
-        };
+        // #3662: l'avvio non accetta piu' i giocatori nel corpo -- si aggiungono dopo, con
+        // POST /sessions/{id}/players. Il percorso resta coperto per intero: la copertura
+        // sui giocatori non viene tolta, viene spostata sull'endpoint che oggi la fornisce.
+        var sessionId = await StartSessionAsync(_testGameId);
 
-        var startResponse = await Client.PostAsJsonAsync("/api/v1/sessions", startPayload);
+        foreach (var (name, order) in new[] { ("Alice", 1), ("Bob", 2), ("Charlie", 3) })
+        {
+            var addPlayerResponse = await Client.PostAsJsonAsync(
+                $"/api/v1/sessions/{sessionId}/players",
+                new { playerName = name, playerOrder = order });
+            addPlayerResponse.EnsureSuccessStatusCode();
+        }
+
+        var startResponse = await Client.GetAsync($"/api/v1/sessions/{sessionId}");
         startResponse.EnsureSuccessStatusCode();
         var session = await startResponse.Content.ReadFromJsonAsync<GameSessionDto>();
 
@@ -276,7 +301,7 @@ public sealed class GameManagementE2ETests : E2ETestBase
 
         // Step 5: Complete the game with a winner
         var completePayload = new { winnerName = "Bob" };
-        var completeResponse = await Client.PostAsJsonAsync($"/api/v1/sessions/{session.Id}/complete", completePayload);
+        var completeResponse = await Client.PostAsJsonAsync($"/api/v1/sessions/{sessionId}/complete", completePayload);
         completeResponse.EnsureSuccessStatusCode();
 
         var completedSession = await completeResponse.Content.ReadFromJsonAsync<GameSessionDto>();
@@ -296,23 +321,14 @@ public sealed class GameManagementE2ETests : E2ETestBase
         var (sessionToken, _) = await RegisterUserAsync(email, "ValidUnusualPwd123!");
         SetSessionCookie(sessionToken);
 
-        var createPayload = new
-        {
-            gameId = _testGameId,
-            players = new[]
-            {
-                new { playerName = "Player 1", playerOrder = 1 },
-                new { playerName = "Player 2", playerOrder = 2 }
-            }
-        };
-
-        var createResponse = await Client.PostAsJsonAsync("/api/v1/sessions", createPayload);
-        createResponse.EnsureSuccessStatusCode();
-        var session = await createResponse.Content.ReadFromJsonAsync<GameSessionDto>();
+        // #3662: il vecchio `POST /api/v1/sessions` non esiste piu'. Una Session
+        // appartiene a una GameNight (invariante «GameNight 1..N Session»): si crea
+        // la serata e vi si avvia dentro la sessione.
+        var sessionId = await StartSessionAsync(_testGameId);
 
         // Act - Add another player
         var addPlayerPayload = new { playerName = "Player 3", playerOrder = 3 };
-        var addResponse = await Client.PostAsJsonAsync($"/api/v1/sessions/{session!.Id}/players", addPlayerPayload);
+        var addResponse = await Client.PostAsJsonAsync($"/api/v1/sessions/{sessionId}/players", addPlayerPayload);
 
         // Assert
         addResponse.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -353,4 +369,56 @@ public sealed class GameManagementE2ETests : E2ETestBase
         string PlayerName,
         int PlayerOrder,
         string? Color);
+
+    /// <summary>
+    /// #3662: sostituisce il vecchio <c>POST /api/v1/sessions</c>, che non esiste piu'.
+    ///
+    /// Non e' una route rinominata ma un cambio di modello: una Session appartiene a una
+    /// GameNight, quindi il flusso e' in due passi. Il risultato porta DUE id --
+    /// <c>SessionId</c> (l'aggregato <c>GameSession</c>) e <c>GameNightSessionId</c> (il link
+    /// con la serata): gli endpoint <c>/sessions/{id}/complete|abandon|pause|resume|players</c>
+    /// vogliono il PRIMO. Scambiarli darebbe 404 su ogni chiamata successiva.
+    ///
+    /// <para><b>LIMITE NOTO (#3662).</b> Questo helper porta il flusso fino all'avvio della
+    /// sessione -- e quello ora funziona -- ma i cinque test del ciclo di vita restano rossi
+    /// con 404. Il motivo e' architetturale, non un URL sbagliato: <c>/sessions/{id}/complete
+    /// |abandon|pause|resume</c> operano su <c>IGameSessionRepository</c>, cioe' l'aggregato
+    /// <b>GameSession</b> (GameManagement), mentre l'avvio da una serata crea un
+    /// <b>SessionTracking.Session</b>. Sono due dei tre aggregati di ADR-089, e il
+    /// <c>SessionId</c> restituito qui NON e' quello che quegli endpoint risolvono.</para>
+    ///
+    /// <para>Il collegamento (<c>CorrelatedGameSessionId</c>) viene creato piu' avanti nel
+    /// ciclo di vita — <c>LifecycleCommandHandlers.cs:86</c> — e <b>non e' esposto da alcuna
+    /// risposta</b>: <c>GoLiveSessionResult</c> porta SessionId/GameNightId/
+    /// GameNightSessionId/PlayOrder/Status, mai l'id correlato. Serve stabilire quale sia il
+    /// percorso HTTP supportato per ottenere un GameSession: e' una domanda sul contratto,
+    /// non un aggiustamento di test.</para>
+    /// </summary>
+    private async Task<Guid> StartSessionAsync(Guid gameId, string gameTitle = "E2E Test Game")
+    {
+        var nightResponse = await Client.PostAsJsonAsync("/api/v1/game-nights", new
+        {
+            title = $"E2E Night {Guid.NewGuid():N}",
+            // Il validator pretende `> UtcNow.AddHours(1)` STRETTAMENTE: con AddHours(1)
+            // esatto la data e' gia' scaduta quando il server la valuta, e la risposta e' 422.
+            scheduledAt = DateTimeOffset.UtcNow.AddDays(1)
+        });
+        nightResponse.EnsureSuccessStatusCode();
+        var gameNightId = await nightResponse.Content.ReadFromJsonAsync<Guid>();
+
+        // Una serata nasce in stato Draft e non accetta sessioni («Cannot add sessions to a
+        // Draft game night»): va pubblicata prima.
+        var publishResponse = await Client.PostAsync($"/api/v1/game-nights/{gameNightId}/publish", null);
+        publishResponse.EnsureSuccessStatusCode();
+
+        var sessionResponse = await Client.PostAsJsonAsync(
+            $"/api/v1/game-nights/{gameNightId}/sessions", new { gameId, gameTitle });
+        sessionResponse.EnsureSuccessStatusCode();
+        var started = await sessionResponse.Content.ReadFromJsonAsync<StartSessionResult>();
+        return started!.SessionId;
+    }
+
+    private sealed record StartSessionResult(
+        Guid SessionId, Guid GameNightSessionId, string SessionCode, int PlayOrder);
+
 }


### PR DESCRIPTION
Parte di #3662. **Progresso parziale, dichiarato**: l'avvio sessione ora funziona, i 5 test del ciclo di vita restano rossi per un motivo architetturale.

## Il vecchio `POST /api/v1/sessions` non esiste più

Non è una route rinominata: una Session appartiene a una GameNight (invariante «GameNight 1..N Session»), quindi il flusso è diventato a più passi. Il nuovo helper `StartSessionAsync` li esegue tutti, e ognuno è stato scoperto **facendo parlare la risposta** invece di indovinare:

| passo | cosa ho scoperto |
|---|---|
| `POST /game-nights` | il validator pretende `ScheduledAt > UtcNow.AddHours(1)` **strettamente**: con `AddHours(1)` esatto la data è già scaduta quando il server la valuta → **422** |
| `POST /game-nights/{id}/publish` | una serata nasce in `Draft` e non accetta sessioni: *«Cannot add sessions to a Draft game night»* → **409** |
| `POST /game-nights/{id}/sessions` | richiede una knowledge base **pronta** → **422 `kb_not_ready`** |

Per il terzo punto il seed ora crea un `PdfDocument` in stato `Ready` **e** un `VectorDocument` con `IndexingStatus = "completed"`: secondo `GetKbReadinessQueryHandler` servono entrambi, con il solo PDF lo stato resta non-ready.

`CompleteGameJourney` aggiunge i giocatori via `POST /sessions/{id}/players`, perché l'avvio non li accetta più nel corpo. La copertura sui giocatori non viene tolta: viene spostata sull'endpoint che oggi la fornisce.

## Perché restano 5 rossi

`/sessions/{id}/complete|abandon|pause|resume` operano su `IGameSessionRepository`, cioè l'aggregato **`GameSession`**, mentre l'avvio da una serata crea un **`SessionTracking.Session`**. Sono due dei tre aggregati di **ADR-089**, e il `SessionId` restituito **non è** quello che quegli endpoint risolvono — da cui il 404.

Il collegamento `CorrelatedGameSessionId` nasce più avanti nel ciclo di vita (`LifecycleCommandHandlers.cs:86`) e **non è esposto da alcuna risposta**: `GoLiveSessionResult` porta `SessionId`/`GameNightId`/`GameNightSessionId`/`PlayOrder`/`Status`, mai l'id correlato.

Quindi la domanda aperta non è «quale URL chiamare» ma **quale sia il percorso HTTP supportato per ottenere un `GameSession`**. È una questione di contratto: inventarne uno produrrebbe un verde che non copre nulla — cioè un altro membro del cluster #3622→#3662. Il limite è documentato nel codice, sopra l'helper.

## Perché committare un progresso che non muove il conteggio

Il conteggio di questo file resta 4/9. Ma il codice precedente chiamava una route **definitivamente morta**: le tre scoperte qui sopra sono conoscenza verificata e necessaria in ogni caso, e chi riprenderà il lavoro parte dal punto in cui la sessione si avvia davvero invece che da un 404 sul primo `POST`.
