### PR TITLE
fix(pdf): xmin=0 su grafo detached, ogni update dava 409 (#3694)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Entities/PdfDocument.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Entities/PdfDocument.cs
@@ -120,6 +120,28 @@ internal sealed class PdfDocument : AggregateRoot<Guid>
 
     // Issue #4219: Progress tracking and ETA calculation
     public int ProgressPercentage => CalculateProgressPercentage();
+
+    /// <summary>
+    /// Token di concorrenza ottimistica (colonna di sistema PostgreSQL <c>xmin</c>, ADR-060).
+    /// <para>
+    /// #3694 — deve attraversare l'aggregato perché <c>PdfDocumentRepository.UpdateAsync</c>
+    /// persiste un grafo <b>detached</b> (<c>MapToPersistence</c> + <c>DbSet.Update()</c>): EF non
+    /// ha una riga tracciata da cui ricavare l'<i>original value</i> del token e usa quello sulla
+    /// proprietà. Senza questo trasporto valeva sempre <c>0</c> — mai un xid reale — quindi ogni
+    /// UPDATE emetteva <c>WHERE xmin = 0</c>, colpiva 0 righe e falliva con
+    /// <c>DbUpdateConcurrencyException</c> <b>anche senza concorrenza</b>.
+    /// </para>
+    /// <para>
+    /// Il difetto è arrivato in produzione con #3658 (conversione da <c>bytea</c> a <c>xmin</c>)
+    /// perché prima la coincidenza lo mascherava: <c>RowVersion</c> era NULL sull'entità e sulla
+    /// riga, quindi EF generava <c>row_version IS NULL</c>, sempre vero.
+    /// </para>
+    /// <para>
+    /// Vale <c>0</c> per un documento appena creato: quel percorso è un INSERT, dove il token non
+    /// si usa ed è Postgres a valorizzarlo.
+    /// </para>
+    /// </summary>
+    public uint XminVersion { get; private set; }
     public TimeSpan? EstimatedTimeRemaining { get; private set; }
     public TimeSpan? TotalDuration => ProcessedAt.HasValue ? ProcessedAt.Value - UploadedAt : null;
 
@@ -230,10 +252,12 @@ internal sealed class PdfDocument : AggregateRoot<Guid>
         string? coverGenerationStatus = null,
         int? coverPageIndex = null,
         string? coverGenerationError = null,
-        int coverGenerationAttempts = 0)
+        int coverGenerationAttempts = 0,
+        uint xminVersion = 0)
     {
         var document = new PdfDocument
         {
+            XminVersion = xminVersion,
             Id = id,
             GameId = gameId,
             FileName = fileName,

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Persistence/PdfDocumentRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Persistence/PdfDocumentRepository.cs
@@ -260,13 +260,19 @@ internal class PdfDocumentRepository : RepositoryBase, IPdfDocumentRepository
             tags: entity.Tags, // Issue #1687
             updatedAt: entity.UpdatedAt, // Issue #1687
             updatedBy: entity.UpdatedBy, // Issue #1687
-            // Issue #3401: cover state round-trip — without these the read path defaults
-            // cover fields (null / Pending) and UpdateAsync then zeroes the DB row.
+                                         // Issue #3401: cover state round-trip — without these the read path defaults
+                                         // cover fields (null / Pending) and UpdateAsync then zeroes the DB row.
             coverR2Key: entity.CoverR2Key,
             coverGenerationStatus: entity.CoverGenerationStatus,
             coverPageIndex: entity.CoverPageIndex,
             coverGenerationError: entity.CoverGenerationError,
-            coverGenerationAttempts: entity.CoverGenerationAttempts
+            coverGenerationAttempts: entity.CoverGenerationAttempts,
+            // #3694: il token di concorrenza deve attraversare l'aggregato per la stessa ragione
+            // strutturale delle colonne cover qui sopra — l'UpdateAsync è su grafo detached, e ciò
+            // che non viene riletto qui va perduto o azzerato al primo salvataggio. Per il token
+            // l'effetto è peggiore: resterebbe 0, e `WHERE xmin = 0` non corrisponde mai a una
+            // riga reale, quindi OGNI update fallirebbe con DbUpdateConcurrencyException.
+            xminVersion: entity.Xmin
         );
     }
 
@@ -322,7 +328,14 @@ internal class PdfDocumentRepository : RepositoryBase, IPdfDocumentRepository
             CoverGenerationStatus = domain.CoverGenerationStatus.ToString(),
             CoverPageIndex = domain.CoverPageIndex,
             CoverGenerationError = domain.CoverGenerationError,
-            CoverGenerationAttempts = domain.CoverGenerationAttempts
+            CoverGenerationAttempts = domain.CoverGenerationAttempts,
+            // #3694 — token di concorrenza (ADR-060). UpdateAsync riattacca questa entità con
+            // DbSet.Update() su un grafo detached: EF non ha un original value da cui partire e
+            // usa quello che trova qui. Omettendolo resterebbe 0, e ogni UPDATE emetterebbe
+            // `WHERE xmin = 0` colpendo 0 righe — cioè un DbUpdateConcurrencyException su ogni
+            // scrittura, anche senza concorrenza. Con il valore letto in MapToDomain il confronto
+            // è quello giusto: passa se la riga non è cambiata, fallisce con 409 se lo è.
+            Xmin = domain.XminVersion
         };
     }
 }

--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/PdfDocumentXminWritePathTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/PdfDocumentXminWritePathTests.cs
@@ -1,0 +1,162 @@
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Persistence;
+using Api.Tests.BoundedContexts.DocumentProcessing.TestHelpers;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Integration.DocumentProcessing;
+
+/// <summary>
+/// Regressione di #3694 — il write-path detached di <see cref="PdfDocumentRepository"/>.
+///
+/// #3658 ha convertito <c>pdf_documents</c> da <c>byte[] RowVersion</c> (<c>bytea</c>) alla
+/// colonna di sistema <c>xmin</c>. La conversione era corretta a livello di schema, ma
+/// <c>UpdateAsync</c> persiste un grafo <b>detached</b> (<c>MapToPersistence</c> +
+/// <c>DbSet.Update()</c>) e il token <b>non attraversava il dominio</b>: l'aggregato non aveva la
+/// proprietà, e nessuno dei due mapper la toccava.
+///
+/// Su un'entità mai tracciata EF non ha una riga da cui ricavare l'<i>original value</i> del token
+/// e usa quello che trova sulla proprietà — <c>0</c>, che non è mai un xid reale. Ogni UPDATE
+/// emetteva perciò <c>WHERE id = @id AND xmin = 0</c>, colpiva 0 righe e sollevava
+/// <c>DbUpdateConcurrencyException</c> <b>anche senza alcuna concorrenza</b>.
+///
+/// Prima di #3658 la coincidenza lo mascherava: <c>RowVersion</c> era NULL sull'entità <i>e</i>
+/// sulla riga, quindi EF generava <c>row_version IS NULL</c>, sempre vero.
+///
+/// I due test coprono le direzioni opposte, ed è la ragione per cui il guasto era passato: chi
+/// verifica solo la seconda vede un token che «funziona», perché un token rotto in questo modo
+/// solleva l'eccezione attesa — per il motivo sbagliato.
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "3694")]
+public sealed class PdfDocumentXminWritePathTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = null!;
+    private string _connectionString = null!;
+    private MeepleAiDbContext _dbContext = null!;
+
+    public PdfDocumentXminWritePathTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"pdf_xmin_writepath_{Guid.NewGuid():N}";
+        _connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        _dbContext = _fixture.CreateDbContext(_connectionString);
+        await _dbContext.Database.MigrateAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _dbContext.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    private static PdfDocumentRepository CreateRepository(MeepleAiDbContext dbContext) =>
+        new(dbContext, new Mock<IDomainEventCollector>().Object);
+
+    /// <summary>
+    /// Semina l'utente e il gioco — entrambi FK di <c>pdf_documents</c>
+    /// (<c>FK_pdf_documents_users_UploadedByUserId</c> e il gioco) — più un documento già
+    /// completato. Con id inventati l'INSERT fallisce con 23503 prima ancora di arrivare al
+    /// token, e il rosso direbbe la cosa sbagliata (pitfall #2620).
+    /// </summary>
+    private async Task<Guid> SeedDocumentAsync()
+    {
+        var userId = Guid.NewGuid();
+        _dbContext.Set<UserEntity>().Add(new UserEntity
+        {
+            Id = userId,
+            Email = $"pdf-xmin-{userId:N}@test.com",
+            DisplayName = "Pdf Xmin Write-Path Test User",
+            Role = "user",
+            Tier = "free",
+            CreatedAt = DateTime.UtcNow
+        });
+
+        var gameId = Guid.NewGuid();
+        _dbContext.SharedGames.Add(new SharedGameEntity { Id = gameId, Title = "Gioco con regolamento" });
+        await _dbContext.SaveChangesAsync();
+
+        var document = new PdfDocumentBuilder()
+            .WithGameId(gameId)
+            .WithUploadedBy(userId)
+            .ThatIsCompleted()
+            .Build();
+
+        var repository = CreateRepository(_dbContext);
+        await repository.AddAsync(document, CancellationToken.None);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        return document.Id;
+    }
+
+    [Fact(DisplayName = "PdfDocument: un solo scrittore riesce — nessuna concorrenza, nessun 409")]
+    public async Task UpdateAsync_WithNoConcurrentWriter_Succeeds()
+    {
+        // ── Arrange ───────────────────────────────────────────────────────────────
+        var documentId = await SeedDocumentAsync();
+        var repository = CreateRepository(_dbContext);
+
+        // ── Act: rileggo, muto e persisto — nessun altro scrittore ────────────────
+        var loaded = await repository.GetByIdAsync(documentId, CancellationToken.None);
+        loaded.Should().NotBeNull();
+
+        loaded!.SetActiveForRag(false);
+        await repository.UpdateAsync(loaded, CancellationToken.None);
+
+        Func<Task> act = async () => await _dbContext.SaveChangesAsync();
+
+        // ── Assert ────────────────────────────────────────────────────────────────
+        await act.Should().NotThrowAsync(
+            "senza scritture concorrenti l'update deve passare. Se il token letto dal DB non " +
+            "attraversa l'aggregato, l'UPDATE emette `WHERE xmin = 0` — mai un xid reale — " +
+            "colpisce 0 righe e ogni scrittura sul documento diventa un 409 (#3694)");
+    }
+
+    [Fact(DisplayName = "PdfDocument: due scrittori concorrenti, il secondo è rifiutato")]
+    public async Task UpdateAsync_AfterConcurrentWrite_ThrowsConcurrencyException()
+    {
+        // ── Arrange ───────────────────────────────────────────────────────────────
+        var documentId = await SeedDocumentAsync();
+
+        await using var dbA = _fixture.CreateDbContext(_connectionString);
+        await using var dbB = _fixture.CreateDbContext(_connectionString);
+        var repoA = CreateRepository(dbA);
+        var repoB = CreateRepository(dbB);
+
+        var docA = await repoA.GetByIdAsync(documentId, CancellationToken.None);
+        var docB = await repoB.GetByIdAsync(documentId, CancellationToken.None);
+        docA.Should().NotBeNull();
+        docB.Should().NotBeNull();
+
+        // ── Act: A committa per primo, B resta con un token vecchio ───────────────
+        docA!.SetActiveForRag(false);
+        await repoA.UpdateAsync(docA, CancellationToken.None);
+        await dbA.SaveChangesAsync();
+
+        docB!.SetContentHash("hash-scritto-da-b");
+        await repoB.UpdateAsync(docB, CancellationToken.None);
+        Func<Task> act = async () => await dbB.SaveChangesAsync();
+
+        // ── Assert ────────────────────────────────────────────────────────────────
+        await act.Should().ThrowAsync<DbUpdateConcurrencyException>(
+            "B ha letto prima del commit di A: la protezione deve restare attiva. Questo test " +
+            "da solo non basta a dire che il token funziona — passerebbe anche con un token " +
+            "sempre a 0, che rifiuta ogni scrittura");
+    }
+}


### PR DESCRIPTION
Chiude #3694 — **regressione in produzione**: ogni `UpdateAsync` su `PdfDocument` restituiva 409 anche in totale assenza di concorrenza.

## Come è emersa

Non cercandola. Verificando il lotto 3 di #3651, un test è risultato rosso; `git stash` ha mostrato che falliva **anche senza le mie modifiche**, su `main-dev` pulito. Da lì l'indagine.

`git merge-base --is-ancestor` colloca #3658 in `origin/main`, `main-staging` e `main-dev`: **è live**.

## Causa

`PdfDocumentRepository.UpdateAsync` persiste un grafo **detached** (`MapToPersistence` + `DbSet.Update()`). Su un'entità mai tracciata EF non ha una riga da cui ricavare l'*original value* del token e usa quello che trova sulla proprietà. Ma `Xmin` **non attraversava il dominio**: l'aggregato non aveva la proprietà, e nessuno dei due mapper la toccava (zero occorrenze, verificato).

Il valore era quindi `0` — mai un xid reale — e ogni UPDATE emetteva:

```sql
UPDATE pdf_documents … WHERE id = @id AND xmin = 0   -- 0 righe, sempre
```

#3658 aveva convertito lo schema da `bytea` a `xmin` correttamente. Prima, la coincidenza mascherava tutto: `RowVersion` era NULL sull'entità **e** sulla riga, quindi EF generava `row_version IS NULL`, sempre vero. **Il difetto che #3658 correggeva era anche ciò che teneva in piedi il write-path.**

È lo stesso guasto poi trovato su `SharedGame` in #3683 — lì la review pre-merge l'ha fermato, qui era già passato.

## Fix

`uint XminVersion` sull'aggregato, parametro opzionale in coda a `Reconstitute`, popolato in `MapToDomain` da `entity.Xmin` e riproposto in `MapToPersistence`. Stesso pattern di #3683 e dei tre aggregati che già lo usano in `SharedGameCatalog`. **Nessun handler toccato.**

## L'impatto era peggiore della stima nella issue

Nella issue avevo lasciato aperto quanto la pipeline «degradasse in silenzio». Esaminati gli 11 `catch (DbUpdateConcurrencyException)` di `PdfProcessingPipelineService`: **non mascherano nulla**. Registrano la metrica `meepleai.pdf.concurrency.conflicts.total`, loggano un warning e ritornano `PdfPipelineOutcome.AbortedConcurrency` — un esito esplicito, non un successo.

Quindi non è degrado silenzioso: la pipeline **abortiva sistematicamente ogni elaborazione**, attribuendola a un conflitto inesistente.

Il guasto era perciò strumentato e osservabile. Non è stato osservato perché **su quella metrica non esiste alcun alert Prometheus** (verificato in `infra/`) — lo stesso schema del cluster «gate che non esaminano nulla», spostato dalla CI all'osservabilità. Vale una issue a parte.

## Test — ed è il punto che spiega perché #3658 passò la review

Due test sul percorso reale (il repository, non il `DbContext`), in direzioni opposte:

| test | prima | dopo |
|---|---|---|
| `UpdateAsync_WithNoConcurrentWriter_Succeeds` | ❌ `DbUpdateConcurrencyException` senza rivali | ✅ |
| `UpdateAsync_AfterConcurrentWrite_ThrowsConcurrencyException` | ❌ esplodeva già la scrittura di **A** | ✅ |

Prima del fix fallivano **entrambi**: il secondo non arrivava nemmeno a testare la concorrenza.

Da qui la lezione: **un test che verifica solo il conflitto passa anche con un token sempre a 0**, per il motivo sbagliato. Serve la direzione opposta per distinguere una protezione che funziona da una che rifiuta tutto. Criterio ora nella DoD di #3651 e in ADR-060.

## Verifica

- `Propose_MaterializesPendingCoverAndCreatesPendingShareRequest` (il canary che ha rivelato il bug): **verde**
- `Parallel_TwoReindex_OnlyOneSucceeds`, `Reindex_RacesWithBackgroundPipeline_AdminGets409`: verdi
- Restano rossi i **due già documentati in #3633** (guardia di stato sul retry; `successCount = 2` su uno scenario non deterministico) — verificata la stessa firma di allora, non toccati qui
- `dotnet format --verify-no-changes` pulito

## Nota sulla promozione

Essendo una regressione live, valutare se promuovere a staging/prod senza attendere il prossimo treno di release. Decisione del maintainer, non implicita in questa PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
