### PR TITLE
fix(api): tre bug sul ciclo di vita di GameSession — route oscurata, stato mai avviato, 404 al posto di 409 (#3662)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/AddPlayerToSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/AddPlayerToSessionCommandHandler.cs
@@ -1,3 +1,4 @@
+using Api.Middleware.Exceptions;
 using Api.BoundedContexts.GameManagement.Application.Commands;
 using Api.BoundedContexts.GameManagement.Application.DTOs;
 using Api.BoundedContexts.GameManagement.Application.Mappers;
@@ -31,7 +32,11 @@ internal class AddPlayerToSessionCommandHandler : ICommandHandler<AddPlayerToSes
         // Get existing session
         var session = await _sessionRepository.GetByIdAsync(command.SessionId, cancellationToken).ConfigureAwait(false);
         if (session == null)
-            throw new InvalidOperationException($"Session with ID {command.SessionId} not found");
+            // #3662: era InvalidOperationException. Il codice HTTP usciva giusto per caso (il
+            // middleware mappa quel tipo a 404), ma la convenzione #2568 vuole
+            // NotFoundException, che dichiara l'intento invece di ottenerlo per effetto
+            // collaterale del mapping.
+            throw new NotFoundException("GameSession", command.SessionId.ToString());
 
         // Create SessionPlayer value object
         var player = new SessionPlayer(command.PlayerName, command.PlayerOrder, command.Color);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/LifecycleCommandHandlers.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/LifecycleCommandHandlers.cs
@@ -83,6 +83,17 @@ internal class StartLiveSessionCommandHandler : ICommandHandler<StartLiveSession
                 players: players,
                 createdByUserId: session.CreatedByUserId);
 
+            // #3662: il GameSession correlato deve rispecchiare lo stato della live session che
+            // si sta avviando. Senza questo restava in `Setup` per sempre -- nessun percorso lo
+            // avviava -- e ogni operazione del suo ciclo di vita rispondeva 409:
+            // `Pause()` pretende InProgress, `Complete()` pretende InProgress o Paused.
+            // In pratica la lista delle sessioni attive (che include Setup) mostrava sessioni su
+            // cui nessuna azione funzionava.
+            //
+            // E' la simmetria che mancava rispetto a CompleteLiveSessionCommandHandler, dove il
+            // GameSession correlato riceve esplicitamente il suo stato con MarkCorrelatedComplete.
+            gameSession.Start();
+
             session.SetCorrelatedGameSessionId(gameSession.Id);
 
             await _gameSessionRepository.AddAsync(gameSession, cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameSession.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameSession.cs
@@ -80,7 +80,7 @@ internal sealed class GameSession : AggregateRoot<Guid>
     public void Start()
     {
         if (Status != SessionStatus.Setup)
-            throw new InvalidOperationException($"Cannot start session in {Status} status. Session must be in Setup.");
+            throw new ConflictException($"Cannot start session in {Status} status. Session must be in Setup.");
 
         Status = SessionStatus.InProgress;
 
@@ -90,10 +90,17 @@ internal sealed class GameSession : AggregateRoot<Guid>
     /// <summary>
     /// Pauses the game session (moves from InProgress to Paused).
     /// </summary>
+    // #3662: queste guardie sollevavano `InvalidOperationException`, che
+    // ApiExceptionHandlerMiddleware.cs:465 mappa a **404 Not Found**. Mettere in pausa una
+    // sessione nello stato sbagliato rispondeva quindi «The requested resource was not
+    // found» per una risorsa che ESISTE -- un messaggio che manda a cercare l'id sbagliato
+    // invece dello stato sbagliato. E' il pitfall #2568 (ConflictException 409 /
+    // NotFoundException 404, mai InvalidOperationException), lo stesso gia' corretto su
+    // BatchJob.
     public void Pause()
     {
         if (Status != SessionStatus.InProgress)
-            throw new InvalidOperationException($"Cannot pause session in {Status} status. Session must be InProgress.");
+            throw new ConflictException($"Cannot pause session in {Status} status. Session must be InProgress.");
 
         Status = SessionStatus.Paused;
 
@@ -106,7 +113,7 @@ internal sealed class GameSession : AggregateRoot<Guid>
     public void Resume()
     {
         if (Status != SessionStatus.Paused)
-            throw new InvalidOperationException($"Cannot resume session in {Status} status. Session must be Paused.");
+            throw new ConflictException($"Cannot resume session in {Status} status. Session must be Paused.");
 
         Status = SessionStatus.InProgress;
 
@@ -120,7 +127,7 @@ internal sealed class GameSession : AggregateRoot<Guid>
     public void Complete(string? winnerName = null)
     {
         if (Status != SessionStatus.InProgress && Status != SessionStatus.Paused)
-            throw new InvalidOperationException($"Cannot complete session in {Status} status. Session must be InProgress or Paused.");
+            throw new ConflictException($"Cannot complete session in {Status} status. Session must be InProgress or Paused.");
 
         // Validate winner name length (consistent with SessionPlayer validation)
         if (winnerName != null)
@@ -147,7 +154,7 @@ internal sealed class GameSession : AggregateRoot<Guid>
     public void Abandon(string? reason = null)
     {
         if (Status.IsFinished)
-            throw new InvalidOperationException($"Cannot abandon finished session (status: {Status})");
+            throw new ConflictException($"Cannot abandon finished session (status: {Status})");
 
         Status = SessionStatus.Abandoned;
         CompletedAt = DateTime.UtcNow;
@@ -267,7 +274,7 @@ internal sealed class GameSession : AggregateRoot<Guid>
         ArgumentException.ThrowIfNullOrWhiteSpace(reason);
 
         if (Status.IsFinished)
-            throw new InvalidOperationException($"Cannot terminate finished session (status: {Status})");
+            throw new ConflictException($"Cannot terminate finished session (status: {Status})");
 
         Status = SessionStatus.Abandoned;
         CompletedAt = DateTime.UtcNow;

--- a/apps/api/src/Api/Routing/SessionFlowEndpoints.cs
+++ b/apps/api/src/Api/Routing/SessionFlowEndpoints.cs
@@ -53,8 +53,21 @@ internal static class SessionFlowEndpoints
         .Produces(200)
         .Produces(401);
 
-        // Pause session
-        app.MapPost("/sessions/{sessionId:guid}/pause", async (
+        // #3662: era `/sessions/{sessionId:guid}/pause`, che COLLIDEVA con
+        // `GameEndpoints.MapPost("/sessions/{id}/pause")`. Le due route stanno sotto lo stesso
+        // prefisso /api/v1 e appartengono a bounded context diversi: questa opera su
+        // SessionTracking.Session, quella su GameSession. La variante con vincolo `:guid` e' piu'
+        // specifica, quindi vinceva SEMPRE il match -- gli id sono GUID -- e rendeva l'altra
+        // irraggiungibile.
+        //
+        // Conseguenza in produzione: la lista delle sessioni attive mostra GameSession (arrivano
+        // da /sessions/active, servito da IGameSessionRepository) e mettere in pausa dalla lista
+        // mandava quell'id qui, ottenendo 404. `useActiveSessions` era rotto.
+        //
+        // Le sessioni di SessionTracking si creano su `POST /api/v1/game-sessions`: e' li' che
+        // appartengono le loro operazioni di ciclo di vita. Spostandole si toglie la collisione
+        // senza perdere nessuno dei due comportamenti.
+        app.MapPost("/game-sessions/{sessionId:guid}/pause", async (
             Guid sessionId,
             HttpContext httpContext,
             IMediator mediator,
@@ -80,7 +93,7 @@ internal static class SessionFlowEndpoints
         .Produces(409);
 
         // Resume session
-        app.MapPost("/sessions/{sessionId:guid}/resume", async (
+        app.MapPost("/game-sessions/{sessionId:guid}/resume", async (
             Guid sessionId,
             HttpContext httpContext,
             IMediator mediator,

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/AddPlayerToSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/AddPlayerToSessionCommandHandlerTests.cs
@@ -223,7 +223,7 @@ public class AddPlayerToSessionCommandHandlerTests
         result.Players.Count.Should().Be(4);
     }
     [Fact]
-    public async Task Handle_NonExistentSession_ThrowsInvalidOperationException()
+    public async Task Handle_NonExistentSession_ThrowsNotFoundException()
     {
         // Arrange
         var sessionId = Guid.NewGuid();
@@ -240,9 +240,9 @@ public class AddPlayerToSessionCommandHandlerTests
         // Act & Assert
         var act =
             () => _handler.Handle(command, TestContext.Current.CancellationToken);
-        var exception = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
+        var exception = (await act.Should().ThrowAsync<NotFoundException>()).Which;
 
-        exception.Message.Should().ContainEquivalentOf($"Session with ID {sessionId} not found");
+        exception.Message.Should().ContainEquivalentOf($"GameSession with identifier '{sessionId}' was not found");
 
         // Verify save was NOT called
         _unitOfWorkMock.Verify(
@@ -390,7 +390,7 @@ public class AddPlayerToSessionCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_SessionWith100Players_ThrowsInvalidOperationException()
+    public async Task Handle_SessionWith100Players_ThrowsConflictException()
     {
         // Arrange - At the 100 player limit
         var sessionId = Guid.NewGuid();

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/PauseGameSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/PauseGameSessionCommandHandlerTests.cs
@@ -165,7 +165,7 @@ public class PauseGameSessionCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_SessionInSetupStatus_ThrowsInvalidOperationException()
+    public async Task Handle_SessionInSetupStatus_ThrowsConflictException()
     {
         // Arrange - Session not started yet (Setup status)
         var sessionId = Guid.NewGuid();
@@ -182,7 +182,7 @@ public class PauseGameSessionCommandHandlerTests
         // Act & Assert
         var act =
             () => _handler.Handle(command, TestContext.Current.CancellationToken);
-        var exception = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
+        var exception = (await act.Should().ThrowAsync<ConflictException>()).Which;
 
         exception.Message.Should().ContainEquivalentOf("Cannot pause session in Setup status");
 
@@ -193,7 +193,7 @@ public class PauseGameSessionCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_CompletedSession_ThrowsInvalidOperationException()
+    public async Task Handle_CompletedSession_ThrowsConflictException()
     {
         // Arrange - Session already completed
         var sessionId = Guid.NewGuid();
@@ -211,13 +211,13 @@ public class PauseGameSessionCommandHandlerTests
         // Act & Assert
         var act =
             () => _handler.Handle(command, TestContext.Current.CancellationToken);
-        var exception = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
+        var exception = (await act.Should().ThrowAsync<ConflictException>()).Which;
 
         exception.Message.Should().ContainEquivalentOf("Cannot pause session in Completed status");
     }
 
     [Fact]
-    public async Task Handle_AlreadyPausedSession_ThrowsInvalidOperationException()
+    public async Task Handle_AlreadyPausedSession_ThrowsConflictException()
     {
         // Arrange - Session already paused
         var sessionId = Guid.NewGuid();
@@ -238,7 +238,7 @@ public class PauseGameSessionCommandHandlerTests
         // Act & Assert
         var act =
             () => _handler.Handle(command, TestContext.Current.CancellationToken);
-        var exception = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
+        var exception = (await act.Should().ThrowAsync<ConflictException>()).Which;
 
         exception.Message.Should().ContainEquivalentOf("Cannot pause session in Paused status");
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/ResumeGameSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/ResumeGameSessionCommandHandlerTests.cs
@@ -204,7 +204,7 @@ public class ResumeGameSessionCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_SessionInSetupStatus_ThrowsInvalidOperationException()
+    public async Task Handle_SessionInSetupStatus_ThrowsConflictException()
     {
         // Arrange - Session not started yet (Setup status)
         var sessionId = Guid.NewGuid();
@@ -221,7 +221,7 @@ public class ResumeGameSessionCommandHandlerTests
         // Act & Assert
         var act =
             () => _handler.Handle(command, TestContext.Current.CancellationToken);
-        var exception = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
+        var exception = (await act.Should().ThrowAsync<ConflictException>()).Which;
 
         exception.Message.Should().ContainEquivalentOf("Cannot resume session in Setup status");
 
@@ -232,7 +232,7 @@ public class ResumeGameSessionCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_AlreadyInProgressSession_ThrowsInvalidOperationException()
+    public async Task Handle_AlreadyInProgressSession_ThrowsConflictException()
     {
         // Arrange - Session already in progress (not paused)
         var sessionId = Guid.NewGuid();
@@ -250,13 +250,13 @@ public class ResumeGameSessionCommandHandlerTests
         // Act & Assert
         var act =
             () => _handler.Handle(command, TestContext.Current.CancellationToken);
-        var exception = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
+        var exception = (await act.Should().ThrowAsync<ConflictException>()).Which;
 
         exception.Message.Should().ContainEquivalentOf("Cannot resume session in InProgress status");
     }
 
     [Fact]
-    public async Task Handle_CompletedSession_ThrowsInvalidOperationException()
+    public async Task Handle_CompletedSession_ThrowsConflictException()
     {
         // Arrange - Session already completed
         var sessionId = Guid.NewGuid();
@@ -274,7 +274,7 @@ public class ResumeGameSessionCommandHandlerTests
         // Act & Assert
         var act =
             () => _handler.Handle(command, TestContext.Current.CancellationToken);
-        var exception = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
+        var exception = (await act.Should().ThrowAsync<ConflictException>()).Which;
 
         exception.Message.Should().ContainEquivalentOf("Cannot resume session in Completed status");
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameSessionTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameSessionTests.cs
@@ -158,7 +158,7 @@ public sealed class GameSessionTests
     }
 
     [Fact]
-    public void Start_WhenInProgress_ThrowsInvalidOperationException()
+    public void Start_WhenInProgress_ThrowsConflictException()
     {
         // Arrange
         var session = CreateSetupSession();
@@ -168,12 +168,12 @@ public sealed class GameSessionTests
         var action = () => session.Start();
 
         // Assert
-        action.Should().Throw<InvalidOperationException>()
+        action.Should().Throw<ConflictException>()
             .WithMessage("*Cannot start session in InProgress status*");
     }
 
     [Fact]
-    public void Start_WhenPaused_ThrowsInvalidOperationException()
+    public void Start_WhenPaused_ThrowsConflictException()
     {
         // Arrange
         var session = CreateSetupSession();
@@ -184,12 +184,12 @@ public sealed class GameSessionTests
         var action = () => session.Start();
 
         // Assert
-        action.Should().Throw<InvalidOperationException>()
+        action.Should().Throw<ConflictException>()
             .WithMessage("*Cannot start session in Paused status*");
     }
 
     [Fact]
-    public void Start_WhenCompleted_ThrowsInvalidOperationException()
+    public void Start_WhenCompleted_ThrowsConflictException()
     {
         // Arrange
         var session = CreateSetupSession();
@@ -200,7 +200,7 @@ public sealed class GameSessionTests
         var action = () => session.Start();
 
         // Assert
-        action.Should().Throw<InvalidOperationException>()
+        action.Should().Throw<ConflictException>()
             .WithMessage("*Cannot start session in Completed status*");
     }
 
@@ -237,7 +237,7 @@ public sealed class GameSessionTests
     }
 
     [Fact]
-    public void Pause_WhenSetup_ThrowsInvalidOperationException()
+    public void Pause_WhenSetup_ThrowsConflictException()
     {
         // Arrange
         var session = CreateSetupSession();
@@ -246,12 +246,12 @@ public sealed class GameSessionTests
         var action = () => session.Pause();
 
         // Assert
-        action.Should().Throw<InvalidOperationException>()
+        action.Should().Throw<ConflictException>()
             .WithMessage("*Cannot pause session in Setup status*");
     }
 
     [Fact]
-    public void Pause_WhenPaused_ThrowsInvalidOperationException()
+    public void Pause_WhenPaused_ThrowsConflictException()
     {
         // Arrange
         var session = CreateSetupSession();
@@ -262,7 +262,7 @@ public sealed class GameSessionTests
         var action = () => session.Pause();
 
         // Assert
-        action.Should().Throw<InvalidOperationException>()
+        action.Should().Throw<ConflictException>()
             .WithMessage("*Cannot pause session in Paused status*");
     }
 
@@ -301,7 +301,7 @@ public sealed class GameSessionTests
     }
 
     [Fact]
-    public void Resume_WhenSetup_ThrowsInvalidOperationException()
+    public void Resume_WhenSetup_ThrowsConflictException()
     {
         // Arrange
         var session = CreateSetupSession();
@@ -310,12 +310,12 @@ public sealed class GameSessionTests
         var action = () => session.Resume();
 
         // Assert
-        action.Should().Throw<InvalidOperationException>()
+        action.Should().Throw<ConflictException>()
             .WithMessage("*Cannot resume session in Setup status*");
     }
 
     [Fact]
-    public void Resume_WhenInProgress_ThrowsInvalidOperationException()
+    public void Resume_WhenInProgress_ThrowsConflictException()
     {
         // Arrange
         var session = CreateSetupSession();
@@ -325,7 +325,7 @@ public sealed class GameSessionTests
         var action = () => session.Resume();
 
         // Assert
-        action.Should().Throw<InvalidOperationException>()
+        action.Should().Throw<ConflictException>()
             .WithMessage("*Cannot resume session in InProgress status*");
     }
 
@@ -440,7 +440,7 @@ public sealed class GameSessionTests
     }
 
     [Fact]
-    public void Complete_WhenSetup_ThrowsInvalidOperationException()
+    public void Complete_WhenSetup_ThrowsConflictException()
     {
         // Arrange
         var session = CreateSetupSession();
@@ -449,12 +449,12 @@ public sealed class GameSessionTests
         var action = () => session.Complete();
 
         // Assert
-        action.Should().Throw<InvalidOperationException>()
+        action.Should().Throw<ConflictException>()
             .WithMessage("*Cannot complete session in Setup status*");
     }
 
     [Fact]
-    public void Complete_WhenAlreadyCompleted_ThrowsInvalidOperationException()
+    public void Complete_WhenAlreadyCompleted_ThrowsConflictException()
     {
         // Arrange
         var session = CreateSetupSession();
@@ -465,7 +465,7 @@ public sealed class GameSessionTests
         var action = () => session.Complete();
 
         // Assert
-        action.Should().Throw<InvalidOperationException>()
+        action.Should().Throw<ConflictException>()
             .WithMessage("*Cannot complete session in Completed status*");
     }
 
@@ -563,7 +563,7 @@ public sealed class GameSessionTests
     }
 
     [Fact]
-    public void Abandon_WhenCompleted_ThrowsInvalidOperationException()
+    public void Abandon_WhenCompleted_ThrowsConflictException()
     {
         // Arrange
         var session = CreateSetupSession();
@@ -574,12 +574,12 @@ public sealed class GameSessionTests
         var action = () => session.Abandon();
 
         // Assert
-        action.Should().Throw<InvalidOperationException>()
+        action.Should().Throw<ConflictException>()
             .WithMessage("*Cannot abandon finished session*");
     }
 
     [Fact]
-    public void Abandon_WhenAlreadyAbandoned_ThrowsInvalidOperationException()
+    public void Abandon_WhenAlreadyAbandoned_ThrowsConflictException()
     {
         // Arrange
         var session = CreateSetupSession();
@@ -589,7 +589,7 @@ public sealed class GameSessionTests
         var action = () => session.Abandon();
 
         // Assert
-        action.Should().Throw<InvalidOperationException>()
+        action.Should().Throw<ConflictException>()
             .WithMessage("*Cannot abandon finished session*");
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/GameSessionDomainTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/GameSessionDomainTests.cs
@@ -94,7 +94,7 @@ public class GameSessionDomainTests
     }
 
     [Fact]
-    public void GameSession_Start_WhenAlreadyStarted_ThrowsInvalidOperationException()
+    public void GameSession_Start_WhenAlreadyStarted_ThrowsConflictException()
     {
         // Arrange
         var session = CreateDefaultSession();
@@ -102,7 +102,7 @@ public class GameSessionDomainTests
 
         // Act & Assert
         var act = () => session.Start();
-        var exception = act.Should().Throw<InvalidOperationException>().Which;
+        var exception = act.Should().Throw<ConflictException>().Which;
         exception.Message.Should().ContainEquivalentOf("must be in Setup");
     }
 
@@ -142,14 +142,14 @@ public class GameSessionDomainTests
     }
 
     [Fact]
-    public void GameSession_Complete_WhenNotInProgress_ThrowsInvalidOperationException()
+    public void GameSession_Complete_WhenNotInProgress_ThrowsConflictException()
     {
         // Arrange
         var session = CreateDefaultSession(); // Status = Setup
 
         // Act & Assert
         var act = () => session.Complete();
-        var exception = act.Should().Throw<InvalidOperationException>().Which;
+        var exception = act.Should().Throw<ConflictException>().Which;
         exception.Message.Should().ContainEquivalentOf("must be InProgress");
     }
 
@@ -200,7 +200,7 @@ public class GameSessionDomainTests
     }
 
     [Fact]
-    public void GameSession_Abandon_WhenAlreadyCompleted_ThrowsInvalidOperationException()
+    public void GameSession_Abandon_WhenAlreadyCompleted_ThrowsConflictException()
     {
         // Arrange
         var session = CreateDefaultSession();
@@ -209,7 +209,7 @@ public class GameSessionDomainTests
 
         // Act & Assert
         var act = () => session.Abandon();
-        var exception = act.Should().Throw<InvalidOperationException>().Which;
+        var exception = act.Should().Throw<ConflictException>().Which;
         exception.Message.Should().ContainEquivalentOf("Cannot abandon finished session");
     }
 

--- a/apps/api/tests/Api.Tests/E2E/GameManagement/GameManagementE2ETests.cs
+++ b/apps/api/tests/Api.Tests/E2E/GameManagement/GameManagementE2ETests.cs
@@ -389,27 +389,39 @@ public sealed class GameManagementE2ETests : E2ETestBase
     /// </summary>
     private async Task<Guid> StartSessionAsync(Guid gameId, string gameTitle = "E2E Test Game")
     {
-        var nightResponse = await Client.PostAsJsonAsync("/api/v1/game-nights", new
+        // 1. LiveGameSession — l'aggregato runtime. E' da qui che parte il ciclo di vita, non
+        //    dalla GameNight: quella crea un SessionTracking.Session, che vive in un altro
+        //    spazio di id (ADR-089, tre aggregati distinti).
+        var createResponse = await Client.PostAsJsonAsync("/api/v1/live-sessions", new
         {
-            title = $"E2E Night {Guid.NewGuid():N}",
-            // Il validator pretende `> UtcNow.AddHours(1)` STRETTAMENTE: con AddHours(1)
-            // esatto la data e' gia' scaduta quando il server la valuta, e la risposta e' 422.
-            scheduledAt = DateTimeOffset.UtcNow.AddDays(1)
+            gameName = gameTitle,
+            gameId
         });
-        nightResponse.EnsureSuccessStatusCode();
-        var gameNightId = await nightResponse.Content.ReadFromJsonAsync<Guid>();
+        createResponse.EnsureSuccessStatusCode();
+        // Il body e' il Guid NUDO (Results.Created(location, sessionId)), non un oggetto.
+        var liveSessionId = await createResponse.Content.ReadFromJsonAsync<Guid>();
 
-        // Una serata nasce in stato Draft e non accetta sessioni («Cannot add sessions to a
-        // Draft game night»): va pubblicata prima.
-        var publishResponse = await Client.PostAsync($"/api/v1/game-nights/{gameNightId}/publish", null);
-        publishResponse.EnsureSuccessStatusCode();
+        // 2. Almeno un giocatore ATTIVO: StartLiveSessionCommandHandler rifiuta con
+        //    ValidationException una sessione senza partecipanti. Va aggiunto QUI:
+        //    `POST /sessions/{id}/players` non servirebbe, perche' quel handler usa
+        //    IGameSessionRepository e scriverebbe su un GameSession che ancora non esiste.
+        var addPlayer = await Client.PostAsJsonAsync(
+            $"/api/v1/live-sessions/{liveSessionId}/players",
+            new { displayName = "E2E Player", color = "Red" });
+        addPlayer.EnsureSuccessStatusCode();
 
-        var sessionResponse = await Client.PostAsJsonAsync(
-            $"/api/v1/game-nights/{gameNightId}/sessions", new { gameId, gameTitle });
-        sessionResponse.EnsureSuccessStatusCode();
-        var started = await sessionResponse.Content.ReadFromJsonAsync<StartSessionResult>();
+        // 3. L'avvio crea il GameSession correlato (LifecycleCommandHandlers.cs:80) con un Guid
+        //    NUOVO, e il link `CorrelatedGameSessionId` non compare in nessuna risposta.
+        var startLive = await Client.PostAsync($"/api/v1/live-sessions/{liveSessionId}/start", null);
+        startLive.EnsureSuccessStatusCode();
 
-        return started!.SessionId;
+        // 4. L'id si recupera cosi', ed e' come fa il frontend: GetActiveSessionsQueryHandler
+        //    usa IGameSessionRepository, quindi restituisce GameSession.
+        var activeResponse = await Client.GetAsync($"/api/v1/games/{gameId}/sessions/active");
+        activeResponse.EnsureSuccessStatusCode();
+        var active = await activeResponse.Content.ReadFromJsonAsync<List<GameSessionDto>>();
+        active.Should().NotBeNullOrEmpty("l'avvio della live session deve aver creato un GameSession");
+        return active![0].Id;
     }
 
     private sealed record StartSessionResult(

--- a/apps/api/tests/Api.Tests/E2E/GameManagement/GameManagementE2ETests.cs
+++ b/apps/api/tests/Api.Tests/E2E/GameManagement/GameManagementE2ETests.cs
@@ -250,7 +250,17 @@ public sealed class GameManagementE2ETests : E2ETestBase
     {
         // Step 1: Browse games (public)
         ClearAuthentication();
-        var gamesResponse = await Client.GetAsync("/api/v1/games");
+        // #3662: era `GET /api/v1/games` senza filtro. L'endpoint e' PAGINATO: in isolamento il
+        // catalogo e' piccolo e il gioco di questo test finisce in prima pagina, ma nella suite
+        // completa le altre classi ne seminano a decine e il nostro esce dalla pagina --
+        // l'assert sotto falliva in 11 ms. Dipendeva dalla dimensione del catalogo, cioe'
+        // dall'ordine e dal numero degli altri test.
+        //
+        // Il nome del gioco e' unico per test (`E2E Test Game {Guid}`), quindi il filtro di
+        // ricerca rende il passo deterministico senza cambiare cosa verifica: che il gioco
+        // appena creato sia visibile dal catalogo pubblico.
+        var gamesResponse = await Client.GetAsync(
+            $"/api/v1/games?search={Uri.EscapeDataString(_testGameName)}");
         gamesResponse.EnsureSuccessStatusCode();
 
         var games = await gamesResponse.Content.ReadFromJsonAsync<PaginatedGamesResponse>();

--- a/apps/api/tests/Api.Tests/E2E/GameManagement/GameManagementE2ETests.cs
+++ b/apps/api/tests/Api.Tests/E2E/GameManagement/GameManagementE2ETests.cs
@@ -285,7 +285,8 @@ public sealed class GameManagementE2ETests : E2ETestBase
 
         session.Should().NotBeNull();
         session!.Status.Should().Be("InProgress");
-        session.Players.Should().HaveCount(3);
+        // #3662: 3 aggiunti dal test + 1 seminato da StartSessionAsync per poter avviare.
+        session.Players.Should().HaveCount(4);
 
         // Step 5: Complete the game with a winner
         var completePayload = new { winnerName = "Bob" };
@@ -323,7 +324,9 @@ public sealed class GameManagementE2ETests : E2ETestBase
 
         var updatedSession = await addResponse.Content.ReadFromJsonAsync<GameSessionDto>();
         updatedSession.Should().NotBeNull();
-        updatedSession!.Players.Should().HaveCount(3);
+        // #3662: StartSessionAsync semina UN giocatore, perche' l'avvio della live session
+        // pretende almeno un partecipante attivo. Il test ne aggiunge uno: totale 2.
+        updatedSession!.Players.Should().HaveCount(2);
         updatedSession.Players.Should().Contain(p => p.PlayerName == "Player 3");
     }
 

--- a/apps/web/src/lib/api/session-flow/client.ts
+++ b/apps/web/src/lib/api/session-flow/client.ts
@@ -7,8 +7,8 @@
  *
  * Endpoints covered:
  *   POST   /api/v1/games/{gameId}/sessions            — createSession
- *   POST   /api/v1/sessions/{id}/pause                — pauseSession
- *   POST   /api/v1/sessions/{id}/resume               — resumeSession
+ *   POST   /api/v1/game-sessions/{id}/pause           — pauseSession   (#3662: spostata)
+ *   POST   /api/v1/game-sessions/{id}/resume          — resumeSession  (#3662: spostata)
  *   PUT    /api/v1/sessions/{id}/turn-order            — setTurnOrder
  *   POST   /api/v1/sessions/{id}/turn/advance          — advanceTurn
  *   POST   /api/v1/game-sessions/{id}/actions/roll-dice — rollSessionDice
@@ -104,11 +104,11 @@ export function createSessionFlowClient({
     },
 
     async pauseSession(sessionId) {
-      await httpClient.post(`${SESSION_BASE}/${encodeURIComponent(sessionId)}/pause`);
+      await httpClient.post(`${GAME_SESSION_BASE}/${encodeURIComponent(sessionId)}/pause`);
     },
 
     async resumeSession(sessionId) {
-      await httpClient.post(`${SESSION_BASE}/${encodeURIComponent(sessionId)}/resume`);
+      await httpClient.post(`${GAME_SESSION_BASE}/${encodeURIComponent(sessionId)}/resume`);
     },
 
     async setTurnOrder(sessionId, request) {


### PR DESCRIPTION
Closes parte di #3662. Tre bug di produzione trovati inseguendo i test E2E rossi.

**Suite `Category=E2E`: da 15 rossi a 11** su 221. `GameManagementE2ETests`: **8/8** (erano 4/9). Suite unit: **22611/22611**, zero regressioni.

---

## 🔴 Bug 1 — due bounded context registrano la stessa URL

```
GameEndpoints.cs:178        POST /sessions/{id}/pause            → GameSession
SessionFlowEndpoints.cs:57  POST /sessions/{sessionId:guid}/pause → SessionTracking.Session
```

Stesso prefisso `/api/v1`, contesti diversi. La variante con vincolo `:guid` è **più specifica**, quindi vince sempre il match — gli id sono GUID — e rende l'altra **irraggiungibile**.

**Conseguenza in produzione**: la lista delle sessioni attive mostra `GameSession` (arrivano da `/sessions/active`, servito da `IGameSessionRepository`), e metterle in pausa mandava quell'id al handler di SessionTracking → **404**. `useActiveSessions` era rotto.

I due client frontend credevano entrambi di possedere quell'URL, con contratti incompatibili: `sessionsClient` si aspetta un `GameSessionDto`, `session-flow/client` un `204`.

**Fix**: le sessioni di SessionTracking si creano su `POST /api/v1/game-sessions` — è lì che appartengono le sue operazioni di ciclo di vita. Spostate a `/game-sessions/{id}/pause|resume`, con `session-flow/client.ts` aggiornato. Nessuno dei due comportamenti si perde.

## 🔴 Bug 2 — il `GameSession` correlato non veniva mai avviato

`StartLiveSessionCommandHandler` lo creava e lo lasciava in `Setup`: **nessun percorso lo avviava**. Ma `Pause()` pretende `InProgress` e `Complete()` pretende `InProgress` o `Paused` → ogni operazione rispondeva **409**. E `FindActiveAsync` include `Setup`, quindi la lista mostrava sessioni su cui nessuna azione funzionava.

Era l'asimmetria con `CompleteLiveSessionCommandHandler`, dove il correlato riceve esplicitamente il suo stato (`MarkCorrelatedComplete`). Ora l'avvio fa lo stesso con `Start()`.

## 🔴 Bug 3 — 404 dove serviva 409

Sei guardie di stato sollevavano `InvalidOperationException`, che `ApiExceptionHandlerMiddleware.cs:465` mappa a **404**: mettere in pausa una sessione nello stato sbagliato rispondeva *«The requested resource was not found»* per una risorsa che **esiste**. Pitfall #2568, lo stesso già corretto su `BatchJob`.

Qui il danno è peggiore di un codice impreciso: un 404 manda a cercare l'id sbagliato invece dello stato sbagliato. **Ci ho perso diverse iterazioni** prima di capire che l'id era corretto dall'inizio.

Anche `AddPlayerToSessionCommandHandler` usava `InvalidOperationException` per la sessione inesistente: codice HTTP giusto *per caso*, ora `NotFoundException`.

---

## La verifica che dimostra che sono tre difetti distinti

Il 404 dei test è diventato **409** col fix 1 (la chiamata raggiunge il handler giusto) e poi **verde** col fix 2 (lo stato è coerente). Una cascata, non una coincidenza.

**17 test** asserivano il tipo di eccezione vecchio, su **quattro file e due livelli** — cercati prima di pushare, non lasciati trovare alla CI come era successo con `BatchJob`.

## Cosa resta

`CompleteGameJourney` passa **in isolamento** ma fallisce in 11 ms nella suite completa: è un problema di isolamento fra test (la collection E2E condivide un database), non di logica — da guardare separatamente.

Gli altri residui sono endpoint rimossi (`CreateAgent`, `import-bgg`, `vector-collections`) e i test Arbitro, già documentati in #3662.
