### PR TITLE
release: promozione main-dev → main-staging (2026-08-12)

### DIFF
--- a/.github/workflows/dev-fast.yml
+++ b/.github/workflows/dev-fast.yml
@@ -20,7 +20,8 @@ on:
       - 'global.json'
       - '.github/workflows/dev-fast.yml'
       - '.github/actions/**'
-      - 'infra/scripts/check-migration-safety.py'
+      - 'infra/scripts/**'
+      - 'infra/seed-schema.version'
   workflow_dispatch:
 
 concurrency:
@@ -40,6 +41,7 @@ jobs:
       backend: ${{ steps.filter.outputs.backend }}
       orchestration: ${{ steps.filter.outputs.orchestration }}
       migrations: ${{ steps.filter.outputs.migrations }}
+      infra: ${{ steps.filter.outputs.infra }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4
@@ -74,6 +76,23 @@ jobs:
               - 'apps/api/src/Api/Infrastructure/Migrations/**/*.cs'
               - 'infra/scripts/check-migration-safety.py'
               - 'infra/scripts/test_check_migration_safety.py'
+              - '.github/workflows/dev-fast.yml'
+            infra:
+              # Issue #3665: the bats suites under infra/scripts/tests/ ran in
+              # NO workflow. ci.yml covers only the Python script tests, and it
+              # triggers on PRs to main/main-staging — not main-dev. Result: a
+              # PR touching only infra/ had practically no CI, and
+              # snapshot-verify.bats stayed red for two months unnoticed.
+              # Scope is infra/scripts/** (not infra/**) so docker-compose,
+              # monitoring and secrets templates don't wake the hot path.
+              # infra/fixtures/** is deliberately NOT here: rag-smoke-assert.bats
+              # writes its own copies of the canonical-queries and golden-baseline
+              # files into a temp tree (lines 20-51) rather than reading the repo
+              # ones, so a PR editing infra/fixtures/ would boot a gate that
+              # cannot observe the change. infra/seed-schema.version IS here —
+              # snapshot-verify.bats reads the live counter.
+              - 'infra/scripts/**'
+              - 'infra/seed-schema.version'
               - '.github/workflows/dev-fast.yml'
 
   # Sharding strategy (incident #1115): the apps/web Vitest suite runs >15min
@@ -316,3 +335,57 @@ jobs:
           name: migration-safety-report
           path: ${{ runner.temp }}/migration-safety-report.json
           retention-days: 90  # Aligned with audit/compliance retention window.
+
+  infra-scripts:
+    # Issue #3665: infra/scripts/tests/ holds four bats suites that no workflow
+    # ran. snapshot-verify.bats had been red since 2026-06-11 — not because it
+    # was hard to fix, but because nobody executed it.
+    name: Infra Scripts (bats)
+    runs-on: ubuntu-latest
+    # Two measurements on PR #3677, back to back:
+    #   run 1 — checkout 9m39s, bats  6s, total 9m49s
+    #   run 2 — checkout   29s, bats  8s, total    39s
+    # The suites are never the cost; `actions/checkout` on this monorepo is,
+    # and it swings ~20x between runs. The typical job is under a minute — the
+    # budget exists for the tail, not the median. A 10m budget cleared run 1 by
+    # 11 seconds, which means the next bad-runner day would have turned this
+    # gate red with nothing broken; a red that doesn't mean a defect is exactly
+    # how this suite stopped being read. 20m, same as migration-safety.
+    #
+    # Sparse-checking out only infra/ would cut this to seconds but was
+    # rejected: snapshot-verify.sh reads apps/api/... at lines 37 and 106 with
+    # `2>/dev/null` fallbacks, so a partial tree would silently empty those
+    # values and the checks would stop asserting without failing.
+    timeout-minutes: 20
+    needs: changes
+    if: needs.changes.outputs.infra == 'true' || github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Verify the suite is non-empty
+        # Deliberate guard, not ceremony: `bats` on a directory with no .bats
+        # file prints "1..0" and exits 0. A moved or renamed tests/ directory
+        # would leave this gate green while examining nothing — the same failure
+        # mode as #3622/#3629/#3632, where a green check stopped meaning
+        # "passed" and started meaning "ran nothing". Fail when there is
+        # nothing to examine.
+        run: |
+          if [ ! -d infra/scripts/tests ]; then
+            echo "::error:: infra/scripts/tests/ does not exist — the suite was moved or deleted; point this gate at its new home"
+            exit 1
+          fi
+          count=$(find infra/scripts/tests -name '*.bats' -type f | wc -l)
+          echo "Discovered ${count} .bats suite(s) under infra/scripts/tests/"
+          if [ "$count" -eq 0 ]; then
+            echo "::error:: no .bats suite found — this gate would report success while checking nothing"
+            exit 1
+          fi
+
+      - name: Run bats suites
+        # Version pinned so a bats major bump cannot silently change semantics.
+        # jq and bash are preinstalled on ubuntu-latest; both scripts need them.
+        # --print-output-on-failure surfaces the failing script's stderr in the
+        # job log, so a red check is diagnosable without a local repro.
+        run: npx --yes bats@1.13.0 --print-output-on-failure infra/scripts/tests/

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/PublishToolkitVersion/PublishToolkitVersionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/PublishToolkitVersion/PublishToolkitVersionCommandHandler.cs
@@ -18,7 +18,7 @@ namespace Api.BoundedContexts.GameToolkit.Application.Commands.PublishToolkitVer
 /// <remarks>
 /// <para>Pipeline (spec-panel §6 Gherkin):</para>
 /// <list type="number">
-///   <item>Load tracked toolkit row — return <c>null</c> if missing (404).</item>
+///   <item>Load the toolkit aggregate through <c>IGameToolkitRepository</c> — <c>null</c> if missing (404).</item>
 ///   <item>Owner check (<c>CreatedByUserId == ViewerId</c>) — throw <c>ForbiddenException</c>.</item>
 ///   <item>Uniqueness check — throw <c>ConflictException</c> if <c>(ToolkitId, VersionNumber)</c> exists
 ///         (covers yanked numbers per §1 — permanently retired).</item>
@@ -34,7 +34,7 @@ namespace Api.BoundedContexts.GameToolkit.Application.Commands.PublishToolkitVer
 internal sealed class PublishToolkitVersionCommandHandler
     : ICommandHandler<PublishToolkitVersionCommand, PublishedToolkitVersionResponse?>
 {
-    private readonly MeepleAiDbContext _context;
+    private readonly IGameToolkitRepository _toolkitRepository;
     private readonly IToolkitVersionRepository _versionRepository;
     private readonly IUnitOfWork _unitOfWork;
     private readonly IHybridCacheService _cache;
@@ -42,14 +42,14 @@ internal sealed class PublishToolkitVersionCommandHandler
     private readonly ILogger<PublishToolkitVersionCommandHandler> _logger;
 
     public PublishToolkitVersionCommandHandler(
-        MeepleAiDbContext context,
+        IGameToolkitRepository toolkitRepository,
         IToolkitVersionRepository versionRepository,
         IUnitOfWork unitOfWork,
         IHybridCacheService cache,
         TimeProvider timeProvider,
         ILogger<PublishToolkitVersionCommandHandler> logger)
     {
-        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _toolkitRepository = toolkitRepository ?? throw new ArgumentNullException(nameof(toolkitRepository));
         _versionRepository = versionRepository ?? throw new ArgumentNullException(nameof(versionRepository));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _cache = cache ?? throw new ArgumentNullException(nameof(cache));
@@ -63,11 +63,17 @@ internal sealed class PublishToolkitVersionCommandHandler
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        // 1) Tracked load — we mutate VersionSemver + IsPublished below and
-        //    rely on EF change tracking to emit the UPDATE inside the UnitOfWork
-        //    transaction. AsNoTracking would discard those changes.
-        var toolkit = await _context.GameToolkits
-            .FirstOrDefaultAsync(t => t.Id == request.ToolkitId, cancellationToken)
+        // 1) Load the aggregate through the repository (#3670). This used to be a TRACKED
+        //    load of the EF entity via MeepleAiDbContext, because step 6 mutated the row
+        //    directly to dodge MapToPersistence's VersionSemver synthesis. The aggregate now
+        //    owns VersionSemver, so the normal repository path works.
+        //
+        //    Do NOT reintroduce a tracked load alongside UpdateAsync: GetByIdAsync is
+        //    AsNoTracking, and UpdateAsync calls Set<GameToolkitEntity>().Update() with a
+        //    freshly mapped instance. Two instances of the same key in the change tracker
+        //    would throw ("instance with the same key value is already being tracked").
+        var toolkit = await _toolkitRepository
+            .GetByIdAsync(request.ToolkitId, cancellationToken)
             .ConfigureAwait(false);
 
         if (toolkit is null)
@@ -128,15 +134,13 @@ internal sealed class PublishToolkitVersionCommandHandler
 
         await _versionRepository.AddAsync(version, cancellationToken).ConfigureAwait(false);
 
-        // 6) Mutate parent toolkit DIRECTLY on the tracked EF entity.
-        //    Bypass GameToolkitRepository.UpdateAsync deliberately: its
-        //    MapToPersistence pass synthesises VersionSemver from the legacy
-        //    int Version field (see #1144 follow-up tracker at GameToolkitRepository.cs:308),
-        //    which would overwrite our user-input semver. Direct mutation
-        //    preserves the user-input value through the UPDATE statement.
-        toolkit.VersionSemver = request.VersionNumber;
-        toolkit.IsPublished = true;
-        toolkit.UpdatedAt = now;
+        // 6) Move the parent toolkit's marketplace pointer through the aggregate (#3670).
+        //    Previously this mutated the tracked EF row directly to bypass
+        //    GameToolkitRepository.UpdateAsync, whose MapToPersistence synthesised
+        //    VersionSemver as "0.{Version}.0" and would have overwritten the user's input.
+        //    That synthesis is gone, so the write goes through the repository like any other.
+        toolkit.PublishMarketplaceVersion(request.VersionNumber, now);
+        await _toolkitRepository.UpdateAsync(toolkit, cancellationToken).ConfigureAwait(false);
 
         // 7) Single transaction — IUnitOfWork dispatches domain events post-commit.
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Domain/Entities/GameToolkit.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Domain/Entities/GameToolkit.cs
@@ -21,6 +21,37 @@ internal sealed class GameToolkit : AggregateRoot<Guid>
     public Guid? PrivateGameId { get; private set; }
     public string Name { get; private set; }
     public int Version { get; private set; }
+
+    /// <summary>
+    /// Marketplace version pointer, in semver. Issue #3670.
+    /// </summary>
+    /// <remarks>
+    /// Distinct from <see cref="Version"/>, which is a legacy monotonic counter for session
+    /// immutability. This is the user-authored version published to the marketplace, and it
+    /// is the aggregate's own state — before #3670 the aggregate did not carry it, so the
+    /// persistence mapper synthesised <c>"0.{Version}.0"</c> and every write path had to
+    /// defend against that synthesis overwriting the real value.
+    /// </remarks>
+    public string VersionSemver { get; private set; } = SeedSemver;
+
+    /// <summary>
+    /// Postgres <c>xmin</c> concurrency token (ADR-060). Carried by the aggregate so the
+    /// repository can hand EF the real original value when persisting a detached entity.
+    /// </summary>
+    /// <remarks>
+    /// Without it, <c>UpdateAsync</c> attaches an entity whose <c>Xmin</c> is 0 and EF emits
+    /// <c>WHERE "Id" = @p AND xmin = 0</c>, which matches no live tuple: every update raised
+    /// DbUpdateConcurrencyException on Postgres while the InMemory tests stayed green.
+    /// Same pattern as <c>AlertChannel</c> (#2690).
+    /// </remarks>
+    public uint Xmin { get; private set; }
+
+    /// <summary>Semver assigned to a toolkit that has never been published to the marketplace.</summary>
+    /// <remarks>
+    /// Matches what the old <c>MapToPersistence</c> synthesis produced for a brand-new toolkit
+    /// (<c>Version</c> starts at 1 → <c>"0.1.0"</c>), so existing rows keep their value.
+    /// </remarks>
+    internal const string SeedSemver = "0.1.0";
     public Guid CreatedByUserId { get; private set; }
     public DateTime CreatedAt { get; private set; }
     public DateTime UpdatedAt { get; private set; }
@@ -89,6 +120,12 @@ internal sealed class GameToolkit : AggregateRoot<Guid>
         PrivateGameId = hasPrivateGameId ? privateGameId : null;
         Name = name.Trim();
         Version = 1;
+        VersionSemver = SeedSemver;
+        // A toolkit that has never been persisted has no xmin yet — Postgres assigns it on
+        // INSERT. Stated explicitly rather than left to the type default: the setter is
+        // otherwise only reached by MapToDomain's reflection, and S1144 reads it as dead code
+        // (the analyzer has already had DI constructors deleted out from under it, #2296).
+        Xmin = 0;
         CreatedByUserId = createdByUserId;
         CreatedAt = DateTime.UtcNow;
         UpdatedAt = DateTime.UtcNow;
@@ -140,6 +177,27 @@ internal sealed class GameToolkit : AggregateRoot<Guid>
         Version++;
         UpdatedAt = DateTime.UtcNow;
         AddDomainEvent(new ToolkitPublishedEvent(Id, Version));
+    }
+
+    /// <summary>
+    /// Moves the marketplace pointer to a newly published semver. Issue #3670.
+    /// </summary>
+    /// <remarks>
+    /// Ordering against the currently published version is enforced by
+    /// <c>PublishToolkitVersionCommandHandler</c> against the ToolkitVersion aggregate, which
+    /// owns version history; this method only moves the parent's pointer. It exists so the
+    /// publish path can go through the repository like every other write: before #3670 the
+    /// handler had to mutate the tracked EF entity directly, because persisting the aggregate
+    /// would have overwritten the user's semver with a synthesised one.
+    /// </remarks>
+    public void PublishMarketplaceVersion(string versionSemver, DateTime publishedAt)
+    {
+        if (string.IsNullOrWhiteSpace(versionSemver))
+            throw new ArgumentException("Version semver cannot be empty", nameof(versionSemver));
+
+        VersionSemver = versionSemver.Trim();
+        IsPublished = true;
+        UpdatedAt = publishedAt;
     }
 
     // ========================================================================

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Infrastructure/Persistence/GameToolkitRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Infrastructure/Persistence/GameToolkitRepository.cs
@@ -136,14 +136,22 @@ internal class GameToolkitRepository : RepositoryBase, IGameToolkitRepository
         var entity = MapToPersistence(toolkit);
         var entry = DbContext.Set<GameToolkitEntity>().Update(entity);
 
-        // Issue #1458: the domain aggregate carries no VersionSemver/Description/License,
-        // so MapToPersistence cannot reconstruct them — VersionSemver is synthesized as
-        // "0.{Version}.0" and the other two default to null. Update() marks every column
-        // Modified, which would clobber the published marketplace pointer (e.g. reset
-        // "2.3.1" → "0.1.0") and null the description/license on every non-publish update.
-        // Exclude those three columns so their persisted values survive. PublishToolkitVersion
-        // writes VersionSemver on the tracked entity directly, bypassing this method.
-        entry.Property(e => e.VersionSemver).IsModified = false;
+        // Hand EF the real xmin as the ORIGINAL value (#3670). MapToPersistence builds a fresh
+        // detached entity, so without this the token's original value is 0 and the statement
+        // becomes `WHERE "Id" = @p AND xmin = 0`, which matches no live tuple: SaveChanges then
+        // raised DbUpdateConcurrencyException for EVERY write in this bounded context on
+        // Postgres — rename, dice tools, presets — while the InMemory tests stayed green
+        // because that provider has no xmin column. Same pattern as AlertChannelRepository:78.
+        entry.Property(e => e.Xmin).OriginalValue = toolkit.Xmin;
+
+        // The aggregate still carries no Description/License, so MapToPersistence leaves them
+        // null. Update() marks every column Modified, which would null both on every unrelated
+        // update. Exclude them so their persisted values survive.
+        //
+        // VersionSemver was in this list until #3670: it is now real aggregate state, loaded by
+        // MapToDomain and written back here like any other column, so the publish path no longer
+        // has to bypass this method. Re-excluding it would make PublishMarketplaceVersion a
+        // silent no-op — the aggregate would accept the new semver and the UPDATE would drop it.
         entry.Property(e => e.Description).IsModified = false;
         entry.Property(e => e.License).IsModified = false;
 
@@ -184,6 +192,14 @@ internal class GameToolkitRepository : RepositoryBase, IGameToolkitRepository
         SetPrivateProperty(toolkit, "Name", entity.Name);
         SetPrivateProperty(toolkit, "CreatedByUserId", entity.CreatedByUserId);
         SetPrivateProperty(toolkit, "Version", entity.Version);
+        SetPrivateProperty(toolkit, "Xmin", entity.Xmin);
+        // #3670: MUST be loaded. UpdateAsync now writes VersionSemver from the aggregate, so an
+        // aggregate that doesn't know the persisted value would clobber the published marketplace
+        // pointer on any unrelated update (a rename, say). Guarded by
+        // GameToolkitRepositoryUpdatePreservationTests.
+        // The ?? is defensive only: the column is NOT NULL with default "0.1.0"
+        // (GameToolkitEntityConfiguration:33), so materialisation cannot yield null.
+        SetPrivateProperty(toolkit, "VersionSemver", entity.VersionSemver ?? Domain.Entities.GameToolkit.SeedSemver);
         SetPrivateProperty(toolkit, "IsPublished", entity.IsPublished);
         SetPrivateProperty(toolkit, "OverridesTurnOrder", entity.OverridesTurnOrder);
         SetPrivateProperty(toolkit, "OverridesScoreboard", entity.OverridesScoreboard);
@@ -306,24 +322,16 @@ internal class GameToolkitRepository : RepositoryBase, IGameToolkitRepository
             OverridesTurnOrder = toolkit.OverridesTurnOrder,
             OverridesScoreboard = toolkit.OverridesScoreboard,
             OverridesDiceSet = toolkit.OverridesDiceSet,
-#pragma warning disable CS0618 // Issue #1144 / spec D-5: paired write — legacy int + new semver in same MapToPersistence call.
+#pragma warning disable CS0618 // GameToolkitEntity.Version's setter is [Obsolete], but the column still
+                               // backs the (GameId, Version) / (PrivateGameId, Version) unique indexes,
+                               // so the write cannot be dropped until that column is retired. Not to be
+                               // confused with the #3670 breadcrumb, which is gone.
             Version = toolkit.Version,
 #pragma warning restore CS0618
-#pragma warning disable S1135 // TODO: architectural breadcrumb — mitigated footgun: see comment below.
-            // TODO(#3670): VersionSemver already has a real producer.
-            // PublishToolkitVersionCommandHandler.cs:137 writes the user-input
-            // semver and DELIBERATELY bypasses GameToolkitRepository.UpdateAsync
-            // (see handler comment at lines 131-136) precisely because this
-            // MapToPersistence synthesis would otherwise overwrite the user
-            // value with "0.{Version}.0". This synthesis is only meaningful for
-            // AddAsync (brand-new toolkit → seed "0.1.0"): UpdateAsync now excludes
-            // VersionSemver (and Description/License) from the Update() so no
-            // non-publish update path clobbers the published marketplace pointer.
-            // Full fix: surface VersionSemver on the domain aggregate (#3670 —
-            // original paired-write context shipped in #1144 2026-05-14)
-            // so MapToPersistence can read it directly and the synthesis goes away.
-            VersionSemver = $"0.{toolkit.Version}.0",
-#pragma warning restore S1135
+            // #3670: read from the aggregate. This was synthesised as "0.{Version}.0" until
+            // the aggregate carried the value, which forced the publish path to bypass
+            // UpdateAsync so the synthesis wouldn't overwrite the user's semver.
+            VersionSemver = toolkit.VersionSemver,
             CreatedByUserId = toolkit.CreatedByUserId,
             IsPublished = toolkit.IsPublished,
             CreatedAt = toolkit.CreatedAt,

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Application/Commands/PublishToolkitVersionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Application/Commands/PublishToolkitVersionCommandHandlerTests.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.GameToolkit.Application.Commands.PublishToolkitVersion
 using Api.BoundedContexts.GameToolkit.Domain.Entities;
 using Api.BoundedContexts.GameToolkit.Domain.Enums;
 using Api.BoundedContexts.GameToolkit.Domain.Repositories;
+using Api.BoundedContexts.GameToolkit.Infrastructure.Persistence;
 using Api.Infrastructure.Entities.GameToolkit;
 using Api.Middleware.Exceptions;
 using Api.Services;
@@ -9,6 +10,7 @@ using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.Constants;
 using Api.Tests.TestHelpers;
 using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
@@ -48,8 +50,16 @@ public class PublishToolkitVersionCommandHandlerTests
         var unitOfWork = new EfCoreUnitOfWork(context);
         var timeProvider = new FakeTimeProvider(Now);
 
+        // Real repository, not a mock (#3670). The handler no longer mutates the tracked EF
+        // row: it loads the aggregate, calls PublishMarketplaceVersion and persists through
+        // UpdateAsync. A mocked repository would stub out exactly the mapping round-trip that
+        // makes this safe — MapToDomain loading VersionSemver so MapToPersistence can write it
+        // back — and the test would still pass if that round-trip broke.
+        var toolkitRepo = new GameToolkitRepository(
+            context, TestDbContextFactory.CreateMockEventCollector().Object);
+
         var handler = new PublishToolkitVersionCommandHandler(
-            context,
+            toolkitRepo,
             versionRepo.Object,
             unitOfWork,
             cache.Object,
@@ -79,6 +89,14 @@ public class PublishToolkitVersionCommandHandlerTests
             UpdatedAt = Now,        };
 #pragma warning restore CS0618
         context.GameToolkits.Add(toolkit);
+        context.SaveChanges();
+
+        // Detach so the act phase starts with an empty change tracker, which is what a request
+        // actually sees: MeepleAiDbContext is scoped, and the handler's only load is
+        // GetByIdAsync (AsNoTracking). Leaving the seeded instance tracked makes UpdateAsync's
+        // Set<>().Update() attach a second instance of the same key and throw — a fixture
+        // artifact, not a product defect, but one that reads exactly like a real bug (#3670).
+        context.Entry(toolkit).State = EntityState.Detached;
         return toolkit;
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Infrastructure/Persistence/GameToolkitRepositoryUpdatePreservationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Infrastructure/Persistence/GameToolkitRepositoryUpdatePreservationTests.cs
@@ -14,17 +14,24 @@ namespace Api.Tests.BoundedContexts.GameToolkit.Infrastructure.Persistence;
 /// Regression tests for <see cref="GameToolkitRepository.UpdateAsync"/> (issue #1458 footgun).
 ///
 /// <para>
-/// <c>MapToPersistence</c> synthesizes <c>VersionSemver = "0.{Version}.0"</c> and omits
-/// <c>Description</c>/<c>License</c> entirely (the domain aggregate has no knowledge of these
-/// three entity-level marketplace columns). Because <c>UpdateAsync</c> calls
+/// <c>MapToPersistence</c> omits <c>Description</c>/<c>License</c> entirely (the domain aggregate
+/// has no knowledge of those entity-level marketplace columns). Because <c>UpdateAsync</c> calls
 /// <c>DbContext.Update(entity)</c>, which marks EVERY scalar column Modified, any non-publish
-/// update path (rename, add/remove tool, override change, …) silently overwrote the published
-/// marketplace pointer: <c>VersionSemver "2.3.1" → "0.1.0"</c> and nulled <c>Description</c>/<c>License</c>.
+/// update path (rename, add/remove tool, override change, …) would null them.
 /// </para>
 ///
-/// InMemory is the correct vehicle: it honors per-property <c>IsModified</c> flags but ignores
-/// the Postgres <c>xmin</c> concurrency token (which would otherwise mask this bug behind a
-/// <c>DbUpdateConcurrencyException</c> on a real database).
+/// <para>
+/// <c>VersionSemver</c> used to be in that list too, synthesized as <c>"0.{Version}.0"</c>, which
+/// silently reset the published marketplace pointer <c>"2.3.1" → "0.1.0"</c>. Since #3670 it is
+/// real aggregate state, loaded by <c>MapToDomain</c> and written back like any other column —
+/// so this test now guards the round-trip rather than an exclusion, and still goes red if the
+/// synthesis returns.
+/// </para>
+///
+/// InMemory honors per-property <c>IsModified</c> flags, which is what this test asserts on. It
+/// has no <c>xmin</c> column, so it says nothing about the Postgres concurrency token — that is
+/// covered by <c>GameToolkitRepositoryPostgresConcurrencyTests</c> (#3670), added after this
+/// provider gap turned out to be hiding a real DbUpdateConcurrencyException on every write.
 /// </summary>
 [Trait("Category", TestCategories.Unit)]
 [Trait("BoundedContext", "GameToolkit")]

--- a/apps/api/tests/Api.Tests/E2E/GameManagement/GameManagementE2ETests.cs
+++ b/apps/api/tests/Api.Tests/E2E/GameManagement/GameManagementE2ETests.cs
@@ -1,3 +1,4 @@
+using Api.Infrastructure.Entities;
 using Api.Tests.E2E.Infrastructure;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
@@ -50,6 +51,55 @@ public sealed class GameManagementE2ETests : E2ETestBase
         DbContext.SharedGames.Add(game);
         await DbContext.SaveChangesAsync();
         _testGameId = game.Id;
+
+        // #3662: avviare una sessione richiede una knowledge base PRONTA -- altrimenti
+        // CreateSessionCommandHandler risponde 422 `kb_not_ready`. E' una regola di business
+        // aggiunta dopo la scrittura di questi test, e senza di essa nessun test del ciclo di
+        // vita della sessione puo' passare.
+        //
+        // «Pronta» significa, secondo GetKbReadinessQueryHandler: almeno un PdfDocument del
+        // gioco in stato "Ready" E un VectorDocument su quel PDF con IndexingStatus
+        // "completed". Servono entrambi: con il solo PDF lo stato resta non-ready.
+        var kbOwner = new UserEntity
+        {
+            Id = Guid.NewGuid(),
+            Email = $"e2e-kb-owner-{Guid.NewGuid():N}@test.invalid",
+            DisplayName = "E2E KB Owner",
+            PasswordHash = "placeholder.NeverLogsIn",
+            Role = "user",
+            Tier = "free",
+            Status = "Active",
+            EmailVerified = false,
+            CreatedAt = DateTime.UtcNow,
+        };
+        DbContext.Users.Add(kbOwner);
+
+        var pdf = new PdfDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            FileName = "e2e-rulebook.pdf",
+            FilePath = "/tmp/e2e-rulebook.pdf",
+            FileSizeBytes = 1024,
+            ContentType = "application/pdf",
+            UploadedByUserId = kbOwner.Id,
+            SharedGameId = game.Id,
+            ProcessingState = "Ready",
+        };
+        DbContext.PdfDocuments.Add(pdf);
+
+        DbContext.VectorDocuments.Add(new VectorDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            SharedGameId = game.Id,
+            PdfDocumentId = pdf.Id,
+            IndexingStatus = "completed",
+            EmbeddingModel = "e2e-test-model",
+            EmbeddingDimensions = 768,
+            ChunkCount = 1,
+            IndexedAt = DateTime.UtcNow,
+        });
+
+        await DbContext.SaveChangesAsync();
     }
 
     #region Public Game Browsing Tests
@@ -134,23 +184,14 @@ public sealed class GameManagementE2ETests : E2ETestBase
         var (sessionToken, _) = await RegisterUserAsync(email, "ValidUnusualPwd123!");
         SetSessionCookie(sessionToken);
 
-        var createPayload = new
-        {
-            gameId = _testGameId,
-            players = new[]
-            {
-                new { playerName = "Player 1", playerOrder = 1 },
-                new { playerName = "Player 2", playerOrder = 2 }
-            }
-        };
-
-        var createResponse = await Client.PostAsJsonAsync("/api/v1/sessions", createPayload);
-        createResponse.EnsureSuccessStatusCode();
-        var session = await createResponse.Content.ReadFromJsonAsync<GameSessionDto>();
+        // #3662: il vecchio `POST /api/v1/sessions` non esiste piu'. Una Session
+        // appartiene a una GameNight (invariante «GameNight 1..N Session»): si crea
+        // la serata e vi si avvia dentro la sessione.
+        var sessionId = await StartSessionAsync(_testGameId);
 
         // Act - Complete the session
         var completePayload = new { winnerName = "Player 1" };
-        var completeResponse = await Client.PostAsJsonAsync($"/api/v1/sessions/{session!.Id}/complete", completePayload);
+        var completeResponse = await Client.PostAsJsonAsync($"/api/v1/sessions/{sessionId}/complete", completePayload);
 
         // Assert
         completeResponse.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -168,22 +209,13 @@ public sealed class GameManagementE2ETests : E2ETestBase
         var (sessionToken, _) = await RegisterUserAsync(email, "ValidUnusualPwd123!");
         SetSessionCookie(sessionToken);
 
-        var createPayload = new
-        {
-            gameId = _testGameId,
-            players = new[]
-            {
-                new { playerName = "Player 1", playerOrder = 1 },
-                new { playerName = "Player 2", playerOrder = 2 }
-            }
-        };
-
-        var createResponse = await Client.PostAsJsonAsync("/api/v1/sessions", createPayload);
-        createResponse.EnsureSuccessStatusCode();
-        var session = await createResponse.Content.ReadFromJsonAsync<GameSessionDto>();
+        // #3662: il vecchio `POST /api/v1/sessions` non esiste piu'. Una Session
+        // appartiene a una GameNight (invariante «GameNight 1..N Session»): si crea
+        // la serata e vi si avvia dentro la sessione.
+        var sessionId = await StartSessionAsync(_testGameId);
 
         // Act - Abandon the session
-        var abandonResponse = await Client.PostAsJsonAsync($"/api/v1/sessions/{session!.Id}/abandon", new { });
+        var abandonResponse = await Client.PostAsJsonAsync($"/api/v1/sessions/{sessionId}/abandon", new { });
 
         // Assert
         abandonResponse.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -201,29 +233,20 @@ public sealed class GameManagementE2ETests : E2ETestBase
         var (sessionToken, _) = await RegisterUserAsync(email, "ValidUnusualPwd123!");
         SetSessionCookie(sessionToken);
 
-        var createPayload = new
-        {
-            gameId = _testGameId,
-            players = new[]
-            {
-                new { playerName = "Player 1", playerOrder = 1 },
-                new { playerName = "Player 2", playerOrder = 2 }
-            }
-        };
-
-        var createResponse = await Client.PostAsJsonAsync("/api/v1/sessions", createPayload);
-        createResponse.EnsureSuccessStatusCode();
-        var session = await createResponse.Content.ReadFromJsonAsync<GameSessionDto>();
+        // #3662: il vecchio `POST /api/v1/sessions` non esiste piu'. Una Session
+        // appartiene a una GameNight (invariante «GameNight 1..N Session»): si crea
+        // la serata e vi si avvia dentro la sessione.
+        var sessionId = await StartSessionAsync(_testGameId);
 
         // Act - Pause the session
-        var pauseResponse = await Client.PostAsJsonAsync($"/api/v1/sessions/{session!.Id}/pause", new { });
+        var pauseResponse = await Client.PostAsJsonAsync($"/api/v1/sessions/{sessionId}/pause", new { });
         pauseResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var pausedSession = await pauseResponse.Content.ReadFromJsonAsync<GameSessionDto>();
         pausedSession!.Status.Should().Be("Paused");
 
         // Act - Resume the session
-        var resumeResponse = await Client.PostAsJsonAsync($"/api/v1/sessions/{session.Id}/resume", new { });
+        var resumeResponse = await Client.PostAsJsonAsync($"/api/v1/sessions/{sessionId}/resume", new { });
         resumeResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var resumedSession = await resumeResponse.Content.ReadFromJsonAsync<GameSessionDto>();
@@ -255,18 +278,20 @@ public sealed class GameManagementE2ETests : E2ETestBase
         SetSessionCookie(sessionToken);
 
         // Step 4: Start a game session
-        var startPayload = new
-        {
-            gameId = _testGameId,
-            players = new[]
-            {
-                new { playerName = "Alice", playerOrder = 1 },
-                new { playerName = "Bob", playerOrder = 2 },
-                new { playerName = "Charlie", playerOrder = 3 }
-            }
-        };
+        // #3662: l'avvio non accetta piu' i giocatori nel corpo -- si aggiungono dopo, con
+        // POST /sessions/{id}/players. Il percorso resta coperto per intero: la copertura
+        // sui giocatori non viene tolta, viene spostata sull'endpoint che oggi la fornisce.
+        var sessionId = await StartSessionAsync(_testGameId);
 
-        var startResponse = await Client.PostAsJsonAsync("/api/v1/sessions", startPayload);
+        foreach (var (name, order) in new[] { ("Alice", 1), ("Bob", 2), ("Charlie", 3) })
+        {
+            var addPlayerResponse = await Client.PostAsJsonAsync(
+                $"/api/v1/sessions/{sessionId}/players",
+                new { playerName = name, playerOrder = order });
+            addPlayerResponse.EnsureSuccessStatusCode();
+        }
+
+        var startResponse = await Client.GetAsync($"/api/v1/sessions/{sessionId}");
         startResponse.EnsureSuccessStatusCode();
         var session = await startResponse.Content.ReadFromJsonAsync<GameSessionDto>();
 
@@ -276,7 +301,7 @@ public sealed class GameManagementE2ETests : E2ETestBase
 
         // Step 5: Complete the game with a winner
         var completePayload = new { winnerName = "Bob" };
-        var completeResponse = await Client.PostAsJsonAsync($"/api/v1/sessions/{session.Id}/complete", completePayload);
+        var completeResponse = await Client.PostAsJsonAsync($"/api/v1/sessions/{sessionId}/complete", completePayload);
         completeResponse.EnsureSuccessStatusCode();
 
         var completedSession = await completeResponse.Content.ReadFromJsonAsync<GameSessionDto>();
@@ -296,23 +321,14 @@ public sealed class GameManagementE2ETests : E2ETestBase
         var (sessionToken, _) = await RegisterUserAsync(email, "ValidUnusualPwd123!");
         SetSessionCookie(sessionToken);
 
-        var createPayload = new
-        {
-            gameId = _testGameId,
-            players = new[]
-            {
-                new { playerName = "Player 1", playerOrder = 1 },
-                new { playerName = "Player 2", playerOrder = 2 }
-            }
-        };
-
-        var createResponse = await Client.PostAsJsonAsync("/api/v1/sessions", createPayload);
-        createResponse.EnsureSuccessStatusCode();
-        var session = await createResponse.Content.ReadFromJsonAsync<GameSessionDto>();
+        // #3662: il vecchio `POST /api/v1/sessions` non esiste piu'. Una Session
+        // appartiene a una GameNight (invariante «GameNight 1..N Session»): si crea
+        // la serata e vi si avvia dentro la sessione.
+        var sessionId = await StartSessionAsync(_testGameId);
 
         // Act - Add another player
         var addPlayerPayload = new { playerName = "Player 3", playerOrder = 3 };
-        var addResponse = await Client.PostAsJsonAsync($"/api/v1/sessions/{session!.Id}/players", addPlayerPayload);
+        var addResponse = await Client.PostAsJsonAsync($"/api/v1/sessions/{sessionId}/players", addPlayerPayload);
 
         // Assert
         addResponse.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -353,4 +369,56 @@ public sealed class GameManagementE2ETests : E2ETestBase
         string PlayerName,
         int PlayerOrder,
         string? Color);
+
+    /// <summary>
+    /// #3662: sostituisce il vecchio <c>POST /api/v1/sessions</c>, che non esiste piu'.
+    ///
+    /// Non e' una route rinominata ma un cambio di modello: una Session appartiene a una
+    /// GameNight, quindi il flusso e' in due passi. Il risultato porta DUE id --
+    /// <c>SessionId</c> (l'aggregato <c>GameSession</c>) e <c>GameNightSessionId</c> (il link
+    /// con la serata): gli endpoint <c>/sessions/{id}/complete|abandon|pause|resume|players</c>
+    /// vogliono il PRIMO. Scambiarli darebbe 404 su ogni chiamata successiva.
+    ///
+    /// <para><b>LIMITE NOTO (#3662).</b> Questo helper porta il flusso fino all'avvio della
+    /// sessione -- e quello ora funziona -- ma i cinque test del ciclo di vita restano rossi
+    /// con 404. Il motivo e' architetturale, non un URL sbagliato: <c>/sessions/{id}/complete
+    /// |abandon|pause|resume</c> operano su <c>IGameSessionRepository</c>, cioe' l'aggregato
+    /// <b>GameSession</b> (GameManagement), mentre l'avvio da una serata crea un
+    /// <b>SessionTracking.Session</b>. Sono due dei tre aggregati di ADR-089, e il
+    /// <c>SessionId</c> restituito qui NON e' quello che quegli endpoint risolvono.</para>
+    ///
+    /// <para>Il collegamento (<c>CorrelatedGameSessionId</c>) viene creato piu' avanti nel
+    /// ciclo di vita — <c>LifecycleCommandHandlers.cs:86</c> — e <b>non e' esposto da alcuna
+    /// risposta</b>: <c>GoLiveSessionResult</c> porta SessionId/GameNightId/
+    /// GameNightSessionId/PlayOrder/Status, mai l'id correlato. Serve stabilire quale sia il
+    /// percorso HTTP supportato per ottenere un GameSession: e' una domanda sul contratto,
+    /// non un aggiustamento di test.</para>
+    /// </summary>
+    private async Task<Guid> StartSessionAsync(Guid gameId, string gameTitle = "E2E Test Game")
+    {
+        var nightResponse = await Client.PostAsJsonAsync("/api/v1/game-nights", new
+        {
+            title = $"E2E Night {Guid.NewGuid():N}",
+            // Il validator pretende `> UtcNow.AddHours(1)` STRETTAMENTE: con AddHours(1)
+            // esatto la data e' gia' scaduta quando il server la valuta, e la risposta e' 422.
+            scheduledAt = DateTimeOffset.UtcNow.AddDays(1)
+        });
+        nightResponse.EnsureSuccessStatusCode();
+        var gameNightId = await nightResponse.Content.ReadFromJsonAsync<Guid>();
+
+        // Una serata nasce in stato Draft e non accetta sessioni («Cannot add sessions to a
+        // Draft game night»): va pubblicata prima.
+        var publishResponse = await Client.PostAsync($"/api/v1/game-nights/{gameNightId}/publish", null);
+        publishResponse.EnsureSuccessStatusCode();
+
+        var sessionResponse = await Client.PostAsJsonAsync(
+            $"/api/v1/game-nights/{gameNightId}/sessions", new { gameId, gameTitle });
+        sessionResponse.EnsureSuccessStatusCode();
+        var started = await sessionResponse.Content.ReadFromJsonAsync<StartSessionResult>();
+        return started!.SessionId;
+    }
+
+    private sealed record StartSessionResult(
+        Guid SessionId, Guid GameNightSessionId, string SessionCode, int PlayOrder);
+
 }

--- a/apps/api/tests/Api.Tests/E2E/SharedGameCatalog/AdminGameCreationJourneyE2ETests.cs
+++ b/apps/api/tests/Api.Tests/E2E/SharedGameCatalog/AdminGameCreationJourneyE2ETests.cs
@@ -1,3 +1,5 @@
+using Microsoft.EntityFrameworkCore;
+using Api.Infrastructure.Entities;
 using Api.Infrastructure.Entities.SharedGameCatalog;
 using Api.Tests.E2E.Infrastructure;
 using FluentAssertions;
@@ -53,6 +55,57 @@ public sealed class AdminGameCreationJourneyE2ETests : E2ETestBase
         };
 
         DbContext.SharedGames.Add(sharedGame);
+
+        // #3662: `Features.PdfUpload` e' un feature flag con default FALSE
+        // (FeatureFlagService: «Role-specific flag > Global flag > Default false»), e i tre
+        // handler di upload rispondono 403 `feature_disabled` quando non e' attivo
+        // (PdfUploadEndpoints.cs:155). Su un database di test appena migrato quella riga non
+        // esiste, quindi i test di upload non potevano passare in nessuno scenario: il 403 non
+        // era un problema di permessi, era la feature spenta.
+        // `created_by_user_id` e' NOT NULL con FK verso users (delete Restrict): senza questo
+        // utente l'insert fallisce con 23503 e a saltare e' l'INTERA fixture, non un solo test.
+        var seederId = new Guid("c0c0ffee-5eed-4e2e-bbbb-000000003662");
+        if (!await DbContext.Users.AnyAsync(u => u.Id == seederId))
+        {
+            DbContext.Users.Add(new UserEntity
+            {
+                Id = seederId,
+                Email = "e2e-admin-journey-seeder@test.invalid",
+                DisplayName = "E2E Journey Seeder",
+                PasswordHash = "placeholder.NeverLogsIn",
+                Role = "user",
+                Tier = "free",
+                Status = "Active",
+                EmailVerified = false,
+                CreatedAt = DateTime.UtcNow,
+            });
+        }
+
+        // La collection E2E condivide UN database fra tutti i test, ma SeedTestDataAsync gira
+        // per ogni test: senza questa guardia dal secondo in poi si viola
+        // IX_system_configurations_Key_Environment (23505) e salta l'intera fixture.
+        var flagExists = await DbContext.SystemConfigurations
+            .AnyAsync(c => c.Key == "Features.PdfUpload" && c.Environment == "All");
+        if (!flagExists)
+        {
+        DbContext.SystemConfigurations.Add(new SystemConfigurationEntity
+        {
+            Id = Guid.NewGuid(),
+            CreatedByUserId = seederId,
+            Key = "Features.PdfUpload",
+            Value = "true",
+            ValueType = "Boolean",
+            Description = "E2E seed: abilita l'upload PDF per i test del percorso admin",
+            Category = "Features",
+            IsActive = true,
+            RequiresRestart = false,
+            Environment = "All",
+            Version = 1,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        }
+
         await DbContext.SaveChangesAsync();
         _testSharedGameId = sharedGame.Id;
     }
@@ -830,8 +883,10 @@ public sealed class AdminGameCreationJourneyE2ETests : E2ETestBase
             {
                 var registerResult = await registerResponse.Content.ReadFromJsonAsync<RegisterResponse>();
                 var sessionToken = ExtractSessionCookie(registerResponse);
+                var newUserId = registerResult!.User!.Id;
+                await ElevateToAdminAsync(newUserId);
                 return (sessionToken ?? throw new InvalidOperationException("Session token not found"),
-                    registerResult!.User!.Id);
+                    newUserId);
             }
 
             throw new InvalidOperationException($"Could not login or register admin: {response.StatusCode}");
@@ -839,7 +894,28 @@ public sealed class AdminGameCreationJourneyE2ETests : E2ETestBase
 
         var loginResult = await response.Content.ReadFromJsonAsync<LoginResponse>();
         var token = ExtractSessionCookie(response);
-        return (token ?? throw new InvalidOperationException("Session token not found"), loginResult!.User!.Id);
+        var userId = loginResult!.User!.Id;
+        await ElevateToAdminAsync(userId);
+        return (token ?? throw new InvalidOperationException("Session token not found"), userId);
+    }
+
+    /// <summary>
+    /// #3662: <c>LoginAsAdminAsync</c> si chiamava «admin» ma non lo era: registrava un utente
+    /// con ruolo <c>user</c>, quindi ogni endpoint sotto <c>/admin/</c> rispondeva 403. Il nome
+    /// dell'helper descriveva l'intenzione, non il risultato.
+    ///
+    /// Il ruolo si imposta sull'entità di persistenza dopo la creazione della sessione: la
+    /// sessione non lo congela, viene risolto per richiesta. È lo stesso approccio già
+    /// verificato in BatchJobE2ETests.
+    /// </summary>
+    private async Task ElevateToAdminAsync(Guid userId)
+    {
+        var user = await DbContext.Users.FindAsync(userId);
+        if (user is not null && !string.Equals(user.Role, "admin", StringComparison.Ordinal))
+        {
+            user.Role = "admin";
+            await DbContext.SaveChangesAsync();
+        }
     }
 
     private static string? ExtractSessionCookie(HttpResponseMessage response)

--- a/apps/api/tests/Api.Tests/Integration/ToolkitMarketplace/GameToolkitRepositoryPostgresConcurrencyTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/ToolkitMarketplace/GameToolkitRepositoryPostgresConcurrencyTests.cs
@@ -1,0 +1,145 @@
+using Api.BoundedContexts.GameToolkit.Application.Commands;
+using Api.BoundedContexts.GameToolkit.Domain.Enums;
+using Api.BoundedContexts.GameToolkit.Domain.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.GameToolkit;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.ToolkitMarketplace;
+
+/// <summary>
+/// Issue #3670. Exercises <c>GameToolkitRepository.UpdateAsync</c> against a real Postgres.
+/// </summary>
+/// <remarks>
+/// Every other test of this repository runs on the EF InMemory provider, which has no
+/// <c>xmin</c> system column — so it cannot observe what the concurrency token does to the
+/// UPDATE statement. <c>GameToolkitEntityConfiguration</c> declares <c>Xmin</c> as a
+/// concurrency token, and <c>UpdateAsync</c> attaches a freshly mapped (detached) entity whose
+/// <c>Xmin</c> is never assigned. If EF emitted that zero as the original value, the statement
+/// would read <c>WHERE "Id" = @p AND xmin = 0</c>, match no live tuple, and every update in
+/// this bounded context would raise <c>DbUpdateConcurrencyException</c>.
+///
+/// This test exists to answer that empirically rather than by reading EF's source: it is the
+/// difference between "publish is fine" and "renaming a toolkit has been 500ing in production".
+/// </remarks>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "GameToolkit")]
+public sealed class GameToolkitRepositoryPostgresConcurrencyTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+
+    private static readonly Guid OwnerId = Guid.Parse("00000000-0000-0000-0000-000000003670");
+
+    public GameToolkitRepositoryPostgresConcurrencyTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"toolkit_xmin_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        await dbContext.Database.MigrateAsync();
+    }
+
+    public async ValueTask DisposeAsync() => await _factory.DisposeAsync();
+
+    private async Task<Guid> SeedToolkitAsync(string versionSemver)
+    {
+        var toolkitId = Guid.NewGuid();
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+#pragma warning disable CS0618 // legacy int Version — seeding the paired column
+        db.GameToolkits.Add(new GameToolkitEntity
+        {
+            Id = toolkitId,
+            Name = "Original Name",
+            CreatedByUserId = OwnerId,
+            Version = 1,
+            VersionSemver = versionSemver,
+            IsPublished = true,
+            TemplateStatus = (int)TemplateStatus.Approved,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+#pragma warning restore CS0618
+
+        await db.SaveChangesAsync();
+        return toolkitId;
+    }
+
+    [Fact]
+    public async Task UpdateAsync_OnPostgres_SucceedsDespiteDetachedXmin()
+    {
+        var toolkitId = await SeedToolkitAsync("2.3.1");
+
+        // Fresh scope = the change tracker a real request starts with.
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var repository = scope.ServiceProvider.GetRequiredService<IGameToolkitRepository>();
+            var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+
+            var toolkit = await repository.GetByIdAsync(toolkitId);
+            toolkit.Should().NotBeNull();
+
+            toolkit!.UpdateDetails("Renamed Toolkit");
+            await repository.UpdateAsync(toolkit);
+
+            // The assertion that matters: no DbUpdateConcurrencyException.
+            await unitOfWork.SaveChangesAsync();
+        }
+
+        using (var verifyScope = _factory.Services.CreateScope())
+        {
+            var db = verifyScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var reloaded = await db.GameToolkits.AsNoTracking()
+                .FirstAsync(t => t.Id == toolkitId);
+
+            reloaded.Name.Should().Be("Renamed Toolkit");
+            reloaded.VersionSemver.Should().Be("2.3.1",
+                "a non-publish update must not disturb the published marketplace pointer");
+        }
+    }
+
+    [Fact]
+    public async Task PublishMarketplaceVersion_ThroughRepository_PersistsOnPostgres()
+    {
+        var toolkitId = await SeedToolkitAsync("1.0.0");
+        var publishedAt = new DateTime(2026, 8, 12, 10, 0, 0, DateTimeKind.Utc);
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var repository = scope.ServiceProvider.GetRequiredService<IGameToolkitRepository>();
+            var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+
+            var toolkit = await repository.GetByIdAsync(toolkitId);
+            toolkit!.PublishMarketplaceVersion("1.1.0", publishedAt);
+            await repository.UpdateAsync(toolkit);
+            await unitOfWork.SaveChangesAsync();
+        }
+
+        using (var verifyScope = _factory.Services.CreateScope())
+        {
+            var db = verifyScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var reloaded = await db.GameToolkits.AsNoTracking()
+                .FirstAsync(t => t.Id == toolkitId);
+
+            reloaded.VersionSemver.Should().Be("1.1.0");
+            reloaded.IsPublished.Should().BeTrue();
+        }
+    }
+}

--- a/apps/orchestration-service/src/application/orchestrator.py
+++ b/apps/orchestration-service/src/application/orchestrator.py
@@ -236,7 +236,13 @@ class GameOrchestrator:
                 current_agent=AgentType.ARBITRO,
                 conversation_history=state.conversation_history,
                 move_notation=state.pending_move.move_notation if state.pending_move else state.user_query,
-                game_state=None,  # TODO: Extract from board_state
+                # Deliberately None (#3668). board_state is available two lines above, but
+                # RuleEngine has no board model, so populating this would buy nothing:
+                # Constraint rules are skipped (with a warning) whatever it contains.
+                # Extract it together with a real obstruction check, never before — the
+                # previous TODO here promised an extraction that would have made a
+                # placeholder "assume constraint passes" branch reachable.
+                game_state=None,
             )
 
             # Execute Arbitro workflow with retry fallback

--- a/apps/orchestration-service/src/application/rule_engine.py
+++ b/apps/orchestration-service/src/application/rule_engine.py
@@ -241,26 +241,20 @@ class RuleEngine:
         matches = []
 
         for rule in rules:
-            pattern = rule.get("pattern")
             rule_id = UUID(rule["id"])
 
-            # Pattern-based matching
-            if pattern:
-                match = re.match(pattern, move)
-                if match:
-                    matches.append(RuleMatch(
-                        rule_id=rule_id,
-                        rule_name=rule["name"],
-                        rule_type=rule["type"],
-                        matches=True,
-                        reason=rule["description"],
-                        precedence=rule["precedence"],
-                    ))
+            # Constraints are state-based and there is no board model to evaluate them
+            # against, so no RuleMatch is emitted: nothing may claim one passed (#3668).
+            #
+            # Keyed on the TYPE, deliberately, not on a missing pattern. `rules` can come
+            # from the Redis cache (arbitrary JSON), so a Constraint that carries a pattern
+            # would otherwise fall into the branch below and be rubber-stamped matches=True.
+            if rule["type"] == "Constraint":
+                self._warn_constraint_unevaluated(rule["name"])
+                continue
 
-            # State-based validation (requires game state)
-            elif rule["type"] == "Constraint" and game_state:
-                # Placeholder: Would check game state for obstruction
-                # For MVP, assume constraint passes
+            pattern = rule.get("pattern")
+            if pattern and re.match(pattern, move):
                 matches.append(RuleMatch(
                     rule_id=rule_id,
                     rule_name=rule["name"],
@@ -271,6 +265,21 @@ class RuleEngine:
                 ))
 
         return matches
+
+    # Warn once per process, not once per move: the condition is constant and known, and a
+    # per-validation warning would train operators to ignore this service's logs.
+    _warned_constraints: set[str] = set()
+
+    def _warn_constraint_unevaluated(self, rule_name: str) -> None:
+        if rule_name in RuleEngine._warned_constraints:
+            return
+        RuleEngine._warned_constraints.add(rule_name)
+        logger.warning(
+            "Constraint rule '%s' is NOT evaluated: no board model exists to check it "
+            "(#3668). Moves are judged only by the rules that can be evaluated, so a "
+            "verdict of valid does not mean this constraint was satisfied.",
+            rule_name,
+        )
 
     def _determine_validity(
         self,

--- a/apps/orchestration-service/tests/test_rule_engine.py
+++ b/apps/orchestration-service/tests/test_rule_engine.py
@@ -1,0 +1,181 @@
+"""Tests for RuleEngine._match_rules — issue #3668.
+
+The Constraint branch had no tests at all, which is how it kept a body that reported
+every rule as satisfied without checking anything. These tests pin the two behaviours
+that matter: a rule that cannot be evaluated must not be reported as passed, and the
+absence of an evaluation must be visible.
+"""
+
+import logging
+from uuid import uuid4
+
+import pytest
+
+from src.application.rule_engine import RuleEngine, RuleMatch
+
+CONSTRAINT_RULE = {
+    "id": "00000000-0000-0000-0000-000000000003",
+    "name": "No Piece Obstruction",
+    "type": "Constraint",
+    "precedence": 40,
+    "pattern": None,  # state-based: no pattern to match on
+    "description": "Pieces cannot move through other pieces (except Knight)",
+}
+
+MOVEMENT_RULE = {
+    "id": "00000000-0000-0000-0000-000000000002",
+    "name": "Pawn Forward Movement",
+    "type": "Movement",
+    "precedence": 10,
+    "pattern": r"^[a-h][2-7]$",
+    "description": "Pawns move forward one square",
+}
+
+
+@pytest.fixture
+def engine():
+    return RuleEngine()
+
+
+class TestConstraintRuleIsNeverFalselyApproved:
+    """#3668: the placeholder appended matches=True — "for MVP, assume constraint passes"."""
+
+    def test_constraint_without_game_state_is_not_reported_as_matching(self, engine):
+        """Today's real path: the orchestrator passes game_state=None.
+
+        The rule is not evaluated, and that must NOT look like a passed check. Before
+        #3668 this branch was simply skipped, which was already the safer of the two
+        wrong behaviours — this test pins it so a future "just extract game_state"
+        cannot silently turn it into an unconditional approval.
+        """
+        matches = engine._match_rules("e4", [CONSTRAINT_RULE], game_state=None)
+
+        assert matches == [], (
+            "an unevaluated Constraint must produce no RuleMatch at all; "
+            "emitting one with matches=True would report success without checking"
+        )
+
+    def test_constraint_without_game_state_logs_that_it_was_skipped(self, engine, caplog):
+        """A gap nobody can see is the reason this survived until #3668."""
+        RuleEngine._warned_constraints.clear()
+
+        with caplog.at_level(logging.WARNING):
+            engine._match_rules("e4", [CONSTRAINT_RULE], game_state=None)
+
+        # Assert on level + rule name, not on prose: rewording the message must not break
+        # a correct behaviour.
+        assert any(
+            record.levelno == logging.WARNING and "No Piece Obstruction" in record.getMessage()
+            for record in caplog.records
+        ), "skipping a constraint must be logged, not silent"
+
+    def test_constraint_warning_is_not_repeated_every_validation(self, engine, caplog):
+        """The condition is constant; a warning per move would train operators to ignore it."""
+        RuleEngine._warned_constraints.clear()
+
+        with caplog.at_level(logging.WARNING):
+            for _ in range(5):
+                engine._match_rules("e4", [CONSTRAINT_RULE], game_state=None)
+
+        warnings = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING and "No Piece Obstruction" in r.getMessage()
+        ]
+        assert len(warnings) == 1, f"expected one warning per process, got {len(warnings)}"
+
+    def test_constraint_carrying_a_pattern_is_still_not_approved(self, engine):
+        """The hole the first version left open.
+
+        The branch used to key off a missing `pattern`, so a Constraint that *carries* one
+        fell into the pattern arm and was appended matches=True — silently, without even
+        the warning. Not reachable through CHESS_RULES, but `_match_rules` also consumes
+        rules from the Redis cache, which is arbitrary JSON per game.
+        """
+        constraint_with_pattern = {**CONSTRAINT_RULE, "pattern": r"^e[0-9]$"}
+
+        matches = engine._match_rules("e4", [constraint_with_pattern], game_state="FEN")
+
+        assert matches == [], (
+            "a Constraint must never be approved on the strength of a regex: "
+            "the rule type decides, not the presence of a pattern"
+        )
+
+    def test_constraint_with_game_state_is_still_not_approved(self, engine):
+        """The regression guard.
+
+        `validate_move(game_id, move, game_state)` is public, so this branch is reachable
+        even though the orchestrator passes None. Before #3668 that path appended
+        matches=True — the rule was reported as satisfied without a single check, which is
+        worse than not evaluating it because it is invisible in the result.
+        """
+        matches = engine._match_rules(
+            "e4", [CONSTRAINT_RULE], game_state="rnbqkbnr/pppppppp"
+        )
+
+        assert matches == [], (
+            "supplying a game state must not conjure a passing constraint: "
+            "there is still no board model to check obstruction against"
+        )
+
+    def test_constraint_never_yields_a_passing_match(self, engine):
+        """Belt and braces: no game_state value produces matches=True."""
+        for state in (None, "", "rnbqkbnr/pppppppp", "any-state"):
+            produced: list[RuleMatch] = engine._match_rules(
+                "e4", [CONSTRAINT_RULE], game_state=state
+            )
+            assert not any(m.matches for m in produced), (
+                f"constraint reported as matching with game_state={state!r}"
+            )
+
+
+class TestValidateMoveVerdict:
+    """The user-visible layer. The tests above pin `_match_rules`; this is what callers see."""
+
+    @pytest.mark.asyncio
+    async def test_unmatched_move_with_game_state_is_invalid(self, engine):
+        """The regression that mattered most, and it was invisible from `_match_rules`.
+
+        Before #3668, supplying ANY game state made ANY string a legal move: the Constraint
+        rubber-stamp was the only match, `_determine_validity` found no violated constraint
+        and no movement rule, and fell through to "Move notation is valid". Verified against
+        the previous revision — `"total garbage!!"` came back valid.
+        """
+        is_valid, reason, _, _ = await engine.validate_move(
+            uuid4(), "total garbage!!", game_state="rnbqkbnr/pppppppp"
+        )
+
+        assert is_valid is False, (
+            f"a move no rule can evaluate must not be declared valid (reason: {reason})"
+        )
+
+    @pytest.mark.asyncio
+    async def test_pattern_matched_move_stays_valid_with_game_state(self, engine):
+        """The other side of the same coin: the fix must not invalidate real moves."""
+        is_valid, _, applied, _ = await engine.validate_move(
+            uuid4(), "e4", game_state="rnbqkbnr/pppppppp"
+        )
+
+        assert is_valid is True
+        assert applied, "a pattern-matched move must still report the rules it applied"
+
+
+class TestPatternRulesAreUnaffected:
+    """The Constraint change must not disturb the pattern-matching path."""
+
+    def test_pattern_rule_matches_normally(self, engine):
+        matches = engine._match_rules("e4", [MOVEMENT_RULE], game_state=None)
+
+        assert len(matches) == 1
+        assert matches[0].rule_name == "Pawn Forward Movement"
+        assert matches[0].matches is True
+
+    def test_pattern_rule_not_matching_yields_nothing(self, engine):
+        assert engine._match_rules("Qh5", [MOVEMENT_RULE], game_state=None) == []
+
+    def test_mixed_ruleset_still_evaluates_the_pattern_rule(self, engine):
+        """A skipped Constraint must not suppress the rules that CAN be evaluated."""
+        matches = engine._match_rules(
+            "e4", [MOVEMENT_RULE, CONSTRAINT_RULE], game_state=None
+        )
+
+        assert [m.rule_name for m in matches] == ["Pawn Forward Movement"]

--- a/infra/scripts/tests/fixtures/meta-good.json
+++ b/infra/scripts/tests/fixtures/meta-good.json
@@ -1,6 +1,7 @@
 {
   "schema_version": "20260401_AddSearchVector",
   "ef_migration_head": "20260401_AddSearchVector",
+  "seed_table_schema_version": 1,
   "embedding_model": "sentence-transformers/all-MiniLM-L6-v2",
   "embedding_dim": 384,
   "app_commit": "test0000",

--- a/infra/scripts/tests/snapshot-verify.bats
+++ b/infra/scripts/tests/snapshot-verify.bats
@@ -8,7 +8,18 @@ setup() {
     SCRIPT_DIR="$BATS_TEST_DIRNAME/.."
     FIXTURES="$BATS_TEST_DIRNAME/fixtures"
     TMPDIR=$(mktemp -d)
+    META="$TMPDIR/meepleai_seed_test.meta.json"
     export SEED_INDEX_OUT_DIR="$TMPDIR"
+
+    # snapshot-verify.sh resolves infra/seed-schema.version RELATIVE TO CWD
+    # (lines 126-131: infra/… → ../infra/… → seed-schema.version) and falls back
+    # to 0 in silence when none matches. Run from infra/scripts/ the counter is
+    # unreachable, and "exit 5 on seed-table schema-version drift" then fails in
+    # the dangerous direction: expected 0 == current 0, the branch is never
+    # taken, and the test asserting the branch is reachable stops reaching it.
+    # Pin the CWD so the suite tests the script's real resolution path instead
+    # of whichever directory the caller happened to stand in.
+    cd "$BATS_TEST_DIRNAME/../../.." || return 1
 }
 
 teardown() {
@@ -17,7 +28,7 @@ teardown() {
 
 install_fixture() {
     local name=$1
-    cp "$FIXTURES/$name.json" "$TMPDIR/meepleai_seed_test.meta.json"
+    cp "$FIXTURES/$name.json" "$META"
     echo "meepleai_seed_test" > "$TMPDIR/.latest"
 }
 
@@ -27,11 +38,54 @@ set_expected_env() {
     export EXPECTED_EMBEDDING_DIM=384
 }
 
+patch_meta() {
+    # Scratch file lives outside SEED_INDEX_OUT_DIR: the script only reads
+    # .latest and $BASENAME.meta.json today, but a future glob over the
+    # snapshot dir shouldn't trip over our temporaries.
+    jq "$1" "$META" > "$BATS_TEST_TMPDIR/meta.patched" && mv "$BATS_TEST_TMPDIR/meta.patched" "$META"
+}
+
+# infra/seed-schema.version is a counter bumped by any PR that renames a seeded
+# table (#2126 D9). A fixture pinning the literal would go red on the next bump
+# with nothing actually broken — the same "test rots until nobody reads it"
+# trap this suite exists to catch (#3665). Read the live counter instead.
+sync_seed_schema_version() {
+    local live
+    live=$(tr -d '[:space:]' <"$BATS_TEST_DIRNAME/../../seed-schema.version")
+    # Without this the malformed value reaches jq as a filter fragment and the
+    # failure surfaces as a parse error that names neither the file nor why.
+    [[ "$live" =~ ^[0-9]+$ ]] || {
+        echo "seed-schema.version is not a counter: '$live'" >&2
+        return 1
+    }
+    patch_meta ".seed_table_schema_version = $live"
+}
+
 @test "exit 0 when all fields match" {
     install_fixture meta-good
+    sync_seed_schema_version
     set_expected_env
     run bash "$SCRIPT_DIR/snapshot-verify.sh"
     [ "$status" -eq 0 ]
+}
+
+@test "exit 5 on seed-table schema-version drift" {
+    install_fixture meta-good
+    set_expected_env
+    # A sidecar baked before the field existed — snapshot-verify.sh treats the
+    # missing field as version 0, so it drifts from any bumped counter while
+    # every other field still matches.
+    #
+    # This branch shipped in #2134 with no test at all: until #3665 the only
+    # fixture that reached it was meta-good, which reached it by accident and
+    # was asserting exit 0. Breaking the branch deliberately ran green.
+    patch_meta 'del(.seed_table_schema_version)'
+    run bash "$SCRIPT_DIR/snapshot-verify.sh"
+    [ "$status" -eq 5 ]
+    # Assert the reason, not just the number: exit 5 must come from THIS gate.
+    # Without it the test could go green off an unrelated future exit 5, or red
+    # with no hint that the counter simply wasn't found.
+    [[ "$output" == *"seed-table schema-version drift"* ]]
 }
 
 @test "exit 2 on migration drift" {


### PR DESCRIPTION
Cinque commit da `main-dev`.

## Correzioni di comportamento

**#3685 (#3668)** — una regola `Constraint` non viene più dichiarata soddisfatta quando non lo è. È il cambiamento con l'impatto funzionale più diretto di questo lotto.

**#3682 (#3670)** — `VersionSemver` diventa stato dell'aggregato, **e** un fix `xmin` che rompeva ogni write su Postgres. Da leggere insieme al punto sotto: la conversione a `xmin` di #3651 è in corso a lotti e questo era un effetto collaterale.

## Test che nessuno eseguiva

**#3677 (#3665)** — quattro suite `bats` entrano in CI: nessun workflow le eseguiva, una era rossa da due mesi, e il gate `exit 5` di `snapshot-verify.sh` non aveva alcun test (rompendolo di proposito la suite restava verde).

**#3681 + #3684 (#3662)** — allineamento dei test E2E, rimasti ciechi per sette settimane. Sulla suite `Category=E2E`: **da 39 rossi a 15** su 222 test.

Le cause trovate erano quasi tutte diagnosticabili male: un helper chiamato `LoginAsAdminAsync` che non impostava mai il ruolo, un 403 sull'upload PDF che era un feature flag spento (`Features.PdfUpload`, default `false`) e non un problema di permessi, e il flusso sessione che ora passa per una GameNight da pubblicare con una knowledge base pronta.

## Nota sui 15 residui

Non sono test da riparare ma due domande di contratto, entrambe documentate in #3662:

- **9** dipendono da ADR-089: `/sessions/{id}/complete|abandon|pause|resume` operano su `GameSession`, mentre l'unico percorso HTTP di creazione produce un `SessionTracking.Session`, e l'id correlato non è esposto da alcuna risposta;
- **4** chiamano endpoint rimossi (`POST /agents`, `/admin/shared-games/import-bgg`, `/admin/kb/vector-collections`), dove scegliere il sostituto è una decisione di prodotto.

Sono debito preesistente, non introdotto da questa promozione.

## Gate

Nessuna regressione attesa. Su #3684 `Backend Fast` è fallito una volta con `exit 139` (SIGSEGV: **0 test falliti, 12060 passati**, poi crash del processo); al rerun è passato — transitorio.
