### PR TITLE
fix(backup): aws non è nel PATH di cron — l'upload sarebbe fallito solo di notte (#3669)

### DIFF
--- a/infra/scripts/backup.sh
+++ b/infra/scripts/backup.sh
@@ -12,6 +12,15 @@
 # looked exactly like one that succeeded, from the outside (#3669).
 set -Eeuo pipefail
 
+# cron gives user jobs a minimal PATH (/usr/bin:/bin on Debian/Ubuntu) and this
+# crontab sets none. The AWS CLI v2 installer puts `aws` in /usr/local/bin, which is
+# therefore invisible at 03:00 while working perfectly from an interactive shell —
+# the offsite upload would fail nightly and only in the dark. Verified on the staging
+# VPS (2026-08-12): `env -i PATH=/usr/bin:/bin bash -c 'command -v aws'` finds nothing.
+# Fixed here rather than in the crontab so it holds for every host regardless of how
+# the cron entry was installed.
+export PATH="/usr/local/bin:/usr/local/sbin:${PATH}"
+
 # ─────────────────────────────────────────────
 # Error trap — notify on unexpected failure
 # ─────────────────────────────────────────────


### PR DESCRIPTION
## Il difetto

Installati `awscli` e `age` sul VPS di staging (follow-up di #3669, PR #3690). L'AWS CLI v2 va in `/usr/local/bin`; il `PATH` che cron dà ai job utente su Debian/Ubuntu è `/usr/bin:/bin`, e questo crontab non ne imposta uno.

**`aws` funziona da shell interattiva e non esiste alle 03:00.** La copia offsite sarebbe fallita ogni notte, e solo al buio — la classe di guasto peggiore da diagnosticare, perché ogni verifica manuale riesce.

## Verificato sul server, prima e dopo

```bash
env -i PATH=/usr/bin:/bin bash -c 'command -v aws'
# → NON-TROVATO

env -i PATH=/usr/bin:/bin bash -c 'export PATH=/usr/local/bin:$PATH; command -v aws'
# → /usr/local/bin/aws
```

## Perché nello script e non nel crontab

Così vale per **ogni host** indipendentemente da come è stata installata la riga di cron — inclusa la produzione, che è una macchina diversa a cui non ho accesso e che ha con ogni probabilità lo stesso problema.

## Nota sull'installazione (per chi rifarà il giro in produzione)

Il VPS è **arm64** e su Ubuntu 24.04 il pacchetto `awscli` non ha candidato:

```
E: Package 'awscli' has no installation candidate
```

⚠️ **`apt` aborta l'intera transazione**, quindi `apt-get install -y awscli age` non installa **nemmeno `age`**. È facile leggere l'errore come "manca solo awscli" e dare per fatto il resto.

Metodo che funziona — è anche quello raccomandato da AWS, il pacchetto Ubuntu era la v1:

```bash
sudo apt-get install -y age unzip
cd /tmp && curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o awscliv2.zip
unzip -q awscliv2.zip && sudo ./aws/install --update
```

Risultato su staging: `aws-cli/2.36.21` (aarch64), `age 1.1.1`.

## Stato di #3669 dopo questa PR

Sullo staging restano solo le credenziali: `backup.secret` con `S3_BACKUP_ENABLED=true`, endpoint, `S3_BACKUP_REGION` reale e `BACKUP_AGE_RECIPIENT`. La produzione va fatta da zero, pacchetti compresi.

Refs #3669

🤖 Generated with [Claude Code](https://claude.com/claude-code)