### PR TITLE
chore(security): ignora le chiavi age dei backup nella root (#3669)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,16 @@ infra/secrets/prod/*.txt
 infra/secrets/prod/*.pfx
 !infra/secrets/prod/*.txt.example
 
+# Chiavi di cifratura `age` dei backup (#3669) — la chiave PRIVATA decifra ogni dump
+# `*.age` prodotto da infra/hetzner/backup.sh. Le regole qui sopra coprono solo
+# infra/secrets/**: una chiave generata nella root del repo restava fuori da ogni
+# pattern, quindi un `git add -A` la metteva in stage senza avvisare (successo il
+# 2026-08-12). Pattern volutamente specifici: `*age-key*` matcherebbe anche
+# `storage-key.txt`.
+backup-age-key*
+age-key*.txt
+*.age.key
+
 # Logs
 logs/
 # Exception: Allow admin monitor logs page


### PR DESCRIPTION
`backup-age-key.txt` si trovava nella **root del repository**: untracked, ma non coperto da alcun pattern di `.gitignore`.

Le regole esistenti per i segreti coprono solo `infra/secrets/**`, `tools/secrets/**` e `infra/traefik/certs/**` — una chiave generata nella root restava fuori da tutto.

## Come è emerso

Non da un audit: preparando un commit su tutt'altro, `git add -A` l'ha messa in stage insieme ai miei file. Me ne sono accorto rivedendo l'elenco dei file staged prima di committare.

✅ **Verificato che non sia mai entrata nella storia**: `git log --all -- backup-age-key.txt` → vuoto. Nessuna esposizione pregressa, nessuna rotazione necessaria.

## Perché conta

È la chiave **privata** con cui `infra/hetzner/backup.sh` cifra i dump (`*.age`). Committarla renderebbe leggibile ogni backup a chiunque abbia accesso al repository, e la rotazione imporrebbe di ri-cifrare tutto lo storico.

## Sui pattern scelti

Volutamente **specifici** invece del più ovvio `*age-key*`, che matcherebbe anche `storage-key.txt` (contiene `age-key` come sottostringa) escludendo per errore file legittimi. Verificato che nessun file attualmente tracciato sia colpito dalle nuove righe.

## Due note

**Questa è la rete, non la soluzione.** La chiave sta comunque nella root invece che in `infra/secrets/`, dove la convenzione del progetto tiene i segreti e dove `.gitignore` già copre `*.secret` e `*.txt`. Spostarla sarebbe il fix vero.

**Il checkout condiviso rende il `.gitignore` versionato insufficiente da solo**: cambiando branch si perde il file che contiene il pattern, e la chiave torna catturabile. Ho aggiunto in locale gli stessi pattern a `.git/info/exclude`, che vale su ogni branch — ma è locale a quel checkout e non sostituisce questa PR per gli altri sviluppatori e per la CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
