### PR TITLE
docs(backup): la copia offsite è attiva su staging — e due correzioni al runbook (#3669)

### DIFF
--- a/infra/hetzner/disaster-recovery.md
+++ b/infra/hetzner/disaster-recovery.md
@@ -40,13 +40,34 @@ The following code review findings are documented but NOT fixed in Sprint 0:
 - **Item 4** (phantom Prometheus targets): `prometheus.yml` references `postgres-exporter:9187` and `redis-exporter:9121` but no such services exist in the compose stack. Targets must be added before scrape jobs work. Action: comment out or add exporters before deploying.
 - **Item 6** (Loki schema deprecated): `loki-config.yml` uses `boltdb-shipper` + `schema v11` (Loki 2.x format). When Loki 3.x is pulled via `:latest`, runtime warnings or failures may occur. Action: pin Loki to `2.9.10` at deploy time, OR migrate to `tsdb` + `schema v13` for Loki 3.x.
 - **Item 10** (redundant compose install in bootstrap): `cax31-bootstrap.sh` manually downloads `docker-compose-linux-aarch64` after `get.docker.com` already installs the Compose plugin via APT. This may cause version drift. Action: remove manual download step before production deploy.
-- **Offsite copy is configured off, not missing** (#3669). The earlier wording here — *"`backup-to-r2.sh` not implemented; cron line commented out in `backup.cron`"* — described a path that was never deployed. The live backup is `infra/scripts/backup.sh`, installed by `make backup-cron-install`; `infra/hetzner/backup.sh` and `backup.cron` were never copied to `/usr/local/bin` and have been removed.
+- **Offsite copy: LIVE on staging since 2026-08-12, still MISSING on production** (#3669). The earlier wording here — *"`backup-to-r2.sh` not implemented; cron line commented out in `backup.cron`"* — described a path that was never deployed. The live backup is `infra/scripts/backup.sh`, installed by `make backup-cron-install`; `infra/hetzner/backup.sh` and `backup.cron` were never copied to `/usr/local/bin` and have been removed.
 
-  `infra/scripts/backup.sh` **already uploads to S3/R2**, but the upload is gated on `S3_BACKUP_ENABLED`, and `backup.secret` is absent on the host — so every nightly run skips it. Until that secret is filled in, backups and production both live in the same Hetzner account and an incident on that account loses them together.
+  A run that skips the offsite copy now reports `WARN … WITHOUT offsite copy` and sends a `degraded` webhook instead of claiming success — before #3669 it logged *"All backups completed successfully"* while the copy had silently never happened.
 
-  Since #3669 a run that skips the offsite copy reports `WARN … WITHOUT offsite copy` and sends a `degraded` webhook instead of claiming success.
+## Offsite backup — staging (verified 2026-08-12)
 
-  **To close the gap**, on the host: create `infra/secrets/backup.secret` from `backup.secret.example` (`S3_BACKUP_ENABLED=true`, credentials, endpoint, a real `S3_BACKUP_REGION` for AWS, and `BACKUP_AGE_RECIPIENT`), then `apt-get install -y awscli age` — **neither binary is currently installed**.
+| | |
+|---|---|
+| Bucket | `meepleai-backups`, `eu-north-1`, public access blocked |
+| Endpoint | `https://s3.eu-north-1.amazonaws.com` |
+| Versioning | enabled, with the `backup-retention` lifecycle rule above |
+| IAM user | `meepleai-backup` — verified `AccessDenied` on `s3:ListAllMyBuckets`, so a stolen key cannot even enumerate the account |
+| Encryption | client-side `age`; the private key is **not** on the VPS |
+| Binaries | `aws-cli 2.36.21` (aarch64 installer — `apt` has no `awscli` candidate on Ubuntu 24.04 arm64), `age 1.1.1` |
+
+End-to-end proof, run with `env -i PATH=/usr/bin:/bin` so it matches cron's environment rather than an interactive shell:
+
+```
+Encrypted 3/3 files.
+upload: ... postgres.sql.gz.age → s3://meepleai-backups/20260812-145136/
+Backup complete — local: /backups/... | offsite: meepleai-backups
+```
+
+The restore path was exercised too, not just the write path: an object was pulled back from S3, decrypted with the private key, and its content validated (Redis RDB header). **A backup nobody has restored is a hypothesis, not a backup.**
+
+### Still to do on PRODUCTION
+
+Production is a different host and none of the above applies to it yet. Repeat: install `age` + the aarch64 AWS CLI, create `backup.secret`, and generate a **separate** age key and IAM user — sharing them would mean one compromise exposes both environments.
 
 ## Restoring from the offsite copy
 
@@ -93,14 +114,14 @@ Measured on staging (2026-08-12): **177 MB per backup**, 7-day retention, ~1.4 G
 
 ```json
 { "Rules": [
-  { "ID": "expire-noncurrent", "Status": "Enabled", "Filter": {},
-    "NoncurrentVersionExpiration": { "NoncurrentDays": 7 } },
-  { "ID": "abort-multipart", "Status": "Enabled", "Filter": {},
-    "AbortIncompleteMultipartUpload": { "DaysAfterInitiation": 7 } },
-  { "ID": "expire-old-backups", "Status": "Enabled", "Filter": {},
-    "Expiration": { "Days": 14 } }
+  { "ID": "backup-retention", "Status": "Enabled", "Filter": {},
+    "Expiration": { "Days": 14 },
+    "NoncurrentVersionExpiration": { "NoncurrentDays": 7 },
+    "AbortIncompleteMultipartUpload": { "DaysAfterInitiation": 7 } }
 ]}
 ```
+
+⚠️ Do **not** also enable *"delete expired object delete markers"*. The console rejects it: with `Expiration` active on a versioned bucket, S3 already removes the marker once the last noncurrent version expires. An earlier draft of this runbook listed both — they are mutually exclusive.
 
 The 14-day expiry is a backstop **independent of the script**: `clean_s3_backups` swallows a failed `aws s3 ls` (`|| true`) and prunes nothing, silently.
 


### PR DESCRIPTION
## Cosa è cambiato nella realtà

Il backup offsite è **operativo e verificato su staging** dal 2026-08-12. Bucket `meepleai-backups` (`eu-north-1`), versioning + lifecycle, utente IAM dedicato, cifratura client-side `age`.

## Due errori miei nel runbook, scritti in teoria e smentiti dalla console

**1. Le tre lifecycle rules non sono compatibili.** AWS rifiuta *«Elimina i contrassegni di eliminazione degli oggetti scaduti»* quando è attiva *«Scadenza versioni correnti»*: con `Expiration` su un bucket versionato, S3 rimuove già il delete marker alla scadenza dell'ultima versione non corrente. Il JSON diventa **una regola sola con tre proprietà**, non tre regole separate.

**2. La sezione «to close the gap» era superata.** Descriveva ancora uno stato in cui il secret non esisteva. Ora riporta cosa è in piedi su staging con i valori reali, e cosa resta da fare in produzione.

## La verifica, perché il punto non è che il comando sia stato lanciato

| Cosa | Perché conta |
|---|---|
| Eseguito con `env -i PATH=/usr/bin:/bin` | L'ambiente di **cron**, non quello interattivo. `aws` sta in `/usr/local/bin`, che cron non vede: sarebbe fallito solo di notte |
| `Encrypted 3/3 files`, 165 MB caricati | Il riepilogo **nomina la destinazione** invece del generico «completed successfully» |
| **Ripristino provato**, non solo la scrittura | Oggetto riscaricato da S3, decifrato con la chiave privata, contenuto validato (header Redis RDB) |
| `s3:ListAllMyBuckets` → `AccessDenied` | Policy verificata **in negativo**: una chiave esfiltrata non può nemmeno enumerare l'account |

> Un backup che nessuno ha mai ripristinato è un'ipotesi, non un backup.

## Trappole documentate per chi rifarà il giro in produzione

- Su **Ubuntu 24.04 arm64** `apt` non ha un candidato per `awscli` e **aborta l'intera transazione** — quindi `apt-get install -y awscli age` non installa nemmeno `age`. Serve l'installer aarch64 ufficiale.
- `aws` finisce in `/usr/local/bin`, invisibile al `PATH` di cron (corretto nello script in #3693).
- Le lifecycle rules di cui sopra.

## La produzione resta scoperta

Host diverso, e vanno generate **chiave age e credenziali IAM separate**: condividerle significherebbe che una compromissione espone entrambi gli ambienti.

Refs #3669

🤖 Generated with [Claude Code](https://claude.com/claude-code)