### PR TITLE
docs(inventory): l'inventario delle feature, generato invece che scritto

### DIFF
--- a/docs/for-developers/feature-inventory.md
+++ b/docs/for-developers/feature-inventory.md
@@ -1,0 +1,255 @@
+# Inventario delle feature
+
+> **Documento generato — non modificarlo a mano.**
+> Rigeneralo con `make feature-inventory` (o `bash infra/scripts/generate-feature-inventory.sh`).
+> Ogni modifica manuale viene persa alla prossima esecuzione, ed è voluto: un inventario
+> scritto a mano diverge dal codice in pochi giorni. Il predecessore di questo documento
+> — una roadmap redatta a mano — dichiarava «All planned features have been implemented»
+> e vive in `.docs-archive/`.
+
+Conta e localizza **ciò che esiste**. Non dice a cosa serve (→ gli [ADR](../for-claude/architecture/adr/))
+né se funziona (→ i test).
+
+**Generato da**: commit `fe1a30993` · rigenera per aggiornare i conteggi
+
+## Backend — bounded context
+
+Aggregati e entità di dominio, comandi e query per contesto. Un contesto con pochi
+aggregati e zero comandi è tipicamente un'area appena abbozzata, non una feature completa.
+
+| Contesto | Dominio | Comandi | Query | Aggregati principali |
+|---|---:|---:|---:|---|
+| Administration | 93 | 83 | 118 | AdminReport, Alert, AuditLog, BatchJob, DatabaseMetricsSnapshot, ReportExecution |
+| AgentMemory | 16 | 8 | 6 | GameMemory, GroupMemory, PlayerMemory |
+| Authentication | 54 | 49 | 26 | AccessRequest, InvitationGameSuggestion, InvitationToken, OAuthAccount, Session, ShareLink |
+| BusinessSimulations | 17 | 8 | 12 | CostScenario, LedgerEntry, ResourceForecast, UserBudget |
+| DatabaseSync | 13 | 5 | 5 | — |
+| DocumentProcessing | 65 | 42 | 38 | ChunkedUploadSession, DocumentCollection, PdfDocument, PhotoBatchPage, PhotoBatchUpload, ProcessingJob |
+| EntityRelationships | 10 | 3 | 2 | EntityLink |
+| GameManagement | 172 | 118 | 75 | GameBook, GamePhaseTemplate, GameReview, GameSession, GameSessionState, GameStateSnapshot |
+| GameToolbox | 8 | 0 | 0 | Phase, Toolbox, ToolboxTemplate, ToolboxTool |
+| GameToolkit | 20 | 5 | 6 | AiToolkitSuggestionCacheEntry, GameToolkit, Toolkit, ToolkitVersion, ToolkitWidget |
+| Gamification | 6 | 0 | 2 | Achievement, UserAchievement |
+| KbQuality | 10 | 1 | 2 | — |
+| KnowledgeBase | 318 | 83 | 102 | AbTestSession, AbTestVariant, AdminRagStrategy, AgentConfiguration, AgentDefinition, AgentGameStateSnapshot |
+| SecurityAudit | 0 | 0 | 0 | — |
+| SessionTracking | 84 | 46 | 25 | Card, CardDraw, DiceRoll, GamebookCampaignSession, GamebookGlossaryEntry, GamebookPhotoArtifact |
+| SharedGameCatalog | 153 | 113 | 82 | Badge, CatalogSyncRun, CertificationThresholdsConfig, Contributor, CoverAssignmentSource, DeleteRequestStatus |
+| SystemConfiguration | 31 | 32 | 26 | AiModelConfiguration, IncidentBannerState, LlmSystemConfig, ShareRequestLimitConfig, SystemConfiguration, TierDefinition |
+| Testing | 0 | 6 | 0 | — |
+| UserLibrary | 50 | 33 | 26 | GameChecklist, GameLabel, GameSession, GameSuggestion, LibraryShareLink, PrivateGame |
+| UserNotifications | 19 | 26 | 18 | EmailQueueItem, EmailTemplate, Notification, NotificationPreferences, NotificationQueueItem, SlackConnection |
+| **20 contesti** | **1139** | **661** | **571** | |
+
+## Backend — endpoint HTTP
+
+**1381** endpoint registrati, per file di routing:
+
+| File | Endpoint |
+|---|---:|
+| `LiveSessionEndpoints.cs` | 45 |
+| `GameNightEndpoints.cs` | 35 |
+| `KnowledgeBaseEndpoints.cs` | 31 |
+| `GameToolkitRoutes.cs` | 30 |
+| `GameEndpoints.cs` | 27 |
+| `RuleSpecEndpoints.cs` | 19 |
+| `GameToolboxRoutes.cs` | 19 |
+| `AdminQueueEndpoints.cs` | 19 |
+| `AnalyticsEndpoints.cs` | 18 |
+| `AdminMechanicAnalysesEndpoints.cs` | 18 |
+| `PromptManagementEndpoints.cs` | 16 |
+| `PlayRecordEndpoints.cs` | 16 |
+| `AgentsEndpoints.cs` | 16 |
+| `ConfigurationEndpoints.cs` | 15 |
+| `AuthenticationEndpoints.cs` | 15 |
+| `AdminMechanicExtractorValidationEndpoints.cs` | 15 |
+| `UserProfileEndpoints.cs` | 14 |
+| `AgentMemoryEndpoints.cs` | 14 |
+| `AdminCatalogIngestionEndpoints.cs` | 14 |
+| `AdminKnowledgeBaseEndpoints.cs` | 13 |
+| `PlaylistEndpoints.cs` | 11 |
+| `SessionFlowEndpoints.cs` | 10 |
+| `NotificationPreferencesEndpoints.cs` | 10 |
+| `GamebookPhotoEndpoints.cs` | 10 |
+| `DatabaseSyncEndpoints.cs` | 10 |
+| `DashboardEndpoints.cs` | 10 |
+| `AdminPdfManagementEndpoints.cs` | 10 |
+| `AdminAgentDefinitionEndpoints.cs` | 10 |
+| `TierStrategyAdminEndpoints.cs` | 9 |
+| `RagDashboardEndpoints.cs` | 9 |
+| `GamebookCampaignEndpoints.cs` | 9 |
+| `BggImportQueueEndpoints.cs` | 9 |
+| `AlertConfigEndpoints.cs` | 9 |
+| `AiModelAdminEndpoints.cs` | 9 |
+| `AccessRequestEndpoints.cs` | 9 |
+| `RagPipelineAdminEndpoints.cs` | 8 |
+| `PrivateGameEndpoints.cs` | 8 |
+| `ChatSessionEndpoints.cs` | 8 |
+| `AiEndpoints.cs` | 8 |
+| `AdminResourcesEndpoints.cs` | 8 |
+| `TwoFactorEndpoints.cs` | 7 |
+| `FinancialLedgerEndpoints.cs` | 7 |
+| `FeatureFlagEndpoints.cs` | 7 |
+| `AdminInfrastructureEndpoints.cs` | 7 |
+| `AdminEmailTemplateEndpoints.cs` | 7 |
+| `WhiteboardEndpoints.cs` | 6 |
+| `TokenManagementEndpoints.cs` | 6 |
+| `SlackIntegrationEndpoints.cs` | 6 |
+| `SessionInviteEndpoints.cs` | 6 |
+| `RateLimitAdminEndpoints.cs` | 6 |
+| `GameNightImprovvisataEndpoints.cs` | 6 |
+| `DocumentCollectionEndpoints.cs` | 6 |
+| `BatchJobEndpoints.cs` | 6 |
+| `AgentSessionEndpoints.cs` | 6 |
+| `AdminOperationsEndpoints.cs` | 6 |
+| `AdminGameKbEndpoints.cs` | 6 |
+| `AdminEmailEndpoints.cs` | 6 |
+| `AdminConfigEndpoints.cs` | 6 |
+| `AdminAbTestEndpoints.cs` | 6 |
+| `WishlistEndpoints.cs` | 5 |
+| `TurnOrderEndpoints.cs` | 5 |
+| `ToolStateEndpoints.cs` | 5 |
+| `SharedGameTranslationEndpoints.cs` | 5 |
+| `SessionAttachmentEndpoints.cs` | 5 |
+| `RulebookAnalysisEndpoints.cs` | 5 |
+| `ReportingEndpoints.cs` | 5 |
+| `PlaygroundTestScenarioEndpoints.cs` | 5 |
+| `NotificationEndpoints.cs` | 5 |
+| `AdminStrategyEndpoints.cs` | 5 |
+| `AdminSharedGameContentEndpoints.cs` | 5 |
+| `AdminSandboxEndpoints.cs` | 5 |
+| `AdminRagBackupEndpoints.cs` | 5 |
+| `AdminOpenRouterEndpoints.cs` | 5 |
+| `AdminNotificationQueueEndpoints.cs` | 5 |
+| `AdminAnalyticsEndpoints.cs` | 5 |
+| `ShareLinkEndpoints.cs` | 4 |
+| `SessionSnapshotEndpoints.cs` | 4 |
+| `ResourceForecastEndpoints.cs` | 4 |
+| `RagPipelineEndpoints.cs` | 4 |
+| `RagEnhancementAdminEndpoints.cs` | 4 |
+| `PhotoIngestionEndpoints.cs` | 4 |
+| `OAuthEndpoints.cs` | 4 |
+| `MonitoringEndpoints.cs` | 4 |
+| `GameBookEndpoints.cs` | 4 |
+| `EntityLinkUserEndpoints.cs` | 4 |
+| `EntityLinkAdminEndpoints.cs` | 4 |
+| `CostCalculatorEndpoints.cs` | 4 |
+| `AdminTierEndpoints.cs` | 4 |
+| `AdminTestResultEndpoints.cs` | 4 |
+| `AdminProviderEndpoints.cs` | 4 |
+| `AdminGameImportWizardEndpoints.cs` | 4 |
+| `AdminCategoriesEndpoints.cs` | 4 |
+| `UserHandEndpoints.cs` | 3 |
+| `TestingMetricsEndpoints.cs` | 3 |
+| `StatusBannerEndpoints.cs` | 3 |
+| `SessionLimitsConfigEndpoints.cs` | 3 |
+| `SessionEndpoints.cs` | 3 |
+| `PasswordEndpoints.cs` | 3 |
+| `OnboardingEndpoints.cs` | 3 |
+| `LlmAnalyticsEndpoints.cs` | 3 |
+| `LedgerModeEndpoints.cs` | 3 |
+| `KbManagementEndpoints.cs` | 3 |
+| `GamePhaseTemplateEndpoints.cs` | 3 |
+| `CacheEndpoints.cs` | 3 |
+| `AlertEndpoints.cs` | 3 |
+| `AlertConfigurationEndpoints.cs` | 3 |
+| `AlertChannelsEndpoints.cs` | 3 |
+| `AdminStorageMigrationEndpoints.cs` | 3 |
+| `AdminSlackEndpoints.cs` | 3 |
+| `AdminSecretsEndpoints.cs` | 3 |
+| `AdminRagExecutionEndpoints.cs` | 3 |
+| `AdminGameWizardEndpoints.cs` | 3 |
+| `AdminEventsEndpoints.cs` | 3 |
+| `AdminEmergencyControlsEndpoints.cs` | 3 |
+| `AdminBusinessStatsEndpoints.cs` | 3 |
+| `AdminAuditLogEndpoints.cs` | 3 |
+| `UserUsageEndpoints.cs` | 2 |
+| `UserLlmDataEndpoints.cs` | 2 |
+| `UserGameKbEndpoints.cs` | 2 |
+| `UserAiConsentEndpoints.cs` | 2 |
+| `UserAccountEndpoints.cs` | 2 |
+| `TestEndpoints.cs` | 2 |
+| `TermsConsentEndpoints.cs` | 2 |
+| `StatusPageEndpoints.cs` | 2 |
+| `SessionTrackingEndpoints.cs` | 2 |
+| `RulebookEndpoints.cs` | 2 |
+| `RagExecutionAdminEndpoints.cs` | 2 |
+| `PermissionRoutes.cs` | 2 |
+| `PdfUploadLimitsConfigEndpoints.cs` | 2 |
+| `PdfTierUploadLimitsConfigEndpoints.cs` | 2 |
+| `GameLibraryConfigEndpoints.cs` | 2 |
+| `EmailVerificationEndpoints.cs` | 2 |
+| `DeviceEndpoints.cs` | 2 |
+| `ChatHistoryConfigEndpoints.cs` | 2 |
+| `BudgetEndpoints.cs` | 2 |
+| `BggEndpoints.cs` | 2 |
+| `ArbitroAgentEndpoints.cs` | 2 |
+| `AdminServiceCallEndpoints.cs` | 2 |
+| `AdminLlmConfigEndpoints.cs` | 2 |
+| `AdminKBSettingsEndpoints.cs` | 2 |
+| `AdminEmbeddingEndpoints.cs` | 2 |
+| `AdminDockerEndpoints.cs` | 2 |
+| `AdminBulkImportEndpoints.cs` | 2 |
+| `AdminBudgetEndpoints.cs` | 2 |
+| `AdminAgentMetricsEndpoints.cs` | 2 |
+| `AdminAgentAnalyticsEndpoints.cs` | 2 |
+| `AchievementEndpoints.cs` | 2 |
+| `WaitlistEndpoints.cs` | 1 |
+| `UserGamebooksEndpoints.cs` | 1 |
+| `UserActivityEndpoints.cs` | 1 |
+| `UnsubscribeEndpoints.cs` | 1 |
+| `RagStrategyEndpoints.cs` | 1 |
+| `PdfAnalyticsEndpoints.cs` | 1 |
+| `ModelPerformanceEndpoints.cs` | 1 |
+| `ModelEndpoints.cs` | 1 |
+| `LlmEndpoints.cs` | 1 |
+| `ContactEndpoints.cs` | 1 |
+| `CollectionWizardEndpoints.cs` | 1 |
+| `ChatAnalyticsEndpoints.cs` | 1 |
+| `BggAttemptBeaconEndpoints.cs` | 1 |
+| `BatchJobLogsEndpoints.cs` | 1 |
+| `AuditEndpoints.cs` | 1 |
+| `ArbitroAdminEndpoints.cs` | 1 |
+| `AgentTypologiesEndpoints.cs` | 1 |
+| `AgentPlaygroundEndpoints.cs` | 1 |
+| `AdminSeedingEndpoints.cs` | 1 |
+| `AdminRagQualityEndpoints.cs` | 1 |
+| `AdminPipelineEndpoints.cs` | 1 |
+| `AdminPdfStorageEndpoints.cs` | 1 |
+| `AdminPdfMetricsEndpoints.cs` | 1 |
+| `AdminMiscEndpoints.cs` | 1 |
+| `AdminMetricsEndpoints.cs` | 1 |
+| `AdminManualNotificationEndpoints.cs` | 1 |
+| `AdminLogEndpoints.cs` | 1 |
+| `AdminIndexerEndpoints.cs` | 1 |
+| `AdminDebugChatEndpoints.cs` | 1 |
+| `AdminCircuitBreakerEndpoints.cs` | 1 |
+| `AdminAgentTestEndpoints.cs` | 1 |
+| `ActivityTimelineEndpoints.cs` | 1 |
+| `ActivityFeedEndpoints.cs` | 1 |
+
+## Frontend — pagine
+
+**220** pagine (App Router), per gruppo di route — il gruppo segmenta
+**chi** accede, non la feature:
+
+| Gruppo | Pagine |
+|---|---:|
+| `(root)` | 98 |
+| `(authenticated)` | 83 |
+| `(public)` | 25 |
+| `(auth)` | 10 |
+| `(chat)` | 4 |
+
+## Decisioni architetturali
+
+**68** ADR in `docs/for-claude/architecture/adr/`. Sono la fonte del **perché**:
+questo inventario dice cosa esiste, gli ADR dicono per quale ragione e a quali condizioni.
+
+I cinque più recenti:
+
+- [`adr-060-live-session-persistence.md`](../for-claude/architecture/adr/adr-060-live-session-persistence.md) — ADR-060: Live session persistence strategy
+- [`adr-2026-06-09-wikidata-enrichment-architecture.md`](../for-claude/architecture/adr/adr-2026-06-09-wikidata-enrichment-architecture.md) — ADR 2026-06-09 — Wikidata enrichment architecture
+- [`adr-089-session-scoring-ssot.md`](../for-claude/architecture/adr/adr-089-session-scoring-ssot.md) — ADR-089 — SSOT tra i modelli di "sessione live" e i sistemi di scoring
+- [`adr-090-in-session-grounded-answer-ownership.md`](../for-claude/architecture/adr/adr-090-in-session-grounded-answer-ownership.md) — ADR-090 — Ownership della risposta grounded in-sessione: KnowledgeBase owner, SessionTracking consumer
+- [`adr-088-mechanic-cards-as-rag-retrieval-source.md`](../for-claude/architecture/adr/adr-088-mechanic-cards-as-rag-retrieval-source.md) — ADR-088 — Mechanic Cards as RAG Retrieval Source

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -371,6 +371,12 @@ security-audit: ## External port-scan against staging (default) — verifies onl
 	bash scripts/security-audit.sh
 	@echo "✅ Security audit passed"
 
+feature-inventory: ## Rigenera docs/for-developers/feature-inventory.md dal codice
+	@bash scripts/generate-feature-inventory.sh
+
+feature-inventory-check: ## Verifica che l'inventario non sia obsoleto (exit 1 se lo è) — per la CI
+	@bash scripts/generate-feature-inventory.sh --check
+
 test-e2e: ## Playwright E2E tests (requires make dev + api + web running) — mirrors test-e2e.yml
 	@echo "🔵 E2E Playwright tests..."
 	cd $(WEB) && pnpm test:e2e

--- a/infra/scripts/generate-feature-inventory.sh
+++ b/infra/scripts/generate-feature-inventory.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# MeepleAI — generatore dell'inventario delle feature
+#
+#   bash infra/scripts/generate-feature-inventory.sh          # rigenera il documento
+#   bash infra/scripts/generate-feature-inventory.sh --check   # esce 1 se è obsoleto (per la CI)
+#
+# PERCHE' E' GENERATO E NON SCRITTO
+#
+# Questo repo ha già provato la strada opposta: `.docs-archive/roadmap/2026-03-15-roadmap.md`
+# era una vista d'insieme scritta a mano che dichiarava «Open PRs: 0» e «All planned features
+# have been implemented». Oggi quelle righe sono false su ogni conteggio, ed è finita fra i 279
+# file archiviati. Un documento che afferma uno stato mutevole e viene aggiornato a mano ha una
+# durata di validità di ore.
+#
+# Qui l'inventario è derivato dal codice a ogni esecuzione: non può divergere, perché non esiste
+# fra un'esecuzione e l'altra. Il modo per tenerlo onesto è `--check` in CI — se qualcuno
+# aggiunge un bounded context o un endpoint senza rigenerare, il gate lo dice.
+#
+# Cosa NON prova a fare: descrivere a cosa servono le feature, o se funzionano. Conta e localizza
+# ciò che esiste. Il «perché» sta negli ADR, il «funziona» nei test.
+
+set -Eeuo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUTPUT="$REPO_ROOT/docs/for-developers/feature-inventory.md"
+API_BC="$REPO_ROOT/apps/api/src/Api/BoundedContexts"
+API_ROUTING="$REPO_ROOT/apps/api/src/Api/Routing"
+WEB_APP="$REPO_ROOT/apps/web/src/app"
+ADR_DIR="$REPO_ROOT/docs/for-claude/architecture/adr"
+
+CHECK_ONLY=0
+[[ "${1:-}" == "--check" ]] && CHECK_ONLY=1
+
+# `|| true` load-bearing: con `set -e` + `pipefail`, un `find` su una directory inesistente
+# esce 1 e abortisce l'intero script a metà documento. I bounded context NON hanno tutti le
+# stesse sottocartelle (alcuni Domain/Aggregates, altri Domain/Entities), quindi l'assenza è
+# la norma, non un errore.
+count_files() { { find "$1" -name "$2" 2>/dev/null || true; } | wc -l | tr -d ' '; }
+
+generate() {
+  cat <<'HEADER'
+# Inventario delle feature
+
+> **Documento generato — non modificarlo a mano.**
+> Rigeneralo con `make feature-inventory` (o `bash infra/scripts/generate-feature-inventory.sh`).
+> Ogni modifica manuale viene persa alla prossima esecuzione, ed è voluto: un inventario
+> scritto a mano diverge dal codice in pochi giorni. Il predecessore di questo documento
+> — una roadmap redatta a mano — dichiarava «All planned features have been implemented»
+> e vive in `.docs-archive/`.
+
+Conta e localizza **ciò che esiste**. Non dice a cosa serve (→ gli [ADR](../for-claude/architecture/adr/))
+né se funziona (→ i test).
+
+HEADER
+
+  echo "**Generato da**: commit \`$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || echo 'n/d')\` · rigenera per aggiornare i conteggi"
+  echo
+
+  # ── Backend: bounded context ────────────────────────────────────────────────
+  echo "## Backend — bounded context"
+  echo
+  echo "Aggregati e entità di dominio, comandi e query per contesto. Un contesto con pochi"
+  echo "aggregati e zero comandi è tipicamente un'area appena abbozzata, non una feature completa."
+  echo
+  echo "| Contesto | Dominio | Comandi | Query | Aggregati principali |"
+  echo "|---|---:|---:|---:|---|"
+
+  local total_dom=0 total_cmd=0 total_qry=0 bc_count=0
+  for dir in "$API_BC"/*/; do
+    [[ -d "$dir" ]] || continue
+    local name dom cmd qry aggs
+    name="$(basename "$dir")"
+    dom=$(count_files "$dir/Domain" "*.cs")
+    cmd=$(count_files "$dir/Application" "*Command.cs")
+    qry=$(count_files "$dir/Application" "*Query.cs")
+
+    # Gli aggregati stanno in Domain/Aggregates/ in alcuni contesti e Domain/Entities/ in altri.
+    aggs=$({ find "$dir/Domain/Aggregates" "$dir/Domain/Entities" -maxdepth 1 -name "*.cs" 2>/dev/null || true; } \
+      | xargs -r -n1 basename 2>/dev/null | sed 's/\.cs$//' | sort | head -6 \
+      | paste -sd',' - | sed 's/,/, /g')
+    [[ -z "$aggs" ]] && aggs="—"
+
+    echo "| $name | $dom | $cmd | $qry | $aggs |"
+    total_dom=$((total_dom + dom)); total_cmd=$((total_cmd + cmd))
+    total_qry=$((total_qry + qry)); bc_count=$((bc_count + 1))
+  done
+  echo "| **$bc_count contesti** | **$total_dom** | **$total_cmd** | **$total_qry** | |"
+  echo
+
+  # ── Backend: endpoint HTTP ──────────────────────────────────────────────────
+  echo "## Backend — endpoint HTTP"
+  echo
+  local ep_total
+  ep_total=$(grep -rhoE '\.Map(Get|Post|Put|Patch|Delete)\("' "$API_ROUTING" 2>/dev/null | wc -l | tr -d ' ')
+  echo "**$ep_total** endpoint registrati, per file di routing:"
+  echo
+  echo "| File | Endpoint |"
+  echo "|---|---:|"
+  for f in "$API_ROUTING"/*.cs; do
+    [[ -f "$f" ]] || continue
+    local n
+    # `grep -c` stampa già 0 quando non trova nulla: un `|| echo 0` ne aggiungerebbe un
+    # secondo, e "0\n0" fa esplodere il confronto aritmetico sotto. Serve solo assorbire
+    # l'exit code 1 di "nessun match", che con `set -e` abortirebbe lo script.
+    n=$(grep -cE '\.Map(Get|Post|Put|Patch|Delete)\("' "$f" 2>/dev/null || true)
+    [[ -n "$n" && "$n" -gt 0 ]] && echo "| \`$(basename "$f")\` | $n |"
+  done | sort -t'|' -k3 -rn
+  echo
+
+  # ── Frontend ────────────────────────────────────────────────────────────────
+  echo "## Frontend — pagine"
+  echo
+  local pg_total
+  pg_total=$(find "$WEB_APP" -name "page.tsx" 2>/dev/null | wc -l | tr -d ' ')
+  echo "**$pg_total** pagine (App Router), per gruppo di route — il gruppo segmenta"
+  echo "**chi** accede, non la feature:"
+  echo
+  echo "| Gruppo | Pagine |"
+  echo "|---|---:|"
+  find "$WEB_APP" -name "page.tsx" 2>/dev/null \
+    | sed "s|$WEB_APP/||" \
+    | awk -F/ '{ if ($1 ~ /^\(/) print $1; else print "(root)" }' \
+    | sort | uniq -c | sort -rn \
+    | awk '{ printf "| `%s` | %s |\n", $2, $1 }'
+  echo
+
+  # ── Decisioni ───────────────────────────────────────────────────────────────
+  echo "## Decisioni architetturali"
+  echo
+  local adr_total
+  adr_total=$(count_files "$ADR_DIR" "adr-*.md")
+  echo "**$adr_total** ADR in \`docs/for-claude/architecture/adr/\`. Sono la fonte del **perché**:"
+  echo "questo inventario dice cosa esiste, gli ADR dicono per quale ragione e a quali condizioni."
+  echo
+  echo "I cinque più recenti:"
+  echo
+  for f in $(ls -t "$ADR_DIR"/adr-*.md 2>/dev/null | head -5); do
+    echo "- [\`$(basename "$f")\`](../for-claude/architecture/adr/$(basename "$f")) — $(head -1 "$f" | sed 's/^#\+ *//')"
+  done
+}
+
+if [[ "$CHECK_ONLY" -eq 1 ]]; then
+  if [[ ! -f "$OUTPUT" ]]; then
+    echo "❌ $OUTPUT non esiste. Genera con: make feature-inventory" >&2
+    exit 1
+  fi
+  # Il commit di generazione cambia a ogni commit e non è una divergenza di contenuto:
+  # confronta tutto il resto.
+  if diff -q <(generate | grep -v '^\*\*Generato da\*\*') \
+             <(grep -v '^\*\*Generato da\*\*' "$OUTPUT") >/dev/null 2>&1; then
+    echo "✅ L'inventario delle feature è aggiornato."
+    exit 0
+  fi
+  echo "❌ L'inventario delle feature è obsoleto rispetto al codice." >&2
+  echo "   Rigeneralo con: make feature-inventory" >&2
+  diff <(generate | grep -v '^\*\*Generato da\*\*') \
+       <(grep -v '^\*\*Generato da\*\*' "$OUTPUT") | head -20 >&2 || true
+  exit 1
+fi
+
+generate > "$OUTPUT"
+echo "✅ Scritto $OUTPUT"


### PR DESCRIPTION
Risponde a una domanda che oggi non aveva risposta in nessun punto del repo: **«cosa esiste già nel prodotto?»**

Le quattro "mappe" evocate per rispondere — roadmap, featuremap, scenariomap, editormap — **non esistono**. Verificato: c'è solo `.docs-archive/roadmap/`, archiviata.

## Perché generato e non scritto

Questo repo ha già condotto l'esperimento opposto. `.docs-archive/roadmap/2026-03-15-roadmap.md` era una vista d'insieme scritta a mano. Oggi dichiara:

> **Open PRs**: 0 · *No active HIGH-priority tracks.* **All planned features have been implemented.**

Ci sono 7 PR aperte e decine di issue. È finita fra i **279 file** di `.docs-archive/`, insieme a `docs/for-users` (ferma da 3 mesi).

Ciò che invece sopravvive ha una proprietà comune:

| Vivo (30 giorni) | Perché resiste |
|---|---|
| 69 ADR, ultimo toccato 6h fa | ancorato a una **decisione**: resta vero anche se superata |
| `superpowers/plans` — 194 tocchi | legato a un lavoro specifico |
| censimento xmin in ADR-060 | **derivabile**: `grep -c` lo riconta in 3 secondi |

Un inventario delle feature afferma uno stato mutevole: è esattamente il tipo che muore. Quindi non si scrive, si genera.

## Cosa produce

`make feature-inventory` → `docs/for-developers/feature-inventory.md`, derivato dal codice:

- **20 bounded context** con dominio/comandi/query e gli aggregati principali
- **1381 endpoint** HTTP per file di routing
- **220 pagine** frontend per gruppo di route
- gli ADR più recenti, come puntatore al *perché*

Non prova a dire **a cosa servono** le feature (sta negli ADR) né **se funzionano** (sta nei test). Conta e localizza ciò che esiste.

## `--check` è la parte che lo tiene vivo

Senza, sarebbe solo una roadmap più veloce da riscrivere. Con `make feature-inventory-check` il documento diventa **falsificabile**: exit 1 se diverge dal codice, 0 se aggiornato — verificato in entrambe le direzioni introducendo un drift artificiale. Ignora la riga del commit di generazione, che cambia sempre e non è divergenza di contenuto.

Pronto per un gate CI, che **non aggiungo qui**: prima va deciso se il rumore vale il segnale.

## Due bug trovati scrivendolo

Entrambi da `set -Eeuo pipefail`, entrambi silenziosi:

1. `find` su directory inesistente esce 1 e **abortiva lo script a metà documento** — i contesti hanno `Domain/Aggregates` *oppure* `Domain/Entities`, mai entrambe: l'assenza è la norma;
2. `grep -c || echo 0` produceva `"0\n0"` e faceva esplodere il confronto aritmetico — `grep -c` stampa già `0`.

## Primo segnale utile, dal documento appena generato

`SecurityAudit` ha **0 aggregati, 0 comandi, 0 query** pur essendo elencato fra i 20 bounded context in `CLAUDE.md`. `GameToolbox` ha 8 entità ma zero CQRS.

Non li tocco in questa PR — ma è esattamente il tipo di cosa che un inventario deve far vedere, e che nessuno vedeva.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
