### PR TITLE
fix(orchestration): una regola Constraint non viene più dichiarata soddisfatta (#3668)

### DIFF
--- a/apps/orchestration-service/src/application/orchestrator.py
+++ b/apps/orchestration-service/src/application/orchestrator.py
@@ -236,7 +236,13 @@ class GameOrchestrator:
                 current_agent=AgentType.ARBITRO,
                 conversation_history=state.conversation_history,
                 move_notation=state.pending_move.move_notation if state.pending_move else state.user_query,
-                game_state=None,  # TODO: Extract from board_state
+                # Deliberately None (#3668). board_state is available two lines above, but
+                # RuleEngine has no board model, so populating this would buy nothing:
+                # Constraint rules are skipped (with a warning) whatever it contains.
+                # Extract it together with a real obstruction check, never before — the
+                # previous TODO here promised an extraction that would have made a
+                # placeholder "assume constraint passes" branch reachable.
+                game_state=None,
             )
 
             # Execute Arbitro workflow with retry fallback

--- a/apps/orchestration-service/src/application/rule_engine.py
+++ b/apps/orchestration-service/src/application/rule_engine.py
@@ -257,18 +257,28 @@ class RuleEngine:
                         precedence=rule["precedence"],
                     ))
 
-            # State-based validation (requires game state)
-            elif rule["type"] == "Constraint" and game_state:
-                # Placeholder: Would check game state for obstruction
-                # For MVP, assume constraint passes
-                matches.append(RuleMatch(
-                    rule_id=rule_id,
-                    rule_name=rule["name"],
-                    rule_type=rule["type"],
-                    matches=True,
-                    reason=rule["description"],
-                    precedence=rule["precedence"],
-                ))
+            # State-based rules are not evaluated: there is no board model to check them
+            # against (#3668).
+            #
+            # This branch used to be guarded by `and game_state` and, when reached, appended
+            # a RuleMatch with matches=True — "for MVP, assume constraint passes". Since the
+            # orchestrator always passed game_state=None the branch was dead, which hid how
+            # bad its body was: implementing the accompanying TODO (extract game_state from
+            # board_state) would have flipped the engine from "this rule is not evaluated"
+            # to "this rule is satisfied", asserted without a single check. The second is
+            # worse precisely because it is invisible.
+            #
+            # Emitting no RuleMatch at all keeps the outcome truthful — nothing claims the
+            # constraint passed — and leaves moves to be judged by the rules that CAN be
+            # evaluated. The warning is what makes the gap visible; silence is how this
+            # survived from #3759 to #3668.
+            elif rule["type"] == "Constraint":
+                logger.warning(
+                    "Constraint rule '%s' NOT evaluated: no board model exists to check it "
+                    "(#3668). The move was not verified against this rule.",
+                    rule["name"],
+                )
+                continue
 
         return matches
 

--- a/apps/orchestration-service/src/application/rule_engine.py
+++ b/apps/orchestration-service/src/application/rule_engine.py
@@ -241,46 +241,45 @@ class RuleEngine:
         matches = []
 
         for rule in rules:
-            pattern = rule.get("pattern")
             rule_id = UUID(rule["id"])
 
-            # Pattern-based matching
-            if pattern:
-                match = re.match(pattern, move)
-                if match:
-                    matches.append(RuleMatch(
-                        rule_id=rule_id,
-                        rule_name=rule["name"],
-                        rule_type=rule["type"],
-                        matches=True,
-                        reason=rule["description"],
-                        precedence=rule["precedence"],
-                    ))
-
-            # State-based rules are not evaluated: there is no board model to check them
-            # against (#3668).
+            # Constraints are state-based and there is no board model to evaluate them
+            # against, so no RuleMatch is emitted: nothing may claim one passed (#3668).
             #
-            # This branch used to be guarded by `and game_state` and, when reached, appended
-            # a RuleMatch with matches=True — "for MVP, assume constraint passes". Since the
-            # orchestrator always passed game_state=None the branch was dead, which hid how
-            # bad its body was: implementing the accompanying TODO (extract game_state from
-            # board_state) would have flipped the engine from "this rule is not evaluated"
-            # to "this rule is satisfied", asserted without a single check. The second is
-            # worse precisely because it is invisible.
-            #
-            # Emitting no RuleMatch at all keeps the outcome truthful — nothing claims the
-            # constraint passed — and leaves moves to be judged by the rules that CAN be
-            # evaluated. The warning is what makes the gap visible; silence is how this
-            # survived from #3759 to #3668.
-            elif rule["type"] == "Constraint":
-                logger.warning(
-                    "Constraint rule '%s' NOT evaluated: no board model exists to check it "
-                    "(#3668). The move was not verified against this rule.",
-                    rule["name"],
-                )
+            # Keyed on the TYPE, deliberately, not on a missing pattern. `rules` can come
+            # from the Redis cache (arbitrary JSON), so a Constraint that carries a pattern
+            # would otherwise fall into the branch below and be rubber-stamped matches=True.
+            if rule["type"] == "Constraint":
+                self._warn_constraint_unevaluated(rule["name"])
                 continue
 
+            pattern = rule.get("pattern")
+            if pattern and re.match(pattern, move):
+                matches.append(RuleMatch(
+                    rule_id=rule_id,
+                    rule_name=rule["name"],
+                    rule_type=rule["type"],
+                    matches=True,
+                    reason=rule["description"],
+                    precedence=rule["precedence"],
+                ))
+
         return matches
+
+    # Warn once per process, not once per move: the condition is constant and known, and a
+    # per-validation warning would train operators to ignore this service's logs.
+    _warned_constraints: set[str] = set()
+
+    def _warn_constraint_unevaluated(self, rule_name: str) -> None:
+        if rule_name in RuleEngine._warned_constraints:
+            return
+        RuleEngine._warned_constraints.add(rule_name)
+        logger.warning(
+            "Constraint rule '%s' is NOT evaluated: no board model exists to check it "
+            "(#3668). Moves are judged only by the rules that can be evaluated, so a "
+            "verdict of valid does not mean this constraint was satisfied.",
+            rule_name,
+        )
 
     def _determine_validity(
         self,

--- a/apps/orchestration-service/tests/test_rule_engine.py
+++ b/apps/orchestration-service/tests/test_rule_engine.py
@@ -1,0 +1,115 @@
+"""Tests for RuleEngine._match_rules — issue #3668.
+
+The Constraint branch had no tests at all, which is how it kept a body that reported
+every rule as satisfied without checking anything. These tests pin the two behaviours
+that matter: a rule that cannot be evaluated must not be reported as passed, and the
+absence of an evaluation must be visible.
+"""
+
+import logging
+
+import pytest
+
+from src.application.rule_engine import RuleEngine, RuleMatch
+
+CONSTRAINT_RULE = {
+    "id": "00000000-0000-0000-0000-000000000003",
+    "name": "No Piece Obstruction",
+    "type": "Constraint",
+    "precedence": 40,
+    "pattern": None,  # state-based: no pattern to match on
+    "description": "Pieces cannot move through other pieces (except Knight)",
+}
+
+MOVEMENT_RULE = {
+    "id": "00000000-0000-0000-0000-000000000002",
+    "name": "Pawn Forward Movement",
+    "type": "Movement",
+    "precedence": 10,
+    "pattern": r"^[a-h][2-7]$",
+    "description": "Pawns move forward one square",
+}
+
+
+@pytest.fixture
+def engine():
+    return RuleEngine()
+
+
+class TestConstraintRuleIsNeverFalselyApproved:
+    """#3668: the placeholder appended matches=True — "for MVP, assume constraint passes"."""
+
+    def test_constraint_without_game_state_is_not_reported_as_matching(self, engine):
+        """Today's real path: the orchestrator passes game_state=None.
+
+        The rule is not evaluated, and that must NOT look like a passed check. Before
+        #3668 this branch was simply skipped, which was already the safer of the two
+        wrong behaviours — this test pins it so a future "just extract game_state"
+        cannot silently turn it into an unconditional approval.
+        """
+        matches = engine._match_rules("e4", [CONSTRAINT_RULE], game_state=None)
+
+        assert matches == [], (
+            "an unevaluated Constraint must produce no RuleMatch at all; "
+            "emitting one with matches=True would report success without checking"
+        )
+
+    def test_constraint_without_game_state_logs_that_it_was_skipped(self, engine, caplog):
+        """A gap nobody can see is the reason this survived until #3668."""
+        with caplog.at_level(logging.WARNING):
+            engine._match_rules("e4", [CONSTRAINT_RULE], game_state=None)
+
+        assert any(
+            "No Piece Obstruction" in record.getMessage()
+            and "NOT evaluated" in record.getMessage()
+            for record in caplog.records
+        ), "skipping a constraint must be logged, not silent"
+
+    def test_constraint_with_game_state_is_still_not_approved(self, engine):
+        """The regression guard.
+
+        `validate_move(game_id, move, game_state)` is public, so this branch is reachable
+        even though the orchestrator passes None. Before #3668 that path appended
+        matches=True — the rule was reported as satisfied without a single check, which is
+        worse than not evaluating it because it is invisible in the result.
+        """
+        matches = engine._match_rules(
+            "e4", [CONSTRAINT_RULE], game_state="rnbqkbnr/pppppppp"
+        )
+
+        assert matches == [], (
+            "supplying a game state must not conjure a passing constraint: "
+            "there is still no board model to check obstruction against"
+        )
+
+    def test_constraint_never_yields_a_passing_match(self, engine):
+        """Belt and braces: no game_state value produces matches=True."""
+        for state in (None, "", "rnbqkbnr/pppppppp", "any-state"):
+            produced: list[RuleMatch] = engine._match_rules(
+                "e4", [CONSTRAINT_RULE], game_state=state
+            )
+            assert not any(m.matches for m in produced), (
+                f"constraint reported as matching with game_state={state!r}"
+            )
+
+
+class TestPatternRulesAreUnaffected:
+    """The Constraint change must not disturb the pattern-matching path."""
+
+    def test_pattern_rule_matches_normally(self, engine):
+        matches = engine._match_rules("e4", [MOVEMENT_RULE], game_state=None)
+
+        assert len(matches) == 1
+        assert matches[0].rule_name == "Pawn Forward Movement"
+        assert matches[0].matches is True
+
+    def test_pattern_rule_not_matching_yields_nothing(self, engine):
+        assert engine._match_rules("Qh5", [MOVEMENT_RULE], game_state=None) == []
+
+    def test_mixed_ruleset_still_evaluates_the_pattern_rule(self, engine):
+        """A skipped Constraint must not suppress the rules that CAN be evaluated."""
+        matches = engine._match_rules(
+            "e4", [MOVEMENT_RULE, CONSTRAINT_RULE], game_state=None
+        )
+
+        assert [m.rule_name for m in matches] == ["Pawn Forward Movement"]

--- a/apps/orchestration-service/tests/test_rule_engine.py
+++ b/apps/orchestration-service/tests/test_rule_engine.py
@@ -7,6 +7,7 @@ absence of an evaluation must be visible.
 """
 
 import logging
+from uuid import uuid4
 
 import pytest
 
@@ -56,14 +57,48 @@ class TestConstraintRuleIsNeverFalselyApproved:
 
     def test_constraint_without_game_state_logs_that_it_was_skipped(self, engine, caplog):
         """A gap nobody can see is the reason this survived until #3668."""
+        RuleEngine._warned_constraints.clear()
+
         with caplog.at_level(logging.WARNING):
             engine._match_rules("e4", [CONSTRAINT_RULE], game_state=None)
 
+        # Assert on level + rule name, not on prose: rewording the message must not break
+        # a correct behaviour.
         assert any(
-            "No Piece Obstruction" in record.getMessage()
-            and "NOT evaluated" in record.getMessage()
+            record.levelno == logging.WARNING and "No Piece Obstruction" in record.getMessage()
             for record in caplog.records
         ), "skipping a constraint must be logged, not silent"
+
+    def test_constraint_warning_is_not_repeated_every_validation(self, engine, caplog):
+        """The condition is constant; a warning per move would train operators to ignore it."""
+        RuleEngine._warned_constraints.clear()
+
+        with caplog.at_level(logging.WARNING):
+            for _ in range(5):
+                engine._match_rules("e4", [CONSTRAINT_RULE], game_state=None)
+
+        warnings = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING and "No Piece Obstruction" in r.getMessage()
+        ]
+        assert len(warnings) == 1, f"expected one warning per process, got {len(warnings)}"
+
+    def test_constraint_carrying_a_pattern_is_still_not_approved(self, engine):
+        """The hole the first version left open.
+
+        The branch used to key off a missing `pattern`, so a Constraint that *carries* one
+        fell into the pattern arm and was appended matches=True — silently, without even
+        the warning. Not reachable through CHESS_RULES, but `_match_rules` also consumes
+        rules from the Redis cache, which is arbitrary JSON per game.
+        """
+        constraint_with_pattern = {**CONSTRAINT_RULE, "pattern": r"^e[0-9]$"}
+
+        matches = engine._match_rules("e4", [constraint_with_pattern], game_state="FEN")
+
+        assert matches == [], (
+            "a Constraint must never be approved on the strength of a regex: "
+            "the rule type decides, not the presence of a pattern"
+        )
 
     def test_constraint_with_game_state_is_still_not_approved(self, engine):
         """The regression guard.
@@ -91,6 +126,37 @@ class TestConstraintRuleIsNeverFalselyApproved:
             assert not any(m.matches for m in produced), (
                 f"constraint reported as matching with game_state={state!r}"
             )
+
+
+class TestValidateMoveVerdict:
+    """The user-visible layer. The tests above pin `_match_rules`; this is what callers see."""
+
+    @pytest.mark.asyncio
+    async def test_unmatched_move_with_game_state_is_invalid(self, engine):
+        """The regression that mattered most, and it was invisible from `_match_rules`.
+
+        Before #3668, supplying ANY game state made ANY string a legal move: the Constraint
+        rubber-stamp was the only match, `_determine_validity` found no violated constraint
+        and no movement rule, and fell through to "Move notation is valid". Verified against
+        the previous revision — `"total garbage!!"` came back valid.
+        """
+        is_valid, reason, _, _ = await engine.validate_move(
+            uuid4(), "total garbage!!", game_state="rnbqkbnr/pppppppp"
+        )
+
+        assert is_valid is False, (
+            f"a move no rule can evaluate must not be declared valid (reason: {reason})"
+        )
+
+    @pytest.mark.asyncio
+    async def test_pattern_matched_move_stays_valid_with_game_state(self, engine):
+        """The other side of the same coin: the fix must not invalidate real moves."""
+        is_valid, _, applied, _ = await engine.validate_move(
+            uuid4(), "e4", game_state="rnbqkbnr/pppppppp"
+        )
+
+        assert is_valid is True
+        assert applied, "a pattern-matched move must still report the rules it applied"
 
 
 class TestPatternRulesAreUnaffected:


### PR DESCRIPTION
## Il problema

Due placeholder accoppiati, e sistemarne uno solo peggiorava le cose.

**Consumatore** (`rule_engine.py`): il ramo `elif type == "Constraint" and game_state:` appendeva un `RuleMatch` con `matches=True` — *«for MVP, assume constraint passes»*.

**Produttore** (`orchestrator.py`): passava `game_state=None` con un `TODO: Extract from board_state`.

Finché quel TODO restava aperto il ramo era morto, e questo **nascondeva quanto fosse cattivo il suo corpo**: implementare il TODO alla lettera avrebbe fatto passare il motore da «la regola non viene valutata» a «la regola è soddisfatta», affermato senza un solo controllo. Il secondo stato è peggiore proprio perché è invisibile nel risultato.

## Il fix

Il ramo non emette più alcun `RuleMatch` e logga il salto. Niente da dichiarare soddisfatto, e la lacuna diventa **osservabile** — il silenzio è il motivo per cui è sopravvissuta da #3759 fino a oggi.

### Correzione: il comportamento **cambia**, in meglio

Avevo scritto che il comportamento osservabile non cambia. È vero solo per il percorso dell'orchestrator (`game_state=None`). Con uno stato presente cambia eccome — e in una direzione che vale la pena guardare:

| mossa | `game_state` | prima | dopo |
|---|---|---|---|
| `"Nf3"` | valorizzato | valida | valida |
| `"O-O"` | valorizzato | **valida** | non valida |
| `"total garbage!!"` | valorizzato | **valida** | non valida |
| tutte | `None` | invariato | invariato |

Prima di questa PR, **passare un `game_state` qualsiasi rendeva legale qualunque stringa**: il timbro del `Constraint` era l'unico match, `_determine_validity` non trovava né constraint violati né regole di movimento, e cadeva nel ramo *«Move notation is valid»*. È esattamente la mina che il punto 2 del DoD avrebbe fatto esplodere.

Il TODO del produttore diventa una nota che spiega perché `game_state` resta `None`: valorizzarlo non comprerebbe niente finché non esiste un controllo vero.

## Due cose emerse verificando, che la issue non diceva

**1. Non esiste alcun rule store.** La issue dà come criterio di scoping: *«`rules` arriva dal rule store, quindi il dato dice se esistono regole di quel tipo»*. Falso — `CHESS_RULES` è dato **hardcoded** per una demo MVP, col commento *«Hardcoded Chess rules for MVP (Issue #3759). Future: Load from PostgreSQL + Qdrant»*. Implementare un vero controllo di ostruzione significherebbe costruire un modello di scacchiera per tre regole di demo, con `game_state` che è un `Optional[str]` senza struttura.

**2. Il ramo NON era irraggiungibile.** `validate_move(game_id, move, game_state)` è pubblico e `test_arbitro_agent` lo chiama **con** uno stato. Una prima versione che sollevava `NotImplementedError` faceva fallire `test_valid_knight_move`: toglieva all'Arbitro la capacità di validare *qualsiasi* mossa quando le si passa uno stato di gioco. Saltare senza emettere match ottiene la stessa onestà senza rompere nulla.

## Test

`RuleEngine` — il componente che decide se una mossa è valida — **non aveva alcun test diretto**. È così che quel corpo è rimasto lì dal 2026. Aggiunto `tests/test_rule_engine.py` (7 test).

| Verifica | Esito |
|---|---|
| Nuovi test | **11/11** |
| `test_arbitro_agent.py` | **7/7** (incluso `test_valid_knight_move`) |
| Verifica **negativa** contro il codice precedente | **6 su 11 falliscono** — proteggono qualcosa |
| `test_orchestrator.py` | 9 rossi **pre-esistenti**, misurati sul commit base `c144c6324` prima di toccare qualsiasi cosa |

## Esito della code review (secondo commit)

**Il buco vero**: il ramo si agganciava a `pattern`, non al tipo. Una regola `Constraint` che **porta** un pattern finiva nel ramo di matching e veniva timbrata `matches=True`, per giunta senza warning. Non raggiungibile via `CHESS_RULES`, ma `_match_rules` consuma anche le regole dalla **cache Redis**, che è JSON arbitrario per partita. Il mio test passava solo perché la fixture ha `pattern: None` — verificava la mia assunzione, non l'invariante.

**Test al livello che conta**: tutti i precedenti esercitavano il privato `_match_rules`, mentre l'invariante visibile vive in `validate_move`. Aggiunti due test lì, incluso quello sulla mossa spazzatura.

**Warning una-tantum per processo**: la condizione è costante e nota; un warning per mossa insegna solo a ignorare i log di questo servizio.

Ridotto il commento a due righe di *perché* (il resto era changelog, che in sorgente marcisce), rimosso un `continue` no-op, e l'asserzione sul log ora guarda livello + nome regola invece della prosa.

### Follow-up non affrontati

- **Il verdetto all'utente resta una falsa approvazione.** `validate_move("Nf3", state)` torna `is_valid=True` e l'Arbitro dice *«la mossa è legale»* senza che l'ostruzione sia mai stata verificata. Il warning va nel log, non nel risultato: servirebbe propagare la lacuna (es. `unevaluated_rule_ids` fino a `EXPLANATION_PROMPT`).
- **`_determine_validity` ha un ramo morto**: gestisce `any(not c.matches for c in constraints)`, ma `matches=False` non viene costruito da nessuna parte. È esattamente la macchineria che servirebbe al punto 1 del DoD.

## DoD #3668

- [x] **Il ramo `Constraint` non dichiara più la regola soddisfatta** — nessun `matches=True` incondizionato residuo
- [~] **Clausola di rinvio** — rispettata nella sostanza, **non alla lettera**. Il DoD prescrive *«un errore esplicito»*; questa PR fa warn-and-skip. Una prima versione sollevava davvero `NotImplementedError` e toglieva all'Arbitro la capacità di validare qualsiasi mossa con stato presente. «Non emettere giudizio, e rendere visibile il buco» è una terza via che la dicotomia del DoD (errore *oppure* falsa approvazione) non contemplava
- [ ] **`game_state` valorizzato da `board_state`** — deliberatamente **non fatto**: valorizzarlo senza un modello di scacchiera non cambia nulla, e il TODO che lo prometteva è ciò che rendeva pericoloso il placeholder. Va estratto insieme al controllo vero, mai prima
- [ ] **Una mossa che viola un `Constraint` risulta non valida** — richiede il modello di scacchiera, fuori portata per dato di demo hardcoded

Gli ultimi due punti restano aperti per scelta, non per omissione: sono esattamente il caso previsto dalla clausola *«Given che il controllo reale non sia ancora fattibile When si decide di rinviarlo Then il codice non dichiara la regola soddisfatta»*.

Refs #3668

🤖 Generated with [Claude Code](https://claude.com/claude-code)
