### PR TITLE
ci(deploy): retention dei backup pre-migration, 3 conservati (#3689)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -922,6 +922,27 @@ jobs:
           echo "📦 Creating pre-migration backup: ${BACKUP_NAME}"
           $SSH_CMD "set -o pipefail; docker exec meepleai-postgres pg_dump -U meepleai -d meepleai_staging --no-owner --no-acl | gzip > /tmp/${BACKUP_NAME} && gzip -t /tmp/${BACKUP_NAME} && ls -lh /tmp/${BACKUP_NAME} || { echo '❌ backup failed — removing partial file'; rm -f /tmp/${BACKUP_NAME}; exit 1; }"
 
+          # Step 1b (#3689) — retention dei backup.
+          #
+          # Questo dump pesa ~166 MB e fino al 2026-08-12 NON veniva mai rimosso: se ne erano
+          # accumulati 46 in /tmp, 4,9 GB, il piu' vecchio del 5 agosto. Il deploy di quella
+          # notte e' morto sul gate di pre-volo — «Insufficient disk for AI image pull: 12 GB
+          # free < 15 GB» — senza nemmeno arrivare a toccare staging. Su una partizione da
+          # 75 GB gia' all'84%, 166 MB persi a ogni esecuzione sono una scadenza, non un rischio.
+          #
+          # NON si cancella tutto: `rollback-trigger.sh --restore-db` ripristina «from latest
+          # pre-migration backup», quindi questi file sono la rete di sicurezza del rollback.
+          # Se ne tengono 3 (~500 MB): coprono piu' di un deploy indietro senza ricreare il
+          # problema.
+          #
+          # 🔴 L'ORDINE E' PARTE DEL FIX: la retention gira DOPO il `gzip -t` qui sopra, mai
+          # prima. Il comando precedente esce 1 su backup fallito o corrotto e con `set -e`
+          # ferma lo step, quindi non si arriva mai a cancellare il backup buono precedente
+          # per far posto a uno inutilizzabile.
+          BACKUP_KEEP=3
+          echo "🧹 Retention backup: conservo i ${BACKUP_KEEP} piu' recenti"
+          $SSH_CMD "ls -1t /tmp/pre-migration-*.sql.gz 2>/dev/null | tail -n +\$((${BACKUP_KEEP}+1)) | xargs -r rm -f; echo \"   rimasti: \$(ls -1 /tmp/pre-migration-*.sql.gz 2>/dev/null | wc -l)\"; df -h / | tail -1"
+
           # Step 1.5 — pre-flight: detect whether the script's target migration
           # is already in __EFMigrationsHistory. Fixes #2020: after the 81→1
           # squash (PR fab0dc8eb), `dotnet ef migrations script --idempotent`


### PR DESCRIPTION
Closes #3689

## Il problema

Il dump di sicurezza scritto prima delle migration (`deploy-staging.yml:923`) pesa **~166 MB** e non veniva **mai** rimosso.

Al 2026-08-12 se ne erano accumulati **46** in `/tmp` del VPS di staging — **4,9 GB**, il più vecchio del 5 agosto. Il deploy di quella notte è morto sul gate di pre-volo:

```
##[error]Insufficient disk for AI image pull: 12 GB free < 15 GB
```

senza nemmeno arrivare a toccare staging. Su una partizione da 75 GB già occupata all'84%, 166 MB persi a ogni esecuzione non sono un rischio: sono una scadenza.

## Perché non si cancella tutto

`infra/scripts/rollback-trigger.sh` documenta `--restore-db` come ripristino *«from latest pre-migration backup»*: questi file sono la rete di sicurezza del rollback. Il difetto è la **retention assente**, non la loro esistenza.

Se ne tengono **3** (~500 MB): coprono più di un deploy indietro senza ricreare il problema.

## 🔴 L'ordine è parte del fix

La retention gira **dopo** il `gzip -t`, mai prima. Il comando di backup esce 1 su fallimento o archivio corrotto e con `set -e` ferma lo step, quindi non si arriva mai a cancellare il backup buono precedente per far posto a uno inutilizzabile.

È il primo punto della DoD proprio perché è l'errore facile da commettere scrivendo questa pulizia.

## Verifica

**Quoting** — il comando che arriva al remoto è:

```
ls -1t /tmp/pre-migration-*.sql.gz 2>/dev/null | tail -n +$((3+1)) | xargs -r rm -f; …
```

con `$(...)` e `$((...))` differiti al remoto e il glob non espanso in locale.

Una nota su come l'ho verificato: il primo test usava `eval`, che aggiunge un livello di interpretazione e valutava `$(...)` **localmente** — dando un falso negativo. Il test valido scrive la riga in uno script con `SSH_CMD=echo` e la esegue, riproducendo esattamente il contesto del workflow.

**Logica, provata sul VPS in sola lettura**: con 4 dump presenti seleziona esattamente il più vecchio e ne lascia 3.

## Altri artefatti

Verificato che nessun altro workflow accumuli sul VPS. Le altre scritture in `/tmp` (`api.log`, `migrations.log`, `staging-health.json`, `previous-baseline.json`, `cover.webp`) stanno sul **runner effimero**, e hanno comunque nomi fissi: si sovrascrivono invece di sommarsi. Solo il backup usa un nome con timestamp, ed è per questo che solo lui si accumulava.

## Stato attuale di staging

Sbloccato a mano rimuovendo i 43 dump più vecchi: da 12 a **16 GB liberi**. Il deploy rilanciato è **riuscito** — staging ha la promozione di `main-staging`.
