### PR TITLE
fix(toolkit): il token xmin attraversa ToolkitVersion (#3688)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Domain/Entities/ToolkitVersion.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Domain/Entities/ToolkitVersion.cs
@@ -45,6 +45,20 @@ internal sealed class ToolkitVersion : AggregateRoot<Guid>
     public string? YankReason { get; private set; }
     public Guid? YankedBy { get; private set; }
 
+    /// <summary>Token di concorrenza ottimistica Postgres (<c>xmin</c>). Di proprietà del server;
+    /// il repository lo round-trippa per l'Update su grafo detached (ADR-060). #3688.
+    /// <para>
+    /// Senza questo trasporto <c>MapToPersistence</c> produce un'entità con <c>Xmin = 0</c> — mai
+    /// un xid reale — e l'UPDATE emette <c>WHERE xmin = 0</c>, colpendo 0 righe: ogni pubblicazione
+    /// o yank di una versione fallirebbe con <c>DbUpdateConcurrencyException</c> anche in assenza
+    /// di concorrenza. Stesso guasto di #3670 e #3694.
+    /// </para></summary>
+#pragma warning disable S1144 // Il setter è scritto solo da SetPrivateProperty in
+    // ToolkitVersionRepository.MapToDomain (reflection): l'analyzer non lo vede come usato.
+    // Stessa ragione per cui quel repository sopprime già S3011 sulle sue helper.
+    public uint Xmin { get; private set; }
+#pragma warning restore S1144
+
     /// <summary>True when the version has been soft-deleted via <see cref="Yank"/>.</summary>
     public bool IsYanked => YankedAt.HasValue;
 

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Infrastructure/Persistence/ToolkitVersionRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Infrastructure/Persistence/ToolkitVersionRepository.cs
@@ -146,6 +146,9 @@ internal class ToolkitVersionRepository : RepositoryBase, IToolkitVersionReposit
         SetPrivateProperty(version, "YankedAt", entity.YankedAt);
         SetPrivateProperty(version, "YankReason", entity.YankReason);
         SetPrivateProperty(version, "YankedBy", entity.YankedBy);
+        // #3688: il token deve tornare nel dominio, altrimenti MapToPersistence lo riscrive a 0 e
+        // l'UPDATE su grafo detached cerca `WHERE xmin = 0`, che non corrisponde ad alcuna riga.
+        SetPrivateProperty(version, "Xmin", entity.Xmin);
 
         // Reinitialise the domain-events list (GetUninitializedObject leaves it null).
         SetPrivateField(version, "_domainEvents", new List<Api.SharedKernel.Domain.Interfaces.IDomainEvent>());
@@ -166,6 +169,8 @@ internal class ToolkitVersionRepository : RepositoryBase, IToolkitVersionReposit
             YankedAt = version.YankedAt,
             YankReason = version.YankReason,
             YankedBy = version.YankedBy,
+            // #3688 — round-trip del token per l'Update su grafo detached (ADR-060).
+            Xmin = version.Xmin,
         };
     }
 


### PR DESCRIPTION
Uno dei candidati di **#3688**. Dei due che avevo indicato, **uno solo era reale** — e la correzione dell'altro è parte del contributo.

## ✅ `ToolkitVersionRepository` — guasto reale, corretto

`ToolkitVersionEntity` ha il token, ma il repository lo perdeva: `MapToDomain` (che ricostruisce l'aggregato via reflection con `SetPrivateProperty`) non lo leggeva, `MapToPersistence` non lo riscriveva. Ogni `UpdateAsync` produceva un'entità detached con `Xmin = 0` — mai un xid reale — e l'UPDATE emetteva `WHERE xmin = 0`, colpendo 0 righe.

Stesso guasto di #3670 (`GameToolkitRepository`) e #3694 (`PdfDocument`).

Fix col pattern già usato da `PlayRecordRepository`:
- `uint Xmin` sull'aggregato `ToolkitVersion`
- `SetPrivateProperty(version, "Xmin", entity.Xmin)` in `MapToDomain`
- `Xmin = version.Xmin` in `MapToPersistence`

Il setter richiede `#pragma warning disable S1144`: lo scrive solo la reflection, quindi l'analyzer non lo vede usato — stessa ragione per cui quel repository sopprime già S3011 sulle proprie helper.

## ❌ `EnrichmentQueueRepository` — falso positivo, revertato

L'avevo indicato come secondo candidato. **Non lo è**: `EnrichmentQueueEntryEntity` non ha alcun token di concorrenza. Il mio `grep -A 400` sullo snapshot aveva sbordato su un'entità adiacente attribuendogli un `xmin` che non le appartiene.

L'ha smentito il compilatore (`CS0117`), non un ragionamento. Senza token, un `Update()` su grafo detached non ha alcuna clausola `WHERE xmin` da sbagliare — è il caso che #3688 classifica esplicitamente come «cosa NON è un difetto».

## ⚠️ Limite dichiarato

**Verificato in compilazione, non in esecuzione.** La prova che #3688 richiede è un test Testcontainers con un aggiornamento banale via repository e l'asserzione che `SaveChangesAsync` non sollevi. **Non è incluso in questa PR.**

Chi la rivede dovrebbe sapere che il fix è corretto per costruzione — è lo stesso identico pattern applicato e validato tre volte (#2436, #3670, #3696) — ma non ancora dimostrato su Postgres per questa entità specifica.

## Sulla lezione di metodo

L'analisi statica che ha portato qui ha prodotto **un falso positivo su due**. Restringe il campo — da 11 candidati a 2 — non decide. #3688 aveva ragione fin dall'inizio: il verdetto lo dà l'esecuzione.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
